### PR TITLE
fix(storage): resolve alembic script_location against ini directory

### DIFF
--- a/packages/tulip-storage/alembic.ini
+++ b/packages/tulip-storage/alembic.ini
@@ -7,7 +7,7 @@
 # (see env.py). The placeholder below is only used when none is supplied.
 
 [alembic]
-script_location = src/tulip_storage/migrations
+script_location = %(here)s/src/tulip_storage/migrations
 sqlalchemy.url = sqlite:///:memory:
 prepend_sys_path = .
 file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s


### PR DESCRIPTION
## Summary

- One-line fix: `script_location = %(here)s/src/tulip_storage/migrations` so the path resolves relative to the ini file, not cwd.
- The README and the alembic.ini header comment both document running from the repo root (`uv run alembic -c packages/tulip-storage/alembic.ini upgrade head`), but until now that failed with `Path doesn't exist: src/tulip_storage/migrations` unless cwd was `packages/tulip-storage/`.

## How this surfaced

Hit while smoke-testing PR #9 (TOTP enrollment) — the documented setup command for a fresh DB couldn't find the migrations.

## Test plan

- [x] `rm -f /tmp/x.db && TULIP_DATABASE_URL=sqlite:////tmp/x.db uv run alembic -c packages/tulip-storage/alembic.ini upgrade head` from the repo root — now succeeds, both migrations apply
- [x] `uv run pytest` — 184 passing (the conftest in `packages/tulip-api/tests/conftest.py` overrides `script_location` via the Config API, so the test path is unaffected)
- [x] `uv run pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)