### PR TITLE
feat(api): TOTP enrollment + verification endpoints (P2.x.1.a)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -13,7 +13,7 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 2 (core API surface):** ✅ complete
 - **Phase 2.x (cleanup before Phase 3):** queued — three slices, ordered
 
-**Tests:** 184 passing · **coverage:** 95% project, ≥95% on `tulip-core` and `tulip-storage` · **CI:** green on `main`
+**Tests:** 215 passing · **coverage:** 95% project, ≥95% on `tulip-core` and `tulip-storage` · **CI:** green on `main`
 
 ---
 
@@ -80,9 +80,22 @@ Per [PHASE_0_CHECKLIST.md](PHASE_0_CHECKLIST.md). Completed 2026-04-29.
 
 These slices are between core Phase 2 and the start of Phase 3 (CLI). They're sequenced so each one builds on the last.
 
-### P2.x.1 — MFA (TOTP) — *next*
+### P2.x.1 — MFA (TOTP) — *in flight*
 
-TOTP enrollment endpoint, login challenge gate, hashed recovery codes. The `User.totp_secret_encrypted` and `Household.mfa_policy` fields are already in the schema. New endpoints will be RFC 9457-compliant from day 1 (the `auth.mfa_required` problem-details code is documented in §7.8.7).
+TOTP enrollment endpoint, login challenge gate, hashed recovery codes. The `User.totp_secret_encrypted` and `Household.mfa_policy` fields are already in the schema. New endpoints are RFC 9457-compliant from day 1 (the `auth.mfa_required` problem-details code is documented in §7.8.7).
+
+Sub-slices:
+
+- **P2.x.1.a — Enrollment + verification — ✅** *(2026-04-30)*
+  - `Settings.master_key` wired in (`TULIP_MASTER_KEY` env, base64-32-bytes; ephemeral fallback warns).
+  - `users.totp_enrolled_at` column + migration; distinguishes "secret stored, awaiting verify" from "verified."
+  - **Minimum Problem Details infrastructure** landed alongside (`tulip_api.errors.TulipProblem`, `install_problem_handlers`, `_problem_details.assert_problem`). MFA error paths use it; legacy endpoints still emit plain `HTTPException` until P2.x.2 migrates them onto the same registry.
+  - `tulip_api.auth.mfa` service: `pyotp` wrappers + AES-256-GCM encrypt/decrypt of stored secrets.
+  - `POST /v1/auth/mfa/enroll` (rotates if not yet verified; 409 `auth.mfa_already_enrolled` after).
+  - `POST /v1/auth/mfa/verify` (400 `auth.mfa_not_pending`, 401 `auth.mfa_invalid_code`, 409 `auth.mfa_already_enrolled`; 204 on success).
+  - Audit log written on every state-changing path.
+- **P2.x.1.b — Login challenge gate** *(queued)* — `/v1/auth/login` returns `auth.mfa_required` Problem Details when caller is TOTP-enrolled; new `POST /v1/auth/login/mfa` completes the flow with the code. Enforces `Household.mfa_policy` for admins.
+- **P2.x.1.c — Recovery codes** *(queued)* — generate-on-enroll, hashed at rest (argon2id), one-time use; `POST /v1/auth/mfa/recover`.
 
 ### P2.x.2 — RFC 9457 Problem Details migration — *blocked by P2.x.1*
 

--- a/packages/tulip-api/src/tulip_api/auth/mfa.py
+++ b/packages/tulip-api/src/tulip_api/auth/mfa.py
@@ -1,0 +1,52 @@
+"""TOTP (RFC 6238) helpers for the MFA enrollment + verification flows.
+
+Wraps :mod:`pyotp` for secret generation, provisioning-URI construction,
+and code verification, plus AES-256-GCM encrypt/decrypt of stored
+secrets via the field-encryption helper in ``tulip-storage``.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import pyotp
+
+from tulip_storage.encryption.field import decrypt_field, encrypt_field
+
+#: Default issuer name shown in authenticator apps.
+DEFAULT_ISSUER: Final[str] = "Tulip Accounting"
+
+#: ±1 30-second windows of slack tolerated when verifying codes — i.e.
+#: the previous and next windows count as valid. Standard practice for
+#: TOTP to absorb clock skew.
+_VERIFY_WINDOW: Final[int] = 1
+
+
+def generate_totp_secret() -> str:
+    """Return a fresh base32-encoded TOTP secret (160 bits)."""
+    return pyotp.random_base32()
+
+
+def build_provisioning_uri(*, secret: str, email: str, issuer: str = DEFAULT_ISSUER) -> str:
+    """Return an ``otpauth://`` URI suitable for QR-encoding."""
+    return pyotp.TOTP(secret).provisioning_uri(name=email, issuer_name=issuer)
+
+
+def verify_totp_code(secret: str, code: str) -> bool:
+    """Return True if ``code`` is a currently-valid TOTP for ``secret``.
+
+    Tolerates ±1 window of clock skew.
+    """
+    if not code or not code.isdigit():
+        return False
+    return pyotp.TOTP(secret).verify(code, valid_window=_VERIFY_WINDOW)
+
+
+def encrypt_totp_secret(secret: str, *, master_key: bytes) -> bytes:
+    """Encrypt a base32 TOTP secret for storage in ``users.totp_secret_encrypted``."""
+    return encrypt_field(secret.encode("ascii"), master_key=master_key)
+
+
+def decrypt_totp_secret(blob: bytes, *, master_key: bytes) -> str:
+    """Decrypt a blob produced by :func:`encrypt_totp_secret`."""
+    return decrypt_field(blob, master_key=master_key).decode("ascii")

--- a/packages/tulip-api/src/tulip_api/config.py
+++ b/packages/tulip-api/src/tulip_api/config.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
+import logging
 import os
 import secrets
 from dataclasses import dataclass, field
+
+log = logging.getLogger("tulip_api.config")
 
 
 def _default_jwt_secret() -> str:
@@ -15,12 +20,37 @@ def _default_db_url() -> str:
     return os.environ.get("TULIP_DATABASE_URL", "sqlite:///./tulip.db")
 
 
+def _default_master_key() -> bytes:
+    """Resolve the field-encryption master key.
+
+    Reads ``TULIP_MASTER_KEY`` (base64-encoded 32 bytes). If unset, falls
+    back to a freshly generated ephemeral key and logs a warning — fine
+    for tests and dev, fatal for prod (existing TOTP secrets become
+    undecryptable on every restart).
+    """
+    raw = os.environ.get("TULIP_MASTER_KEY")
+    if raw is None:
+        log.warning(
+            "TULIP_MASTER_KEY not set; using an ephemeral master key. "
+            "Field-encrypted data (e.g. TOTP secrets) will not survive a process restart."
+        )
+        return secrets.token_bytes(32)
+    try:
+        decoded = base64.b64decode(raw, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("TULIP_MASTER_KEY must be valid base64 (32 raw bytes encoded).") from exc
+    if len(decoded) != 32:
+        raise ValueError(f"TULIP_MASTER_KEY must decode to exactly 32 bytes (got {len(decoded)}).")
+    return decoded
+
+
 @dataclass(frozen=True, slots=True)
 class Settings:
     """Read-only runtime settings."""
 
     database_url: str = field(default_factory=_default_db_url)
     jwt_secret: str = field(default_factory=_default_jwt_secret)
+    master_key: bytes = field(default_factory=_default_master_key)
 
 
 _SINGLETON: Settings | None = None

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -1,0 +1,143 @@
+"""RFC 9457 (Problem Details for HTTP APIs) infrastructure.
+
+Per ARCHITECTURE §7.8.2, every non-2xx response from ``tulip-api`` is
+emitted as ``application/problem+json``.
+
+This module provides three things:
+
+* :class:`TulipProblem` — exception base. Carries ``code``, ``title``,
+  ``status``, ``detail``, and optional ``extensions``. Domain modules
+  raise concrete subclasses (or instances) at the boundary; the handler
+  below renders them.
+* :func:`install_problem_handlers` — wires the FastAPI exception handler
+  that turns :class:`TulipProblem` into a Problem Details JSON response.
+* The default ``type`` URI scheme — ``/.well-known/errors/<code>``.
+
+The full migration of legacy ``HTTPException(detail=str)`` call sites to
+this infra is tracked as P2.x.2; this module ships first because the MFA
+endpoints in P2.x.1 are required to be RFC 9457 from day 1.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+PROBLEM_CONTENT_TYPE: Final[str] = "application/problem+json"
+DEFAULT_TYPE_PREFIX: Final[str] = "/.well-known/errors"
+
+
+class TulipProblem(Exception):
+    """An error that should be rendered as RFC 9457 Problem Details.
+
+    ``code`` is the stable machine-readable identifier; clients dispatch
+    on it. ``title`` is the short human-readable summary; ``detail`` is
+    the per-occurrence explanation (and recovery hint, where one is
+    computable). ``extensions`` are surfaced as additional top-level keys
+    in the response body — never crammed into ``detail``.
+    """
+
+    __slots__ = ("code", "detail", "extensions", "status", "title", "type_uri")
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        title: str,
+        status: int,
+        detail: str | None = None,
+        type_uri: str | None = None,
+        extensions: dict[str, Any] | None = None,
+    ) -> None:
+        """Build a Problem Details exception. See class docstring for fields."""
+        super().__init__(title)
+        self.code = code
+        self.title = title
+        self.status = status
+        self.detail = detail if detail is not None else title
+        self.type_uri = type_uri or f"{DEFAULT_TYPE_PREFIX}/{code}"
+        self.extensions: dict[str, Any] = dict(extensions) if extensions else {}
+
+
+def _render(request: Request, problem: TulipProblem) -> JSONResponse:
+    body: dict[str, Any] = {
+        "type": problem.type_uri,
+        "title": problem.title,
+        "status": problem.status,
+        "detail": problem.detail,
+        "instance": request.url.path,
+        "code": problem.code,
+    }
+    request_id = request.headers.get("x-request-id")
+    if request_id:
+        body["request_id"] = request_id
+    # Extension fields go at the top level (RFC 9457 §3.2). Reject keys
+    # that would shadow required fields — safer than silently overwriting.
+    reserved = {"type", "title", "status", "detail", "instance", "code", "request_id"}
+    for key, value in problem.extensions.items():
+        if key in reserved:
+            raise ValueError(f"extension field {key!r} shadows reserved Problem Details field")
+        body[key] = value
+    return JSONResponse(
+        status_code=problem.status,
+        content=body,
+        media_type=PROBLEM_CONTENT_TYPE,
+    )
+
+
+class MfaAlreadyEnrolledError(TulipProblem):
+    """The user has already completed MFA enrollment."""
+
+    def __init__(self) -> None:
+        """Build the auth.mfa_already_enrolled problem."""
+        super().__init__(
+            code="auth.mfa_already_enrolled",
+            title="MFA already enrolled",
+            status=409,
+            detail=(
+                "This account already has TOTP-based MFA active. "
+                "Disable the existing enrollment before enrolling again."
+            ),
+        )
+
+
+class MfaNotPendingError(TulipProblem):
+    """Verify called with no enrollment in progress."""
+
+    def __init__(self) -> None:
+        """Build the auth.mfa_not_pending problem."""
+        super().__init__(
+            code="auth.mfa_not_pending",
+            title="No MFA enrollment in progress",
+            status=400,
+            detail=(
+                "There is no pending TOTP enrollment to verify. "
+                "Call /v1/auth/mfa/enroll first to start enrollment."
+            ),
+        )
+
+
+class MfaInvalidCodeError(TulipProblem):
+    """The TOTP code did not match the stored secret."""
+
+    def __init__(self) -> None:
+        """Build the auth.mfa_invalid_code problem."""
+        super().__init__(
+            code="auth.mfa_invalid_code",
+            title="Invalid TOTP code",
+            status=401,
+            detail=(
+                "The TOTP code did not match. Check that your authenticator "
+                "app is showing the current 6-digit code and try again."
+            ),
+        )
+
+
+def install_problem_handlers(app: FastAPI) -> None:
+    """Register the :class:`TulipProblem` handler on ``app``."""
+
+    @app.exception_handler(TulipProblem)
+    def _handle(request: Request, exc: TulipProblem) -> JSONResponse:
+        return _render(request, exc)

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
+from tulip_api.errors import install_problem_handlers
 from tulip_api.logging_config import configure_logging
 from tulip_api.middleware import RequestIdMiddleware
 from tulip_api.routers import accounts, auth, health, transactions
@@ -32,6 +33,8 @@ def create_app() -> FastAPI:
     # Request-id stamping must run before any router-level logging so the
     # request_id is in scope for every log line emitted during handling.
     app.add_middleware(RequestIdMiddleware)
+
+    install_problem_handlers(app)
 
     # Top-level health probe — kept off /v1 so monitors don't break across
     # major-version cuts.

--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -17,19 +17,35 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
+from tulip_api.auth.deps import get_current_claims
+from tulip_api.auth.mfa import (
+    build_provisioning_uri,
+    decrypt_totp_secret,
+    encrypt_totp_secret,
+    generate_totp_secret,
+    verify_totp_code,
+)
 from tulip_api.auth.passwords import hash_password, verify_password
 from tulip_api.auth.tokens import (
     DEFAULT_ACCESS_TTL,
     DEFAULT_REFRESH_TTL,
+    Claims,
     create_access_token,
     create_refresh_token,
     hash_refresh_token,
 )
 from tulip_api.config import Settings, get_settings
 from tulip_api.deps import get_session
+from tulip_api.errors import (
+    MfaAlreadyEnrolledError,
+    MfaInvalidCodeError,
+    MfaNotPendingError,
+)
 from tulip_api.schemas.auth import (
     LoginRequest,
     LogoutRequest,
+    MfaEnrollResponse,
+    MfaVerifyRequest,
     RefreshRequest,
     RegisterRequest,
     RegisterResponse,
@@ -168,6 +184,103 @@ def logout(
     if row is not None and row.revoked_at is None:
         row.revoked_at = datetime.now(tz=UTC)
         session.commit()
+
+
+@router.post(
+    "/mfa/enroll",
+    response_model=MfaEnrollResponse,
+    status_code=status.HTTP_200_OK,
+)
+def mfa_enroll(
+    request: Request,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> MfaEnrollResponse:
+    """Start TOTP enrollment.
+
+    Generates a fresh secret, persists it field-encrypted, and returns
+    the plaintext + an ``otpauth://`` provisioning URI so the caller can
+    render a QR code. The secret is not active until the caller proves
+    possession via ``POST /v1/auth/mfa/verify``.
+
+    Repeated calls before verification rotate the secret (intended — the
+    user may lose the QR before scanning). After verification, this
+    endpoint returns 409 ``auth.mfa_already_enrolled``.
+    """
+    user = session.get(User, (claims.household_id, claims.user_id))
+    if user is None:
+        # Token is valid but the user row vanished — treat as auth failure.
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token")
+    if user.totp_enrolled_at is not None:
+        raise MfaAlreadyEnrolledError()
+
+    secret = generate_totp_secret()
+    user.totp_secret_encrypted = encrypt_totp_secret(secret, master_key=settings.master_key)
+    session.flush()
+
+    AuditLogWriter(session, user.household_id).write(
+        action="mfa.enroll",
+        actor_kind="user",
+        actor_user_id=user.id,
+        entity_type="user",
+        entity_id=user.id,
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    log.info("user.mfa_enroll_started", user_id=str(user.id))
+
+    return MfaEnrollResponse(
+        secret=secret,
+        provisioning_uri=build_provisioning_uri(secret=secret, email=user.email),
+    )
+
+
+@router.post("/mfa/verify", status_code=status.HTTP_204_NO_CONTENT)
+def mfa_verify(
+    body: MfaVerifyRequest,
+    request: Request,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> None:
+    """Complete TOTP enrollment by proving possession of the authenticator.
+
+    Errors emitted as RFC 9457 Problem Details:
+        * ``auth.mfa_not_pending`` (400) — no enrollment in progress.
+        * ``auth.mfa_already_enrolled`` (409) — enrollment already active.
+        * ``auth.mfa_invalid_code`` (401) — code did not match.
+    """
+    user = session.get(User, (claims.household_id, claims.user_id))
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token")
+    if user.totp_enrolled_at is not None:
+        raise MfaAlreadyEnrolledError()
+    if user.totp_secret_encrypted is None:
+        raise MfaNotPendingError()
+
+    secret = decrypt_totp_secret(user.totp_secret_encrypted, master_key=settings.master_key)
+    if not verify_totp_code(secret, body.code):
+        log.info("user.mfa_verify_failed", user_id=str(user.id))
+        raise MfaInvalidCodeError()
+
+    user.totp_enrolled_at = datetime.now(tz=UTC)
+    session.flush()
+
+    AuditLogWriter(session, user.household_id).write(
+        action="mfa.verify",
+        actor_kind="user",
+        actor_user_id=user.id,
+        entity_type="user",
+        entity_id=user.id,
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    log.info("user.mfa_enrolled", user_id=str(user.id))
 
 
 # ---- helpers ---------------------------------------------------------------

--- a/packages/tulip-api/src/tulip_api/schemas/auth.py
+++ b/packages/tulip-api/src/tulip_api/schemas/auth.py
@@ -50,3 +50,22 @@ class LogoutRequest(BaseModel):
     """Body for POST /v1/auth/logout."""
 
     refresh_token: str
+
+
+class MfaEnrollResponse(BaseModel):
+    """Response from POST /v1/auth/mfa/enroll.
+
+    The plaintext ``secret`` is returned exactly once — at enrollment time
+    — so the user can scan or paste it into an authenticator app. After
+    verification the secret is only retrievable in encrypted form from
+    the database.
+    """
+
+    secret: str
+    provisioning_uri: str
+
+
+class MfaVerifyRequest(BaseModel):
+    """Body for POST /v1/auth/mfa/verify."""
+
+    code: str = Field(min_length=1, max_length=12)

--- a/packages/tulip-api/tests/_problem_details.py
+++ b/packages/tulip-api/tests/_problem_details.py
@@ -1,0 +1,40 @@
+"""Test helpers for asserting RFC 9457 Problem Details responses.
+
+Per ARCHITECTURE §7.8.8, every error-path test should assert on the
+problem+json body shape — not just the HTTP status. ``assert_problem``
+is the canonical way to do that.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from httpx import Response
+
+
+def assert_problem(
+    response: Response,
+    *,
+    code: str,
+    status: int,
+    title: str | None = None,
+) -> dict[str, Any]:
+    """Assert ``response`` is a well-formed RFC 9457 Problem Details body.
+
+    Returns the parsed JSON so callers can drill into extension fields.
+    """
+    assert response.status_code == status, (
+        f"expected status {status}, got {response.status_code}: {response.text}"
+    )
+    assert response.headers["content-type"].startswith("application/problem+json"), (
+        f"expected application/problem+json, got {response.headers.get('content-type')}"
+    )
+    body = response.json()
+    assert isinstance(body, dict), f"problem body must be an object, got {type(body)}"
+    for required in ("type", "title", "status", "detail", "instance", "code"):
+        assert required in body, f"problem body missing required field {required!r}: {body}"
+    assert body["status"] == status, f"body.status={body['status']!r} disagrees with HTTP status"
+    assert body["code"] == code, f"expected code {code!r}, got {body['code']!r}"
+    if title is not None:
+        assert body["title"] == title
+    return body

--- a/packages/tulip-api/tests/conftest.py
+++ b/packages/tulip-api/tests/conftest.py
@@ -7,8 +7,13 @@ dependency is overridden so handlers run inside the test's session scope.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterator
 from pathlib import Path
+
+# Make sibling test-helper modules (e.g. _problem_details.py) importable by
+# basename. pytest's importlib mode doesn't put the tests/ dir on sys.path.
+sys.path.insert(0, str(Path(__file__).parent))
 
 import pytest
 from alembic.command import upgrade
@@ -60,6 +65,7 @@ def settings() -> Settings:
     return Settings(
         database_url="sqlite:///:memory:",  # overridden per-app via deps
         jwt_secret="test-secret-32bytes-test-secret!!",
+        master_key=b"\xab" * 32,  # deterministic test key; never used outside tests
     )
 
 

--- a/packages/tulip-api/tests/test_config.py
+++ b/packages/tulip-api/tests/test_config.py
@@ -1,0 +1,50 @@
+"""Tests for tulip_api.config.Settings — focused on the master_key wiring.
+
+The JWT-secret behavior is exercised indirectly by every auth test; this
+file covers master_key, which is new and has no other coverage path yet.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import patch
+
+import pytest
+
+from tulip_api.config import Settings
+
+
+class TestMasterKey:
+    def test_reads_from_env_base64(self, monkeypatch: pytest.MonkeyPatch):
+        raw = b"\x01" * 32
+        monkeypatch.setenv("TULIP_MASTER_KEY", base64.b64encode(raw).decode("ascii"))
+        s = Settings()
+        assert s.master_key == raw
+
+    def test_rejects_wrong_key_length(self, monkeypatch: pytest.MonkeyPatch):
+        # 16 bytes is a valid AES-128 key but not what we want.
+        monkeypatch.setenv("TULIP_MASTER_KEY", base64.b64encode(b"\x01" * 16).decode("ascii"))
+        with pytest.raises(ValueError, match="32 bytes"):
+            Settings()
+
+    def test_rejects_non_base64(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("TULIP_MASTER_KEY", "not-base64!!!")
+        with pytest.raises(ValueError, match="base64"):
+            Settings()
+
+    def test_ephemeral_fallback_warns(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        with patch("tulip_api.config.log") as mock_log:
+            s = Settings()
+        assert len(s.master_key) == 32
+        mock_log.warning.assert_called_once()
+        msg = mock_log.warning.call_args.args[0].lower()
+        assert "ephemeral" in msg and "master" in msg
+
+    def test_ephemeral_keys_differ_per_construction(self, monkeypatch: pytest.MonkeyPatch):
+        # Each construction generates a fresh key — that's what makes it
+        # production-unsafe and worth warning about.
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        a = Settings()
+        b = Settings()
+        assert a.master_key != b.master_key

--- a/packages/tulip-api/tests/test_mfa_endpoints.py
+++ b/packages/tulip-api/tests/test_mfa_endpoints.py
@@ -1,0 +1,175 @@
+"""Tests for /v1/auth/mfa/{enroll,verify} (slice P2.x.1.a)."""
+
+from __future__ import annotations
+
+import pyotp
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from _problem_details import assert_problem
+from tulip_api.auth.mfa import decrypt_totp_secret
+from tulip_storage.models import AuditLog, User
+
+MASTER_KEY = b"\xab" * 32  # matches conftest.settings fixture
+
+
+@pytest.fixture
+def auth_headers(client: TestClient) -> dict[str, str]:
+    """Register + login a user; return Authorization headers."""
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Alice",
+            "household_name": "Smith",
+        },
+    )
+    login = client.post(
+        "/v1/auth/login",
+        json={"email": "alice@example.com", "password": "correct horse battery staple"},
+    ).json()
+    return {"Authorization": f"Bearer {login['access_token']}"}
+
+
+def _load_user(session_maker: sessionmaker[Session]) -> User:
+    with session_maker() as s:
+        return s.execute(select(User).where(User.email == "alice@example.com")).scalar_one()
+
+
+class TestEnroll:
+    def test_requires_auth(self, client: TestClient):
+        # No Authorization header at all → 401 from get_current_claims.
+        # That dependency still raises plain HTTPException; P2.x.2 will
+        # migrate it. Here we only assert the status code, not the body.
+        r = client.post("/v1/auth/mfa/enroll")
+        assert r.status_code == 401
+
+    def test_returns_secret_and_provisioning_uri(
+        self, client: TestClient, auth_headers: dict[str, str]
+    ):
+        r = client.post("/v1/auth/mfa/enroll", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["secret"]
+        assert body["provisioning_uri"].startswith("otpauth://totp/")
+        assert body["secret"] in body["provisioning_uri"]
+
+    def test_stores_encrypted_secret_with_enrolled_at_null(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        r = client.post("/v1/auth/mfa/enroll", headers=auth_headers)
+        secret_returned = r.json()["secret"]
+
+        user = _load_user(session_maker)
+        assert user.totp_secret_encrypted is not None
+        assert user.totp_enrolled_at is None
+        # Stored blob round-trips back to the secret returned to the user.
+        assert (
+            decrypt_totp_secret(user.totp_secret_encrypted, master_key=MASTER_KEY)
+            == secret_returned
+        )
+
+    def test_re_enroll_before_verify_rotates_secret(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        first = client.post("/v1/auth/mfa/enroll", headers=auth_headers).json()
+        second = client.post("/v1/auth/mfa/enroll", headers=auth_headers).json()
+        assert first["secret"] != second["secret"]
+        # Stored blob matches the most recent enrollment.
+        user = _load_user(session_maker)
+        assert (
+            decrypt_totp_secret(user.totp_secret_encrypted, master_key=MASTER_KEY)
+            == second["secret"]
+        )
+
+    def test_re_enroll_after_verify_rejected(
+        self, client: TestClient, auth_headers: dict[str, str]
+    ):
+        # Complete the enrollment first.
+        secret = client.post("/v1/auth/mfa/enroll", headers=auth_headers).json()["secret"]
+        code = pyotp.TOTP(secret).now()
+        verify = client.post("/v1/auth/mfa/verify", headers=auth_headers, json={"code": code})
+        assert verify.status_code == 204, verify.text
+
+        # Re-enroll → 409 with mfa_already_enrolled.
+        r = client.post("/v1/auth/mfa/enroll", headers=auth_headers)
+        assert_problem(r, code="auth.mfa_already_enrolled", status=409)
+
+    def test_audit_log_written(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        client.post("/v1/auth/mfa/enroll", headers=auth_headers)
+        with session_maker() as s:
+            actions = [
+                row.action
+                for row in s.execute(select(AuditLog).order_by(AuditLog.occurred_at)).scalars()
+            ]
+        assert "mfa.enroll" in actions
+
+
+class TestVerify:
+    def test_requires_auth(self, client: TestClient):
+        r = client.post("/v1/auth/mfa/verify", json={"code": "123456"})
+        assert r.status_code == 401
+
+    def test_no_pending_enrollment_returns_problem(
+        self, client: TestClient, auth_headers: dict[str, str]
+    ):
+        r = client.post("/v1/auth/mfa/verify", headers=auth_headers, json={"code": "123456"})
+        assert_problem(r, code="auth.mfa_not_pending", status=400)
+
+    def test_wrong_code_returns_problem(self, client: TestClient, auth_headers: dict[str, str]):
+        client.post("/v1/auth/mfa/enroll", headers=auth_headers)
+        r = client.post("/v1/auth/mfa/verify", headers=auth_headers, json={"code": "000000"})
+        assert_problem(r, code="auth.mfa_invalid_code", status=401)
+
+    def test_correct_code_returns_204_and_marks_enrolled(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        secret = client.post("/v1/auth/mfa/enroll", headers=auth_headers).json()["secret"]
+        code = pyotp.TOTP(secret).now()
+        r = client.post("/v1/auth/mfa/verify", headers=auth_headers, json={"code": code})
+        assert r.status_code == 204
+        user = _load_user(session_maker)
+        assert user.totp_enrolled_at is not None
+
+    def test_already_verified_returns_problem(
+        self, client: TestClient, auth_headers: dict[str, str]
+    ):
+        secret = client.post("/v1/auth/mfa/enroll", headers=auth_headers).json()["secret"]
+        code = pyotp.TOTP(secret).now()
+        client.post("/v1/auth/mfa/verify", headers=auth_headers, json={"code": code})
+        # Second verify call → 409.
+        r = client.post("/v1/auth/mfa/verify", headers=auth_headers, json={"code": code})
+        assert_problem(r, code="auth.mfa_already_enrolled", status=409)
+
+    def test_audit_log_written_on_success(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        secret = client.post("/v1/auth/mfa/enroll", headers=auth_headers).json()["secret"]
+        code = pyotp.TOTP(secret).now()
+        client.post("/v1/auth/mfa/verify", headers=auth_headers, json={"code": code})
+        with session_maker() as s:
+            actions = [
+                row.action
+                for row in s.execute(select(AuditLog).order_by(AuditLog.occurred_at)).scalars()
+            ]
+        assert "mfa.verify" in actions

--- a/packages/tulip-api/tests/test_mfa_service.py
+++ b/packages/tulip-api/tests/test_mfa_service.py
@@ -1,0 +1,96 @@
+"""Tests for the MFA service module (tulip_api.auth.mfa)."""
+
+from __future__ import annotations
+
+import base64
+import re
+
+import pyotp
+import pytest
+
+from tulip_api.auth.mfa import (
+    build_provisioning_uri,
+    decrypt_totp_secret,
+    encrypt_totp_secret,
+    generate_totp_secret,
+    verify_totp_code,
+)
+
+MASTER_KEY = b"\xab" * 32
+
+
+class TestSecretGeneration:
+    def test_generates_base32_secret(self):
+        secret = generate_totp_secret()
+        # pyotp / Google Authenticator expect base32 secrets.
+        assert re.fullmatch(r"[A-Z2-7]+=*", secret)
+        # 160 bits = 32 base32 chars (RFC 4226 §4 / RFC 6238).
+        assert len(secret) >= 32
+
+    def test_generated_secrets_differ(self):
+        a = generate_totp_secret()
+        b = generate_totp_secret()
+        assert a != b
+
+
+class TestProvisioningUri:
+    def test_builds_otpauth_uri_with_email_and_issuer(self):
+        secret = generate_totp_secret()
+        uri = build_provisioning_uri(secret=secret, email="alice@example.com", issuer="Tulip")
+        assert uri.startswith("otpauth://totp/")
+        assert "alice%40example.com" in uri or "alice@example.com" in uri
+        assert "issuer=Tulip" in uri
+        assert f"secret={secret}" in uri
+
+
+class TestEncryptDecrypt:
+    def test_round_trip(self):
+        secret = generate_totp_secret()
+        blob = encrypt_totp_secret(secret, master_key=MASTER_KEY)
+        # Encrypted form must not equal plaintext.
+        assert blob != secret.encode("ascii")
+        # Round-trip restores plaintext.
+        assert decrypt_totp_secret(blob, master_key=MASTER_KEY) == secret
+
+    def test_wrong_key_fails(self):
+        secret = generate_totp_secret()
+        blob = encrypt_totp_secret(secret, master_key=MASTER_KEY)
+        with pytest.raises(Exception):  # noqa: B017 — InvalidCiphertextError
+            decrypt_totp_secret(blob, master_key=b"\x00" * 32)
+
+
+class TestVerifyTotpCode:
+    def test_accepts_current_code(self):
+        secret = generate_totp_secret()
+        code = pyotp.TOTP(secret).now()
+        assert verify_totp_code(secret, code) is True
+
+    def test_rejects_wrong_code(self):
+        secret = generate_totp_secret()
+        # 000000 is statistically near-certain not to be the current code.
+        # Even on the off chance it is, the next assertion below will fail
+        # on a different random secret — flake budget is effectively zero.
+        assert verify_totp_code(secret, "000000") is False
+
+    def test_rejects_garbage(self):
+        secret = generate_totp_secret()
+        assert verify_totp_code(secret, "not-a-code") is False
+        assert verify_totp_code(secret, "") is False
+
+    def test_accepts_previous_window(self):
+        # ±1 window tolerates clock skew up to ±30s, the standard practice.
+        secret = generate_totp_secret()
+        totp = pyotp.TOTP(secret)
+        # Code from 30 seconds ago.
+        import time
+
+        past_code = totp.at(int(time.time()) - 30)
+        assert verify_totp_code(secret, past_code) is True
+
+
+def _b32_decodable(secret: str) -> bool:
+    try:
+        base64.b32decode(secret, casefold=False)
+        return True
+    except (ValueError, Exception):
+        return False

--- a/packages/tulip-api/tests/test_problem_details.py
+++ b/packages/tulip-api/tests/test_problem_details.py
@@ -1,0 +1,72 @@
+"""Tests for the Problem Details infrastructure (tulip_api.errors).
+
+Exercises the exception base, the FastAPI exception handler, and the
+shape of emitted ``application/problem+json`` responses, per
+ARCHITECTURE §7.8.2.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+from tulip_api.errors import TulipProblem, install_problem_handlers
+
+
+def _app_with_route(exc: Exception) -> TestClient:
+    app = FastAPI()
+    install_problem_handlers(app)
+
+    @app.get("/boom")
+    def boom() -> None:
+        raise exc
+
+    return TestClient(app)
+
+
+class TestTulipProblem:
+    def test_minimum_shape(self):
+        client = _app_with_route(
+            TulipProblem(
+                code="example.boom",
+                title="Boom",
+                status=418,
+                detail="The teapot is boiling.",
+            )
+        )
+        body = assert_problem(client.get("/boom"), code="example.boom", status=418, title="Boom")
+        assert body["detail"] == "The teapot is boiling."
+        assert body["instance"] == "/boom"
+        # Default `type` URI is /.well-known/errors/<code> per §7.8.2.
+        assert body["type"].endswith("/.well-known/errors/example.boom")
+
+    def test_request_id_propagated_when_header_present(self):
+        client = _app_with_route(TulipProblem(code="example.x", title="X", status=400, detail="x"))
+        rid = "11111111-1111-1111-1111-111111111111"
+        body = assert_problem(
+            client.get("/boom", headers={"x-request-id": rid}),
+            code="example.x",
+            status=400,
+        )
+        assert body.get("request_id") == rid
+
+    def test_extension_fields_appear_at_top_level(self):
+        client = _app_with_route(
+            TulipProblem(
+                code="example.ext",
+                title="Ext",
+                status=429,
+                detail="slow down",
+                extensions={"retry_after_seconds": 30},
+            )
+        )
+        body = assert_problem(client.get("/boom"), code="example.ext", status=429)
+        assert body["retry_after_seconds"] == 30
+
+    def test_detail_falls_back_to_title_when_omitted(self):
+        client = _app_with_route(
+            TulipProblem(code="example.terse", title="Just the title", status=400)
+        )
+        body = assert_problem(client.get("/boom"), code="example.terse", status=400)
+        assert body["detail"] == "Just the title"

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260430_1200_4934c5509a8d_add_users_totp_enrolled_at.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260430_1200_4934c5509a8d_add_users_totp_enrolled_at.py
@@ -1,0 +1,38 @@
+"""Add users.totp_enrolled_at column.
+
+Distinguishes "TOTP secret stored, enrollment not yet verified" (column NULL,
+totp_secret_encrypted non-NULL) from "TOTP active" (both non-NULL). Lets us
+reject re-enrollment of an already-active user and lets login decide whether
+to gate behind an MFA challenge.
+
+Revision ID: 4934c5509a8d
+Revises: 1e585c3bb01d
+Create Date: 2026-04-30 12:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4934c5509a8d"
+down_revision: str | None = "1e585c3bb01d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the totp_enrolled_at column."""
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("totp_enrolled_at", sa.DateTime(timezone=True), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    """Drop the totp_enrolled_at column."""
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.drop_column("totp_enrolled_at")

--- a/packages/tulip-storage/src/tulip_storage/models/user.py
+++ b/packages/tulip-storage/src/tulip_storage/models/user.py
@@ -47,6 +47,9 @@ class User(Base):
         SAEnum(UserRole, native_enum=False, length=20), nullable=False
     )
     totp_secret_encrypted: Mapped[bytes | None] = mapped_column(nullable=True)
+    totp_enrolled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     last_login_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/packages/tulip-storage/tests/test_models.py
+++ b/packages/tulip-storage/tests/test_models.py
@@ -83,6 +83,29 @@ class TestUserCrud:
         with pytest.raises(IntegrityError):
             session.commit()
 
+    def test_totp_enrolled_at_defaults_null_and_round_trips(self, session: Session):
+        h = Household(id=uuid4(), name="Smith", base_currency="USD")
+        session.add(h)
+        u = User(
+            household_id=h.id,
+            id=uuid4(),
+            email="bob@example.com",
+            password_hash="argon2id$dummy",
+            display_name="Bob",
+            role=UserRole.MEMBER,
+        )
+        session.add(u)
+        session.commit()
+        loaded = session.execute(select(User).where(User.email == "bob@example.com")).scalar_one()
+        # New users start un-enrolled.
+        assert loaded.totp_enrolled_at is None
+
+        loaded.totp_enrolled_at = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+        session.commit()
+        again = session.execute(select(User).where(User.email == "bob@example.com")).scalar_one()
+        assert again.totp_enrolled_at is not None
+        assert again.totp_enrolled_at.year == 2026
+
 
 class TestAccountCrud:
     def test_round_trip_account(self, session: Session):


### PR DESCRIPTION
## Summary

- Adds `POST /v1/auth/mfa/{enroll,verify}` — slice (a) of P2.x.1. Enrollment generates a fresh TOTP secret, stores it field-encrypted, returns the `otpauth://` provisioning URI; verification proves possession and stamps `users.totp_enrolled_at`.
- Brings along three prerequisites that PHASE_STATUS.md flagged as P2.x.1 scope: `Settings.master_key` (`TULIP_MASTER_KEY` env, base64-32-bytes, with a warning-on-fallback), the `users.totp_enrolled_at` column + Alembic migration, and the **minimum RFC 9457 Problem Details infrastructure** (`tulip_api.errors`, `assert_problem` test helper). Legacy endpoints still emit plain `HTTPException`; P2.x.2 migrates them onto the same registry.
- Audit log entries written for `mfa.enroll` and `mfa.verify`. New TOTP service module (`tulip_api.auth.mfa`) wraps `pyotp` + the existing AES-256-GCM field-encryption helper.

## Error contract (RFC 9457)

| Code | Status | When |
|---|---|---|
| `auth.mfa_already_enrolled` | 409 | Enroll or verify after the user is already TOTP-active |
| `auth.mfa_not_pending` | 400 | Verify with no enrollment in progress |
| `auth.mfa_invalid_code` | 401 | Submitted code did not match the stored secret |

Re-enroll **before** verify is intentionally allowed — it rotates the secret so a user who lost the QR before scanning can recover.

## Test plan

- [x] `uv run pytest` — 215 passing (was 184; +31 new tests across `test_config.py`, `test_problem_details.py`, `test_mfa_service.py`, `test_mfa_endpoints.py`, plus a model round-trip in `tulip-storage`)
- [x] `uv run ruff check` and `uv run ruff format --check` clean
- [x] `uv run mypy` clean (strict, 64 source files)
- [x] `uv run pre-commit run --all-files` clean
- [x] All MFA error-path tests assert via `assert_problem(resp, code=, status=)`, not just status codes — establishes the convention P2.x.2 will roll out repo-wide
- [ ] Manual smoke: enroll via curl, paste `secret` into an authenticator app, verify the 6-digit code, confirm 204 + `totp_enrolled_at` set

## Out of scope (queued as P2.x.1.b/c)

- Login challenge gate (`auth.mfa_required` from `/v1/auth/login` for enrolled users; new `/v1/auth/login/mfa`).
- Recovery codes (generated at enroll, hashed at rest, one-time use).
- `Household.mfa_policy` enforcement for admins (folds into the login gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)