### PR TITLE
feat(api): account nesting consistency rules + reparenting (#42.a)

### DIFF
--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -352,6 +352,89 @@ class AccountNotFoundError(TulipProblem):
         )
 
 
+class AccountParentNotFoundError(TulipProblem):
+    """The proposed parent account doesn't exist, isn't visible, or is inactive."""
+
+    def __init__(self) -> None:
+        """Build the account.parent_not_found problem."""
+        super().__init__(
+            code="account.parent_not_found",
+            title="Parent account not found",
+            status=404,
+            detail=(
+                "The parent_account_id either doesn't exist in this household, "
+                "isn't visible to you, or has been deactivated."
+            ),
+        )
+
+
+class AccountParentTypeMismatchError(TulipProblem):
+    """A child account's type must match its parent's."""
+
+    def __init__(self, *, child_type: str, parent_type: str) -> None:
+        """Build the account.parent_type_mismatch problem."""
+        super().__init__(
+            code="account.parent_type_mismatch",
+            title="Parent account type does not match",
+            status=400,
+            detail=(
+                f"This account is a {child_type}; its parent is a {parent_type}. "
+                "Children must share the parent's type. Pick a parent of the "
+                "same type, or change this account's type before reparenting."
+            ),
+        )
+
+
+class AccountParentCurrencyMismatchError(TulipProblem):
+    """A child account's currency must match its parent's (#42; relaxation tracked in #44)."""
+
+    def __init__(self, *, child_currency: str, parent_currency: str) -> None:
+        """Build the account.parent_currency_mismatch problem."""
+        super().__init__(
+            code="account.parent_currency_mismatch",
+            title="Parent account currency does not match",
+            status=400,
+            detail=(
+                f"This account is denominated in {child_currency}; its parent "
+                f"is in {parent_currency}. Children must share the parent's "
+                "currency. Multi-currency hierarchies are tracked separately."
+            ),
+        )
+
+
+class AccountParentVisibilityViolationError(TulipProblem):
+    """A shared child cannot live under a private parent."""
+
+    def __init__(self) -> None:
+        """Build the account.parent_visibility_violation problem."""
+        super().__init__(
+            code="account.parent_visibility_violation",
+            title="Parent visibility forbids this child",
+            status=400,
+            detail=(
+                "A shared account cannot be a child of a private one — the "
+                "child would be visible while its parent is hidden. Either "
+                "make this account private, or pick a shared parent."
+            ),
+        )
+
+
+class AccountParentCycleError(TulipProblem):
+    """Reparenting would create a cycle (parent is a descendant of this account)."""
+
+    def __init__(self) -> None:
+        """Build the account.parent_cycle problem."""
+        super().__init__(
+            code="account.parent_cycle",
+            title="Parent change would create a cycle",
+            status=400,
+            detail=(
+                "The proposed parent is a descendant of this account; "
+                "applying the change would create a cycle in the account tree."
+            ),
+        )
+
+
 class AccountUnknownError(TulipProblem):
     """A transaction posting referenced an account that doesn't exist in this household."""
 

--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -11,7 +11,16 @@ from fastapi import APIRouter, Depends, Query, Request, status
 
 from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.deps import get_session
-from tulip_api.errors import AccountNotFoundError, ForbiddenError, problem_response
+from tulip_api.errors import (
+    AccountNotFoundError,
+    AccountParentCurrencyMismatchError,
+    AccountParentCycleError,
+    AccountParentNotFoundError,
+    AccountParentTypeMismatchError,
+    AccountParentVisibilityViolationError,
+    ForbiddenError,
+    problem_response,
+)
 from tulip_api.schemas.account import AccountCreate, AccountRead, AccountUpdate
 from tulip_api.schemas.balance import AccountBalanceRead
 from tulip_core.money import Money
@@ -53,6 +62,65 @@ def _filter_for_role(account: Account, claims: Claims) -> bool:
     return account.created_by_user_id == claims.user_id
 
 
+def _validate_parent(
+    repo: AccountRepository,
+    *,
+    parent_id: UUID,
+    child_id: UUID | None,
+    child_type: str,
+    child_currency: str,
+    child_visibility: str,
+    claims: Claims,
+) -> Account:
+    """Validate a proposed parent for an account being created or updated.
+
+    Returns the parent ``Account`` row on success; raises one of the
+    ``account.parent_*`` Problem Details errors on any failure. Rules
+    enforced (per #42):
+
+    * Parent exists in this household, is visible to the caller, and is
+      active. Otherwise → ``account.parent_not_found``.
+    * Parent's ``type`` must equal the child's. → ``account.parent_type_mismatch``.
+    * Parent's ``currency`` must equal the child's (#44 tracks the
+      multi-currency relaxation). → ``account.parent_currency_mismatch``.
+    * Shared child must not live under a private parent. →
+      ``account.parent_visibility_violation``.
+    * For PATCH (``child_id`` is not None): the proposed parent must
+      not be a descendant of the child. We walk up from ``parent_id``
+      via ``parent_account_id`` and reject if we hit ``child_id``. →
+      ``account.parent_cycle``.
+
+    The cycle walk also catches the trivial self-parent case (a PATCH
+    that sets ``parent_account_id = id``).
+    """
+    parent = repo.get(parent_id)
+    if parent is None or not parent.is_active or not _filter_for_role(parent, claims):
+        raise AccountParentNotFoundError()
+
+    if child_id is not None:
+        # Walk up the proposed-parent's ancestor chain. If we ever
+        # encounter ``child_id``, applying the change creates a cycle.
+        # Also catches self-parent (parent_id == child_id) on the first hop.
+        cursor: Account | None = parent
+        while cursor is not None:
+            if cursor.id == child_id:
+                raise AccountParentCycleError()
+            if cursor.parent_account_id is None:
+                break
+            cursor = repo.get(cursor.parent_account_id)
+
+    if parent.type.value != child_type:
+        raise AccountParentTypeMismatchError(child_type=child_type, parent_type=parent.type.value)
+    if parent.currency != child_currency:
+        raise AccountParentCurrencyMismatchError(
+            child_currency=child_currency, parent_currency=parent.currency
+        )
+    if parent.visibility == "private" and child_visibility != "private":
+        raise AccountParentVisibilityViolationError()
+
+    return parent
+
+
 @router.get(
     "",
     response_model=list[AccountRead],
@@ -75,7 +143,13 @@ def list_accounts(
     responses={
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
-        400: problem_response("request.body_invalid"),
+        404: problem_response("account.parent_not_found"),
+        400: problem_response(
+            "request.body_invalid",
+            "account.parent_type_mismatch",
+            "account.parent_currency_mismatch",
+            "account.parent_visibility_violation",
+        ),
         422: problem_response("validation.failed"),
     },
 )
@@ -87,6 +161,16 @@ def create_account(
 ) -> AccountRead:
     """Create a new account in the caller's household."""
     repo = AccountRepository(session, claims.household_id)
+    if body.parent_account_id is not None:
+        _validate_parent(
+            repo,
+            parent_id=body.parent_account_id,
+            child_id=None,
+            child_type=body.type,
+            child_currency=body.currency,
+            child_visibility=body.visibility,
+            claims=claims,
+        )
     a = repo.create(
         name=body.name,
         type=AccountType(body.type),
@@ -137,8 +221,14 @@ def get_account(
     responses={
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
-        404: problem_response("account.not_found"),
-        400: problem_response("request.body_invalid"),
+        404: problem_response("account.not_found", "account.parent_not_found"),
+        400: problem_response(
+            "request.body_invalid",
+            "account.parent_type_mismatch",
+            "account.parent_currency_mismatch",
+            "account.parent_visibility_violation",
+            "account.parent_cycle",
+        ),
         422: problem_response("validation.failed"),
     },
 )
@@ -164,7 +254,26 @@ def update_account(
             "Ask an admin, or have the original creator make the change."
         )
 
-    before = {"name": a.name, "code": a.code, "visibility": a.visibility}
+    # Visibility may be changing in this PATCH; if so, the new visibility
+    # is what we validate the parent against. Same for parent itself.
+    new_visibility = body.visibility if body.visibility is not None else a.visibility
+    if body.parent_account_id is not None:
+        _validate_parent(
+            repo,
+            parent_id=body.parent_account_id,
+            child_id=a.id,
+            child_type=a.type.value,
+            child_currency=a.currency,
+            child_visibility=new_visibility,
+            claims=claims,
+        )
+
+    before = {
+        "name": a.name,
+        "code": a.code,
+        "visibility": a.visibility,
+        "parent_account_id": str(a.parent_account_id) if a.parent_account_id else None,
+    }
     if body.name is not None:
         a.name = body.name
     if body.code is not None:
@@ -173,6 +282,8 @@ def update_account(
         a.subtype = body.subtype
     if body.visibility is not None:
         a.visibility = body.visibility
+    if body.parent_account_id is not None:
+        a.parent_account_id = body.parent_account_id
     session.flush()
 
     AuditLogWriter(session, claims.household_id).write(
@@ -182,7 +293,12 @@ def update_account(
         entity_type="account",
         entity_id=a.id,
         before=before,
-        after={"name": a.name, "code": a.code, "visibility": a.visibility},
+        after={
+            "name": a.name,
+            "code": a.code,
+            "visibility": a.visibility,
+            "parent_account_id": str(a.parent_account_id) if a.parent_account_id else None,
+        },
         request_id=_request_uuid(request),
     )
     session.commit()

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -32,6 +32,11 @@ router = APIRouter(prefix="/.well-known/errors", tags=["docs"])
 _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
     "MfaRequiredError": {"mfa_token": "<mfa-challenge-jwt>", "expires_in": 300},
     "AccountUnknownError": {"account_id": "<account-uuid>"},
+    "AccountParentTypeMismatchError": {"child_type": "expense", "parent_type": "asset"},
+    "AccountParentCurrencyMismatchError": {
+        "child_currency": "EUR",
+        "parent_currency": "USD",
+    },
     "TransactionInvalidError": {"reason": "<domain-validation-message>"},
     "TransactionUnbalancedError": {
         "reason": "Transaction does not balance: USD postings sum to 1.00 instead of 0."

--- a/packages/tulip-api/src/tulip_api/schemas/account.py
+++ b/packages/tulip-api/src/tulip_api/schemas/account.py
@@ -26,6 +26,15 @@ class AccountUpdate(BaseModel):
     code: str | None = Field(default=None, max_length=50)
     subtype: str | None = Field(default=None, max_length=50)
     visibility: str | None = Field(default=None, pattern=r"^(shared|private)$")
+    parent_account_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Reparent under another account. Subject to the same type / "
+            "currency / visibility / no-cycle rules as POST /v1/accounts. "
+            "Currently no way to clear the parent via PATCH; create a new "
+            "top-level account instead."
+        ),
+    )
 
 
 class AccountRead(BaseModel):

--- a/packages/tulip-api/tests/test_account_nesting.py
+++ b/packages/tulip-api/tests/test_account_nesting.py
@@ -1,0 +1,291 @@
+"""Parent-account validation: cycle / type / currency / visibility rules.
+
+#42 enforces four consistency rules whenever ``parent_account_id`` is
+set or changed:
+
+1. **No cycles.** On PATCH, the proposed new parent cannot be a
+   descendant of the account being updated.
+2. **Type match.** ``parent.type`` must equal ``child.type``.
+3. **Currency match.** ``parent.currency`` must equal ``child.currency``.
+   (#44 tracks deliberate relaxation for travel-style multi-currency
+   hierarchies.)
+4. **Visibility.** ``child.visibility ≤ parent.visibility`` — a private
+   parent forces children to be private; a shared parent permits either.
+
+The parent must also exist in this household and be active. An inactive
+parent rejects with the same ``account.parent_not_found`` problem an
+absent parent does.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return str(r.json()["access_token"])
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+def _create(
+    client: TestClient,
+    auth_h: dict[str, str],
+    *,
+    name: str,
+    type_: str = "asset",
+    currency: str = "USD",
+    visibility: str = "shared",
+    code: str | None = None,
+    parent_account_id: str | None = None,
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "name": name,
+        "type": type_,
+        "currency": currency,
+        "visibility": visibility,
+    }
+    if code is not None:
+        body["code"] = code
+    if parent_account_id is not None:
+        body["parent_account_id"] = parent_account_id
+    r = client.post("/v1/accounts", headers=auth_h, json=body)
+    assert r.status_code == 201, r.text
+    return dict(r.json())
+
+
+class TestCreateWithParent:
+    def test_happy_nested_create(self, client: TestClient, auth_h: dict[str, str]):
+        parent = _create(client, auth_h, name="Assets", type_="asset")
+        child = _create(
+            client,
+            auth_h,
+            name="Checking",
+            type_="asset",
+            parent_account_id=str(parent["id"]),
+        )
+        assert child["parent_account_id"] == str(parent["id"])
+
+    def test_unknown_parent_returns_problem(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Orphan",
+                "type": "asset",
+                "currency": "USD",
+                "parent_account_id": str(uuid4()),
+            },
+        )
+        assert_problem(r, code="account.parent_not_found", status=404)
+
+    def test_inactive_parent_rejected(self, client: TestClient, auth_h: dict[str, str]):
+        parent = _create(client, auth_h, name="Old", type_="asset")
+        client.delete(f"/v1/accounts/{parent['id']}", headers=auth_h)
+
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Child",
+                "type": "asset",
+                "currency": "USD",
+                "parent_account_id": str(parent["id"]),
+            },
+        )
+        assert_problem(r, code="account.parent_not_found", status=404)
+
+    def test_type_mismatch_rejected(self, client: TestClient, auth_h: dict[str, str]):
+        parent = _create(client, auth_h, name="Assets", type_="asset")
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Wrong type",
+                "type": "expense",
+                "currency": "USD",
+                "parent_account_id": str(parent["id"]),
+            },
+        )
+        body = assert_problem(r, code="account.parent_type_mismatch", status=400)
+        assert "asset" in body["detail"].lower()
+        assert "expense" in body["detail"].lower()
+
+    def test_currency_mismatch_rejected(self, client: TestClient, auth_h: dict[str, str]):
+        parent = _create(client, auth_h, name="USD parent", currency="USD")
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "EUR child",
+                "type": "asset",
+                "currency": "EUR",
+                "parent_account_id": str(parent["id"]),
+            },
+        )
+        body = assert_problem(r, code="account.parent_currency_mismatch", status=400)
+        assert "USD" in body["detail"]
+        assert "EUR" in body["detail"]
+
+    def test_shared_child_under_private_parent_rejected(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        parent = _create(client, auth_h, name="Private parent", visibility="private")
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Shared child",
+                "type": "asset",
+                "currency": "USD",
+                "visibility": "shared",
+                "parent_account_id": str(parent["id"]),
+            },
+        )
+        assert_problem(r, code="account.parent_visibility_violation", status=400)
+
+    def test_private_child_under_private_parent_allowed(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        parent = _create(client, auth_h, name="Private parent", visibility="private")
+        child = _create(
+            client,
+            auth_h,
+            name="Private child",
+            visibility="private",
+            parent_account_id=str(parent["id"]),
+        )
+        assert child["visibility"] == "private"
+
+
+class TestPatchReparent:
+    def test_happy_reparent(self, client: TestClient, auth_h: dict[str, str]):
+        first_parent = _create(client, auth_h, name="P1", type_="asset")
+        second_parent = _create(client, auth_h, name="P2", type_="asset")
+        child = _create(
+            client,
+            auth_h,
+            name="C",
+            type_="asset",
+            parent_account_id=str(first_parent["id"]),
+        )
+
+        r = client.patch(
+            f"/v1/accounts/{child['id']}",
+            headers=auth_h,
+            json={"parent_account_id": str(second_parent["id"])},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["parent_account_id"] == str(second_parent["id"])
+
+    def test_self_parent_rejected_as_cycle(self, client: TestClient, auth_h: dict[str, str]):
+        a = _create(client, auth_h, name="A", type_="asset")
+        r = client.patch(
+            f"/v1/accounts/{a['id']}",
+            headers=auth_h,
+            json={"parent_account_id": str(a["id"])},
+        )
+        assert_problem(r, code="account.parent_cycle", status=400)
+
+    def test_descendant_as_parent_rejected_as_cycle(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        # Build a → b → c. Then try to reparent a under c (cycle).
+        a = _create(client, auth_h, name="A", type_="asset")
+        b = _create(
+            client,
+            auth_h,
+            name="B",
+            type_="asset",
+            parent_account_id=str(a["id"]),
+        )
+        c = _create(
+            client,
+            auth_h,
+            name="C",
+            type_="asset",
+            parent_account_id=str(b["id"]),
+        )
+
+        r = client.patch(
+            f"/v1/accounts/{a['id']}",
+            headers=auth_h,
+            json={"parent_account_id": str(c["id"])},
+        )
+        assert_problem(r, code="account.parent_cycle", status=400)
+
+    def test_patch_type_mismatch_rejected(self, client: TestClient, auth_h: dict[str, str]):
+        asset_parent = _create(client, auth_h, name="A parent", type_="asset")
+        expense_child = _create(client, auth_h, name="An expense", type_="expense")
+
+        r = client.patch(
+            f"/v1/accounts/{expense_child['id']}",
+            headers=auth_h,
+            json={"parent_account_id": str(asset_parent["id"])},
+        )
+        assert_problem(r, code="account.parent_type_mismatch", status=400)
+
+    def test_patch_currency_mismatch_rejected(self, client: TestClient, auth_h: dict[str, str]):
+        usd_parent = _create(client, auth_h, name="USD", currency="USD")
+        eur_child = _create(client, auth_h, name="EUR child", currency="EUR")
+
+        r = client.patch(
+            f"/v1/accounts/{eur_child['id']}",
+            headers=auth_h,
+            json={"parent_account_id": str(usd_parent["id"])},
+        )
+        assert_problem(r, code="account.parent_currency_mismatch", status=400)
+
+    def test_patch_visibility_violation_rejected(self, client: TestClient, auth_h: dict[str, str]):
+        private_parent = _create(client, auth_h, name="Private", visibility="private")
+        shared_child = _create(client, auth_h, name="Shared", visibility="shared")
+
+        r = client.patch(
+            f"/v1/accounts/{shared_child['id']}",
+            headers=auth_h,
+            json={"parent_account_id": str(private_parent["id"])},
+        )
+        assert_problem(r, code="account.parent_visibility_violation", status=400)
+
+    def test_patch_can_omit_parent_to_leave_unchanged(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        parent = _create(client, auth_h, name="P", type_="asset")
+        child = _create(
+            client,
+            auth_h,
+            name="C",
+            type_="asset",
+            parent_account_id=str(parent["id"]),
+        )
+        r = client.patch(
+            f"/v1/accounts/{child['id']}",
+            headers=auth_h,
+            json={"name": "Renamed"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["name"] == "Renamed"
+        assert body["parent_account_id"] == str(parent["id"])


### PR DESCRIPTION
First slice of #42. Closes the **API side**; CLI surfacing (`--parent` flag, tree rendering, parent-name on `show`) follows in #42.b.

## Summary

When `parent_account_id` is set on `POST` or `PATCH`, the API now enforces five rules. Each surfaces a distinct error code so the CLI can render specific guidance per case rather than a generic "parent invalid."

| Rule | Code | Status |
|---|---|---|
| Parent exists in household, visible, active | `account.parent_not_found` | 404 |
| `parent.type == child.type` | `account.parent_type_mismatch` | 400 |
| `parent.currency == child.currency` | `account.parent_currency_mismatch` | 400 |
| Shared child cannot live under private parent | `account.parent_visibility_violation` | 400 |
| Reparent would create a cycle (PATCH only) | `account.parent_cycle` | 400 |

The cycle walk traverses `parent.parent_account_id` up from the proposed new parent; if it ever hits the account being PATCHed, that's a cycle. Also catches the trivial self-parent case (`parent_account_id == id`).

`AccountUpdate` gains `parent_account_id` so PATCH can reparent. **Clearing the parent via PATCH is not currently supported** — `None` means "no change" (matching the existing convention for other optional fields). A follow-up can add an explicit unset sentinel if it's wanted.

OpenAPI `responses=` blocks declare every new error code so schemathesis stays happy.

## Multi-currency parents

`parent.currency == child.currency` is enforced strictly. The deliberate-relaxation use case (USD-base household with travel sub-accounts in EUR / GBP / JPY) is tracked separately in **#44**, with design questions around posting targets, FX-rates table, and base-currency conversion.

## Test plan

- [x] `uv run pytest` — 425 passed (up from 411).
- [x] `uv run ruff check packages` — clean.
- [x] `uv run ruff format --check packages` — clean.
- [x] `uv run mypy` — clean.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] **14 new tests** in `test_account_nesting.py`:
  - **TestCreateWithParent (7)** — happy nested create; unknown parent → `parent_not_found`; inactive parent → `parent_not_found`; type mismatch; currency mismatch; shared-under-private → `parent_visibility_violation`; private-under-private allowed.
  - **TestPatchReparent (7)** — happy reparent; self-parent rejected as cycle; descendant-as-parent rejected as cycle; type / currency / visibility mismatches on reparent; omitted `parent_account_id` leaves the existing parent unchanged.
- [x] `_PLACEHOLDER_ARGS` in `well_known_errors.py` updated for the two new error classes that take constructor args, so `/.well-known/errors/{code}` HTML pages still render and the architecture test stays green.

## Refs

- Part of #42 (closes API side; #42.b is the CLI surfacing).
- #44 — multi-currency parent relaxation (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)