### PR TITLE
feat(cli): P3.4 — tulip accounts add + tulip add (transactions)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -217,7 +217,18 @@ Closes P3.3 (#20). Consumes the balance endpoints landed by #31.
 
 Also incidentally closes the `tulip-storage` `TrialBalanceRow` export gap surfaced during #31.
 
-### P3.4 — Write flows (`accounts add`, `add`) — queued (#21)
+### P3.4 — Write flows (`accounts add`, `add`) — ✅ *(2026-05-01)*
+
+Closes #21.
+
+- `tulip accounts add` — `POST /v1/accounts`. Required: `--name`, `--type`, `--currency`. Optional: `--code`, `--subtype`, `--visibility` (default `shared`). Returns the created account body; `--json` passes through.
+- `tulip add` (transactions) — `POST /v1/transactions`. Required: `--date YYYY-MM-DD`, `--description` (or `-m`), repeated `--post`. Optional: `--reference`.
+- **Posting syntax: `--post account=amount[@CURRENCY]`** — picked over `account:amount` because account codes contain colons (e.g. `assets:checking`). The parser splits on the **last** `=` so codes-with-colons round-trip; `@CURRENCY` is optional and inherits from the account when omitted.
+- New `tulip_cli.commands.transactions` exports `parse_posting()` + `ParsedPosting` so the parser is unit-testable independently of the API.
+- 21 new tests: 10 parser unit tests (account+amount, negative, currency override, UUIDs, multiple-colon codes, malformed shapes); 5 E2E for `accounts add` (happy, minimal-no-code, --json, invalid type, unauthenticated); 6 E2E for `tulip add` (happy with balance round-trip, --json, unbalanced rejection, unknown-account-in-post, single-posting validation, unauthenticated).
+- Project test count: 411 passing.
+
+Phase 3 is now complete except for **P3.5 (toner-friendly print stylesheet)**, which is recommended to defer to Phase 8 alongside the actual reports — see #22.
 
 ### P3.5 — Toner-friendly print stylesheet — queued (#22), may defer to Phase 8
 

--- a/packages/tulip-cli/src/tulip_cli/commands/accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/accounts.py
@@ -155,6 +155,74 @@ def list_accounts(ctx: typer.Context) -> None:
     _render_table(accounts)
 
 
+@accounts_app.command("add")
+def add_account(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Option("--name", help="Display name.")],
+    type_: Annotated[
+        str,
+        typer.Option(
+            "--type",
+            help="One of: asset, liability, equity, income, expense.",
+        ),
+    ],
+    currency: Annotated[
+        str,
+        typer.Option(
+            "--currency",
+            help="ISO 4217 three-letter code (e.g. USD).",
+        ),
+    ],
+    code: Annotated[
+        str | None,
+        typer.Option(
+            "--code",
+            help="Optional short code (e.g. assets:checking).",
+        ),
+    ] = None,
+    subtype: Annotated[
+        str | None,
+        typer.Option("--subtype", help="Optional subtype label."),
+    ] = None,
+    visibility: Annotated[
+        str,
+        typer.Option(
+            "--visibility",
+            help="'shared' (default) or 'private'.",
+        ),
+    ] = "shared",
+) -> None:
+    """Create a new account in the logged-in user's household."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    body: dict[str, Any] = {
+        "name": name,
+        "type": type_,
+        "currency": currency,
+        "visibility": visibility,
+    }
+    if code is not None:
+        body["code"] = code
+    if subtype is not None:
+        body["subtype"] = subtype
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post("/v1/accounts", json=body, authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    payload = response.json()
+    typer.echo(f"Created account {payload.get('id', '')}")
+    _render_account(payload)
+
+
 @accounts_app.command("show")
 def show_account(
     ctx: typer.Context,

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -1,0 +1,191 @@
+"""``tulip add`` — create a balanced transaction.
+
+Postings are passed as repeated ``--post account=amount[@CURRENCY]`` flags.
+The account portion is either an ``Account.code`` or a UUID; we resolve
+it via the same helper ``tulip accounts show`` uses (``_resolve_account``).
+``CURRENCY`` is optional — when omitted, the resolved account's primary
+currency is used.
+
+Why ``account=amount`` and not space-separated parts: codes contain
+colons (e.g. ``assets:checking``), so a colon-delimited ``account:amount``
+syntax is ambiguous. ``=`` is unambiguous and we ``rsplit`` on it so
+codes-with-colons round-trip. Editor-driven input (the ``$EDITOR``
+template alternative) is a future slice if it's wanted; the issue
+recommends shipping the flag form first.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date as date_type
+from decimal import Decimal, InvalidOperation
+from typing import Annotated, Any
+
+import typer
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.commands.accounts import _resolve_account
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+_CURRENCY_RE = re.compile(r"^[A-Za-z]{3}$")
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedPosting:
+    """One ``--post`` value, parsed but not yet resolved against the API."""
+
+    account: str  # code or UUID; resolution happens later
+    amount: Decimal
+    currency: str | None  # None means "inherit from the account"
+
+
+def parse_posting(value: str) -> ParsedPosting:
+    """Parse one ``--post`` value into a :class:`ParsedPosting`.
+
+    Format: ``account=amount[@CURRENCY]``. ``account`` may contain
+    colons; we split on the **last** ``=``. ``CURRENCY`` is exactly
+    three ASCII letters per ISO 4217.
+
+    Raises :class:`ValueError` on any malformed shape.
+    """
+    if "=" not in value:
+        raise ValueError(f"--post must be 'account=amount[@CURRENCY]', got {value!r}")
+    account, _, rhs = value.rpartition("=")
+    account = account.strip()
+    rhs = rhs.strip()
+    if not account:
+        raise ValueError(f"--post {value!r}: account is empty")
+    if not rhs:
+        raise ValueError(f"--post {value!r}: amount is empty")
+
+    currency: str | None = None
+    if "@" in rhs:
+        amount_str, _, currency = rhs.partition("@")
+        amount_str = amount_str.strip()
+        currency = currency.strip()
+        if not _CURRENCY_RE.fullmatch(currency):
+            raise ValueError(
+                f"--post {value!r}: currency must be three ASCII letters (got {currency!r})"
+            )
+        currency = currency.upper()
+    else:
+        amount_str = rhs
+
+    try:
+        amount = Decimal(amount_str)
+    except InvalidOperation as exc:
+        raise ValueError(
+            f"--post {value!r}: amount {amount_str!r} is not a decimal number"
+        ) from exc
+
+    return ParsedPosting(account=account, amount=amount, currency=currency)
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+def _render_transaction(body: dict[str, Any]) -> None:
+    typer.echo(f"Created transaction {body.get('id', '')}")
+    typer.echo(f"  date:        {body.get('date', '')}")
+    typer.echo(f"  description: {body.get('description', '')}")
+    typer.echo(f"  status:      {body.get('status', '')}")
+    typer.echo("  postings:")
+    for p in body.get("postings", []):
+        amount = p.get("amount", "")
+        currency = p.get("currency", "")
+        account = p.get("account_id", "")
+        typer.echo(f"    {account}: {amount} {currency}")
+
+
+def add(
+    ctx: typer.Context,
+    tx_date: Annotated[
+        str,
+        typer.Option(
+            "--date",
+            help="Transaction date (YYYY-MM-DD).",
+        ),
+    ],
+    description: Annotated[
+        str,
+        typer.Option(
+            "--description",
+            "-m",
+            help="Short human-readable description.",
+        ),
+    ],
+    posts: Annotated[
+        list[str],
+        typer.Option(
+            "--post",
+            help=(
+                "Posting in the form 'account=amount[@CURRENCY]'. "
+                "Repeat for each leg of the transaction. Account is a "
+                "code (e.g. assets:checking) or a UUID. Currency is "
+                "inherited from the account when omitted."
+            ),
+        ),
+    ],
+    reference: Annotated[
+        str | None,
+        typer.Option(
+            "--reference",
+            help="Optional external reference (check number, statement id, etc.).",
+        ),
+    ] = None,
+) -> None:
+    """Create a balanced transaction from one or more ``--post`` flags."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    try:
+        date_type.fromisoformat(tx_date)
+    except ValueError as exc:
+        raise typer.BadParameter("--date must be YYYY-MM-DD") from exc
+
+    parsed: list[ParsedPosting] = []
+    for raw in posts:
+        try:
+            parsed.append(parse_posting(raw))
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            postings_body: list[dict[str, Any]] = []
+            for p in parsed:
+                resolved = _resolve_account(client, p.account)
+                currency = p.currency or resolved.get("currency")
+                if not isinstance(currency, str):
+                    raise typer.BadParameter(
+                        f"posting {p.account}: account has no currency and none specified"
+                    )
+                postings_body.append(
+                    {
+                        "account_id": resolved["id"],
+                        "amount": str(p.amount),
+                        "currency": currency,
+                    }
+                )
+
+            body: dict[str, Any] = {
+                "date": tx_date,
+                "description": description,
+                "postings": postings_body,
+            }
+            if reference is not None:
+                body["reference"] = reference
+            response = client.post("/v1/transactions", json=body, authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    _render_transaction(response.json())

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -18,6 +18,7 @@ from tulip_cli.commands.accounts import accounts_app
 from tulip_cli.commands.auth import auth_app
 from tulip_cli.commands.balance import balance as balance_command
 from tulip_cli.commands.register import register as register_command
+from tulip_cli.commands.transactions import add as add_command
 from tulip_cli.config import Config, load_config
 from tulip_cli.errors import EXIT_OK, CliError
 from tulip_cli.http import TulipClient
@@ -87,6 +88,7 @@ def ping(ctx: typer.Context) -> None:
 
 app.command("register")(register_command)
 app.command("balance")(balance_command)
+app.command("add")(add_command)
 app.add_typer(auth_app, name="auth")
 app.add_typer(accounts_app, name="accounts")
 

--- a/packages/tulip-cli/tests/test_posting_parser.py
+++ b/packages/tulip-cli/tests/test_posting_parser.py
@@ -1,0 +1,72 @@
+"""Unit tests for the ``--post`` value parser used by ``tulip add``.
+
+Format: ``account=amount[@CURRENCY]``. The account portion may contain
+colons (e.g. ``assets:checking``); the parser splits on the **last**
+``=`` so codes-with-colons resolve correctly. The optional ``@CURRENCY``
+suffix lets the caller override the account's primary currency for FX
+postings.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from tulip_cli.commands.transactions import ParsedPosting, parse_posting
+
+
+def test_simple_account_and_amount() -> None:
+    p = parse_posting("expenses:food=12.50")
+    assert p == ParsedPosting(account="expenses:food", amount=Decimal("12.50"), currency=None)
+
+
+def test_negative_amount() -> None:
+    p = parse_posting("assets:checking=-12.50")
+    assert p.amount == Decimal("-12.50")
+    assert p.account == "assets:checking"
+
+
+def test_amount_with_explicit_currency() -> None:
+    p = parse_posting("assets:cash=100@EUR")
+    assert p.account == "assets:cash"
+    assert p.amount == Decimal("100")
+    assert p.currency == "EUR"
+
+
+def test_uuid_account() -> None:
+    uuid = "5b9c08a8-1c1c-4f12-9f6a-b6d3a2f4d4b8"
+    p = parse_posting(f"{uuid}=42.00")
+    assert p.account == uuid
+
+
+def test_account_with_multiple_colons() -> None:
+    p = parse_posting("assets:bank:checking:joint=10.00")
+    assert p.account == "assets:bank:checking:joint"
+
+
+def test_missing_equals_sign_raises() -> None:
+    with pytest.raises(ValueError, match="account=amount"):
+        parse_posting("just-an-account-name")
+
+
+def test_empty_account_raises() -> None:
+    with pytest.raises(ValueError, match="account"):
+        parse_posting("=12.50")
+
+
+def test_empty_amount_raises() -> None:
+    with pytest.raises(ValueError, match="amount"):
+        parse_posting("expenses:food=")
+
+
+def test_non_decimal_amount_raises() -> None:
+    with pytest.raises(ValueError, match="amount"):
+        parse_posting("expenses:food=not-a-number")
+
+
+def test_currency_must_be_three_letters() -> None:
+    with pytest.raises(ValueError, match="currency"):
+        parse_posting("assets:cash=10@LONGER")
+    with pytest.raises(ValueError, match="currency"):
+        parse_posting("assets:cash=10@US")

--- a/packages/tulip-cli/tests/test_write_flows.py
+++ b/packages/tulip-cli/tests/test_write_flows.py
@@ -1,0 +1,310 @@
+"""End-to-end tests for ``tulip accounts add`` and ``tulip add`` (transactions)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=20,
+    )
+
+
+@pytest.fixture
+def authed_session(live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    cli_login = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert cli_login.returncode == 0, cli_login.stderr
+    return live_api
+
+
+# ---------- tulip accounts add ----------
+
+
+@pytest.mark.integration
+def test_accounts_add_happy_path(authed_session: str) -> None:
+    result = _run_cli(
+        "accounts",
+        "add",
+        "--name",
+        "Checking",
+        "--type",
+        "asset",
+        "--currency",
+        "USD",
+        "--code",
+        "assets:checking",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Checking" in result.stdout
+    assert "assets:checking" in result.stdout
+
+    # The account should now be visible via the existing list command.
+    list_result = _run_cli("accounts", "list", api_url=authed_session)
+    assert "assets:checking" in list_result.stdout
+    assert "Checking" in list_result.stdout
+
+
+@pytest.mark.integration
+def test_accounts_add_minimal_no_code(authed_session: str) -> None:
+    result = _run_cli(
+        "accounts",
+        "add",
+        "--name",
+        "Cash",
+        "--type",
+        "asset",
+        "--currency",
+        "USD",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.integration
+def test_accounts_add_json_emits_created_body(authed_session: str) -> None:
+    result = _run_cli(
+        "--json",
+        "accounts",
+        "add",
+        "--name",
+        "Savings",
+        "--type",
+        "asset",
+        "--currency",
+        "USD",
+        "--code",
+        "assets:savings",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["name"] == "Savings"
+    assert payload["code"] == "assets:savings"
+    assert payload["type"] == "asset"
+
+
+@pytest.mark.integration
+def test_accounts_add_invalid_type_yields_user_error(authed_session: str) -> None:
+    result = _run_cli(
+        "accounts",
+        "add",
+        "--name",
+        "Wat",
+        "--type",
+        "not-a-type",
+        "--currency",
+        "USD",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "type" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_accounts_add_unauthenticated_fails_clearly(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli(
+        "accounts",
+        "add",
+        "--name",
+        "X",
+        "--type",
+        "asset",
+        "--currency",
+        "USD",
+        api_url=live_api,
+    )
+    assert result.returncode == 2, (result.stdout, result.stderr)
+
+
+# ---------- tulip add (transactions) ----------
+
+
+def _add_account(api_url: str, code: str, name: str, type_: str) -> None:
+    result = _run_cli(
+        "accounts",
+        "add",
+        "--name",
+        name,
+        "--type",
+        type_,
+        "--currency",
+        "USD",
+        "--code",
+        code,
+        api_url=api_url,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.integration
+def test_add_transaction_happy_path(authed_session: str) -> None:
+    _add_account(authed_session, "assets:checking", "Checking", "asset")
+    _add_account(authed_session, "expenses:food", "Food", "expense")
+
+    today = date.today().isoformat()
+    result = _run_cli(
+        "add",
+        "--date",
+        today,
+        "--description",
+        "Lunch",
+        "--post",
+        "expenses:food=12.50",
+        "--post",
+        "assets:checking=-12.50",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Lunch" in result.stdout
+    assert "12.50" in result.stdout
+
+    # Balance check round-trips: food should now be at 12.50.
+    bal = _run_cli("balance", "expenses:food", api_url=authed_session)
+    assert "12.50" in bal.stdout
+
+
+@pytest.mark.integration
+def test_add_transaction_json_returns_created_body(authed_session: str) -> None:
+    _add_account(authed_session, "assets:cash", "Cash", "asset")
+    _add_account(authed_session, "expenses:fun", "Fun", "expense")
+
+    result = _run_cli(
+        "--json",
+        "add",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Movie",
+        "--post",
+        "expenses:fun=15.00",
+        "--post",
+        "assets:cash=-15.00",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["description"] == "Movie"
+    assert payload["status"] == "posted"
+    assert len(payload["postings"]) == 2
+
+
+@pytest.mark.integration
+def test_add_transaction_unbalanced_yields_user_error(authed_session: str) -> None:
+    _add_account(authed_session, "assets:cash", "Cash", "asset")
+    _add_account(authed_session, "expenses:fun", "Fun", "expense")
+
+    result = _run_cli(
+        "add",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Bad",
+        "--post",
+        "expenses:fun=10.00",
+        "--post",
+        "assets:cash=-9.00",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "balance" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_add_transaction_unknown_account_in_post_yields_user_error(
+    authed_session: str,
+) -> None:
+    _add_account(authed_session, "assets:cash", "Cash", "asset")
+
+    result = _run_cli(
+        "add",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Bad post",
+        "--post",
+        "no-such-account=10.00",
+        "--post",
+        "assets:cash=-10.00",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "no-such-account" in result.stderr.lower() or "not found" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_add_transaction_requires_at_least_two_postings(
+    authed_session: str,
+) -> None:
+    _add_account(authed_session, "assets:cash", "Cash", "asset")
+
+    result = _run_cli(
+        "add",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Solo",
+        "--post",
+        "assets:cash=10.00",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1, (result.stdout, result.stderr)
+
+
+@pytest.mark.integration
+def test_add_transaction_unauthenticated_fails_clearly(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli(
+        "add",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Hi",
+        "--post",
+        "x=1",
+        "--post",
+        "y=-1",
+        api_url=live_api,
+    )
+    assert result.returncode == 2, (result.stdout, result.stderr)


### PR DESCRIPTION
Closes #21.

## Summary

- **`tulip accounts add`** → `POST /v1/accounts`. `--name` / `--type` / `--currency` required; `--code` / `--subtype` / `--visibility` (default `shared`) optional. `--json` passes through the created body.
- **`tulip add`** (transactions) → `POST /v1/transactions`. `--date YYYY-MM-DD` and `--description` (alias `-m`) required, repeated `--post` flags for the legs. Optional `--reference`.
- **Posting syntax: `--post account=amount[@CURRENCY]`** — picked over `account:amount` because account codes contain colons (e.g. `assets:checking`). The parser splits on the **last** `=` so codes-with-colons round-trip; `@CURRENCY` is optional and inherits from the resolved account when omitted.
- New `tulip_cli.commands.transactions` exports `parse_posting()` + `ParsedPosting` so the parser is unit-testable independent of the API.

## Test plan

- [x] `uv run pytest` — 411 passed (up from 390).
- [x] `uv run ruff check packages` — clean.
- [x] `uv run ruff format --check packages` — clean.
- [x] `uv run mypy` — 85 source files, no issues.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] **21 new tests**:
  - **10 parser unit tests** — account+amount, negative amount, explicit `@CURRENCY`, UUID account, multi-colon code (`assets:bank:checking:joint`), missing `=`, empty account, empty amount, non-decimal amount, currency-not-three-letters.
  - **5 `accounts add` E2E** — happy path with code, minimal (no code), `--json` body, invalid type → user error, unauthenticated → exit 2.
  - **6 `tulip add` E2E** — happy path with balance round-trip, `--json` body, unbalanced postings → `transaction.unbalanced` exit 1, unknown account in `--post` → exit 1, single posting → API validation exit 1, unauthenticated → exit 2.
- [x] Manual smoke flow (full register → login → accounts add → tx add → balance loop):
  ```bash
  rm -f /tmp/tulip-smoke.db
  export TULIP_DATABASE_URL='sqlite:////tmp/tulip-smoke.db'
  export TULIP_JWT_SECRET='dev-secret-32bytes-dev-secret-xyz'
  export TULIP_MASTER_KEY='q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s='
  uv run alembic -c packages/tulip-storage/alembic.ini upgrade head
  uv run uvicorn tulip_api.main:create_app --factory &
  uv run tulip register --email me@example.com --display-name Me --household Mine
  uv run tulip auth login --email me@example.com
  uv run tulip accounts add --name Checking --type asset --currency USD --code assets:checking
  uv run tulip accounts add --name Food --type expense --currency USD --code expenses:food
  uv run tulip add --date 2026-05-01 --description Lunch \
    --post expenses:food=12.50 --post assets:checking=-12.50
  uv run tulip balance
  ```

## Phase 3 status

After this lands, Phase 3 is complete except **P3.5 (toner-friendly print stylesheet)** — recommended to defer to Phase 8 alongside actual reports (see #22).

## Refs

- Closes #21.
- Builds on #37 / #38 (balance endpoints + CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)