### PR TITLE
fix(api): wrap unhandled exceptions in problem+json (P2.x.4)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -143,6 +143,15 @@ P2.x.2 closes; P2.x.3 (schemathesis contract tests) is unblocked next.
 
 P2.x is now fully complete; the next slice is **Phase 3 — CLI (Typer) + first useful flows**.
 
+### P2.x.4 — catch-all unhandled-exception handler — ✅ *(2026-05-01)*
+
+Closes #26. Surfaced during P3.2.a smoke testing when a SQLAlchemy URL parse error escaped the Problem Details middleware and emitted Starlette's default `text/plain` 500.
+
+- New `InternalServerError` (`server.internal_error`, 500) `TulipProblem` subclass — generic detail, no exception text or traceback in the body (per ARCHITECTURE.md §1.1.7 / §7.8.6).
+- `install_problem_handlers` registers a fourth handler for the `Exception` base class. Starlette dispatches by MRO so the existing `TulipProblem` / `RequestValidationError` / `StarletteHTTPException` handlers still win for their specific types; the catch-all only fires for genuinely-unhandled exceptions.
+- Logs the full exception (with traceback, via `structlog.exception(exc_info=...)`) under the request's structlog context — operators have the detail in logs, clients don't.
+- 5 new tests against a deliberate-panic FastAPI app: 500 problem+json shape, no leak of exception text / class name / traceback in the body, all exception types caught (RuntimeError, ValueError, KeyError), client-supplied `X-Request-Id` echoed, typed `TulipProblem` handler still wins over the catch-all.
+
 ---
 
 ## Phase 3 — CLI (Typer) + first useful flows — in flight

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -485,16 +485,54 @@ _FRAMEWORK_ERROR_CODES: Final[dict[int, str]] = {
 }
 
 
+class InternalServerError(TulipProblem):
+    """Catch-all for an unhandled exception escaping a route handler.
+
+    The detail is deliberately generic — exception messages and
+    tracebacks belong in server logs, not in HTTP responses. Clients see
+    a stable ``server.internal_error`` code and a request_id (when one
+    was supplied) for support correlation.
+    """
+
+    def __init__(self) -> None:
+        """Build the server.internal_error problem (no exception text leaked)."""
+        super().__init__(
+            code="server.internal_error",
+            title="Internal server error",
+            status=500,
+            detail=(
+                "An unexpected error occurred on the server. If you can reproduce "
+                "this, the request_id below identifies the failing request in the "
+                "server logs."
+            ),
+        )
+
+
 def install_problem_handlers(app: FastAPI) -> None:
     """Register the :class:`TulipProblem` handler on ``app``.
 
-    Also wraps FastAPI's ``RequestValidationError`` (422) and Starlette's
-    framework-level ``HTTPException`` (400 bad body, 404 no route, 405
-    wrong method, etc.) so the *entire* error surface is RFC 9457 —
-    schemathesis's contract test asserts this.
+    Wires up four handlers, in order of specificity (Starlette dispatches
+    by MRO, picking the most specific match):
+
+    * :class:`TulipProblem` — typed domain errors raised by route code.
+    * :class:`fastapi.exceptions.RequestValidationError` — Pydantic 422.
+    * :class:`starlette.exceptions.HTTPException` — framework-level
+      400 (malformed body), 404 (no route), 405 (wrong method), 415, etc.
+    * :class:`Exception` — last-resort catch-all so an unhandled
+      exception never escapes as the default ``text/plain`` 500.
+
+    With all four registered, every non-2xx response is RFC 9457
+    ``application/problem+json``. Schemathesis's contract test asserts
+    this for documented endpoints; the catch-all closes the
+    "unhandled-exception" gap that schemathesis can't see (production
+    routes don't declare ``500`` because that's not a normal client
+    response — it's a server bug).
     """
+    import structlog
     from fastapi.exceptions import RequestValidationError
     from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    log = structlog.get_logger("tulip_api.errors")
 
     @app.exception_handler(TulipProblem)
     def _handle(request: Request, exc: TulipProblem) -> JSONResponse:
@@ -503,6 +541,21 @@ def install_problem_handlers(app: FastAPI) -> None:
     @app.exception_handler(RequestValidationError)
     def _handle_validation(request: Request, exc: RequestValidationError) -> JSONResponse:
         return _render(request, ValidationFailedError(errors=list(exc.errors())))
+
+    @app.exception_handler(Exception)
+    def _handle_unhandled(request: Request, exc: Exception) -> JSONResponse:
+        # Log the full exception (with traceback, via exc_info) under
+        # the request's structlog context so operators can find it.
+        # Critically, do NOT include the exception text in the response
+        # body — that's the principle in ARCHITECTURE.md §1.1.7
+        # (no internal identifiers in user-facing copy).
+        log.exception(
+            "internal_error",
+            exc_info=exc,
+            exc_type=type(exc).__name__,
+            path=request.url.path,
+        )
+        return _render(request, InternalServerError())
 
     @app.exception_handler(StarletteHTTPException)
     def _handle_starlette(request: Request, exc: StarletteHTTPException) -> JSONResponse:

--- a/packages/tulip-api/tests/test_internal_error_handler.py
+++ b/packages/tulip-api/tests/test_internal_error_handler.py
@@ -1,0 +1,114 @@
+"""Tests for the catch-all unhandled-exception handler.
+
+`tulip_api.errors.install_problem_handlers` registers handlers for
+``TulipProblem`` (typed errors), ``RequestValidationError`` (Pydantic
+422), and Starlette's ``HTTPException`` (framework 400/404/405). This
+slice (#26) closes the last gap: an unhandled exception escaping a
+route handler must also produce ``application/problem+json``, not the
+``text/plain`` 500 Starlette emits by default.
+
+These tests use a dedicated FastAPI app with deliberate-panic routes
+rather than the production app — schemathesis asserts that documented
+responses match what comes back, and 500 is intentionally **not**
+declared on production routes (it's an "unexpected" path that should
+never be a normal client response).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tulip_api.errors import PROBLEM_CONTENT_TYPE, install_problem_handlers
+
+
+@pytest.fixture
+def panic_client() -> TestClient:
+    app = FastAPI()
+    install_problem_handlers(app)
+
+    @app.get("/boom-runtime")
+    def _boom_runtime() -> dict[str, str]:
+        raise RuntimeError("the secret detail nobody should see")
+
+    @app.get("/boom-value")
+    def _boom_value() -> dict[str, str]:
+        raise ValueError("another internal hint")
+
+    @app.get("/boom-key")
+    def _boom_key() -> dict[str, str]:
+        d: dict[str, str] = {}
+        return {"x": d["missing"]}
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_unhandled_runtime_error_renders_problem_json(panic_client: TestClient) -> None:
+    response = panic_client.get("/boom-runtime")
+    assert response.status_code == 500
+    assert response.headers["content-type"] == PROBLEM_CONTENT_TYPE
+    body = response.json()
+    assert body["status"] == 500
+    assert body["code"] == "server.internal_error"
+    assert body["title"]
+    assert body["detail"]
+
+
+def test_internal_error_does_not_leak_exception_text(panic_client: TestClient) -> None:
+    response = panic_client.get("/boom-runtime")
+    raw = response.text
+    # The exception message must not appear in the body — that's the
+    # whole point of the handler.
+    assert "the secret detail" not in raw
+    assert "RuntimeError" not in raw
+    assert "Traceback" not in raw
+
+
+def test_internal_error_handler_works_for_other_exception_types(
+    panic_client: TestClient,
+) -> None:
+    """Catch-all means catch-all — ValueError, KeyError, anything."""
+    for path in ("/boom-value", "/boom-key"):
+        response = panic_client.get(path)
+        assert response.status_code == 500
+        assert response.json()["code"] == "server.internal_error"
+
+
+def test_internal_error_carries_request_id_when_supplied_by_client(
+    panic_client: TestClient,
+) -> None:
+    """A client-supplied X-Request-Id is echoed in the body so support tickets reference it."""
+    response = panic_client.get(
+        "/boom-runtime",
+        headers={"x-request-id": "00000000-0000-0000-0000-000000000abc"},
+    )
+    assert response.json().get("request_id") == "00000000-0000-0000-0000-000000000abc"
+
+
+def test_typed_problem_handler_still_wins_over_catchall(panic_client: TestClient) -> None:
+    """Registering an Exception handler must not shadow the TulipProblem handler.
+
+    Starlette dispatches exception handlers by MRO, picking the most
+    specific match — but verify that explicitly. A TulipProblem subclass
+    must still render with its own status / code, not the 500 wrapper.
+    """
+    from tulip_api.errors import TulipProblem
+
+    app = FastAPI()
+    install_problem_handlers(app)
+
+    class TypedFailure(TulipProblem):
+        def __init__(self) -> None:
+            super().__init__(code="x.typed", title="Typed", status=409, detail="typed detail")
+
+    @app.get("/typed")
+    def _typed() -> None:
+        raise TypedFailure()
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/typed")
+    assert response.status_code == 409
+    body = response.json()
+    assert body["code"] == "x.typed"
+    assert body["title"] == "Typed"


### PR DESCRIPTION
Closes #26.

## Summary

Surfaced during P3.2.a smoke testing when a SQLAlchemy URL parse error escaped the Problem Details middleware and emitted Starlette's default `text/plain` 500 — violating the architecture's promise that every non-2xx response is `application/problem+json`. This PR closes the gap.

## What changed

- New `InternalServerError` `TulipProblem` subclass (`code: server.internal_error`, status 500). Generic detail; **no exception text or traceback in the body** (per [ARCHITECTURE.md §1.1.7 / §7.8.6](../docs/ARCHITECTURE.md) — internals belong in logs).
- `install_problem_handlers` registers a fourth handler for the `Exception` base class. Starlette dispatches by MRO so the existing `TulipProblem` / `RequestValidationError` / `StarletteHTTPException` handlers still win for their specific types; the catch-all only fires for genuinely-unhandled exceptions.
- Logs the full exception with traceback via `structlog.exception(exc_info=...)` under the request's structlog context — operators have the detail in logs, clients don't see it.

## What didn't change

- **No production routes declare `500` in their `responses=`** — that's deliberate. 500 is the unhandled-exception path; documenting it would mislead clients into thinking it's a normal response. Schemathesis would balk at undocumented 500s in its fuzz tests, which is exactly the right behavior — a fuzzed 500 indicates a real bug to fix, not a missing schema entry.

## Test plan

- [x] `uv run pytest` — 355 passed.
- [x] `uv run ruff check packages` — clean.
- [x] `uv run ruff format --check packages` — clean.
- [x] `uv run mypy` — clean.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] **5 new tests** against a deliberate-panic FastAPI app:
  - 500 ``application/problem+json`` shape.
  - No leak of exception text / class name / traceback in the body.
  - All exception types caught (RuntimeError, ValueError, KeyError).
  - Client-supplied `X-Request-Id` echoed in the body.
  - Typed `TulipProblem` handler still wins over the catch-all (MRO dispatch).
- [x] **Smoke**: with a deliberately-bad `TULIP_DATABASE_URL=...`, the API now returns:
  ```
  HTTP/1.1 500 Internal Server Error
  content-type: application/problem+json
  
  {
    "type": "/.well-known/errors/server.internal_error",
    "title": "Internal server error",
    "status": 500,
    "detail": "An unexpected error occurred on the server. ...",
    "instance": "/v1/auth/register",
    "code": "server.internal_error"
  }
  ```
  …and the CLI's existing `5xx → server.unexpected_response` heuristic (PR #25) treats it correctly with exit code 3.

## Refs

- Closes #26.
- Surfaced during PR #25 (P3.2.a) smoke testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)