### PR TITLE
docs: refresh PHASE_STATUS, README, ARCHITECTURE for current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Household-focused, double-entry accounting system with first-class envelope budgeting and sinking-fund support.
 
-> **Status:** Pre-alpha — Phases 0, 1, and 2 complete (project bootstrap, storage + accounting engine, API surface for auth + accounts + transactions). See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for current progress and the queued Phase 2.x work, or [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full design.
+> **Status:** Pre-alpha — Phases 0–3 complete (project bootstrap, storage + accounting engine, API surface for auth/accounts/transactions/balance, scriptable CLI client). Phase 4 (envelopes + sinking funds) not yet started. See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture, or [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
 
 ---
 
@@ -56,7 +56,7 @@ git clone https://github.com/<your-org>/tulip-accounting
 cd tulip-accounting
 uv sync                          # installs all workspace packages + dev deps
 uv run pre-commit install        # enable pre-commit hooks
-uv run pytest                    # confirm tests pass (184 tests, ~5s)
+uv run pytest                    # confirm tests pass (460 tests, ~90s)
 ```
 
 > **Note for committers:** `main` is branch-protected and **requires every commit to be signed**. Configure SSH or GPG commit signing before your first push (`git config --global commit.gpgsign true` plus a signing key); see [CONTRIBUTING.md](CONTRIBUTING.md#branch-protection-on-main) for the details, the most common failure modes, and the diagnostic checklist if a push is rejected as unsigned.
@@ -91,21 +91,28 @@ TULIP_JWT_SECRET="$(uv run python -c 'import secrets; print(secrets.token_urlsaf
 
 Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.0.0.1:8000/openapi.json` for the OpenAPI spec. Available endpoints:
 
-- `POST /v1/auth/{register,login,refresh,logout}`
-- `GET/POST/PATCH/DELETE /v1/accounts[/{id}]`
+- `POST /v1/auth/{register,login,login/mfa,login/recover,refresh,logout}`
+- `POST /v1/auth/mfa/{enroll,verify,recovery-codes/regenerate}` · `GET /v1/auth/mfa/recovery-codes/status`
+- `GET/POST/PATCH/DELETE /v1/accounts[/{id}]` · `GET /v1/accounts/{id}/balance`
 - `GET/POST /v1/transactions[/{id}]`
+- `GET /v1/reports/trial-balance`
 
-In production, supply `TULIP_JWT_SECRET` from a secret store rather than generating fresh on every start (existing tokens won't validate after a restart with a new secret).
+Every non-2xx response is `application/problem+json` per RFC 9457. In production, supply `TULIP_JWT_SECRET` and `TULIP_MASTER_KEY` from a secret store rather than generating fresh on every start (existing tokens and field-encrypted columns won't validate after a restart with new secrets).
 
-### Running the CLI (once Phase 3 lands)
+### Running the CLI
 
 ```bash
-uv run tulip auth login
-uv run tulip accounts list
-uv run tulip add 2026-04-29 'Grocery store' \
-  --debit 'Expenses:Food:Groceries' 87.42 \
-  --credit 'Assets:Checking' 87.42
+uv run tulip register --email me@example.com --display-name Me --household Mine
+uv run tulip auth login --email me@example.com
+uv run tulip accounts add --name Checking --type asset --currency USD --code assets:checking
+uv run tulip accounts add --name Food --type expense --currency USD --code expenses:food
+uv run tulip add --date 2026-04-29 --description 'Grocery store' \
+  --post expenses:food=87.42 \
+  --post assets:checking=-87.42
+uv run tulip balance
 ```
+
+`tulip add --edit` opens `$EDITOR` with a hledger-style template instead of taking flags. `tulip accounts list` renders a Rich tree when nesting exists, a flat table otherwise (`--flat` to force the table for scripting). Tokens persist in the OS keyring; the CLI exit-code map and full RFC 9457 error rendering are documented in [docs/ARCHITECTURE.md §7.8.5](docs/ARCHITECTURE.md).
 
 ## Development discipline
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -735,18 +735,17 @@ For each class of failure the system has a defined recovery path:
 
 - **Tests** — every error path test asserts the response is a Problem Details body, not just the status code. A reusable `assert_problem(resp, code=..., status=...)` helper lives in `packages/tulip-api/tests/_problem_details.py`.
 - **OpenAPI spec** — every operation's `responses` block lists the Problem Details schemas it can return; schemathesis (Phase 2.x) drives this and fails on undeclared error responses.
-- **Architecture test** — no router function may `raise HTTPException(detail=<str>)` without going through the helper that wraps it as a Problem Details body. (Phase 2.x; current Phase 2 emits plain `detail` strings and is tracked for migration in the §10 plan.)
+- **Architecture test** — `tests/test_architecture_no_http_exception.py` AST-scans `tulip_api/src/` and rejects any reference to FastAPI's plain `HTTPException`. Re-introducing the legacy pattern is a CI failure.
 
 #### 7.8.9 Status of the current code
 
-Phase 2 endpoints currently raise `HTTPException(status_code=..., detail="...")` — FastAPI's default shape, not RFC 9457. The migration to Problem Details is a Phase 2.x slice (`P2.x: RFC 9457 errors + recovery hints`) that:
+✅ Shipped end to end (Phase 2.x.1 – 2.x.4).
 
-1. Adds a project-wide exception → Problem Details mapper (FastAPI exception handler).
-2. Replaces ad-hoc `detail=` strings with typed exceptions whose `code`, `title`, and `detail` come from a registry.
-3. Adds the `assert_problem` test helper and migrates the existing tests to use it.
-4. Publishes `/.well-known/errors/<code>` HTML pages with the canonical explanation.
-
-This is non-blocking for Phase 3 (CLI), since the CLI can be written against the eventual shape from day 1 and the API migration can land underneath it.
+1. Project-wide `TulipProblem` base + FastAPI exception handlers (`install_problem_handlers` in `tulip_api.errors`).
+2. Typed exception classes whose `code`, `title`, `status`, and `detail` are constructed from a single registry; routers raise these instead of `HTTPException`.
+3. `assert_problem` test helper at `packages/tulip-api/tests/_problem_details.py`; every error-path test uses it.
+4. `/.well-known/errors/{code}` HTML pages auto-published from `TulipProblem.__subclasses__()`; index at `/.well-known/errors/`.
+5. Schemathesis contract tests fuzz every documented operation (`tests/test_openapi_contract.py`); every non-2xx response is `application/problem+json`, including `RequestValidationError` (422), Starlette framework errors (400/404/405/415), and unhandled exceptions (catch-all → `server.internal_error` 500).
 
 ---
 
@@ -904,23 +903,34 @@ The roadmap below is suggested; Claude Code can sequence within each phase as th
 - Accounting engine: post transaction, balanced-postings invariant, period-aware writes
 - Property-based tests over `Money`; example-based + hypothesis-strategies on the engine
 
-### Phase 2 — API surface (auth + accounts + transactions) ✅ complete (core) · 🟡 cleanup queued in Phase 2.x
+### Phase 2 — API surface (auth + accounts + transactions) ✅ complete
 - FastAPI app with structured logging and request_id middleware
-- Auth endpoints — register, login, refresh, logout (MFA queued in P2.x.1)
+- Auth endpoints — register, login, refresh, logout
 - CRUD for accounts and transactions with permission enforcement
-- OpenAPI spec rendered (schemathesis contract tests queued in P2.x.3)
+- OpenAPI spec rendered
 - Audit log writer wired into every mutation
 
-### Phase 2.x — Cleanup before Phase 3 — queued
-- **P2.x.1** — MFA (TOTP) enrollment, login challenge, hashed recovery codes
-- **P2.x.2** — RFC 9457 Problem Details migration (see §7.8)
-- **P2.x.3** — schemathesis contract tests in CI
+### Phase 2.x — Cleanup before Phase 3 ✅ complete
+- **P2.x.1** ✅ — MFA (TOTP) enrollment, login challenge, hashed recovery codes
+- **P2.x.2** ✅ — RFC 9457 Problem Details migration (see §7.8)
+- **P2.x.3** ✅ — schemathesis contract tests in CI
+- **P2.x.4** ✅ — catch-all unhandled-exception handler so even uncaught exceptions emit `application/problem+json`
 
-### Phase 3 — CLI (Typer) + first useful flows
-- `tulip auth login`, `tulip add`, `tulip register`, `tulip balance`, `tulip accounts`
-- Token storage via keyring
-- End-to-end tests of CLI against a spawned API server
-- Toner-friendly print stylesheet finalized
+### Phase 3 — CLI (Typer) + first useful flows ✅ complete
+- ✅ `tulip register`, `tulip auth {login,logout,status}` (login handles MFA + recovery branches)
+- ✅ `tulip accounts {list,show,add}` with parent nesting; `tulip add` (transactions) in flag and `--edit` editor modes
+- ✅ `tulip balance` (single account or trial-balance summary)
+- ✅ Token storage via OS keyring (file-backed fallback under `TULIP_TOKEN_STORE` for tests / CI)
+- ✅ End-to-end tests of CLI against a spawned uvicorn (`live_api` fixture)
+- 🟡 Toner-friendly print stylesheet — deferred to Phase 8 (#22), where it lands alongside actual reports
+
+#### Phase 3 follow-ups also shipped
+
+These weren't in the original Phase 3 list but landed before Phase 4 because the CLI's full ergonomic loop wanted them:
+
+- Balance + trial-balance API endpoints (#31, PR #37) — `GET /v1/accounts/{id}/balance` and `GET /v1/reports/trial-balance`, both with `?as_of=YYYY-MM-DD`.
+- Account nesting end-to-end (#42) — `parent_account_id` consistency rules (type / currency / visibility / no-cycle), reparenting via PATCH, CLI `--parent` flag, tree rendering, parent-name surfacing on `show`. Multi-currency parents deliberately rejected for now (#44 is the holding pen).
+- Interactive `tulip add --edit` (#43) — opens `$EDITOR` with a hledger-subset template; reopens with a banner on parse / balance / unknown-account errors.
 
 ### Phase 4 — Envelopes + sinking funds
 - Allocation pool models and CRUD

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-01 · `main` @ `ba5beb8`
+**Last updated:** 2026-05-01 · `main` @ `39e1498`
 
 ---
 
@@ -11,10 +11,12 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 0:** ✅ complete
 - **Phase 1:** ✅ complete
 - **Phase 2 (core API surface):** ✅ complete
-- **Phase 2.x (cleanup before Phase 3):** ✅ complete
-- **Phase 3 (CLI):** in flight — P3.1 skeleton landed, P3.2–P3.5 queued (issues #18–#22)
+- **Phase 2.x (cleanup before Phase 3):** ✅ complete (P2.x.1 – P2.x.4)
+- **Phase 3 (CLI):** ✅ complete — P3.1 through P3.4 shipped; P3.5 (toner-friendly print stylesheet) deferred to Phase 8 alongside the actual reports (#22)
+- **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
+- **Phase 4 (envelopes + sinking funds):** not started
 
-**Tests:** 304 passing · **CI:** green on `main`
+**Tests:** 460 passing · **CI:** green on `main`
 
 ---
 
@@ -228,9 +230,45 @@ Closes #21.
 - 21 new tests: 10 parser unit tests (account+amount, negative, currency override, UUIDs, multiple-colon codes, malformed shapes); 5 E2E for `accounts add` (happy, minimal-no-code, --json, invalid type, unauthenticated); 6 E2E for `tulip add` (happy with balance round-trip, --json, unbalanced rejection, unknown-account-in-post, single-posting validation, unauthenticated).
 - Project test count: 411 passing.
 
-Phase 3 is now complete except for **P3.5 (toner-friendly print stylesheet)**, which is recommended to defer to Phase 8 alongside the actual reports — see #22.
+### P3.5 — Toner-friendly print stylesheet — deferred to Phase 8 (#22)
 
-### P3.5 — Toner-friendly print stylesheet — queued (#22), may defer to Phase 8
+Phase 3 originally included a print-stylesheet skeleton, but with no reports to render against, the invariants are easy to drift out of sync. Recommended deferral until Phase 8 reports work; #22 stays open as the holding pen.
+
+---
+
+## Post-Phase-3 enhancements
+
+These weren't in the original Phase 3 plan but landed before Phase 4 work begins, and the CLI's full ergonomic loop (register → login → accounts add (with parent) → add (interactive or flag) → balance) needed all three to feel complete.
+
+### Balance endpoints + `tulip balance` (#31, #20-b) — ✅ *(2026-05-01)*
+
+- **API**: `TransactionRepository.balance_for_account` and `TransactionRepository.trial_balance` (POSTED + RECONCILED only; pending is workflow state). New schemas in `tulip_api.schemas.balance`. Two endpoints: `GET /v1/accounts/{id}/balance` and `GET /v1/reports/trial-balance` (new `routers/reports.py`). Both accept `?as_of=YYYY-MM-DD`. All Decimal balances are quantized to currency minor units via `Money.quantize_to_currency()`.
+- **CLI**: `tulip balance` (no arg) renders trial balance with debit/credit zero-sum check; `tulip balance ACCOUNT` (code or UUID) shows a single account's balance.
+- 23 new tests (8 storage, 10 API, 8 CLI). PRs #37 + #38.
+
+### Account nesting end-to-end (#42) — ✅ *(2026-05-01)*
+
+- **API** (#42.a, PR #45): On `POST` and `PATCH /v1/accounts`, parent_account_id is validated against four rules: `parent.type == child.type`, `parent.currency == child.currency`, no shared-child-under-private-parent, and no cycles (cycle walk on PATCH only). Five new error codes: `account.parent_not_found`, `account.parent_type_mismatch`, `account.parent_currency_mismatch`, `account.parent_visibility_violation`, `account.parent_cycle`. `AccountUpdate` learns `parent_account_id` so PATCH can reparent.
+- **CLI** (#42.b, PR #47): `tulip accounts add --parent ACCOUNT` (code or UUID); `tulip accounts list` defaults to a Rich tree when nesting exists, falls back to flat table when it doesn't or under `--flat`; `tulip accounts show` resolves and displays the parent's code+name.
+- Multi-currency parent hierarchies (USD-base household with EUR/GBP/JPY travel sub-accounts) are deliberately rejected; the design discussion lives in **#44** as a holding pen.
+- 23 new tests (14 API, 9 CLI).
+
+### Interactive `tulip add --edit` (#43) — ✅ *(2026-05-01)*
+
+PR #48. Editor-driven transaction entry as an alternative to the flag mode.
+
+- New `tulip_cli.commands._editor` spawns `$VISUAL` → `$EDITOR` → `vi`/`notepad` (with `shlex.split` so `EDITOR='code --wait'` works).
+- New `tulip_cli.commands._ledger` parses a strict subset of hledger syntax: `YYYY-MM-DD <description>` header, indented `<account>  <amount> [<currency>]` postings, `#` and `;` comments. Errors carry line numbers.
+- The editor loop reopens with a banner on parse / balance / unknown-account / period-closed errors so users fix their typing rather than re-typing from scratch (matches `git commit` ergonomics). Saving an empty/comments-only buffer aborts cleanly with exit `0`.
+- 26 new tests: 15 parser unit, 5 editor-spawn unit, 6 E2E with a fake editor (happy + abort + 3 reopen-on-error + `--json`).
+
+---
+
+## Other shipped fixes
+
+### P2.x.4 — catch-all unhandled-exception handler — ✅ *(2026-05-01)*
+
+PR #30. Closed #26. Surfaced during P3.2.a smoke testing when a SQLAlchemy URL parse error escaped the Problem Details middleware and emitted Starlette's default `text/plain` 500. New `InternalServerError` (`server.internal_error`, 500) `TulipProblem` subclass; `install_problem_handlers` registers a fourth handler for the `Exception` base. Exception text and tracebacks stay in logs; clients get a generic detail with a `request_id` for support correlation.
 
 ---
 


### PR DESCRIPTION
PR #48 (interactive `tulip add --edit`) closed the last big-ticket Phase 3 item, but the top-of-tree docs still described an earlier state. This PR makes them match what's actually shipped.

## Changes

### `docs/PHASE_STATUS.md`

- Header: bump to "Phase 3 complete (P3.5 deferred)" + 460 passing + current `main` hash.
- New **Post-Phase-3 enhancements** section covering #31 (balance endpoints), #42 (account nesting), #43 (interactive add).
- New P2.x.4 entry for the catch-all 500 handler shipped in #30.
- P3.5 status: "queued (#22), may defer to Phase 8" → "deferred to Phase 8 (#22)".

### `README.md`

- Status line: Phases 0–2 complete → Phases 0–3 complete; Phase 4 not started.
- Pytest count + timing: 184 tests / ~5s → 460 tests / ~90s.
- Endpoint list: add MFA endpoints, `/v1/accounts/{id}/balance`, `/v1/reports/trial-balance`; note every non-2xx is `application/problem+json`.
- CLI quick-start: replace the "once Phase 3 lands" placeholder with the real register → login → accounts add → tx add → balance loop, using the actual `--post account=amount` syntax. Mention `--edit` mode and the tree-vs-flat list rendering.

### `docs/ARCHITECTURE.md`

- §7.8.9: replace "Phase 2 endpoints currently raise HTTPException, migration is queued" with the shipped P2.x.1–4 status. Reference the architecture-test guard.
- §10 phase roadmap: mark Phase 2.x and Phase 3 complete (with sub-bullets where the original list items now resolve). Add a follow-ups subsection for #31, #42, #43.

## Test plan

- [x] `uv run pytest` — 460 passing, no behavior changes.
- [x] `uv run pre-commit run --all-files` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)