### PR TITLE
feat(api): balance + trial-balance read endpoints (#31)

### DIFF
--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI
 from tulip_api.errors import install_problem_handlers
 from tulip_api.logging_config import configure_logging
 from tulip_api.middleware import RequestIdMiddleware
-from tulip_api.routers import accounts, auth, health, transactions, well_known_errors
+from tulip_api.routers import accounts, auth, health, reports, transactions, well_known_errors
 
 API_VERSION = "v1"
 API_TITLE = "Tulip Accounting API"
@@ -43,5 +43,6 @@ def create_app() -> FastAPI:
     app.include_router(auth.router)
     app.include_router(accounts.router)
     app.include_router(transactions.router)
+    app.include_router(reports.router)
 
     return app

--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
+from datetime import date as date_type
 from typing import TYPE_CHECKING
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 
 from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.deps import get_session
 from tulip_api.errors import AccountNotFoundError, ForbiddenError, problem_response
 from tulip_api.schemas.account import AccountCreate, AccountRead, AccountUpdate
+from tulip_api.schemas.balance import AccountBalanceRead
+from tulip_core.money import Money
 from tulip_storage.models import AccountType
-from tulip_storage.repositories import AccountRepository, AuditLogWriter
+from tulip_storage.repositories import AccountRepository, AuditLogWriter, TransactionRepository
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -184,6 +187,53 @@ def update_account(
     )
     session.commit()
     return _to_read(a)
+
+
+@router.get(
+    "/{account_id}/balance",
+    response_model=AccountBalanceRead,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        404: problem_response("account.not_found"),
+    },
+)
+def get_account_balance(
+    account_id: UUID,
+    as_of: date_type | None = Query(  # noqa: B008 — FastAPI uses Query() in defaults
+        default=None,
+        description=(
+            "Optional point-in-time date (YYYY-MM-DD). Includes only "
+            "transactions on or before this date. Defaults to today."
+        ),
+    ),
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> AccountBalanceRead:
+    """Return the ledger balance of an account in its primary currency.
+
+    Pending transactions are excluded — only POSTED + RECONCILED contribute.
+    Postings in other currencies on this account (e.g. FX postings) are
+    not included; use the trial-balance report for the multi-currency view.
+    """
+    a = AccountRepository(session, claims.household_id).get(account_id)
+    if a is None or not _filter_for_role(a, claims):
+        raise AccountNotFoundError()
+
+    effective_as_of = as_of or date_type.today()
+    raw_balance = TransactionRepository(session, claims.household_id).balance_for_account(
+        a.id, currency=a.currency, as_of=effective_as_of
+    )
+    # Quantize to the currency's minor units so the JSON representation
+    # is the natural "12.50" rather than the storage-precision "12.50000000".
+    balance = Money(raw_balance, a.currency).quantize_to_currency().amount
+    return AccountBalanceRead(
+        account_id=a.id,
+        code=a.code,
+        name=a.name,
+        currency=a.currency,
+        balance=balance,
+        as_of=effective_as_of,
+    )
 
 
 @router.delete(

--- a/packages/tulip-api/src/tulip_api/routers/reports.py
+++ b/packages/tulip-api/src/tulip_api/routers/reports.py
@@ -1,0 +1,119 @@
+"""GET /v1/reports/trial-balance.
+
+Trial balance is the canonical "is the ledger healthy" view: every
+posted transaction's debit and credit postings should sum to zero per
+currency. The endpoint exposes both the per-account rows and the
+per-currency totals so a caller can both display the report and assert
+the zero-sum invariant.
+
+Pending transactions are excluded (they're workflow state, not ledger
+state). Role-based filtering matches ``GET /v1/accounts`` — admins see
+private accounts, members and viewers only see shared accounts and
+their own.
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Depends, Query
+
+from tulip_api.auth.deps import get_current_claims
+from tulip_api.deps import get_session
+from tulip_api.errors import problem_response
+from tulip_api.schemas.balance import (
+    CurrencyTotal,
+    TrialBalanceRead,
+    TrialBalanceRow,
+)
+from tulip_core.money import Money
+from tulip_storage.repositories import AccountRepository, TransactionRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_api.auth.tokens import Claims
+
+
+router = APIRouter(prefix="/v1/reports", tags=["reports"])
+
+
+def _filter_for_role(account_visibility: str, created_by: object, claims: Claims) -> bool:
+    """Mirror routers.accounts._filter_for_role for trial-balance row filtering."""
+    if account_visibility == "shared":
+        return True
+    if claims.role == "admin":
+        return True
+    return created_by == claims.user_id
+
+
+@router.get(
+    "/trial-balance",
+    response_model=TrialBalanceRead,
+    responses={401: problem_response("auth.unauthorized")},
+)
+def trial_balance(
+    as_of: date_type | None = Query(  # noqa: B008 — FastAPI uses Query() in defaults
+        default=None,
+        description=(
+            "Optional point-in-time date (YYYY-MM-DD). Includes only "
+            "transactions on or before this date. Defaults to today."
+        ),
+    ),
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> TrialBalanceRead:
+    """Return per-account, per-currency balances for the household ledger.
+
+    Pending transactions are excluded. Visibility filtering matches the
+    accounts list — accounts the caller can't see don't appear here.
+    """
+    effective_as_of = as_of or date_type.today()
+    tx_repo = TransactionRepository(session, claims.household_id)
+    account_repo = AccountRepository(session, claims.household_id)
+
+    accounts_by_id = {a.id: a for a in account_repo.list_active()}
+    raw = tx_repo.trial_balance(as_of=effective_as_of)
+
+    rows: list[TrialBalanceRow] = []
+    debits_by_currency: dict[str, Decimal] = {}
+    credits_by_currency: dict[str, Decimal] = {}
+    for r in raw:
+        a = accounts_by_id.get(r.account_id)
+        if a is None or not _filter_for_role(a.visibility, a.created_by_user_id, claims):
+            continue
+        balance = Money(r.balance, r.currency).quantize_to_currency().amount
+        rows.append(
+            TrialBalanceRow(
+                account_id=a.id,
+                code=a.code,
+                name=a.name,
+                type=a.type.value,
+                currency=r.currency,
+                balance=balance,
+            )
+        )
+        if balance > 0:
+            debits_by_currency[r.currency] = (
+                debits_by_currency.get(r.currency, Decimal("0")) + balance
+            )
+        elif balance < 0:
+            credits_by_currency[r.currency] = credits_by_currency.get(r.currency, Decimal("0")) + (
+                -balance
+            )
+
+    currencies = sorted(set(debits_by_currency) | set(credits_by_currency))
+    totals = [
+        CurrencyTotal(
+            currency=c,
+            debits=Money(debits_by_currency.get(c, Decimal("0")), c).quantize_to_currency().amount,
+            credits=Money(credits_by_currency.get(c, Decimal("0")), c)
+            .quantize_to_currency()
+            .amount,
+        )
+        for c in currencies
+    ]
+
+    return TrialBalanceRead(as_of=effective_as_of, rows=rows, totals_by_currency=totals)

--- a/packages/tulip-api/src/tulip_api/schemas/balance.py
+++ b/packages/tulip-api/src/tulip_api/schemas/balance.py
@@ -1,0 +1,58 @@
+"""Read schemas for the balance endpoints (#31)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class AccountBalanceRead(BaseModel):
+    """Response from ``GET /v1/accounts/{id}/balance``."""
+
+    account_id: UUID
+    code: str | None = None
+    name: str
+    currency: str
+    balance: Decimal = Field(
+        description=(
+            "Sum of POSTED + RECONCILED postings on this account in its currency. "
+            "Pending transactions are not included."
+        ),
+    )
+    as_of: date
+
+
+class TrialBalanceRow(BaseModel):
+    """One row of the trial-balance report (per account, per currency)."""
+
+    account_id: UUID
+    code: str | None = None
+    name: str
+    type: str
+    currency: str
+    balance: Decimal
+
+
+class CurrencyTotal(BaseModel):
+    """Per-currency debit/credit summary used for the zero-sum check."""
+
+    currency: str
+    debits: Decimal
+    credits: Decimal
+
+
+class TrialBalanceRead(BaseModel):
+    """Response from ``GET /v1/reports/trial-balance``."""
+
+    as_of: date
+    rows: list[TrialBalanceRow]
+    totals_by_currency: list[CurrencyTotal] = Field(
+        description=(
+            "Per-currency totals of positive (debit) and negative (credit) "
+            "balances. They sum to zero per currency in a healthy ledger; a "
+            "non-zero sum indicates a data issue."
+        ),
+    )

--- a/packages/tulip-api/tests/test_balance_endpoints.py
+++ b/packages/tulip-api/tests/test_balance_endpoints.py
@@ -1,0 +1,180 @@
+"""Tests for the balance-read endpoints (#31).
+
+* ``GET /v1/accounts/{id}/balance`` — single-account ledger balance.
+* ``GET /v1/reports/trial-balance`` — household-wide per-account
+  per-currency balances + totals.
+
+Both endpoints exclude pending transactions (POSTED + RECONCILED only)
+and accept an optional ``as_of=YYYY-MM-DD`` query for point-in-time
+balances.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return str(r.json()["access_token"])
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+def _account(client: TestClient, headers: dict[str, str], **extra: object) -> str:
+    body = {"name": "X", "type": "asset", "currency": "USD"}
+    body.update(extra)
+    return str(client.post("/v1/accounts", headers=headers, json=body).json()["id"])
+
+
+def _post_tx(
+    client: TestClient,
+    headers: dict[str, str],
+    *,
+    debit: str,
+    credit: str,
+    amount: str,
+    on: date | None = None,
+) -> None:
+    on = on or date.today()
+    r = client.post(
+        "/v1/transactions",
+        headers=headers,
+        json={
+            "date": on.isoformat(),
+            "description": f"{amount}",
+            "postings": [
+                {"account_id": debit, "amount": amount, "currency": "USD"},
+                {"account_id": credit, "amount": f"-{amount}", "currency": "USD"},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+
+
+class TestAccountBalance:
+    def test_returns_zero_for_account_with_no_postings(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        r = client.get(f"/v1/accounts/{cash}/balance", headers=auth_h)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["account_id"] == cash
+        assert body["currency"] == "USD"
+        assert body["balance"] == "0.00"
+
+    def test_returns_summed_balance(self, client: TestClient, auth_h: dict[str, str]):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="12.50")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="7.25")
+
+        r = client.get(f"/v1/accounts/{food}/balance", headers=auth_h)
+        body = r.json()
+        assert body["balance"] == "19.75"
+
+        r = client.get(f"/v1/accounts/{cash}/balance", headers=auth_h)
+        body = r.json()
+        assert body["balance"] == "-19.75"
+
+    def test_respects_as_of(self, client: TestClient, auth_h: dict[str, str]):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="20.00", on=date(2026, 1, 15))
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="30.00", on=date(2026, 6, 1))
+
+        r = client.get(
+            f"/v1/accounts/{food}/balance",
+            headers=auth_h,
+            params={"as_of": "2026-05-01"},
+        )
+        assert r.json()["balance"] == "20.00"
+
+    def test_unknown_account_returns_404(self, client: TestClient, auth_h: dict[str, str]):
+        from uuid import uuid4
+
+        r = client.get(f"/v1/accounts/{uuid4()}/balance", headers=auth_h)
+        assert_problem(r, code="account.not_found", status=404)
+
+    def test_no_token_returns_unauthorized(self, client: TestClient, auth_h: dict[str, str]):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        r = client.get(f"/v1/accounts/{cash}/balance")
+        assert_problem(r, code="auth.unauthorized", status=401)
+
+
+class TestTrialBalance:
+    def test_empty_household_yields_empty_rows(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.get("/v1/reports/trial-balance", headers=auth_h)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["rows"] == []
+        assert body["totals_by_currency"] == []
+        assert body["as_of"]  # always present, defaults to today
+
+    def test_returns_per_account_per_currency_rows(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="12.50")
+
+        body = client.get("/v1/reports/trial-balance", headers=auth_h).json()
+        rows_by_account = {r["account_id"]: r for r in body["rows"]}
+        assert rows_by_account[food]["balance"] == "12.50"
+        assert rows_by_account[food]["code"] == "5100"
+        assert rows_by_account[food]["name"] == "Food"
+        assert rows_by_account[food]["type"] == "expense"
+        assert rows_by_account[food]["currency"] == "USD"
+        assert rows_by_account[cash]["balance"] == "-12.50"
+
+    def test_totals_by_currency_sum_to_zero(self, client: TestClient, auth_h: dict[str, str]):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="12.50")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="7.50")
+
+        body = client.get("/v1/reports/trial-balance", headers=auth_h).json()
+        totals = {t["currency"]: t for t in body["totals_by_currency"]}
+        assert totals["USD"]["debits"] == "20.00"
+        assert totals["USD"]["credits"] == "20.00"
+
+    def test_respects_as_of(self, client: TestClient, auth_h: dict[str, str]):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="5.00", on=date(2026, 1, 15))
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="7.00", on=date(2026, 8, 1))
+
+        body = client.get(
+            "/v1/reports/trial-balance",
+            headers=auth_h,
+            params={"as_of": "2026-05-01"},
+        ).json()
+        rows_by_account = {r["account_id"]: r for r in body["rows"]}
+        assert rows_by_account[food]["balance"] == "5.00"
+        assert body["as_of"] == "2026-05-01"
+
+    def test_no_token_returns_unauthorized(self, client: TestClient):
+        r = client.get("/v1/reports/trial-balance")
+        assert_problem(r, code="auth.unauthorized", status=401)

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -12,11 +12,12 @@ higher layers (the API) call it on every business mutation.
 from tulip_storage.repositories.account import AccountRepository
 from tulip_storage.repositories.audit_log import AuditLogWriter
 from tulip_storage.repositories.period import PeriodRepository
-from tulip_storage.repositories.transaction import TransactionRepository
+from tulip_storage.repositories.transaction import TransactionRepository, TrialBalanceRow
 
 __all__ = [
     "AccountRepository",
     "AuditLogWriter",
     "PeriodRepository",
     "TransactionRepository",
+    "TrialBalanceRow",
 ]

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
@@ -10,11 +10,14 @@ writes.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from datetime import date as date_type
+from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 
 from tulip_storage.models import Posting, Transaction, TransactionStatus
 
@@ -30,6 +33,19 @@ _DOMAIN_TO_STORAGE_STATUS: dict[str, TransactionStatus] = {
     "posted": TransactionStatus.POSTED,
     "reconciled": TransactionStatus.RECONCILED,
 }
+
+#: Statuses whose postings count toward the ledger. Pending transactions
+#: are workflow state, not ledger state, and are excluded from balances.
+_LEDGER_STATUSES = (TransactionStatus.POSTED, TransactionStatus.RECONCILED)
+
+
+@dataclass(frozen=True, slots=True)
+class TrialBalanceRow:
+    """One row of a per-(account, currency) trial-balance result."""
+
+    account_id: UUID
+    currency: str
+    balance: Decimal
 
 
 class TransactionRepository:
@@ -61,6 +77,75 @@ class TransactionRepository:
             .scalars()
             .all()
         )
+
+    def balance_for_account(
+        self,
+        account_id: UUID,
+        *,
+        currency: str,
+        as_of: date_type | None = None,
+    ) -> Decimal:
+        """Sum the ledger postings on ``account_id`` in ``currency``.
+
+        Pending transactions are excluded — only POSTED and RECONCILED
+        contribute. ``as_of`` limits to transactions on or before that
+        date; ``None`` means "all time."
+        """
+        query = (
+            select(func.coalesce(func.sum(Posting.amount), 0))
+            .join(Transaction, Transaction.id == Posting.transaction_id)
+            .where(
+                Posting.household_id == self._household_id,
+                Posting.account_id == account_id,
+                Posting.currency == currency,
+                Transaction.status.in_(_LEDGER_STATUSES),
+            )
+        )
+        if as_of is not None:
+            query = query.where(Transaction.date <= as_of)
+        result = self._session.execute(query).scalar_one()
+        # SQLite returns int 0 from ``coalesce(..., 0)`` even when the
+        # column is NUMERIC; normalize to Decimal so callers don't see
+        # a type drift on the empty-result branch.
+        return Decimal(str(result))
+
+    def trial_balance(
+        self,
+        *,
+        as_of: date_type | None = None,
+    ) -> list[TrialBalanceRow]:
+        """Return one row per (account_id, currency) for the household's ledger.
+
+        Pending transactions are excluded. ``as_of`` filters to
+        transactions on or before that date; ``None`` means "all time."
+        Accounts with no postings (or only zero-net postings) still
+        appear when they have any matching posting at all — callers may
+        filter zeros if they want.
+        """
+        query = (
+            select(
+                Posting.account_id,
+                Posting.currency,
+                func.coalesce(func.sum(Posting.amount), 0).label("balance"),
+            )
+            .join(Transaction, Transaction.id == Posting.transaction_id)
+            .where(
+                Posting.household_id == self._household_id,
+                Transaction.status.in_(_LEDGER_STATUSES),
+            )
+            .group_by(Posting.account_id, Posting.currency)
+        )
+        if as_of is not None:
+            query = query.where(Transaction.date <= as_of)
+        rows = self._session.execute(query).all()
+        return [
+            TrialBalanceRow(
+                account_id=account_id,
+                currency=currency,
+                balance=Decimal(str(balance)),
+            )
+            for account_id, currency, balance in rows
+        ]
 
     def save_balanced(self, domain_tx: DomainTransaction) -> Transaction:
         """Persist a balanced Domain Transaction.

--- a/packages/tulip-storage/tests/test_repositories.py
+++ b/packages/tulip-storage/tests/test_repositories.py
@@ -195,6 +195,298 @@ class TestTransactionRepository:
         assert len(rows) == 2
         assert sum(r.amount for r in rows) == Decimal("0")
 
+    def _post_tx(
+        self,
+        session: Session,
+        household: Household,
+        *,
+        tx_date: date,
+        debit_account: AccountModel,
+        credit_account: AccountModel,
+        amount: Decimal,
+        currency: str = "USD",
+        status: DomainTxStatus = DomainTxStatus.POSTED,
+    ) -> None:
+        domain_tx = DomainTransaction(
+            id=uuid4(),
+            household_id=household.id,
+            date=tx_date,
+            description=f"{amount} on {tx_date}",
+            postings=(
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=debit_account.id,
+                    amount=Money(amount, currency),
+                ),
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=credit_account.id,
+                    amount=Money(-amount, currency),
+                ),
+            ),
+            status=status,
+        )
+        TransactionRepository(session, household.id).save_balanced(domain_tx)
+        session.commit()
+
+    def test_balance_for_account_sums_posted_amounts(self, session: Session, household: Household):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+
+        # Two grocery runs.
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("12.50"),
+        )
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 2),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("7.25"),
+        )
+
+        repo = TransactionRepository(session, household.id)
+        assert repo.balance_for_account(food.id, currency="USD") == Decimal("19.75")
+        assert repo.balance_for_account(cash.id, currency="USD") == Decimal("-19.75")
+
+    def test_balance_for_account_excludes_pending(self, session: Session, household: Household):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("10.00"),
+            status=DomainTxStatus.POSTED,
+        )
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 2),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("99.00"),
+            status=DomainTxStatus.PENDING,
+        )
+
+        repo = TransactionRepository(session, household.id)
+        assert repo.balance_for_account(food.id, currency="USD") == Decimal("10.00")
+
+    def test_balance_for_account_filters_to_currency(self, session: Session, household: Household):
+        repo_a = AccountRepository(session, household.id)
+        usd_a = repo_a.create(code="A", name="A", type=AccountType.ASSET, currency="USD")
+        usd_b = repo_a.create(code="B", name="B", type=AccountType.ASSET, currency="USD")
+        eur_a = repo_a.create(code="EA", name="EA", type=AccountType.ASSET, currency="EUR")
+        eur_b = repo_a.create(code="EB", name="EB", type=AccountType.ASSET, currency="EUR")
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+
+        # USD-only transaction: $5 from usd_a to usd_b.
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=usd_b,
+            credit_account=usd_a,
+            amount=Decimal("5.00"),
+            currency="USD",
+        )
+        # EUR-only transaction: €3 from eur_a to eur_b.
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 2),
+            debit_account=eur_b,
+            credit_account=eur_a,
+            amount=Decimal("3.00"),
+            currency="EUR",
+        )
+
+        repo = TransactionRepository(session, household.id)
+        # USD query should not pick up EUR postings (and vice versa).
+        assert repo.balance_for_account(usd_b.id, currency="USD") == Decimal("5.00")
+        assert repo.balance_for_account(eur_b.id, currency="EUR") == Decimal("3.00")
+        assert repo.balance_for_account(usd_b.id, currency="EUR") == Decimal("0")
+
+    def test_balance_for_account_respects_as_of(self, session: Session, household: Household):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 1, 15),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("20.00"),
+        )
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("30.00"),
+        )
+
+        repo = TransactionRepository(session, household.id)
+        assert repo.balance_for_account(food.id, currency="USD") == Decimal("50.00")
+        assert repo.balance_for_account(food.id, currency="USD", as_of=date(2026, 5, 1)) == Decimal(
+            "20.00"
+        )
+        assert repo.balance_for_account(
+            food.id, currency="USD", as_of=date(2025, 12, 31)
+        ) == Decimal("0")
+
+    def test_trial_balance_groups_by_account_and_currency(
+        self, session: Session, household: Household
+    ):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("12.50"),
+        )
+
+        repo = TransactionRepository(session, household.id)
+        rows = sorted(repo.trial_balance(), key=lambda r: r.account_id.bytes)
+        balances_by_account = {r.account_id: (r.currency, r.balance) for r in rows}
+        assert balances_by_account[food.id] == ("USD", Decimal("12.50"))
+        assert balances_by_account[cash.id] == ("USD", Decimal("-12.50"))
+
+    def test_trial_balance_excludes_pending_and_other_households(
+        self, session: Session, household: Household
+    ):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+
+        # PENDING — should be excluded.
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("99.00"),
+            status=DomainTxStatus.PENDING,
+        )
+
+        # POSTED — should appear.
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("10.00"),
+            status=DomainTxStatus.POSTED,
+        )
+
+        # Different household; should not leak.
+        other = Household(id=uuid4(), name="Jones", base_currency="USD")
+        session.add(other)
+        session.commit()
+        other_repo = AccountRepository(session, other.id)
+        oc = other_repo.create(code="X", name="X", type=AccountType.ASSET, currency="USD")
+        of = other_repo.create(code="Y", name="Y", type=AccountType.EXPENSE, currency="USD")
+        PeriodRepository(session, other.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        self._post_tx(
+            session,
+            other,
+            tx_date=date(2026, 6, 1),
+            debit_account=of,
+            credit_account=oc,
+            amount=Decimal("777.00"),
+            status=DomainTxStatus.POSTED,
+        )
+
+        rows = TransactionRepository(session, household.id).trial_balance()
+        balances_by_account = {r.account_id: r.balance for r in rows}
+        # Only the POSTED USD tx in the household, not the PENDING and not the other household.
+        assert balances_by_account.get(food.id) == Decimal("10.00")
+        assert balances_by_account.get(cash.id) == Decimal("-10.00")
+        assert oc.id not in balances_by_account
+        assert of.id not in balances_by_account
+
+    def test_trial_balance_respects_as_of(self, session: Session, household: Household):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 1, 15),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("5.00"),
+        )
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 8, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("7.00"),
+        )
+
+        repo = TransactionRepository(session, household.id)
+        early = {r.account_id: r.balance for r in repo.trial_balance(as_of=date(2026, 5, 1))}
+        late = {r.account_id: r.balance for r in repo.trial_balance()}
+        assert early[food.id] == Decimal("5.00")
+        assert late[food.id] == Decimal("12.00")
+
     def test_save_unbalanced_posted_aborts_via_trigger(
         self, session: Session, household: Household
     ):


### PR DESCRIPTION
Closes #31 server-side; unblocks the CLI `tulip balance` command (P3.3.b, part of #20).

## Summary

- **`TransactionRepository.balance_for_account(account_id, *, currency, as_of)`** → `Decimal`. POSTED + RECONCILED only; pending is workflow state, not ledger state.
- **`TransactionRepository.trial_balance(*, as_of)`** → `list[TrialBalanceRow]`. Returns one row per `(account_id, currency)` for the household.
- **`GET /v1/accounts/{id}/balance`** — single-account ledger balance in the account's primary currency. 404 `account.not_found` if the account isn't visible.
- **`GET /v1/reports/trial-balance`** (new `reports.py` router) — per-account / per-currency balances + per-currency debit/credit totals for the zero-sum sanity check. Visibility filtering matches the accounts list (admin sees private, member/viewer only see shared + their own).
- All Decimal balances are quantized to the currency's minor units via `Money.quantize_to_currency()`, so JSON sees `"12.50"` not the storage-precision `"12.50000000"`.
- Both endpoints accept optional `?as_of=YYYY-MM-DD`; defaults to today.

## Open design choices made (per #31)

- Per-account balance returns the **account's primary currency only**. Multi-currency views go through trial balance. (Per #31 recommendation.)
- Trial balance includes accounts with non-zero net postings. Zero-net accounts that have postings still appear; truly empty accounts are filtered. Callers may filter the rows further.
- `totals_by_currency` reports debits and credits as positive numbers; equal totals indicate a healthy ledger. Surfacing them separately makes the zero-sum check obvious.
- Pending transactions are excluded with no opt-in flag — postponed until a use case appears.

## Test plan

- [x] `uv run pytest` — 382 passed (up from 363).
- [x] `uv run ruff check packages` — clean.
- [x] `uv run ruff format --check packages` — clean.
- [x] `uv run mypy` — 83 source files, no issues.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] **15 new tests**:
  - 7 storage-repository tests: balance_for_account sums correctly, excludes pending, filters by currency, respects as_of; trial_balance groups by (account, currency), excludes pending, excludes other households, respects as_of.
  - 5 single-account API tests: zero balance, summed balance, as_of, 404 unknown account, 401 unauthenticated.
  - 5 trial-balance API tests: empty household, per-account rows, totals sum to zero, respects as_of, 401 unauthenticated.

## Refs

- Closes #31.
- Unblocks CLI P3.3.b (`tulip balance`) — next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)