### PR TITLE
feat(cli): P3.3.a — tulip accounts list + show

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -194,7 +194,19 @@ Closes #19.
 - `tulip auth status` — reads tokens locally and decodes the access-token payload to display email, household_id, role, and access-token TTL. No network call; full server-side validation lands behind a `--check` flag once #24 (`GET /v1/auth/me`) ships.
 - 35 new tests (token store round-trip with both backends, JWT decode, transparent refresh via `httpx.MockTransport`, plus 9 E2E covering happy login, MFA-TOTP, MFA-recovery, wrong-password exit code, status logged-in/out, JSON status, logout, idempotent logout). Project test count: 350 passing.
 
-### P3.3 — Read flows (`accounts`, `balance`) — queued (#20)
+### P3.3 — Read flows (`accounts`, `balance`) — in flight (#20)
+
+#### P3.3.a — `tulip accounts list` + `show` — ✅ *(2026-05-01)*
+
+- New `tulip_cli.commands.accounts` registers an `accounts` Typer subcommand group.
+- `tulip accounts list` consumes `GET /v1/accounts` (authenticated). Renders a Rich table for humans (`code`/`name`/`type`/`currency`/`visibility`); `--json` passes through the raw array. Empty households get a "no accounts yet" hint pointing at the (yet-to-land) `add` command.
+- `tulip accounts show ACCOUNT` resolves the identifier as a UUID first, falling back to a `code` lookup over the listed accounts. `code` has no server-side uniqueness constraint, so multiple matches surface a CLI-side `account.ambiguous_code` problem (exit 1) rather than silently picking one.
+- First slice that exercises the authenticated request path → `TulipClient.request(authenticated=True)` → transparent refresh from P3.2.b. Logged-out invocations cleanly surface `auth.not_logged_in` with exit 2.
+- 8 new E2E tests: empty list, multi-account table, `--json` array, `show` by code, `show` by UUID, unknown code → user error, ambiguous code → user error, unauthenticated → exit 2. Project test count: 363 passing.
+
+#### P3.3.b — `tulip balance` — queued, blocked on #31
+
+The CLI command needs balance endpoints in the API; currently the trial-balance computation only lives in a `tulip-storage` test fixture. Tracked as #31; once that lands, this slice is small.
 
 ### P3.4 — Write flows (`accounts add`, `add`) — queued (#21)
 

--- a/packages/tulip-cli/src/tulip_cli/commands/accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/accounts.py
@@ -1,0 +1,182 @@
+"""``tulip accounts`` — list and show.
+
+Read-only commands consume ``GET /v1/accounts`` and
+``GET /v1/accounts/{id}``. Write paths (``add``, ``deactivate``) land in
+P3.4 (#21).
+
+The ``show`` command resolves an identifier as a UUID first and falls
+back to a code lookup over the listed accounts. ``code`` has no
+uniqueness constraint server-side, so duplicates produce an ambiguous-id
+error rather than silently picking the first match.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Annotated, Any
+from uuid import UUID
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.config import Config
+from tulip_cli.errors import EXIT_USER, CliError
+from tulip_cli.http import TulipClient
+
+accounts_app = typer.Typer(
+    name="accounts",
+    help="List and inspect accounts.",
+    no_args_is_help=True,
+)
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+def _ambiguous_code_problem(identifier: str, count: int) -> dict[str, object]:
+    return {
+        "type": "/.well-known/errors/account.ambiguous_code",
+        "title": "Account code matches multiple accounts",
+        "status": 0,
+        "detail": (
+            f"{count} accounts have code {identifier!r}. "
+            "Use the account UUID to disambiguate, or rename one of the duplicates."
+        ),
+        "instance": "",
+        "code": "account.ambiguous_code",
+    }
+
+
+def _not_found_problem(identifier: str) -> dict[str, object]:
+    return {
+        "type": "/.well-known/errors/account.not_found",
+        "title": "Account not found",
+        "status": 0,
+        "detail": (
+            f"No account with code or id {identifier!r} is visible to this user. "
+            "Run `tulip accounts list` to see what's available."
+        ),
+        "instance": "",
+        "code": "account.not_found",
+    }
+
+
+def _resolve_account(client: TulipClient, identifier: str) -> dict[str, Any]:
+    """Return a single account dict by UUID or by ``code``.
+
+    UUID-shaped strings are looked up via ``GET /v1/accounts/{id}``.
+    Anything else is matched against the listed accounts' ``code`` field.
+    """
+    try:
+        UUID(identifier)
+    except ValueError:
+        # Not a UUID — fall through to code lookup.
+        pass
+    else:
+        response = client.get(f"/v1/accounts/{identifier}", authenticated=True)
+        return dict(response.json())
+
+    response = client.get("/v1/accounts", authenticated=True)
+    accounts = response.json()
+    matches = [a for a in accounts if a.get("code") == identifier]
+    if not matches:
+        raise CliError(
+            problem=_not_found_problem(identifier),
+            as_json=False,
+            exit_code=EXIT_USER,
+        )
+    if len(matches) > 1:
+        raise CliError(
+            problem=_ambiguous_code_problem(identifier, len(matches)),
+            as_json=False,
+            exit_code=EXIT_USER,
+        )
+    return dict(matches[0])
+
+
+def _render_table(accounts: list[dict[str, Any]]) -> None:
+    """Render a list of account dicts as a Rich table to stdout."""
+    table = Table(show_header=True, show_lines=False)
+    table.add_column("code")
+    table.add_column("name")
+    table.add_column("type")
+    table.add_column("currency")
+    table.add_column("visibility")
+    for a in accounts:
+        table.add_row(
+            a.get("code") or "—",
+            a.get("name") or "",
+            a.get("type") or "",
+            a.get("currency") or "",
+            a.get("visibility") or "",
+        )
+    Console().print(table)
+
+
+def _render_account(account: dict[str, Any]) -> None:
+    """Render a single account dict as a vertical key/value list."""
+    typer.echo(f"id:           {account.get('id', '')}")
+    typer.echo(f"code:         {account.get('code') or '—'}")
+    typer.echo(f"name:         {account.get('name', '')}")
+    typer.echo(f"type:         {account.get('type', '')}")
+    if account.get("subtype"):
+        typer.echo(f"subtype:      {account['subtype']}")
+    typer.echo(f"currency:     {account.get('currency', '')}")
+    typer.echo(f"visibility:   {account.get('visibility', '')}")
+    typer.echo(f"is_active:    {account.get('is_active', '')}")
+    if account.get("parent_account_id"):
+        typer.echo(f"parent:       {account['parent_account_id']}")
+
+
+@accounts_app.command("list")
+def list_accounts(ctx: typer.Context) -> None:
+    """List active accounts visible to the logged-in user."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get("/v1/accounts", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    accounts = response.json()
+    if not accounts:
+        typer.echo("No accounts. Run `tulip accounts add` to create one (P3.4 — coming soon).")
+        return
+    _render_table(accounts)
+
+
+@accounts_app.command("show")
+def show_account(
+    ctx: typer.Context,
+    identifier: Annotated[
+        str,
+        typer.Argument(
+            help="Account code (e.g. assets:checking) or UUID.",
+            metavar="ACCOUNT",
+        ),
+    ],
+) -> None:
+    """Show one account by code or UUID."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            account = _resolve_account(client, identifier)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(json.dumps(account) + "\n")
+        return
+    _render_account(account)

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -14,6 +14,7 @@ from typing import Annotated
 import typer
 
 from tulip_cli import __version__
+from tulip_cli.commands.accounts import accounts_app
 from tulip_cli.commands.auth import auth_app
 from tulip_cli.commands.register import register as register_command
 from tulip_cli.config import Config, load_config
@@ -85,6 +86,7 @@ def ping(ctx: typer.Context) -> None:
 
 app.command("register")(register_command)
 app.add_typer(auth_app, name="auth")
+app.add_typer(accounts_app, name="accounts")
 
 
 if __name__ == "__main__":

--- a/packages/tulip-cli/tests/test_accounts.py
+++ b/packages/tulip-cli/tests/test_accounts.py
@@ -1,0 +1,238 @@
+"""End-to-end tests for ``tulip accounts list`` and ``tulip accounts show``.
+
+Each test spawns the API via ``live_api``, registers a user, logs in
+(populating a per-test JSON token store), and then runs the CLI as a
+subprocess. The CLI's authenticated read path goes through P3.2.b's
+transparent-refresh ``TulipClient``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=20,
+    )
+
+
+def _register_and_login(api_url: str, email: str = "alice@example.com") -> str:
+    """Register a user and obtain an access token."""
+    httpx.post(
+        f"{api_url}/v1/auth/register",
+        json={
+            "email": email,
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    r = httpx.post(
+        f"{api_url}/v1/auth/login",
+        json={"email": email, "password": _PASSWORD},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return str(r.json()["access_token"])
+
+
+def _create_account(
+    api_url: str,
+    access_token: str,
+    *,
+    code: str | None,
+    name: str,
+    type_: str = "asset",
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "name": name,
+        "type": type_,
+        "currency": "USD",
+        "visibility": "shared",
+    }
+    if code is not None:
+        body["code"] = code
+    r = httpx.post(
+        f"{api_url}/v1/accounts",
+        json=body,
+        headers={"authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return dict(r.json())
+
+
+@pytest.fixture
+def authed_session(live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Log a user in via the CLI and return the API URL.
+
+    Side effects:
+    - ``TULIP_TOKEN_STORE`` is set to a per-test JSON file.
+    - The user ``alice@example.com`` exists in the spawned API.
+    """
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    result = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert result.returncode == 0, result.stderr
+    return live_api
+
+
+@pytest.mark.integration
+def test_accounts_list_when_empty(authed_session: str) -> None:
+    result = _run_cli("accounts", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    # Empty households still register an opening message — not just blank stdout.
+    assert "no accounts" in result.stdout.lower()
+
+
+@pytest.mark.integration
+def test_accounts_list_renders_table(authed_session: str) -> None:
+    access = _register_and_login(authed_session, email="bob@example.com")
+    # Bob is a separate household; create a couple of accounts under
+    # Alice's household instead by re-fetching Alice's token.
+    alice_login = httpx.post(
+        f"{authed_session}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    alice_login.raise_for_status()
+    alice_access = str(alice_login.json()["access_token"])
+    _create_account(authed_session, alice_access, code="assets:checking", name="Checking")
+    _create_account(
+        authed_session,
+        alice_access,
+        code="expenses:groceries",
+        name="Groceries",
+        type_="expense",
+    )
+
+    result = _run_cli("accounts", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "assets:checking" in result.stdout
+    assert "Checking" in result.stdout
+    assert "expenses:groceries" in result.stdout
+    # The other household's data must not leak in (Bob is irrelevant here, just
+    # asserting the list is filtered to Alice's household).
+    assert "bob" not in result.stdout.lower()
+    # Unused fixture-side helper to keep the linter happy.
+    _ = access
+
+
+@pytest.mark.integration
+def test_accounts_list_json_emits_array(authed_session: str) -> None:
+    alice_login = httpx.post(
+        f"{authed_session}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    alice_login.raise_for_status()
+    alice_access = str(alice_login.json()["access_token"])
+    _create_account(authed_session, alice_access, code="assets:cash", name="Cash")
+
+    result = _run_cli("--json", "accounts", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list)
+    assert any(a["code"] == "assets:cash" for a in payload)
+
+
+@pytest.mark.integration
+def test_accounts_show_by_code(authed_session: str) -> None:
+    alice_login = httpx.post(
+        f"{authed_session}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    alice_login.raise_for_status()
+    alice_access = str(alice_login.json()["access_token"])
+    _create_account(authed_session, alice_access, code="assets:checking", name="Checking")
+
+    result = _run_cli("accounts", "show", "assets:checking", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "Checking" in result.stdout
+    assert "assets:checking" in result.stdout
+
+
+@pytest.mark.integration
+def test_accounts_show_by_uuid(authed_session: str) -> None:
+    alice_login = httpx.post(
+        f"{authed_session}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    alice_login.raise_for_status()
+    alice_access = str(alice_login.json()["access_token"])
+    created = _create_account(authed_session, alice_access, code="assets:savings", name="Savings")
+
+    result = _run_cli("accounts", "show", str(created["id"]), api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "Savings" in result.stdout
+
+
+@pytest.mark.integration
+def test_accounts_show_unknown_code_yields_user_error(authed_session: str) -> None:
+    result = _run_cli("accounts", "show", "no-such-code", api_url=authed_session)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "no-such-code" in result.stderr.lower() or "not found" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_accounts_show_ambiguous_code_yields_user_error(authed_session: str) -> None:
+    """``code`` has no uniqueness constraint, so duplicates are possible. CLI must complain."""
+    alice_login = httpx.post(
+        f"{authed_session}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    alice_login.raise_for_status()
+    alice_access = str(alice_login.json()["access_token"])
+    _create_account(authed_session, alice_access, code="assets:duplicated", name="Dup A")
+    _create_account(authed_session, alice_access, code="assets:duplicated", name="Dup B")
+
+    result = _run_cli("accounts", "show", "assets:duplicated", api_url=authed_session)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "ambiguous" in result.stderr.lower() or "multiple" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_accounts_list_unauthenticated_fails_clearly(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli("accounts", "list", api_url=live_api)
+    assert result.returncode == 2, (result.stdout, result.stderr)
+    assert "not logged in" in result.stderr.lower() or "log in" in result.stderr.lower()


### PR DESCRIPTION
First slice of P3.3 (#20). Read commands consume the existing `GET /v1/accounts` endpoint; the `balance` work is split into a follow-up because the API has no balance endpoint yet (tracked separately as #31).

## Summary

- New `tulip_cli.commands.accounts` registers an `accounts` Typer subcommand group.
- `tulip accounts list` → `GET /v1/accounts` (authenticated). Rich table for humans (`code`/`name`/`type`/`currency`/`visibility`); `--json` passes through the raw array. Empty households get a "no accounts yet" hint.
- `tulip accounts show ACCOUNT` resolves the identifier as a UUID first, falls back to a `code` lookup over the listed accounts.
- **First slice that exercises the authenticated request path** → `TulipClient.request(authenticated=True)` → transparent refresh from P3.2.b. Logged-out invocations cleanly surface `auth.not_logged_in` with exit code `2`.

## Note on ambiguous codes

`Account.code` has no server-side uniqueness constraint (it's `String(50), nullable=True`). Two accounts with the same code is permitted by the schema. The CLI surfaces this as `account.ambiguous_code` (exit `1`) when `show` finds multiple matches by code, rather than silently picking the first one. UUID lookup is unambiguous.

## Test plan

- [x] `uv run pytest` — 363 passed (up from 355).
- [x] `uv run ruff check packages` — clean.
- [x] `uv run ruff format --check packages` — clean.
- [x] `uv run mypy` — 81 source files, no issues.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] **8 new E2E tests**:
  - empty household → "no accounts" message
  - multi-account table renders codes + names
  - `--json` returns the raw array
  - `show` by code
  - `show` by UUID
  - unknown code → user error (exit 1)
  - ambiguous code → user error with `account.ambiguous_code`
  - unauthenticated → exit 2 (`auth.not_logged_in` from the transparent-refresh path)
- [x] Manual smoke flow:
  ```bash
  rm -f /tmp/tulip-smoke.db
  export TULIP_DATABASE_URL='sqlite:////tmp/tulip-smoke.db'
  export TULIP_JWT_SECRET='dev-secret-32bytes-dev-secret-xyz'
  export TULIP_MASTER_KEY='q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s='
  uv run alembic -c packages/tulip-storage/alembic.ini upgrade head
  uv run uvicorn tulip_api.main:create_app --factory &
  uv run tulip register --email me@example.com --display-name Me --household Mine
  uv run tulip auth login --email me@example.com
  uv run tulip accounts list
  ```

## Refs

- Part of #20 (P3.3 umbrella).
- #31 — balance endpoints; blocks P3.3.b (`tulip balance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)