### PR TITLE
feat(cli): P3.3.b — tulip balance command

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -204,9 +204,18 @@ Closes #19.
 - First slice that exercises the authenticated request path → `TulipClient.request(authenticated=True)` → transparent refresh from P3.2.b. Logged-out invocations cleanly surface `auth.not_logged_in` with exit 2.
 - 8 new E2E tests: empty list, multi-account table, `--json` array, `show` by code, `show` by UUID, unknown code → user error, ambiguous code → user error, unauthenticated → exit 2. Project test count: 363 passing.
 
-#### P3.3.b — `tulip balance` — queued, blocked on #31
+#### P3.3.b — `tulip balance` — ✅ *(2026-05-01)*
 
-The CLI command needs balance endpoints in the API; currently the trial-balance computation only lives in a `tulip-storage` test fixture. Tracked as #31; once that lands, this slice is small.
+Closes P3.3 (#20). Consumes the balance endpoints landed by #31.
+
+- New `tulip_cli.commands.balance` registers a top-level `tulip balance` command.
+- **No argument** → `GET /v1/reports/trial-balance`. Renders a Rich table (`code`/`name`/`type`/`currency`/`balance`) plus per-currency totals (debits / credits / ✓ or ⚠ marker for the zero-sum check).
+- **With `ACCOUNT`** (code or UUID) → `GET /v1/accounts/{id}/balance`. Reuses the UUID-or-code resolver from P3.3.a.
+- `--as-of YYYY-MM-DD` flag passes through to the API for both shapes; client-side validation rejects malformed dates with `typer.BadParameter`.
+- `--json` passes through the raw API body.
+- 8 new E2E tests: empty trial balance, populated trial balance, JSON trial balance, single-account by code, single-account by UUID, as-of filtering, unknown code → user error, unauthenticated → exit 2. Project test count: 390 passing.
+
+Also incidentally closes the `tulip-storage` `TrialBalanceRow` export gap surfaced during #31.
 
 ### P3.4 — Write flows (`accounts add`, `add`) — queued (#21)
 

--- a/packages/tulip-cli/src/tulip_cli/commands/balance.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/balance.py
@@ -1,0 +1,130 @@
+"""``tulip balance`` — single-account balance or trial-balance summary.
+
+Without an argument, calls ``GET /v1/reports/trial-balance`` and renders
+a per-account table plus per-currency totals. With an account code or
+UUID, calls ``GET /v1/accounts/{id}/balance`` for that one account.
+
+Both shapes accept ``--as-of YYYY-MM-DD`` to query a point in time.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date as date_type
+from typing import Annotated, Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.commands.accounts import _resolve_account
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+def _render_account_balance(body: dict[str, Any]) -> None:
+    """Render a single ``AccountBalanceRead`` body."""
+    code = body.get("code") or "—"
+    typer.echo(f"{code} — {body.get('name', '')}")
+    typer.echo(f"  balance: {body.get('balance', '')} {body.get('currency', '')}")
+    typer.echo(f"  as of:   {body.get('as_of', '')}")
+
+
+def _render_trial_balance(body: dict[str, Any]) -> None:
+    """Render a ``TrialBalanceRead`` body as a table + totals."""
+    rows = body.get("rows") or []
+    if not rows:
+        typer.echo(f"No postings on or before {body.get('as_of', 'today')}.")
+        return
+
+    table = Table(title=f"Trial balance as of {body.get('as_of', '')}", show_header=True)
+    table.add_column("code")
+    table.add_column("name")
+    table.add_column("type")
+    table.add_column("currency")
+    table.add_column("balance", justify="right")
+    for r in rows:
+        table.add_row(
+            r.get("code") or "—",
+            r.get("name") or "",
+            r.get("type") or "",
+            r.get("currency") or "",
+            r.get("balance") or "",
+        )
+    console = Console()
+    console.print(table)
+
+    totals = body.get("totals_by_currency") or []
+    for t in totals:
+        currency = t.get("currency", "")
+        debits = t.get("debits", "")
+        credits = t.get("credits", "")
+        marker = "✓" if debits == credits else "⚠"
+        console.print(
+            f"  {currency}: debits {debits}, credits {credits} {marker}",
+        )
+
+
+def balance(
+    ctx: typer.Context,
+    account: Annotated[
+        str | None,
+        typer.Argument(
+            help="Account code (e.g. assets:cash) or UUID. Omit for a trial-balance summary.",
+            metavar="ACCOUNT",
+        ),
+    ] = None,
+    as_of: Annotated[
+        str | None,
+        typer.Option(
+            "--as-of",
+            help="Point-in-time date (YYYY-MM-DD). Defaults to today.",
+        ),
+    ] = None,
+) -> None:
+    """Show a single account's balance, or the household trial balance."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    if as_of is not None:
+        try:
+            date_type.fromisoformat(as_of)
+        except ValueError as exc:
+            raise typer.BadParameter("--as-of must be YYYY-MM-DD") from exc
+
+    params = {"as_of": as_of} if as_of else None
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            if account is None:
+                response = client.get(
+                    "/v1/reports/trial-balance",
+                    authenticated=True,
+                    params=params,
+                )
+            else:
+                resolved = _resolve_account(client, account)
+                response = client.get(
+                    f"/v1/accounts/{resolved['id']}/balance",
+                    authenticated=True,
+                    params=params,
+                )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    body = response.json()
+    if account is None:
+        _render_trial_balance(body)
+    else:
+        _render_account_balance(body)

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -16,6 +16,7 @@ import typer
 from tulip_cli import __version__
 from tulip_cli.commands.accounts import accounts_app
 from tulip_cli.commands.auth import auth_app
+from tulip_cli.commands.balance import balance as balance_command
 from tulip_cli.commands.register import register as register_command
 from tulip_cli.config import Config, load_config
 from tulip_cli.errors import EXIT_OK, CliError
@@ -85,6 +86,7 @@ def ping(ctx: typer.Context) -> None:
 
 
 app.command("register")(register_command)
+app.command("balance")(balance_command)
 app.add_typer(auth_app, name="auth")
 app.add_typer(accounts_app, name="accounts")
 

--- a/packages/tulip-cli/tests/test_balance.py
+++ b/packages/tulip-cli/tests/test_balance.py
@@ -1,0 +1,239 @@
+"""End-to-end tests for ``tulip balance``.
+
+* No argument → trial-balance summary.
+* With an ACCOUNT argument (code or UUID) → that account's balance.
+* ``--as-of YYYY-MM-DD`` → point-in-time balance.
+* ``--json`` → raw API body.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=20,
+    )
+
+
+def _create_account(
+    api_url: str,
+    access_token: str,
+    *,
+    code: str | None,
+    name: str,
+    type_: str = "asset",
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "name": name,
+        "type": type_,
+        "currency": "USD",
+        "visibility": "shared",
+    }
+    if code is not None:
+        body["code"] = code
+    r = httpx.post(
+        f"{api_url}/v1/accounts",
+        json=body,
+        headers={"authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return dict(r.json())
+
+
+def _post_tx(
+    api_url: str,
+    access_token: str,
+    *,
+    debit_id: str,
+    credit_id: str,
+    amount: str,
+    on: date | None = None,
+) -> None:
+    on = on or date.today()
+    r = httpx.post(
+        f"{api_url}/v1/transactions",
+        json={
+            "date": on.isoformat(),
+            "description": amount,
+            "postings": [
+                {"account_id": debit_id, "amount": amount, "currency": "USD"},
+                {"account_id": credit_id, "amount": f"-{amount}", "currency": "USD"},
+            ],
+        },
+        headers={"authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+
+
+@pytest.fixture
+def authed_session(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[str, str]:
+    """Log a user in via the CLI and return (api_url, access_token).
+
+    The access token is also returned so test setup can hit the API
+    directly to seed accounts and transactions without going through
+    the CLI for every fixture step.
+    """
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    cli_login = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert cli_login.returncode == 0, cli_login.stderr
+
+    api_login = httpx.post(
+        f"{live_api}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    api_login.raise_for_status()
+    return live_api, str(api_login.json()["access_token"])
+
+
+@pytest.mark.integration
+def test_balance_no_arg_when_empty(authed_session: tuple[str, str]) -> None:
+    api_url, _ = authed_session
+    result = _run_cli("balance", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    assert "no postings" in result.stdout.lower() or "0.00" in result.stdout
+
+
+@pytest.mark.integration
+def test_balance_no_arg_renders_trial_balance(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    cash = _create_account(api_url, access, code="assets:cash", name="Cash")
+    food = _create_account(api_url, access, code="expenses:food", name="Food", type_="expense")
+    _post_tx(api_url, access, debit_id=str(food["id"]), credit_id=str(cash["id"]), amount="12.50")
+
+    result = _run_cli("balance", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    assert "expenses:food" in result.stdout
+    assert "12.50" in result.stdout
+    assert "assets:cash" in result.stdout
+    assert "-12.50" in result.stdout
+
+
+@pytest.mark.integration
+def test_balance_no_arg_json(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    cash = _create_account(api_url, access, code="assets:cash", name="Cash")
+    food = _create_account(api_url, access, code="expenses:food", name="Food", type_="expense")
+    _post_tx(api_url, access, debit_id=str(food["id"]), credit_id=str(cash["id"]), amount="5.00")
+
+    result = _run_cli("--json", "balance", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "rows" in payload
+    assert "totals_by_currency" in payload
+    assert "as_of" in payload
+
+
+@pytest.mark.integration
+def test_balance_for_single_account_by_code(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    cash = _create_account(api_url, access, code="assets:cash", name="Cash")
+    food = _create_account(api_url, access, code="expenses:food", name="Food", type_="expense")
+    _post_tx(api_url, access, debit_id=str(food["id"]), credit_id=str(cash["id"]), amount="20.00")
+
+    result = _run_cli("balance", "expenses:food", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    assert "expenses:food" in result.stdout
+    assert "20.00" in result.stdout
+    assert "USD" in result.stdout
+
+
+@pytest.mark.integration
+def test_balance_for_single_account_by_uuid(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    cash = _create_account(api_url, access, code="assets:cash", name="Cash")
+    food = _create_account(api_url, access, code="expenses:food", name="Food", type_="expense")
+    _post_tx(api_url, access, debit_id=str(food["id"]), credit_id=str(cash["id"]), amount="3.50")
+
+    result = _run_cli("balance", str(food["id"]), api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    assert "3.50" in result.stdout
+
+
+@pytest.mark.integration
+def test_balance_respects_as_of(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    cash = _create_account(api_url, access, code="assets:cash", name="Cash")
+    food = _create_account(api_url, access, code="expenses:food", name="Food", type_="expense")
+    _post_tx(
+        api_url,
+        access,
+        debit_id=str(food["id"]),
+        credit_id=str(cash["id"]),
+        amount="5.00",
+        on=date(2026, 1, 15),
+    )
+    _post_tx(
+        api_url,
+        access,
+        debit_id=str(food["id"]),
+        credit_id=str(cash["id"]),
+        amount="7.00",
+        on=date(2026, 3, 1),
+    )
+
+    early = _run_cli("balance", "expenses:food", "--as-of", "2026-02-01", api_url=api_url)
+    assert early.returncode == 0, early.stderr
+    assert "5.00" in early.stdout
+    assert "7.00" not in early.stdout
+
+    later = _run_cli("balance", "expenses:food", "--as-of", "2026-04-01", api_url=api_url)
+    assert "12.00" in later.stdout
+
+
+@pytest.mark.integration
+def test_balance_unknown_code_yields_user_error(authed_session: tuple[str, str]) -> None:
+    api_url, _ = authed_session
+    result = _run_cli("balance", "no-such-code", api_url=api_url)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "no-such-code" in result.stderr.lower() or "not found" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_balance_unauthenticated_fails_clearly(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli("balance", api_url=live_api)
+    assert result.returncode == 2, (result.stdout, result.stderr)
+    assert "not logged in" in result.stderr.lower() or "log in" in result.stderr.lower()


### PR DESCRIPTION
Closes P3.3 (#20). Consumes the balance endpoints landed in #31 / #37.

## Summary

- New `tulip_cli.commands.balance` registers a top-level `tulip balance` command.
- **No argument** → `GET /v1/reports/trial-balance`. Renders a Rich table (`code`/`name`/`type`/`currency`/`balance`) plus per-currency totals (debits / credits / ✓ or ⚠ marker for the zero-sum check).
- **With `ACCOUNT`** (code or UUID) → `GET /v1/accounts/{id}/balance`. Reuses the UUID-or-code resolver from P3.3.a.
- `--as-of YYYY-MM-DD` passes through to the API for both shapes; client-side validation rejects malformed dates with a clean `typer.BadParameter`.
- `--json` passes through the raw API body.

## Test plan

- [x] `uv run pytest` — 390 passed (up from 382).
- [x] `uv run ruff check packages` — clean.
- [x] `uv run ruff format --check packages` — clean.
- [x] `uv run mypy` — 84 source files, no issues.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] **8 new E2E tests**:
  - empty household → "No postings on or before today" message
  - populated household → trial-balance table renders correct codes + signed amounts
  - `--json` returns the raw API body with `rows` + `totals_by_currency`
  - single-account `show by code`
  - single-account `show by UUID`
  - `--as-of` filters early/late correctly
  - unknown code → exit 1 with `account.not_found`
  - unauthenticated → exit 2 with `auth.not_logged_in`
- [x] Manual smoke flow:
  ```bash
  rm -f /tmp/tulip-smoke.db
  export TULIP_DATABASE_URL='sqlite:////tmp/tulip-smoke.db'
  export TULIP_JWT_SECRET='dev-secret-32bytes-dev-secret-xyz'
  export TULIP_MASTER_KEY='q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s='
  uv run alembic -c packages/tulip-storage/alembic.ini upgrade head
  uv run uvicorn tulip_api.main:create_app --factory &
  uv run tulip register --email me@example.com --display-name Me --household Mine
  uv run tulip auth login --email me@example.com
  uv run tulip balance
  uv run tulip balance assets:checking
  uv run tulip balance --as-of 2026-01-01
  ```

## Refs

- Closes #20 (P3.3 umbrella).
- Builds on #37 (server-side balance endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)