### PR TITLE
docs: require PR manual smoke tests to include runnable steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,22 @@ If your change involves a non-trivial architectural decision — choosing betwee
    - Briefly explain the change and the rationale.
    - Note any user-visible impact.
    - Confirm that tests were written first (the TDD rule).
+   - **If the test plan lists a manual smoke test, include the runnable steps inline.** See "Manual smoke tests" below.
 6. CI runs automatically. All required checks must pass before review.
 7. A reviewer (currently the maintainer; eventually anyone designated) will review and either request changes or merge.
+
+### Manual smoke tests
+
+A "manual smoke test" item in a PR test plan is only useful if a reviewer (or future-you) can actually run it. If you list one, the PR body must contain the **complete** runnable steps:
+
+- Every command needed to set up the environment (env vars, fresh DB, dependencies).
+- Every request to make, with the exact body and headers — `curl` or equivalent, copy-pasteable.
+- The expected outcome at each step (status code, body shape, side effect).
+- A cleanup step.
+
+The bar is: a reviewer with a fresh checkout can paste the block into a terminal and reproduce the test without asking questions. "Smoke-test the new endpoint" alone doesn't pass that bar; "Run these eight `curl` commands and confirm step 4 returns a 204" does.
+
+If the smoke test is too long for the PR description, put it in a fenced block at the bottom of the description or in a comment on the PR — but don't omit it. A "[ ] Manual smoke" checkbox with no steps is treated as a missing test plan item.
 
 ## Branch protection on `main`
 


### PR DESCRIPTION
## Summary

- Adds a "Manual smoke tests" subsection to `CONTRIBUTING.md` under "Submitting a pull request": if a PR's test plan lists a manual smoke test, the body must include the **complete** runnable steps inline — commands, bodies, expected outcomes per step, and cleanup.
- Adds a bullet to the existing PR-description checklist pointing at the new subsection.

## Motivation

PR #9 listed `- [ ] Manual smoke: enroll via curl, paste secret into authenticator…` with no commands; the author then had to write the actual eight-step block when asked. That's the failure mode this rule prevents — a reviewer should be able to paste the smoke test into a terminal and reproduce it without follow-up questions.

## What's not in this PR

- No back-fill of past PR descriptions. The convention applies forward.
- No tooling to enforce it (a PR-template addition is plausible but out of scope here).

## Test plan

- [x] `uv run pre-commit run --all-files` clean (only `CONTRIBUTING.md` changed)
- No code or tests touched, so pytest/mypy/ruff are unaffected.
- No manual smoke test applies — this is a documentation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)