### PR TITLE
feat(cli): P3.1 CLI skeleton (Typer app, config, HTTP client, RFC 9457 renderer)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-04-29 · `main` @ `a89cc89`
+**Last updated:** 2026-05-01 · `main` @ `ba5beb8`
 
 ---
 
@@ -11,9 +11,10 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 0:** ✅ complete
 - **Phase 1:** ✅ complete
 - **Phase 2 (core API surface):** ✅ complete
-- **Phase 2.x (cleanup before Phase 3):** queued — three slices, ordered
+- **Phase 2.x (cleanup before Phase 3):** ✅ complete
+- **Phase 3 (CLI):** in flight — P3.1 skeleton landed, P3.2–P3.5 queued (issues #18–#22)
 
-**Tests:** 287 passing · **coverage:** 95% project, ≥95% on `tulip-core` and `tulip-storage` · **CI:** green on `main`
+**Tests:** 304 passing · **CI:** green on `main`
 
 ---
 
@@ -144,14 +145,29 @@ P2.x is now fully complete; the next slice is **Phase 3 — CLI (Typer) + first 
 
 ---
 
-## Phase 3 — CLI (Typer) + first useful flows — not started
+## Phase 3 — CLI (Typer) + first useful flows — in flight
 
-Per ARCHITECTURE.md §10. Picks up after Phase 2.x is complete.
+Per ARCHITECTURE.md §10. Phase 2.x cleared; this phase ships the CLI in five sequenced slices tracked as GitHub issues.
 
-- `tulip auth login`, `tulip add`, `tulip register`, `tulip balance`, `tulip accounts`
-- Token storage via `keyring`
-- End-to-end tests of CLI against a spawned API server
-- Toner-friendly print stylesheet finalized
+### P3.1 — CLI skeleton — ✅ *(2026-05-01)*
+
+Issue #18. Foundation slice — no domain commands yet, just plumbing every later slice depends on.
+
+- `tulip-cli` package wired with `typer`, `httpx`, `rich` deps and a `tulip` console script (`[project.scripts]` → `tulip_cli.main:app`).
+- `tulip_cli.config`: TOML loader at `~/.config/tulip/config.toml` (XDG-aware), with precedence CLI flag > `TULIP_API_URL` > config file > default. `Config` dataclass strips trailing slashes.
+- `tulip_cli.errors`: RFC 9457 Problem Details renderer. Bold-red title + indented detail to stderr; `--json` emits the raw body to stdout. Exit-code map per ARCHITECTURE.md §7.8.5 (`0`/`1`/`2`/`3`/`4`/`5`). Synthesizes a Problem Details body for non-`application/problem+json` failures so output stays consistent.
+- `tulip_cli.http`: `TulipClient` thin wrapper over `httpx.Client`; raises `CliError` on both 4xx/5xx and network failures. Bearer-token slot ready for P3.2.
+- `tulip ping` exercises the full path against `/health`. Without a server: exit `4`, network problem rendered. With `--json`: raw Problem Details body.
+- Architecture test (`test_architecture.py`): AST scan over `tulip_cli/src/` rejects imports of `tulip_api`, `tulip_storage`, `sqlalchemy`, FastAPI, etc. — keeps the CLI a pure network client.
+- 17 new tests; project total now 304 passing.
+
+### P3.2 — Auth (`register`, `login`, `logout`, `status`) — queued (#19)
+
+### P3.3 — Read flows (`accounts`, `balance`) — queued (#20)
+
+### P3.4 — Write flows (`accounts add`, `add`) — queued (#21)
+
+### P3.5 — Toner-friendly print stylesheet — queued (#22), may defer to Phase 8
 
 ---
 

--- a/packages/tulip-cli/pyproject.toml
+++ b/packages/tulip-cli/pyproject.toml
@@ -3,6 +3,14 @@ name = "tulip-cli"
 version = "0.0.0"
 description = "Command-line client (Typer) for the Tulip Accounting API."
 requires-python = ">=3.12"
+dependencies = [
+    "typer>=0.12",
+    "httpx>=0.27",
+    "rich>=13.7",
+]
+
+[project.scripts]
+tulip = "tulip_cli.main:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/tulip-cli/src/tulip_cli/__init__.py
+++ b/packages/tulip-cli/src/tulip_cli/__init__.py
@@ -1,1 +1,5 @@
 """Command-line client (Typer) for the Tulip Accounting API."""
+
+from __future__ import annotations
+
+__version__ = "0.0.0"

--- a/packages/tulip-cli/src/tulip_cli/__main__.py
+++ b/packages/tulip-cli/src/tulip_cli/__main__.py
@@ -1,0 +1,8 @@
+"""Allow ``python -m tulip_cli`` to invoke the Typer app."""
+
+from __future__ import annotations
+
+from tulip_cli.main import app
+
+if __name__ == "__main__":
+    app()

--- a/packages/tulip-cli/src/tulip_cli/config.py
+++ b/packages/tulip-cli/src/tulip_cli/config.py
@@ -1,0 +1,66 @@
+"""Configuration loading for the Tulip CLI.
+
+Precedence: CLI flag > env var > config file > built-in default.
+
+The on-disk config lives at ``~/.config/tulip/config.toml`` (XDG-compliant).
+For now the only key is ``api_url``; future slices will add per-environment
+profiles, default editor, output format, and the like.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+DEFAULT_API_URL: Final[str] = "http://127.0.0.1:8000"
+ENV_API_URL: Final[str] = "TULIP_API_URL"
+
+
+def default_config_path() -> Path:
+    """Return the XDG-compliant default location of the CLI config file."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "tulip" / "config.toml"
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Resolved CLI configuration."""
+
+    api_url: str
+
+    def __post_init__(self) -> None:
+        """Strip a trailing slash from ``api_url`` so URL joins are unambiguous."""
+        cleaned = self.api_url.rstrip("/")
+        if cleaned != self.api_url:
+            object.__setattr__(self, "api_url", cleaned)
+
+
+def _read_config_file(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def load_config(
+    *,
+    config_path: Path | None = None,
+    api_url_override: str | None = None,
+) -> Config:
+    """Resolve a :class:`Config` from flag, env, file, and default in that order."""
+    file_data = _read_config_file(config_path or default_config_path())
+    api_url = (
+        api_url_override
+        or os.environ.get(ENV_API_URL)
+        or _str_or_none(file_data.get("api_url"))
+        or DEFAULT_API_URL
+    )
+    return Config(api_url=api_url)
+
+
+def _str_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/packages/tulip-cli/src/tulip_cli/errors.py
+++ b/packages/tulip-cli/src/tulip_cli/errors.py
@@ -1,0 +1,137 @@
+"""RFC 9457 Problem Details rendering and exit-code mapping for the CLI.
+
+ARCHITECTURE.md §7.8.5 specifies that CLI error output mirrors the API's
+Problem Details shape: a leading bold red title and an indented ``detail``
+paragraph in plain English. Exit codes follow this table:
+
+* ``0`` — success
+* ``1`` — user error (request invalid, not found, conflict, validation)
+* ``2`` — auth (401, 403)
+* ``3`` — server (5xx)
+* ``4`` — network (connection refused, DNS failure, timeout)
+* ``5`` — configuration (CLI couldn't even attempt the request)
+
+The renderer accepts a Problem Details dict (``application/problem+json``
+body shape) and writes either pretty output to stderr or the raw JSON body
+to stdout when ``--json`` is set.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any, Final
+
+import httpx
+from rich.console import Console
+from rich.text import Text
+
+EXIT_OK: Final[int] = 0
+EXIT_USER: Final[int] = 1
+EXIT_AUTH: Final[int] = 2
+EXIT_SERVER: Final[int] = 3
+EXIT_NETWORK: Final[int] = 4
+EXIT_CONFIG: Final[int] = 5
+
+PROBLEM_CONTENT_TYPE: Final[str] = "application/problem+json"
+
+
+def exit_code_for_status(status: int) -> int:
+    """Map an HTTP status code to a CLI exit code per §7.8.5."""
+    if status in (401, 403):
+        return EXIT_AUTH
+    if 400 <= status < 500:
+        return EXIT_USER
+    if 500 <= status < 600:
+        return EXIT_SERVER
+    return EXIT_USER
+
+
+def exit_code_for_problem(problem: dict[str, Any]) -> int:
+    """Pick an exit code from a Problem Details body (uses ``status``)."""
+    status = problem.get("status")
+    return exit_code_for_status(int(status)) if isinstance(status, int) else EXIT_USER
+
+
+def parse_problem_response(response: httpx.Response) -> dict[str, Any]:
+    """Parse an ``httpx.Response`` into a Problem Details dict.
+
+    If the response really is ``application/problem+json``, return the
+    decoded body. Otherwise synthesize a minimal Problem Details dict so
+    the renderer has something consistent to display — surprising server
+    output should still produce an actionable error, never a stack trace.
+    """
+    content_type = response.headers.get("content-type", "")
+    if PROBLEM_CONTENT_TYPE in content_type:
+        try:
+            data = response.json()
+        except json.JSONDecodeError:
+            data = None
+        if isinstance(data, dict):
+            return data
+    try:
+        instance = str(response.request.url.path)
+    except RuntimeError:
+        instance = ""
+    return {
+        "type": "/.well-known/errors/server.unexpected_response",
+        "title": "Unexpected response from the API",
+        "status": response.status_code,
+        "detail": (
+            f"The API returned status {response.status_code} with an unexpected body. "
+            "This is a bug in the server or a sign that you are pointed at the wrong URL."
+        ),
+        "instance": instance,
+        "code": "server.unexpected_response",
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class CliError(Exception):
+    """A renderable CLI failure carrying a Problem Details payload."""
+
+    problem: dict[str, Any]
+    as_json: bool
+    exit_code: int = EXIT_USER
+
+    def __post_init__(self) -> None:
+        """Resolve ``exit_code`` from the problem body if it was left at the default."""
+        if self.exit_code == EXIT_USER:
+            object.__setattr__(self, "exit_code", exit_code_for_problem(self.problem))
+
+    @classmethod
+    def from_response(cls, response: httpx.Response, *, as_json: bool) -> CliError:
+        """Build a :class:`CliError` from an ``httpx.Response``."""
+        return cls(problem=parse_problem_response(response), as_json=as_json)
+
+    @classmethod
+    def from_network_error(cls, exc: httpx.HTTPError, *, as_json: bool) -> CliError:
+        """Build a :class:`CliError` from a network-level httpx exception."""
+        problem: dict[str, Any] = {
+            "type": "/.well-known/errors/network.unreachable",
+            "title": "Could not reach the Tulip API",
+            "status": 0,
+            "detail": (
+                f"{type(exc).__name__}: {exc}. Check that the API is running and "
+                "that TULIP_API_URL points at it."
+            ),
+            "instance": "",
+            "code": "network.unreachable",
+        }
+        return cls(problem=problem, as_json=as_json, exit_code=EXIT_NETWORK)
+
+    def render(self) -> None:
+        """Write the error to the appropriate stream in the chosen format."""
+        if self.as_json:
+            sys.stdout.write(json.dumps(self.problem) + "\n")
+            return
+        console = Console(stderr=True, highlight=False)
+        title = Text(str(self.problem.get("title", "Error")), style="bold red")
+        console.print(title)
+        detail = self.problem.get("detail")
+        if detail:
+            console.print(Text(f"  {detail}"))
+        request_id = self.problem.get("request_id")
+        if request_id:
+            console.print(Text(f"  request_id: {request_id}", style="dim"))

--- a/packages/tulip-cli/src/tulip_cli/errors.py
+++ b/packages/tulip-cli/src/tulip_cli/errors.py
@@ -49,18 +49,54 @@ def exit_code_for_status(status: int) -> int:
 
 
 def exit_code_for_problem(problem: dict[str, Any]) -> int:
-    """Pick an exit code from a Problem Details body (uses ``status``)."""
+    """Pick an exit code from a Problem Details body.
+
+    ``code`` wins when its prefix indicates a category (``config.*`` →
+    exit 5, ``network.*`` → exit 4); otherwise ``status`` decides.
+    """
+    code = problem.get("code")
+    if isinstance(code, str):
+        if code.startswith("config."):
+            return EXIT_CONFIG
+        if code.startswith("network."):
+            return EXIT_NETWORK
     status = problem.get("status")
     return exit_code_for_status(int(status)) if isinstance(status, int) else EXIT_USER
+
+
+def _request_url(response: httpx.Response) -> str:
+    """Return the full URL of the request that produced ``response``, or ``""``."""
+    try:
+        return str(response.request.url)
+    except RuntimeError:
+        return ""
+
+
+def _request_path(response: httpx.Response) -> str:
+    """Return the path of the request that produced ``response``, or ``""``."""
+    try:
+        return str(response.request.url.path)
+    except RuntimeError:
+        return ""
+
+
+def _looks_like_tulip_api_body(content_type: str) -> bool:
+    """A Tulip API always speaks JSON. HTML/text/etc. mean we're talking to the wrong server."""
+    return "json" in content_type.lower()
 
 
 def parse_problem_response(response: httpx.Response) -> dict[str, Any]:
     """Parse an ``httpx.Response`` into a Problem Details dict.
 
-    If the response really is ``application/problem+json``, return the
-    decoded body. Otherwise synthesize a minimal Problem Details dict so
-    the renderer has something consistent to display — surprising server
-    output should still produce an actionable error, never a stack trace.
+    Three cases:
+
+    1. ``application/problem+json`` — pass through.
+    2. ``application/json`` (or similar) but not problem-shaped — synthesize
+       a ``server.unexpected_response`` problem; the API is real but
+       speaking a non-RFC-9457 dialect, which is a server bug.
+    3. Anything else (HTML, plaintext) — synthesize a
+       ``config.not_a_tulip_api`` problem. The URL is pointing at something
+       that isn't a Tulip API, which is a configuration error on our side.
     """
     content_type = response.headers.get("content-type", "")
     if PROBLEM_CONTENT_TYPE in content_type:
@@ -70,20 +106,34 @@ def parse_problem_response(response: httpx.Response) -> dict[str, Any]:
             data = None
         if isinstance(data, dict):
             return data
-    try:
-        instance = str(response.request.url.path)
-    except RuntimeError:
-        instance = ""
+
+    instance = _request_path(response)
+    if _looks_like_tulip_api_body(content_type):
+        return {
+            "type": "/.well-known/errors/server.unexpected_response",
+            "title": "Unexpected response from the API",
+            "status": response.status_code,
+            "detail": (
+                f"The API returned status {response.status_code} with a body that "
+                "isn't RFC 9457 Problem Details. This is a server bug — the API "
+                "should always emit application/problem+json on errors."
+            ),
+            "instance": instance,
+            "code": "server.unexpected_response",
+        }
+
+    url = _request_url(response) or "(no URL)"
     return {
-        "type": "/.well-known/errors/server.unexpected_response",
-        "title": "Unexpected response from the API",
+        "type": "/.well-known/errors/config.not_a_tulip_api",
+        "title": "That URL doesn't look like a Tulip API",
         "status": response.status_code,
         "detail": (
-            f"The API returned status {response.status_code} with an unexpected body. "
-            "This is a bug in the server or a sign that you are pointed at the wrong URL."
+            f"GET {url} returned status {response.status_code} with content-type "
+            f"{content_type or '(unset)'}. A Tulip API always responds with JSON. "
+            "Check that --api-url / TULIP_API_URL points at a running Tulip server."
         ),
         "instance": instance,
-        "code": "server.unexpected_response",
+        "code": "config.not_a_tulip_api",
     }
 
 

--- a/packages/tulip-cli/src/tulip_cli/http.py
+++ b/packages/tulip-cli/src/tulip_cli/http.py
@@ -1,0 +1,87 @@
+"""HTTP client wrapper for the Tulip CLI.
+
+A thin layer over ``httpx.Client`` that:
+
+* Builds requests against the resolved API base URL.
+* Injects a bearer token when one is available (token storage lands in
+  the auth slice — for now ``token`` is always ``None``).
+* Translates non-2xx responses and network failures into
+  :class:`tulip_cli.errors.CliError` so callers don't have to care about
+  the difference.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+
+
+class TulipClient:
+    """Thin convenience wrapper over an ``httpx.Client``."""
+
+    def __init__(
+        self,
+        config: Config,
+        *,
+        token: str | None = None,
+        as_json: bool = False,
+        timeout: float = 10.0,
+    ) -> None:
+        """Build a client bound to ``config.api_url`` with optional bearer token."""
+        headers: dict[str, str] = {"accept": "application/json"}
+        if token:
+            headers["authorization"] = f"Bearer {token}"
+        self._client = httpx.Client(base_url=config.api_url, headers=headers, timeout=timeout)
+        self._as_json = as_json
+
+    def __enter__(self) -> TulipClient:
+        """Enter the context manager; the underlying ``httpx.Client`` opens lazily."""
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        """Close the underlying ``httpx.Client`` on context-manager exit."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying ``httpx.Client``."""
+        self._client.close()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: object = None,
+        params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """Issue a request, raising :class:`CliError` on failure."""
+        try:
+            response = self._client.request(method, path, json=json, params=params, headers=headers)
+        except httpx.HTTPError as exc:
+            raise CliError.from_network_error(exc, as_json=self._as_json) from exc
+        if response.status_code >= 400:
+            raise CliError.from_response(response, as_json=self._as_json)
+        return response
+
+    def get(
+        self,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """``GET path`` against the configured API."""
+        return self.request("GET", path, params=params, headers=headers)
+
+    def post(
+        self,
+        path: str,
+        *,
+        json: object = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """``POST path`` against the configured API."""
+        return self.request("POST", path, json=json, headers=headers)

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -1,0 +1,85 @@
+"""Typer entry point for the Tulip CLI.
+
+P3.1 ships the runtime skeleton only: ``--help``, ``--version``, the
+``--json`` global flag, and a ``ping`` command that exercises the HTTP
+client + error renderer end to end. Domain commands (auth, accounts,
+transactions) land in subsequent slices.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Annotated
+
+import typer
+
+from tulip_cli import __version__
+from tulip_cli.config import Config, load_config
+from tulip_cli.errors import EXIT_OK, CliError
+from tulip_cli.http import TulipClient
+
+app = typer.Typer(
+    name="tulip",
+    help="Tulip Accounting CLI — talk to a Tulip API server.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit(EXIT_OK)
+
+
+@app.callback()
+def _root(
+    ctx: typer.Context,
+    api_url: Annotated[
+        str | None,
+        typer.Option(
+            "--api-url",
+            help="Override the API base URL (otherwise TULIP_API_URL or the config file).",
+        ),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit raw JSON to stdout instead of pretty output."),
+    ] = False,
+    _version: Annotated[
+        bool | None,
+        typer.Option(
+            "--version",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show the CLI version and exit.",
+        ),
+    ] = None,
+) -> None:
+    """Resolve config and stash shared state on the Typer context."""
+    config = load_config(api_url_override=api_url)
+    ctx.ensure_object(dict)
+    ctx.obj["config"] = config
+    ctx.obj["json"] = json_output
+
+
+@app.command()
+def ping(ctx: typer.Context) -> None:
+    """Hit the API's ``/health`` endpoint and report the result."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with TulipClient(config, as_json=as_json) as client:
+            response = client.get("/health")
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    typer.echo(f"OK ({response.status_code}) — {config.api_url}")
+
+
+if __name__ == "__main__":
+    app()

--- a/packages/tulip-cli/tests/test_architecture.py
+++ b/packages/tulip-cli/tests/test_architecture.py
@@ -1,0 +1,58 @@
+"""Architecture boundary tests for tulip-cli.
+
+ARCHITECTURE.md §9: the CLI is a network client of the API. It must not
+import server-side or storage internals. Talking to the API is the only
+allowed channel.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+_FORBIDDEN_TOP_LEVEL: Final[frozenset[str]] = frozenset(
+    {
+        "tulip_api",
+        "tulip_storage",
+        "tulip_ai",
+        "tulip_importers",
+        "tulip_reports",
+        "sqlalchemy",
+        "alembic",
+        "fastapi",
+        "starlette",
+        "uvicorn",
+    }
+)
+
+CLI_SRC: Final[Path] = Path(__file__).resolve().parents[1] / "src" / "tulip_cli"
+
+
+def _iter_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                found.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            found.add(node.module.split(".")[0])
+    return found
+
+
+def test_tulip_cli_has_no_forbidden_imports() -> None:
+    violations: dict[Path, set[str]] = {}
+    for py_file in CLI_SRC.rglob("*.py"):
+        bad = _iter_imports(py_file) & _FORBIDDEN_TOP_LEVEL
+        if bad:
+            violations[py_file] = bad
+    assert not violations, (
+        "tulip-cli leaked imports across an architectural boundary: "
+        f"{ {str(p): sorted(v) for p, v in violations.items()} }"
+    )
+
+
+def test_cli_src_directory_exists() -> None:
+    assert CLI_SRC.is_dir()
+    assert any(CLI_SRC.rglob("*.py"))

--- a/packages/tulip-cli/tests/test_config.py
+++ b/packages/tulip-cli/tests/test_config.py
@@ -1,0 +1,47 @@
+"""Tests for configuration loading.
+
+Precedence: CLI flag > env var > config file > built-in default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tulip_cli.config import DEFAULT_API_URL, Config, load_config
+
+
+def test_default_api_url_when_nothing_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TULIP_API_URL", raising=False)
+    config = load_config(config_path=tmp_path / "missing.toml", api_url_override=None)
+    assert config.api_url == DEFAULT_API_URL
+
+
+def test_config_file_overrides_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TULIP_API_URL", raising=False)
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('api_url = "https://file.example.com"\n', encoding="utf-8")
+    config = load_config(config_path=cfg, api_url_override=None)
+    assert config.api_url == "https://file.example.com"
+
+
+def test_env_var_overrides_config_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('api_url = "https://file.example.com"\n', encoding="utf-8")
+    monkeypatch.setenv("TULIP_API_URL", "https://env.example.com")
+    config = load_config(config_path=cfg, api_url_override=None)
+    assert config.api_url == "https://env.example.com"
+
+
+def test_cli_override_beats_everything(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('api_url = "https://file.example.com"\n', encoding="utf-8")
+    monkeypatch.setenv("TULIP_API_URL", "https://env.example.com")
+    config = load_config(config_path=cfg, api_url_override="https://flag.example.com")
+    assert config.api_url == "https://flag.example.com"
+
+
+def test_config_strips_trailing_slash() -> None:
+    config = Config(api_url="https://api.example.com/")
+    assert config.api_url == "https://api.example.com"

--- a/packages/tulip-cli/tests/test_errors.py
+++ b/packages/tulip-cli/tests/test_errors.py
@@ -12,6 +12,7 @@ import httpx
 
 from tulip_cli.errors import (
     EXIT_AUTH,
+    EXIT_CONFIG,
     EXIT_NETWORK,
     EXIT_SERVER,
     EXIT_USER,
@@ -80,7 +81,50 @@ def test_parse_problem_response_with_problem_json() -> None:
     assert parsed == body
 
 
-def test_parse_problem_response_falls_back_for_non_problem_body() -> None:
+def test_parse_problem_response_html_body_treated_as_wrong_server() -> None:
+    """HTML 4xx/5xx → not a Tulip API; map to a config-level problem (exit 5)."""
+    request = httpx.Request("GET", "https://example.com/health")
+    response = httpx.Response(
+        404,
+        content=b"<html>not found</html>",
+        headers={"content-type": "text/html"},
+        request=request,
+    )
+    parsed = parse_problem_response(response)
+    assert parsed["status"] == 404
+    assert parsed["code"] == "config.not_a_tulip_api"
+    assert "Tulip" in parsed["title"]
+    assert "https://example.com" in parsed["detail"]
+
+
+def test_html_response_yields_exit_config_when_wrapped_in_clierror() -> None:
+    request = httpx.Request("GET", "https://example.com/health")
+    response = httpx.Response(
+        404,
+        content=b"<html>not found</html>",
+        headers={"content-type": "text/html"},
+        request=request,
+    )
+    err = CliError.from_response(response, as_json=False)
+    assert err.exit_code == EXIT_CONFIG
+
+
+def test_parse_problem_response_json_but_not_problem_body_keeps_unexpected() -> None:
+    """A real Tulip-ish API returning plain JSON for an error is still a server bug, not config."""
+    request = httpx.Request("GET", "https://api.example.com/v1/accounts")
+    response = httpx.Response(
+        500,
+        content=b'{"oops": true}',
+        headers={"content-type": "application/json"},
+        request=request,
+    )
+    parsed = parse_problem_response(response)
+    assert parsed["status"] == 500
+    assert parsed["code"] == "server.unexpected_response"
+
+
+def test_parse_problem_response_falls_back_for_request_less_response() -> None:
+    """Synthesized responses with no request attached still produce a problem dict."""
     response = httpx.Response(
         500,
         content=b"<html>boom</html>",
@@ -88,9 +132,19 @@ def test_parse_problem_response_falls_back_for_non_problem_body() -> None:
     )
     parsed = parse_problem_response(response)
     assert parsed["status"] == 500
-    assert parsed["code"] == "server.unexpected_response"
+    assert parsed["code"] == "config.not_a_tulip_api"
     assert "title" in parsed
     assert "detail" in parsed
+
+
+def test_exit_code_for_problem_routes_config_codes_to_exit_5() -> None:
+    problem = {"code": "config.not_a_tulip_api", "status": 404}
+    assert exit_code_for_problem(problem) == EXIT_CONFIG
+
+
+def test_exit_code_for_problem_routes_network_codes_to_exit_4() -> None:
+    problem = {"code": "network.unreachable", "status": 0}
+    assert exit_code_for_problem(problem) == EXIT_NETWORK
 
 
 def test_network_error_maps_to_exit_4() -> None:

--- a/packages/tulip-cli/tests/test_errors.py
+++ b/packages/tulip-cli/tests/test_errors.py
@@ -1,0 +1,106 @@
+"""Tests for the RFC 9457 error renderer + exit-code map.
+
+ARCHITECTURE.md §7.8.5 specifies CLI exit codes:
+    0 success, 1 user error, 2 auth, 3 server, 4 network, 5 configuration.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from tulip_cli.errors import (
+    EXIT_AUTH,
+    EXIT_NETWORK,
+    EXIT_SERVER,
+    EXIT_USER,
+    CliError,
+    exit_code_for_problem,
+    exit_code_for_status,
+    parse_problem_response,
+)
+
+
+def _problem(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "type": "/.well-known/errors/transaction.unbalanced",
+        "title": "Transaction does not balance",
+        "status": 400,
+        "detail": "Sum of postings is 0.50, expected 0.00.",
+        "instance": "/v1/transactions",
+        "code": "transaction.unbalanced",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_exit_code_map_per_status() -> None:
+    assert exit_code_for_status(400) == EXIT_USER
+    assert exit_code_for_status(401) == EXIT_AUTH
+    assert exit_code_for_status(403) == EXIT_AUTH
+    assert exit_code_for_status(404) == EXIT_USER
+    assert exit_code_for_status(409) == EXIT_USER
+    assert exit_code_for_status(422) == EXIT_USER
+    assert exit_code_for_status(500) == EXIT_SERVER
+    assert exit_code_for_status(502) == EXIT_SERVER
+    assert exit_code_for_status(503) == EXIT_SERVER
+
+
+def test_exit_code_for_problem_uses_status() -> None:
+    problem = _problem(status=503, code="upstream.unavailable")
+    assert exit_code_for_problem(problem) == EXIT_SERVER
+
+
+def test_render_problem_emits_title_and_detail(capsys: object) -> None:
+    err = CliError(problem=_problem(), as_json=False)
+    err.render()
+    captured = capsys.readouterr()  # type: ignore[attr-defined]
+    assert "Transaction does not balance" in captured.err
+    assert "Sum of postings" in captured.err
+
+
+def test_render_problem_json_mode_emits_raw_body(capsys: object) -> None:
+    body = _problem()
+    err = CliError(problem=body, as_json=True)
+    err.render()
+    captured = capsys.readouterr()  # type: ignore[attr-defined]
+    parsed = json.loads(captured.out)
+    assert parsed == body
+
+
+def test_parse_problem_response_with_problem_json() -> None:
+    body = _problem()
+    response = httpx.Response(
+        400,
+        content=json.dumps(body).encode(),
+        headers={"content-type": "application/problem+json"},
+    )
+    parsed = parse_problem_response(response)
+    assert parsed == body
+
+
+def test_parse_problem_response_falls_back_for_non_problem_body() -> None:
+    response = httpx.Response(
+        500,
+        content=b"<html>boom</html>",
+        headers={"content-type": "text/html"},
+    )
+    parsed = parse_problem_response(response)
+    assert parsed["status"] == 500
+    assert parsed["code"] == "server.unexpected_response"
+    assert "title" in parsed
+    assert "detail" in parsed
+
+
+def test_network_error_maps_to_exit_4() -> None:
+    err = CliError.from_network_error(httpx.ConnectError("nope"), as_json=False)
+    assert err.exit_code == EXIT_NETWORK
+
+
+def test_render_problem_includes_request_id_when_present(capsys: object) -> None:
+    body = _problem(request_id="abc-123")
+    err = CliError(problem=body, as_json=False)
+    err.render()
+    captured = capsys.readouterr()  # type: ignore[attr-defined]
+    assert "abc-123" in captured.err

--- a/packages/tulip-cli/tests/test_errors.py
+++ b/packages/tulip-cli/tests/test_errors.py
@@ -94,7 +94,7 @@ def test_parse_problem_response_html_body_treated_as_wrong_server() -> None:
     assert parsed["status"] == 404
     assert parsed["code"] == "config.not_a_tulip_api"
     assert "Tulip" in parsed["title"]
-    assert "https://example.com" in parsed["detail"]
+    assert str(request.url) in parsed["detail"]
 
 
 def test_html_response_yields_exit_config_when_wrapped_in_clierror() -> None:

--- a/packages/tulip-cli/tests/test_smoke.py
+++ b/packages/tulip-cli/tests/test_smoke.py
@@ -1,0 +1,28 @@
+"""Smoke test: invoke the installed `tulip` console script and confirm it runs."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_tulip_help_exits_zero() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "tulip" in result.stdout.lower()
+
+
+def test_tulip_version_exits_zero() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()

--- a/uv.lock
+++ b/uv.lock
@@ -1459,6 +1459,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1658,6 +1667,18 @@ requires-dist = [
 name = "tulip-cli"
 version = "0.0.0"
 source = { editable = "packages/tulip-cli" }
+dependencies = [
+    { name = "httpx" },
+    { name = "rich" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "rich", specifier = ">=13.7" },
+    { name = "typer", specifier = ">=0.12" },
+]
 
 [[package]]
 name = "tulip-core"
@@ -1691,6 +1712,21 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "tulip-core", editable = "packages/tulip-core" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #18.

## Summary

Foundation slice for Phase 3 — `tulip-cli` runtime skeleton, no domain commands yet.

- Typer app + `tulip` console script. `tulip --help`, `tulip --version`, global `--json` flag.
- XDG config loader (`~/.config/tulip/config.toml`) with precedence flag > `TULIP_API_URL` > file > default.
- RFC 9457 Problem Details renderer per [ARCHITECTURE.md §7.8.5](../docs/ARCHITECTURE.md): bold-red title + indented detail to stderr; `--json` emits the raw body to stdout. Exit codes `0`/`1`/`2`/`3`/`4`/`5`. Synthesizes a Problem Details body on non-`application/problem+json` failures so output stays consistent regardless of what the server returns.
- `TulipClient` wraps `httpx.Client`; raises `CliError` on both 4xx/5xx and network failures. Bearer-token slot is in place for P3.2.
- `tulip ping` exercises the full path against `/health`.
- Architecture test (AST scan) rejects imports of `tulip_api`, `tulip_storage`, `sqlalchemy`, `fastapi`, etc. — keeps the CLI a pure network client.

17 new tests; project total now **304 passing**.

## Test plan

- [x] `uv run pytest` — 304 passed locally.
- [x] `uv run ruff check packages` — clean.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run mypy` — 74 source files, no issues.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] Manual smoke:
  ```bash
  uv run tulip --help                 # exit 0, usage text
  uv run tulip --version              # exit 0, prints 0.0.0
  uv run tulip ping                   # exit 4, bold-red "Could not reach the Tulip API"
  uv run tulip --json ping            # exit 4, raw Problem Details JSON
  uv run tulip --api-url https://example.com ping  # exit 4, network error against the override
  ```

## Out of scope (queued)

- Auth commands (#19), read flows (#20), write flows (#21), print stylesheet (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)