### PR TITLE
feat(cli): account nesting surfacing in CLI (#42.b)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/commands/accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/accounts.py
@@ -20,6 +20,7 @@ from uuid import UUID
 import typer
 from rich.console import Console
 from rich.table import Table
+from rich.tree import Tree
 
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.config import Config
@@ -117,8 +118,60 @@ def _render_table(accounts: list[dict[str, Any]]) -> None:
     Console().print(table)
 
 
-def _render_account(account: dict[str, Any]) -> None:
-    """Render a single account dict as a vertical key/value list."""
+def _render_tree(accounts: list[dict[str, Any]]) -> None:
+    """Render the account list as a tree grouped by ``parent_account_id``."""
+    by_id = {a["id"]: a for a in accounts}
+    children_by_parent: dict[str | None, list[dict[str, Any]]] = {}
+    for a in accounts:
+        parent_id = a.get("parent_account_id")
+        children_by_parent.setdefault(parent_id, []).append(a)
+
+    def _label(a: dict[str, Any]) -> str:
+        code = a.get("code") or "—"
+        name = a.get("name") or ""
+        atype = a.get("type") or ""
+        return f"{code}  [dim]{name} · {atype}[/dim]"
+
+    def _attach(node: Tree, account: dict[str, Any]) -> None:
+        for child in sorted(
+            children_by_parent.get(account["id"], []),
+            key=lambda c: (c.get("code") or "", c.get("name") or ""),
+        ):
+            child_node = node.add(_label(child))
+            _attach(child_node, child)
+
+    root = Tree("[bold]accounts[/bold]")
+    top_level = sorted(
+        children_by_parent.get(None, []),
+        key=lambda c: (c.get("code") or "", c.get("name") or ""),
+    )
+    # Also include any accounts whose declared parent isn't in our list
+    # (orphans — shouldn't happen given the API's role filtering, but
+    # render them anyway so we don't silently swallow rows).
+    orphans = [
+        a
+        for a in accounts
+        if a.get("parent_account_id") is not None and a.get("parent_account_id") not in by_id
+    ]
+    for a in top_level:
+        node = root.add(_label(a))
+        _attach(node, a)
+    for a in orphans:
+        node = root.add(_label(a) + " [yellow](parent not visible)[/yellow]")
+        _attach(node, a)
+    Console().print(root)
+
+
+def _has_nesting(accounts: list[dict[str, Any]]) -> bool:
+    return any(a.get("parent_account_id") for a in accounts)
+
+
+def _render_account(account: dict[str, Any], parent: dict[str, Any] | None = None) -> None:
+    """Render a single account dict as a vertical key/value list.
+
+    If ``parent`` is provided, the parent's code/name are surfaced inline
+    so users don't have to mentally resolve a UUID.
+    """
     typer.echo(f"id:           {account.get('id', '')}")
     typer.echo(f"code:         {account.get('code') or '—'}")
     typer.echo(f"name:         {account.get('name', '')}")
@@ -129,12 +182,29 @@ def _render_account(account: dict[str, Any]) -> None:
     typer.echo(f"visibility:   {account.get('visibility', '')}")
     typer.echo(f"is_active:    {account.get('is_active', '')}")
     if account.get("parent_account_id"):
-        typer.echo(f"parent:       {account['parent_account_id']}")
+        if parent is not None:
+            parent_label = f"{parent.get('code') or '—'} ({parent.get('name', '')})"
+            typer.echo(f"parent:       {parent_label} [{account['parent_account_id']}]")
+        else:
+            typer.echo(f"parent:       {account['parent_account_id']}")
 
 
 @accounts_app.command("list")
-def list_accounts(ctx: typer.Context) -> None:
-    """List active accounts visible to the logged-in user."""
+def list_accounts(
+    ctx: typer.Context,
+    flat: Annotated[
+        bool,
+        typer.Option(
+            "--flat",
+            help="Force the flat table view instead of the default tree.",
+        ),
+    ] = False,
+) -> None:
+    """List active accounts visible to the logged-in user.
+
+    Default rendering is a tree when any account has a parent; otherwise
+    a flat table. ``--flat`` forces the table view (useful for scripts).
+    """
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
     try:
@@ -150,9 +220,12 @@ def list_accounts(ctx: typer.Context) -> None:
 
     accounts = response.json()
     if not accounts:
-        typer.echo("No accounts. Run `tulip accounts add` to create one (P3.4 — coming soon).")
+        typer.echo("No accounts. Run `tulip accounts add` to create one.")
         return
-    _render_table(accounts)
+    if flat or not _has_nesting(accounts):
+        _render_table(accounts)
+    else:
+        _render_tree(accounts)
 
 
 @accounts_app.command("add")
@@ -191,6 +264,17 @@ def add_account(
             help="'shared' (default) or 'private'.",
         ),
     ] = "shared",
+    parent: Annotated[
+        str | None,
+        typer.Option(
+            "--parent",
+            help=(
+                "Optional parent account (code or UUID). The parent's type "
+                "and currency must match this account, and a private parent "
+                "forces a private child."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Create a new account in the logged-in user's household."""
     config: Config = ctx.obj["config"]
@@ -209,6 +293,9 @@ def add_account(
 
     try:
         with _client(config, as_json=as_json) as client:
+            if parent is not None:
+                resolved = _resolve_account(client, parent)
+                body["parent_account_id"] = resolved["id"]
             response = client.post("/v1/accounts", json=body, authenticated=True)
     except CliError as err:
         err.render()
@@ -237,9 +324,21 @@ def show_account(
     """Show one account by code or UUID."""
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
+    parent: dict[str, Any] | None = None
     try:
         with _client(config, as_json=as_json) as client:
             account = _resolve_account(client, identifier)
+            parent_id = account.get("parent_account_id")
+            if parent_id:
+                # Fetch the parent to surface its code/name. A 404 here
+                # would be unexpected (the API just returned this child)
+                # but if it happens we render the child without the
+                # enriched parent line rather than crashing.
+                try:
+                    parent_response = client.get(f"/v1/accounts/{parent_id}", authenticated=True)
+                    parent = dict(parent_response.json())
+                except CliError:
+                    parent = None
     except CliError as err:
         err.render()
         raise typer.Exit(err.exit_code) from None
@@ -247,4 +346,4 @@ def show_account(
     if as_json:
         sys.stdout.write(json.dumps(account) + "\n")
         return
-    _render_account(account)
+    _render_account(account, parent=parent)

--- a/packages/tulip-cli/tests/test_account_nesting.py
+++ b/packages/tulip-cli/tests/test_account_nesting.py
@@ -1,0 +1,220 @@
+"""End-to-end tests for the CLI surfacing of account nesting (#42.b).
+
+* ``tulip accounts add --parent ACCOUNT`` — accepts code or UUID; resolved
+  via the same path as ``show``/``balance``.
+* ``tulip accounts list`` — renders a tree by default when any nesting
+  exists; ``--flat`` falls back to the table view for scripting.
+* ``tulip accounts show`` — when ``parent_account_id`` is set, displays
+  the parent's code/name alongside the UUID.
+
+The API-side validation (#42.a) is exercised by surfacing those error
+codes in the CLI: an unknown parent code surfaces ``account.not_found``
+during local resolution; an API-side reject (type mismatch, etc.) renders
+via the existing RFC 9457 path with the appropriate exit code.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=20,
+    )
+
+
+@pytest.fixture
+def authed_session(live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    cli_login = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert cli_login.returncode == 0, cli_login.stderr
+    return live_api
+
+
+def _add(
+    api_url: str,
+    *,
+    name: str,
+    type_: str = "asset",
+    code: str | None = None,
+    parent: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    args = ["accounts", "add", "--name", name, "--type", type_, "--currency", "USD"]
+    if code is not None:
+        args += ["--code", code]
+    if parent is not None:
+        args += ["--parent", parent]
+    return _run_cli(*args, api_url=api_url)
+
+
+# ---------- --parent on add ----------
+
+
+@pytest.mark.integration
+def test_accounts_add_with_parent_code(authed_session: str) -> None:
+    parent = _add(authed_session, name="Assets", code="assets")
+    assert parent.returncode == 0, parent.stderr
+
+    child = _add(authed_session, name="Checking", code="assets:checking", parent="assets")
+    assert child.returncode == 0, child.stderr
+
+    show = _run_cli("accounts", "show", "assets:checking", api_url=authed_session)
+    # When the API returns a parent_account_id, the CLI displays it; the
+    # parent-name surfacing is exercised below.
+    assert "Checking" in show.stdout
+
+
+@pytest.mark.integration
+def test_accounts_add_with_parent_uuid(authed_session: str) -> None:
+    """A UUID in --parent works as well as a code."""
+    import json
+
+    create_parent = _run_cli(
+        "--json",
+        "accounts",
+        "add",
+        "--name",
+        "Assets",
+        "--type",
+        "asset",
+        "--currency",
+        "USD",
+        "--code",
+        "assets",
+        api_url=authed_session,
+    )
+    assert create_parent.returncode == 0, create_parent.stderr
+    parent_id = json.loads(create_parent.stdout)["id"]
+
+    child = _add(authed_session, name="Cash", parent=parent_id)
+    assert child.returncode == 0, child.stderr
+
+
+@pytest.mark.integration
+def test_accounts_add_with_unknown_parent_code_yields_user_error(
+    authed_session: str,
+) -> None:
+    result = _add(authed_session, name="Orphan", parent="no-such-parent")
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "no-such-parent" in result.stderr.lower() or "not found" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_accounts_add_with_type_mismatched_parent_surfaces_api_error(
+    authed_session: str,
+) -> None:
+    """API enforces parent.type == child.type. The CLI must surface the message clearly."""
+    parent = _add(authed_session, name="Assets", type_="asset", code="assets")
+    assert parent.returncode == 0, parent.stderr
+
+    result = _add(authed_session, name="Wrong", type_="expense", parent="assets")
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "type" in result.stderr.lower()
+
+
+# ---------- list rendering ----------
+
+
+@pytest.mark.integration
+def test_accounts_list_default_view_is_tree_when_nested(authed_session: str) -> None:
+    _add(authed_session, name="Assets", code="assets")
+    _add(authed_session, name="Checking", code="assets:checking", parent="assets")
+    _add(authed_session, name="Savings", code="assets:savings", parent="assets")
+
+    result = _run_cli("accounts", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "Assets" in result.stdout
+    assert "Checking" in result.stdout
+    assert "Savings" in result.stdout
+    # Children should appear under the parent — easiest portable check is
+    # that each child name appears AFTER the parent name in the output.
+    parent_idx = result.stdout.find("Assets")
+    checking_idx = result.stdout.find("Checking")
+    savings_idx = result.stdout.find("Savings")
+    assert parent_idx < checking_idx
+    assert parent_idx < savings_idx
+
+
+@pytest.mark.integration
+def test_accounts_list_flat_flag_renders_table(authed_session: str) -> None:
+    _add(authed_session, name="Assets", code="assets")
+    _add(authed_session, name="Checking", code="assets:checking", parent="assets")
+
+    result = _run_cli("accounts", "list", "--flat", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    # Flat view = the existing table renderer; both rows present.
+    assert "assets:checking" in result.stdout
+    assert "assets" in result.stdout
+
+
+@pytest.mark.integration
+def test_accounts_list_with_no_nesting_renders_flat_by_default(
+    authed_session: str,
+) -> None:
+    """No nesting → no point in tree headers; fall back to the table."""
+    _add(authed_session, name="Cash", code="assets:cash")
+    _add(authed_session, name="Food", type_="expense", code="expenses:food")
+
+    result = _run_cli("accounts", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "assets:cash" in result.stdout
+    assert "expenses:food" in result.stdout
+
+
+# ---------- show with parent name ----------
+
+
+@pytest.mark.integration
+def test_accounts_show_displays_parent_code_and_name(authed_session: str) -> None:
+    _add(authed_session, name="Assets", code="assets")
+    _add(authed_session, name="Checking", code="assets:checking", parent="assets")
+
+    result = _run_cli("accounts", "show", "assets:checking", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    # The parent UUID line was already there; the new behavior surfaces
+    # the parent's code/name so users don't have to mentally resolve it.
+    assert "Assets" in result.stdout  # parent name
+    assert "assets" in result.stdout  # parent code (also matches own code, fine)
+
+
+@pytest.mark.integration
+def test_accounts_show_no_parent_omits_parent_line(authed_session: str) -> None:
+    _add(authed_session, name="Top", code="top")
+
+    result = _run_cli("accounts", "show", "top", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    # No "parent:" line should appear at all when there is no parent.
+    assert "parent:" not in result.stdout


### PR DESCRIPTION
Closes #42. Builds on #45 (#42.a — API-side validation).

## Summary

- **`tulip accounts add --parent ACCOUNT`** — accepts a code or UUID; resolves via the same path as `show`/`balance`. The API-side consistency rules from #42.a (type / currency / visibility / cycle) surface as standard Problem Details with the existing exit-code map.
- **`tulip accounts list`** — defaults to a Rich tree when any account has a parent; otherwise renders the existing flat table. `--flat` forces the table for scripting. Orphans (rows whose parent isn't visible to this user) render at the top level with a `(parent not visible)` marker rather than being silently dropped.
- **`tulip accounts show`** — when an account has a parent, also fetches and displays the parent's code/name alongside the UUID. A parent that vanishes between the two API calls falls back to UUID-only rather than crashing.

## Decision: tree-by-default

When no account has a parent, the tree adds noise (a single root with a flat list of children). The CLI auto-detects nesting and falls back to the table view there. Power users who script against the output should pass `--flat` for stability.

## Test plan

- [x] `uv run pytest` — 434 passed (up from 425).
- [x] `uv run ruff check packages` — clean.
- [x] `uv run ruff format --check packages` — clean.
- [x] `uv run mypy` — clean.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] **9 new E2E tests**:
  - **add (4)** — `--parent` by code, `--parent` by UUID, unknown parent → user error, type-mismatched parent → API error surfaced clearly.
  - **list (3)** — tree by default with parents-before-children, `--flat` flag, no-nesting falls back to table.
  - **show (2)** — parent code+name displayed when parent exists, no-parent omits the line entirely.
- [x] Manual smoke flow:
  ```bash
  rm -f /tmp/tulip-smoke.db
  export TULIP_DATABASE_URL='sqlite:////tmp/tulip-smoke.db'
  export TULIP_JWT_SECRET='dev-secret-32bytes-dev-secret-xyz'
  export TULIP_MASTER_KEY='q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s='
  uv run alembic -c packages/tulip-storage/alembic.ini upgrade head
  uv run uvicorn tulip_api.main:create_app --factory &
  uv run tulip register --email me@example.com --display-name Me --household Mine
  uv run tulip auth login --email me@example.com
  uv run tulip accounts add --name Assets --type asset --currency USD --code assets
  uv run tulip accounts add --name Checking --type asset --currency USD --code assets:checking --parent assets
  uv run tulip accounts add --name Savings --type asset --currency USD --code assets:savings --parent assets
  uv run tulip accounts list
  uv run tulip accounts show assets:checking
  ```

## Refs

- Closes #42 (full nesting feature).
- Builds on #45 (#42.a — API consistency rules).
- Out of scope: trial-balance roll-up (deferred to Phase 8 reports), multi-currency parents (#44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)