### PR TITLE
feat(cli): P3.6 — read+edit completeness (#54)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-01 · `main` @ `39e1498`
+**Last updated:** 2026-05-01 · `main` @ `0ab586c`
 
 ---
 
@@ -12,12 +12,12 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 1:** ✅ complete
 - **Phase 2 (core API surface):** ✅ complete
 - **Phase 2.x (cleanup before Phase 3):** ✅ complete (P2.x.1 – P2.x.4)
-- **Phase 3 (CLI):** ✅ complete — P3.1 through P3.4 shipped; P3.5 (toner-friendly print stylesheet) deferred to Phase 8 alongside the actual reports (#22)
+- **Phase 3 (CLI):** ✅ complete — P3.1 through P3.4 + P3.6 shipped; P3.5 (toner-friendly print stylesheet) deferred to Phase 8 alongside the actual reports (#22)
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
-- **Queued before Phase 4:** P3.6 — CLI read+edit completeness (#54); threat-model checkpoint (#56). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
+- **Queued before Phase 4:** threat-model checkpoint (#56). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
 - **Phase 4 (envelopes + sinking funds):** not started
 
-**Tests:** 460 passing · **CI:** green on `main`
+**Tests:** 496 passing · **CI:** green on `main`
 
 ---
 
@@ -235,9 +235,17 @@ Closes #21.
 
 Phase 3 originally included a print-stylesheet skeleton, but with no reports to render against, the invariants are easy to drift out of sync. Recommended deferral until Phase 8 reports work; #22 stays open as the holding pen.
 
-### P3.6 — CLI read+edit completeness — queued (#54)
+### P3.6 — CLI read+edit completeness — ✅ *(2026-05-01)*
 
-Pure CLI work against endpoints that already exist on the API: `tulip transactions list` / `show` (against `GET /v1/transactions` and `GET /v1/transactions/{id}`), `tulip accounts edit` (against `PATCH /v1/accounts/{id}`, including `--parent` reparent — parent validation already landed with #42.a), and `tulip accounts deactivate` (against `DELETE /v1/accounts/{id}`). Closes the "you can write but can't read your own data via CLI" gap before Phase 4. Transaction edit/delete/void deliberately *not* in scope — see #55.
+Closes #54. Filled the "you can write but can't read your own data via CLI" gap before Phase 4 starts. Originally scoped as pure CLI work; the `GET /v1/transactions` endpoint had no filter params, so the slice grew a small repo + API extension as well.
+
+- **Storage**: new `TransactionRepository.list_headers(account_id, from_date, to_date, status, limit)` replaces the inline SQL the API router used to do. Filters AND together; `account_id` matches any transaction with at least one posting on that account; date range is inclusive; ordered date desc, created_at desc.
+- **API**: `GET /v1/transactions` learns `account_id` / `from` / `to` / `status` / `limit` query params. `status` is regex-validated to `pending|posted|reconciled`, `limit` is bounded to 1-1000 — both surface as `validation.failed` (422) on bad input. The router now delegates to `list_headers` rather than inlining its own query.
+- **CLI**: new `tulip transactions list` (with `--account` code-or-UUID, `--from`, `--to`, `--status`, `--limit`, plus `--json` passthrough) and `tulip transactions show TXID` (header + posting table). New `tulip accounts edit ACCOUNT` — only sends explicitly-passed fields; supports `--name` / `--code` / `--subtype` / `--visibility` / `--parent` (the last one re-uses the parent-validation rules from #42.a). New `tulip accounts deactivate ACCOUNT` — confirmation prompt by default, `--yes` to skip.
+- **HTTP**: `TulipClient` learned `patch()` and `delete()` for the new account flows.
+- 36 new tests (5 storage, 7 API, 24 CLI E2E across all four commands incl. happy / filter combos / error paths / `--json` / unauthenticated). Project test count: 496 passing.
+
+Transaction edit / delete / void deliberately not in scope — see #55, deferred to Phase 5 alongside reconciliation.
 
 ### Transaction void / PENDING-only edit — deferred to Phase 5 (#55)
 

--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import date as date_type
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 import structlog
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 
 from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.deps import get_session
@@ -40,6 +41,7 @@ from tulip_core.transactions import (
 from tulip_core.transactions import (
     TransactionStatus as DomainTxStatus,
 )
+from tulip_storage.models import TransactionStatus as StorageTxStatus
 from tulip_storage.repositories import (
     AccountRepository,
     AuditLogWriter,
@@ -161,25 +163,58 @@ def get_transaction(
 @router.get(
     "",
     response_model=list[TransactionRead],
-    responses={401: problem_response("auth.unauthorized")},
+    responses={
+        401: problem_response("auth.unauthorized"),
+        422: problem_response("validation.failed"),
+    },
 )
 def list_transactions(
+    account_id: UUID | None = Query(  # noqa: B008
+        default=None,
+        description=(
+            "Restrict to transactions with at least one posting on this account (any currency)."
+        ),
+    ),
+    from_date: date_type | None = Query(  # noqa: B008
+        default=None,
+        alias="from",
+        description="Inclusive lower bound on transaction date (YYYY-MM-DD).",
+    ),
+    to_date: date_type | None = Query(  # noqa: B008
+        default=None,
+        alias="to",
+        description="Inclusive upper bound on transaction date (YYYY-MM-DD).",
+    ),
+    status_: str | None = Query(
+        default=None,
+        alias="status",
+        description="One of 'pending', 'posted', 'reconciled'.",
+        pattern="^(pending|posted|reconciled)$",
+    ),
+    limit: int | None = Query(
+        default=None,
+        ge=1,
+        le=1000,
+        description="Cap on rows returned (1-1000). Omit for no limit.",
+    ),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> list[TransactionRead]:
-    """List all transactions in the caller's household, newest first."""
-    from sqlalchemy import select
+    """List transactions in the caller's household, newest first.
 
-    from tulip_storage.models import Transaction as TxModel
-
-    rows = list(
-        session.execute(
-            select(TxModel)
-            .where(TxModel.household_id == claims.household_id)
-            .order_by(TxModel.date.desc(), TxModel.created_at.desc())
-        )
-        .scalars()
-        .all()
+    All filter params are optional and AND together. ``account_id`` is
+    a UUID. Date params use the ``from`` / ``to`` query keys (inclusive
+    on both ends). ``status`` is one of the lifecycle states.
+    """
+    storage_status: StorageTxStatus | None = (
+        StorageTxStatus(status_) if status_ is not None else None
+    )
+    rows = TransactionRepository(session, claims.household_id).list_headers(
+        account_id=account_id,
+        from_date=from_date,
+        to_date=to_date,
+        status=storage_status,
+        limit=limit,
     )
     return [_read_response(t.id, claims.household_id, session) for t in rows]
 

--- a/packages/tulip-api/tests/test_transactions_endpoints.py
+++ b/packages/tulip-api/tests/test_transactions_endpoints.py
@@ -188,3 +188,139 @@ class TestReadTransactions:
             )
         rows = client.get("/v1/transactions", headers=auth_h).json()
         assert len(rows) == 3
+
+
+class TestListTransactionsFilters:
+    """`GET /v1/transactions` filter query params (P3.6)."""
+
+    @pytest.fixture
+    def seeded(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ) -> tuple[str, str, str]:
+        """Seed three transactions across different dates and a third account.
+
+        Returns ``(cash_id, food_id, rent_id)``.
+        """
+        cash, food = cash_and_food
+        rent = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Rent", "type": "expense", "currency": "USD", "code": "5200"},
+        ).json()["id"]
+
+        for tx_date, desc, debit_account, amount in [
+            (date(date.today().year, 1, 15), "lunch-jan", food, "10.00"),
+            (date(date.today().year, 6, 15), "rent-jun", rent, "1500.00"),
+            (date(date.today().year, 11, 15), "lunch-nov", food, "12.00"),
+        ]:
+            r = client.post(
+                "/v1/transactions",
+                headers=auth_h,
+                json={
+                    "date": tx_date.isoformat(),
+                    "description": desc,
+                    "postings": [
+                        {"account_id": debit_account, "amount": amount, "currency": "USD"},
+                        {"account_id": cash, "amount": f"-{amount}", "currency": "USD"},
+                    ],
+                },
+            )
+            assert r.status_code == 201, r.text
+
+        return cash, food, rent
+
+    def test_filter_by_account(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        seeded: tuple[str, str, str],
+    ):
+        _cash, food, rent = seeded
+        food_rows = client.get(
+            "/v1/transactions", headers=auth_h, params={"account_id": food}
+        ).json()
+        assert {r["description"] for r in food_rows} == {"lunch-jan", "lunch-nov"}
+        rent_rows = client.get(
+            "/v1/transactions", headers=auth_h, params={"account_id": rent}
+        ).json()
+        assert {r["description"] for r in rent_rows} == {"rent-jun"}
+
+    def test_filter_by_date_range(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        seeded: tuple[str, str, str],
+    ):
+        year = date.today().year
+        rows = client.get(
+            "/v1/transactions",
+            headers=auth_h,
+            params={"from": f"{year}-06-01", "to": f"{year}-06-30"},
+        ).json()
+        assert {r["description"] for r in rows} == {"rent-jun"}
+
+    def test_filter_by_status(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        seeded: tuple[str, str, str],
+    ):
+        # All seeded transactions land as POSTED, so 'posted' returns three
+        # and 'pending' / 'reconciled' return none.
+        posted = client.get("/v1/transactions", headers=auth_h, params={"status": "posted"}).json()
+        assert len(posted) == 3
+        pending = client.get(
+            "/v1/transactions", headers=auth_h, params={"status": "pending"}
+        ).json()
+        assert pending == []
+
+    def test_invalid_status_rejected_with_validation_failed(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        r = client.get("/v1/transactions", headers=auth_h, params={"status": "bogus"})
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_limit_caps_results(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        seeded: tuple[str, str, str],
+    ):
+        rows = client.get("/v1/transactions", headers=auth_h, params={"limit": 2}).json()
+        assert len(rows) == 2
+        # Newest first, so the November lunch and June rent.
+        assert {r["description"] for r in rows} == {"lunch-nov", "rent-jun"}
+
+    def test_limit_out_of_range_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        r = client.get("/v1/transactions", headers=auth_h, params={"limit": 0})
+        assert_problem(r, code="validation.failed", status=422)
+        r = client.get("/v1/transactions", headers=auth_h, params={"limit": 99999})
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_filters_compose(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        seeded: tuple[str, str, str],
+    ):
+        _cash, food, _rent = seeded
+        year = date.today().year
+        rows = client.get(
+            "/v1/transactions",
+            headers=auth_h,
+            params={
+                "account_id": food,
+                "from": f"{year}-10-01",
+                "status": "posted",
+            },
+        ).json()
+        assert {r["description"] for r in rows} == {"lunch-nov"}

--- a/packages/tulip-cli/src/tulip_cli/commands/accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/accounts.py
@@ -310,6 +310,134 @@ def add_account(
     _render_account(payload)
 
 
+@accounts_app.command("edit")
+def edit_account(
+    ctx: typer.Context,
+    identifier: Annotated[
+        str,
+        typer.Argument(
+            help="Account code (e.g. assets:checking) or UUID.",
+            metavar="ACCOUNT",
+        ),
+    ],
+    name: Annotated[
+        str | None,
+        typer.Option("--name", help="New display name."),
+    ] = None,
+    code: Annotated[
+        str | None,
+        typer.Option("--code", help="New short code."),
+    ] = None,
+    subtype: Annotated[
+        str | None,
+        typer.Option("--subtype", help="New subtype label."),
+    ] = None,
+    visibility: Annotated[
+        str | None,
+        typer.Option("--visibility", help="'shared' or 'private'."),
+    ] = None,
+    parent: Annotated[
+        str | None,
+        typer.Option(
+            "--parent",
+            help=(
+                "New parent account (code or UUID). The same parent-validation "
+                "rules from `accounts add` apply (type/currency match, "
+                "visibility, no cycles)."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Update mutable fields on an existing account.
+
+    Only flags that are explicitly passed are sent — PATCH semantics, so
+    omitted fields stay as-is. Resolves the target via the same UUID-or-
+    code lookup as ``show``.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    body: dict[str, Any] = {}
+    if name is not None:
+        body["name"] = name
+    if code is not None:
+        body["code"] = code
+    if subtype is not None:
+        body["subtype"] = subtype
+    if visibility is not None:
+        body["visibility"] = visibility
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            target = _resolve_account(client, identifier)
+            if parent is not None:
+                resolved_parent = _resolve_account(client, parent)
+                body["parent_account_id"] = resolved_parent["id"]
+            response = client.patch(f"/v1/accounts/{target['id']}", json=body, authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    payload = response.json()
+    typer.echo(f"Updated account {payload.get('id', '')}")
+    _render_account(payload)
+
+
+@accounts_app.command("deactivate")
+def deactivate_account(
+    ctx: typer.Context,
+    identifier: Annotated[
+        str,
+        typer.Argument(
+            help="Account code (e.g. assets:checking) or UUID.",
+            metavar="ACCOUNT",
+        ),
+    ],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip the interactive confirmation prompt.",
+        ),
+    ] = False,
+) -> None:
+    """Soft-delete (deactivate) an account.
+
+    The account stays in the database (audit trail) but disappears from
+    ``accounts list``. Admin-only on the API side. By default prompts for
+    confirmation; ``--yes`` skips for scripts.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            target = _resolve_account(client, identifier)
+            if not yes:
+                label = target.get("code") or target.get("name") or str(target["id"])
+                if not typer.confirm(
+                    f"Deactivate account {label}? It will disappear from `accounts list`.",
+                    default=False,
+                ):
+                    typer.echo("Aborted; no changes made.")
+                    return
+            client.delete(f"/v1/accounts/{target['id']}", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        # The API returns 204 No Content; emit an explicit body for scripts.
+        sys.stdout.write(json.dumps({"deactivated": str(target["id"])}) + "\n")
+        return
+    typer.echo(f"Deactivated account {target.get('code') or target['id']}.")
+
+
 @accounts_app.command("show")
 def show_account(
     ctx: typer.Context,

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -1,6 +1,6 @@
-"""``tulip add`` — create a balanced transaction.
+"""``tulip add`` (transaction create) and ``tulip transactions`` (read).
 
-Two input modes:
+Two input modes for creation:
 
 * **Flag mode** (the original P3.4 surface) — repeated
   ``--post account=amount[@CURRENCY]`` flags. Scriptable, unambiguous.
@@ -14,6 +14,11 @@ Why ``account=amount`` and not space-separated parts in flag mode:
 codes contain colons (e.g. ``assets:checking``), so a colon-delimited
 ``account:amount`` syntax is ambiguous. ``=`` is unambiguous and we
 ``rsplit`` on it so codes-with-colons round-trip.
+
+Read commands (``tulip transactions list`` / ``show``) consume
+``GET /v1/transactions`` (with the filter query params landed in P3.6)
+and ``GET /v1/transactions/{id}``. ``list`` renders a Rich table by
+default; ``show`` renders header-plus-postings.
 """
 
 from __future__ import annotations
@@ -24,8 +29,11 @@ from dataclasses import dataclass
 from datetime import date as date_type
 from decimal import Decimal, InvalidOperation
 from typing import Annotated, Any
+from uuid import UUID
 
 import typer
+from rich.console import Console
+from rich.table import Table
 
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands._editor import edit_buffer
@@ -345,3 +353,198 @@ def _with_banner(prior: str, message: str) -> str:
         and not line.startswith("# Fix the lines below")
     )
     return banner + body
+
+
+# ---- read commands: tulip transactions list / show -------------------------
+
+
+transactions_app = typer.Typer(
+    name="transactions",
+    help="List and inspect existing transactions.",
+    no_args_is_help=True,
+)
+
+
+def _validate_iso_date(value: str | None, *, flag: str) -> str | None:
+    if value is None:
+        return None
+    try:
+        date_type.fromisoformat(value)
+    except ValueError as exc:
+        raise typer.BadParameter(f"{flag} must be YYYY-MM-DD") from exc
+    return value
+
+
+_VALID_STATUSES = ("pending", "posted", "reconciled")
+
+
+def _resolve_account_id_for_filter(client: TulipClient, identifier: str) -> str:
+    """Resolve ``--account`` to a UUID string via the shared resolver."""
+    resolved = _resolve_account(client, identifier)
+    return str(resolved["id"])
+
+
+def _render_tx_list_table(rows: list[dict[str, Any]]) -> None:
+    table = Table(show_header=True, show_lines=False)
+    table.add_column("date")
+    table.add_column("description")
+    table.add_column("reference")
+    table.add_column("status")
+    table.add_column("postings")
+    for row in rows:
+        postings = row.get("postings") or []
+        summary_parts = []
+        for p in postings:
+            amount = p.get("amount", "")
+            currency = p.get("currency", "")
+            account = p.get("account_id", "")
+            short = str(account)[:8] if account else "—"
+            summary_parts.append(f"{short} {amount} {currency}")
+        summary = "\n".join(summary_parts)
+        table.add_row(
+            str(row.get("date") or ""),
+            row.get("description") or "",
+            row.get("reference") or "—",
+            row.get("status") or "",
+            summary,
+        )
+    Console().print(table)
+
+
+def _render_tx_detail(tx: dict[str, Any]) -> None:
+    typer.echo(f"id:           {tx.get('id', '')}")
+    typer.echo(f"date:         {tx.get('date', '')}")
+    typer.echo(f"description:  {tx.get('description', '')}")
+    typer.echo(f"reference:    {tx.get('reference') or '—'}")
+    typer.echo(f"status:       {tx.get('status', '')}")
+    typer.echo("postings:")
+    table = Table(show_header=True, show_lines=False)
+    table.add_column("account_id")
+    table.add_column("amount", justify="right")
+    table.add_column("currency")
+    table.add_column("memo")
+    for p in tx.get("postings") or []:
+        table.add_row(
+            str(p.get("account_id", "")),
+            str(p.get("amount", "")),
+            str(p.get("currency", "")),
+            str(p.get("memo") or ""),
+        )
+    Console().print(table)
+
+
+@transactions_app.command("list")
+def list_transactions(
+    ctx: typer.Context,
+    account: Annotated[
+        str | None,
+        typer.Option(
+            "--account",
+            help=(
+                "Filter to transactions touching this account (code or UUID). "
+                "Resolved via the same UUID-or-code lookup as `accounts show`."
+            ),
+        ),
+    ] = None,
+    from_date: Annotated[
+        str | None,
+        typer.Option(
+            "--from",
+            help="Inclusive lower bound on transaction date (YYYY-MM-DD).",
+        ),
+    ] = None,
+    to_date: Annotated[
+        str | None,
+        typer.Option(
+            "--to",
+            help="Inclusive upper bound on transaction date (YYYY-MM-DD).",
+        ),
+    ] = None,
+    status_: Annotated[
+        str | None,
+        typer.Option(
+            "--status",
+            help="One of: pending, posted, reconciled.",
+        ),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        typer.Option(
+            "--limit",
+            help="Cap on rows returned (1-1000). Omit for no limit.",
+            min=1,
+            max=1000,
+        ),
+    ] = None,
+) -> None:
+    """List transactions, newest first. All filters are optional and AND together."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    _validate_iso_date(from_date, flag="--from")
+    _validate_iso_date(to_date, flag="--to")
+    if status_ is not None and status_ not in _VALID_STATUSES:
+        raise typer.BadParameter(
+            f"--status must be one of {', '.join(_VALID_STATUSES)} (got {status_!r})"
+        )
+
+    params: dict[str, str] = {}
+    try:
+        with _client(config, as_json=as_json) as client:
+            if account is not None:
+                params["account_id"] = _resolve_account_id_for_filter(client, account)
+            if from_date is not None:
+                params["from"] = from_date
+            if to_date is not None:
+                params["to"] = to_date
+            if status_ is not None:
+                params["status"] = status_
+            if limit is not None:
+                params["limit"] = str(limit)
+            response = client.get("/v1/transactions", authenticated=True, params=params)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    rows = response.json()
+    if not rows:
+        typer.echo("No transactions match.")
+        return
+    _render_tx_list_table(rows)
+
+
+@transactions_app.command("show")
+def show_transaction(
+    ctx: typer.Context,
+    tx_id: Annotated[
+        str,
+        typer.Argument(
+            help="Transaction UUID.",
+            metavar="TXID",
+        ),
+    ],
+) -> None:
+    """Show one transaction (header + postings) by UUID."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    try:
+        UUID(tx_id)
+    except ValueError as exc:
+        raise typer.BadParameter("TXID must be a UUID") from exc
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get(f"/v1/transactions/{tx_id}", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    _render_tx_detail(response.json())

--- a/packages/tulip-cli/src/tulip_cli/http.py
+++ b/packages/tulip-cli/src/tulip_cli/http.py
@@ -151,6 +151,27 @@ class TulipClient:
         """``POST path`` against the configured API."""
         return self.request("POST", path, authenticated=authenticated, json=json, headers=headers)
 
+    def patch(
+        self,
+        path: str,
+        *,
+        authenticated: bool = False,
+        json: object = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """``PATCH path`` against the configured API."""
+        return self.request("PATCH", path, authenticated=authenticated, json=json, headers=headers)
+
+    def delete(
+        self,
+        path: str,
+        *,
+        authenticated: bool = False,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """``DELETE path`` against the configured API."""
+        return self.request("DELETE", path, authenticated=authenticated, headers=headers)
+
     def _access_token(self) -> str:
         store = self._token_store
         if store is None:

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -19,6 +19,7 @@ from tulip_cli.commands.auth import auth_app
 from tulip_cli.commands.balance import balance as balance_command
 from tulip_cli.commands.register import register as register_command
 from tulip_cli.commands.transactions import add as add_command
+from tulip_cli.commands.transactions import transactions_app
 from tulip_cli.config import Config, load_config
 from tulip_cli.errors import EXIT_OK, CliError
 from tulip_cli.http import TulipClient
@@ -91,6 +92,7 @@ app.command("balance")(balance_command)
 app.command("add")(add_command)
 app.add_typer(auth_app, name="auth")
 app.add_typer(accounts_app, name="accounts")
+app.add_typer(transactions_app, name="transactions")
 
 
 if __name__ == "__main__":

--- a/packages/tulip-cli/tests/test_p36_read_edit.py
+++ b/packages/tulip-cli/tests/test_p36_read_edit.py
@@ -1,0 +1,437 @@
+"""End-to-end tests for P3.6 CLI commands (#54).
+
+Covers:
+
+* ``tulip transactions list`` (with all five filters and ``--json``)
+* ``tulip transactions show``
+* ``tulip accounts edit`` (PATCH-semantics, --parent reparent, etc.)
+* ``tulip accounts deactivate`` (with confirmation prompt and ``--yes``)
+
+Each test spawns the API via ``live_api``, registers + logs in (writing
+to a per-test JSON token store), and runs the real ``tulip`` console
+script as a subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=20,
+    )
+
+
+@pytest.fixture
+def authed_session(live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    cli_login = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert cli_login.returncode == 0, cli_login.stderr
+    return live_api
+
+
+def _add_account(
+    api_url: str,
+    code: str,
+    name: str,
+    type_: str,
+    *,
+    parent: str | None = None,
+) -> str:
+    args = [
+        "--json",
+        "accounts",
+        "add",
+        "--name",
+        name,
+        "--type",
+        type_,
+        "--currency",
+        "USD",
+        "--code",
+        code,
+    ]
+    if parent is not None:
+        args += ["--parent", parent]
+    result = _run_cli(*args, api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    # `accounts add` prints "Created account <id>\n<details>" then JSON via --json.
+    # With --json it prints just the body to stdout.
+    return str(json.loads(result.stdout)["id"])
+
+
+def _add_tx(api_url: str, *, tx_date: str, description: str, posts: list[str]) -> str:
+    args = ["--json", "add", "--date", tx_date, "--description", description]
+    for p in posts:
+        args += ["--post", p]
+    result = _run_cli(*args, api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    return str(json.loads(result.stdout)["id"])
+
+
+# ---------- tulip transactions list ----------
+
+
+@pytest.fixture
+def seeded_session(authed_session: str) -> tuple[str, str, str, str]:
+    """Seed two accounts and three transactions across different dates.
+
+    Returns ``(api_url, checking_id, food_id, rent_id)``.
+    """
+    checking_id = _add_account(authed_session, "assets:checking", "Checking", "asset")
+    food_id = _add_account(authed_session, "expenses:food", "Food", "expense")
+    rent_id = _add_account(authed_session, "expenses:rent", "Rent", "expense")
+
+    year = date.today().year
+    _add_tx(
+        authed_session,
+        tx_date=f"{year}-01-15",
+        description="lunch-jan",
+        posts=["expenses:food=10.00", "assets:checking=-10.00"],
+    )
+    _add_tx(
+        authed_session,
+        tx_date=f"{year}-06-15",
+        description="rent-jun",
+        posts=["expenses:rent=1500.00", "assets:checking=-1500.00"],
+    )
+    _add_tx(
+        authed_session,
+        tx_date=f"{year}-11-15",
+        description="lunch-nov",
+        posts=["expenses:food=12.00", "assets:checking=-12.00"],
+    )
+    return authed_session, checking_id, food_id, rent_id
+
+
+@pytest.mark.integration
+def test_transactions_list_renders_all(seeded_session: tuple[str, str, str, str]) -> None:
+    api_url, _checking, _food, _rent = seeded_session
+    result = _run_cli("transactions", "list", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    # All three descriptions should show up in the table.
+    for desc in ("lunch-jan", "rent-jun", "lunch-nov"):
+        assert desc in result.stdout
+
+
+@pytest.mark.integration
+def test_transactions_list_filters_by_account_code(
+    seeded_session: tuple[str, str, str, str],
+) -> None:
+    api_url, _checking, _food, _rent = seeded_session
+    result = _run_cli("transactions", "list", "--account", "expenses:rent", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    assert "rent-jun" in result.stdout
+    assert "lunch-jan" not in result.stdout
+    assert "lunch-nov" not in result.stdout
+
+
+@pytest.mark.integration
+def test_transactions_list_filters_by_date_range(
+    seeded_session: tuple[str, str, str, str],
+) -> None:
+    api_url, _checking, _food, _rent = seeded_session
+    year = date.today().year
+    result = _run_cli(
+        "transactions",
+        "list",
+        "--from",
+        f"{year}-06-01",
+        "--to",
+        f"{year}-06-30",
+        api_url=api_url,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "rent-jun" in result.stdout
+    assert "lunch-jan" not in result.stdout
+    assert "lunch-nov" not in result.stdout
+
+
+@pytest.mark.integration
+def test_transactions_list_limit_caps_results(
+    seeded_session: tuple[str, str, str, str],
+) -> None:
+    api_url, _checking, _food, _rent = seeded_session
+    result = _run_cli("--json", "transactions", "list", "--limit", "1", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    rows = json.loads(result.stdout)
+    assert len(rows) == 1
+    # Newest first → November lunch.
+    assert rows[0]["description"] == "lunch-nov"
+
+
+@pytest.mark.integration
+def test_transactions_list_status_filter(
+    seeded_session: tuple[str, str, str, str],
+) -> None:
+    api_url, _checking, _food, _rent = seeded_session
+    # Seeded transactions are POSTED. PENDING should be empty.
+    result = _run_cli("--json", "transactions", "list", "--status", "pending", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == []
+
+
+@pytest.mark.integration
+def test_transactions_list_invalid_status_user_error(authed_session: str) -> None:
+    # Client-side validation goes through typer.BadParameter, which exits 2
+    # (Click usage convention). This matches the existing pattern in
+    # `tulip add` / `tulip balance --as-of`.
+    result = _run_cli("transactions", "list", "--status", "bogus", api_url=authed_session)
+    assert result.returncode == 2, (result.stdout, result.stderr)
+    assert "status" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_transactions_list_invalid_date_user_error(authed_session: str) -> None:
+    result = _run_cli("transactions", "list", "--from", "yesterday", api_url=authed_session)
+    assert result.returncode == 2, (result.stdout, result.stderr)
+    assert "yyyy-mm-dd" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_transactions_list_empty_message(authed_session: str) -> None:
+    result = _run_cli("transactions", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "no transactions" in result.stdout.lower()
+
+
+@pytest.mark.integration
+def test_transactions_list_unauthenticated_fails(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli("transactions", "list", api_url=live_api)
+    assert result.returncode == 2, (result.stdout, result.stderr)
+
+
+# ---------- tulip transactions show ----------
+
+
+@pytest.mark.integration
+def test_transactions_show_by_uuid(seeded_session: tuple[str, str, str, str]) -> None:
+    api_url, _checking, _food, _rent = seeded_session
+    list_result = _run_cli("--json", "transactions", "list", api_url=api_url)
+    rows = json.loads(list_result.stdout)
+    target = next(r for r in rows if r["description"] == "rent-jun")
+
+    result = _run_cli("transactions", "show", target["id"], api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    assert "rent-jun" in result.stdout
+    assert target["id"] in result.stdout
+    assert "1500.00" in result.stdout
+
+
+@pytest.mark.integration
+def test_transactions_show_json_passthrough(
+    seeded_session: tuple[str, str, str, str],
+) -> None:
+    api_url, _checking, _food, _rent = seeded_session
+    list_result = _run_cli("--json", "transactions", "list", api_url=api_url)
+    target = next(r for r in json.loads(list_result.stdout) if r["description"] == "rent-jun")
+
+    result = _run_cli("--json", "transactions", "show", target["id"], api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    body = json.loads(result.stdout)
+    assert body["id"] == target["id"]
+    assert body["description"] == "rent-jun"
+    assert len(body["postings"]) == 2
+
+
+@pytest.mark.integration
+def test_transactions_show_invalid_uuid_user_error(authed_session: str) -> None:
+    result = _run_cli("transactions", "show", "not-a-uuid", api_url=authed_session)
+    assert result.returncode == 2, (result.stdout, result.stderr)
+    assert "uuid" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_transactions_show_unknown_uuid_user_error(authed_session: str) -> None:
+    result = _run_cli(
+        "transactions",
+        "show",
+        "00000000-0000-0000-0000-000000000000",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1, (result.stdout, result.stderr)
+
+
+# ---------- tulip accounts edit ----------
+
+
+@pytest.mark.integration
+def test_accounts_edit_renames(authed_session: str) -> None:
+    _add_account(authed_session, "assets:checking", "Checking", "asset")
+    result = _run_cli(
+        "accounts",
+        "edit",
+        "assets:checking",
+        "--name",
+        "Primary Checking",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Primary Checking" in result.stdout
+
+    show = _run_cli("accounts", "show", "assets:checking", api_url=authed_session)
+    assert "Primary Checking" in show.stdout
+
+
+@pytest.mark.integration
+def test_accounts_edit_only_sends_provided_fields(authed_session: str) -> None:
+    _add_account(authed_session, "assets:checking", "Checking", "asset")
+    # Edit with only --code, leaving name/visibility untouched.
+    result = _run_cli(
+        "--json",
+        "accounts",
+        "edit",
+        "assets:checking",
+        "--code",
+        "assets:primary",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["code"] == "assets:primary"
+    assert payload["name"] == "Checking"  # unchanged
+
+
+@pytest.mark.integration
+def test_accounts_edit_reparent(authed_session: str) -> None:
+    _add_account(authed_session, "expenses:top", "Top", "expense")
+    _add_account(authed_session, "expenses:groceries", "Groceries", "expense")
+    # Re-parent groceries under top.
+    result = _run_cli(
+        "accounts",
+        "edit",
+        "expenses:groceries",
+        "--parent",
+        "expenses:top",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    # And the tree view should now nest groceries under top.
+    list_result = _run_cli("accounts", "list", api_url=authed_session)
+    assert "Top" in list_result.stdout
+    assert "Groceries" in list_result.stdout
+
+
+@pytest.mark.integration
+def test_accounts_edit_parent_cycle_rejected(authed_session: str) -> None:
+    _add_account(authed_session, "expenses:parent", "Parent", "expense")
+    _add_account(authed_session, "expenses:child", "Child", "expense", parent="expenses:parent")
+    # Attempt to re-parent parent under its own child → cycle.
+    result = _run_cli(
+        "accounts",
+        "edit",
+        "expenses:parent",
+        "--parent",
+        "expenses:child",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "cycle" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_accounts_edit_no_changes_passed_is_noop(authed_session: str) -> None:
+    """Calling edit with no flags should not crash; PATCH with empty body is a no-op."""
+    _add_account(authed_session, "assets:checking", "Checking", "asset")
+    result = _run_cli("accounts", "edit", "assets:checking", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.integration
+def test_accounts_edit_unauthenticated_fails(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli(
+        "accounts",
+        "edit",
+        "assets:checking",
+        "--name",
+        "X",
+        api_url=live_api,
+    )
+    assert result.returncode == 2, (result.stdout, result.stderr)
+
+
+# ---------- tulip accounts deactivate ----------
+
+
+@pytest.mark.integration
+def test_accounts_deactivate_with_yes_skip(authed_session: str) -> None:
+    _add_account(authed_session, "assets:old", "Old", "asset")
+    result = _run_cli("accounts", "deactivate", "assets:old", "--yes", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    # The deactivated account should drop out of `accounts list`.
+    list_result = _run_cli("accounts", "list", api_url=authed_session)
+    assert "assets:old" not in list_result.stdout
+
+
+@pytest.mark.integration
+def test_accounts_deactivate_prompts_without_yes(authed_session: str) -> None:
+    """Without ``--yes``, the prompt is interactive; answering 'n' aborts."""
+    _add_account(authed_session, "assets:keepme", "Keep", "asset")
+    result = _run_cli(
+        "accounts",
+        "deactivate",
+        "assets:keepme",
+        api_url=authed_session,
+        stdin="n\n",
+    )
+    # User declined → no-op exit 0.
+    assert result.returncode == 0, result.stderr
+    # Account still active.
+    list_result = _run_cli("accounts", "list", api_url=authed_session)
+    assert "assets:keepme" in list_result.stdout
+
+
+@pytest.mark.integration
+def test_accounts_deactivate_unknown_code_user_error(authed_session: str) -> None:
+    result = _run_cli("accounts", "deactivate", "no-such-code", "--yes", api_url=authed_session)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+
+
+@pytest.mark.integration
+def test_accounts_deactivate_unauthenticated_fails(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli("accounts", "deactivate", "assets:checking", "--yes", api_url=live_api)
+    assert result.returncode == 2, (result.stdout, result.stderr)

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
@@ -65,6 +65,43 @@ class TransactionRepository:
             )
         ).scalar_one_or_none()
 
+    def list_headers(
+        self,
+        *,
+        account_id: UUID | None = None,
+        from_date: date_type | None = None,
+        to_date: date_type | None = None,
+        status: TransactionStatus | None = None,
+        limit: int | None = None,
+    ) -> list[Transaction]:
+        """List transaction headers in this household, newest first.
+
+        Filters compose with AND. ``account_id`` matches any transaction
+        with at least one posting on that account (any currency). Date
+        filters are inclusive on both ends. ``limit`` caps the number of
+        rows returned; ``None`` means no cap.
+        """
+        query = select(Transaction).where(Transaction.household_id == self._household_id)
+        if account_id is not None:
+            query = query.where(
+                Transaction.id.in_(
+                    select(Posting.transaction_id).where(
+                        Posting.household_id == self._household_id,
+                        Posting.account_id == account_id,
+                    )
+                )
+            )
+        if from_date is not None:
+            query = query.where(Transaction.date >= from_date)
+        if to_date is not None:
+            query = query.where(Transaction.date <= to_date)
+        if status is not None:
+            query = query.where(Transaction.status == status)
+        query = query.order_by(Transaction.date.desc(), Transaction.created_at.desc())
+        if limit is not None:
+            query = query.limit(limit)
+        return list(self._session.execute(query).scalars().all())
+
     def list_postings(self, tx_id: UUID) -> list[Posting]:
         """Return all postings belonging to a transaction."""
         return list(

--- a/packages/tulip-storage/tests/test_repositories.py
+++ b/packages/tulip-storage/tests/test_repositories.py
@@ -487,6 +487,208 @@ class TestTransactionRepository:
         assert early[food.id] == Decimal("5.00")
         assert late[food.id] == Decimal("12.00")
 
+    def test_list_headers_orders_by_date_desc(self, session: Session, household: Household):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        for tx_date, amount in [
+            (date(2026, 1, 5), Decimal("1.00")),
+            (date(2026, 6, 1), Decimal("2.00")),
+            (date(2026, 3, 15), Decimal("3.00")),
+        ]:
+            self._post_tx(
+                session,
+                household,
+                tx_date=tx_date,
+                debit_account=food,
+                credit_account=cash,
+                amount=amount,
+            )
+
+        headers = TransactionRepository(session, household.id).list_headers()
+        assert [h.date for h in headers] == [
+            date(2026, 6, 1),
+            date(2026, 3, 15),
+            date(2026, 1, 5),
+        ]
+
+    def test_list_headers_filters_by_account(self, session: Session, household: Household):
+        repo_a = AccountRepository(session, household.id)
+        cash = repo_a.create(code="1110", name="Cash", type=AccountType.ASSET, currency="USD")
+        food = repo_a.create(code="5100", name="Food", type=AccountType.EXPENSE, currency="USD")
+        rent = repo_a.create(code="5200", name="Rent", type=AccountType.EXPENSE, currency="USD")
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("12.50"),
+        )
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 2),
+            debit_account=rent,
+            credit_account=cash,
+            amount=Decimal("1500.00"),
+        )
+
+        repo = TransactionRepository(session, household.id)
+        # Cash sits on both → both transactions returned.
+        assert len(repo.list_headers(account_id=cash.id)) == 2
+        # Food only on the lunch one.
+        food_only = repo.list_headers(account_id=food.id)
+        assert len(food_only) == 1
+        assert food_only[0].description.startswith("12.50")
+        # Rent only on the rent one.
+        rent_only = repo.list_headers(account_id=rent.id)
+        assert len(rent_only) == 1
+        assert rent_only[0].description.startswith("1500.00")
+
+    def test_list_headers_filters_by_date_range(self, session: Session, household: Household):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        for tx_date in [date(2026, 1, 15), date(2026, 6, 15), date(2026, 11, 15)]:
+            self._post_tx(
+                session,
+                household,
+                tx_date=tx_date,
+                debit_account=food,
+                credit_account=cash,
+                amount=Decimal("10.00"),
+            )
+
+        repo = TransactionRepository(session, household.id)
+        from_only = repo.list_headers(from_date=date(2026, 6, 1))
+        assert {h.date for h in from_only} == {date(2026, 6, 15), date(2026, 11, 15)}
+        to_only = repo.list_headers(to_date=date(2026, 6, 30))
+        assert {h.date for h in to_only} == {date(2026, 1, 15), date(2026, 6, 15)}
+        ranged = repo.list_headers(from_date=date(2026, 6, 1), to_date=date(2026, 6, 30))
+        assert {h.date for h in ranged} == {date(2026, 6, 15)}
+
+    def test_list_headers_filters_by_status(self, session: Session, household: Household):
+        from tulip_storage.models import TransactionStatus
+
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("10.00"),
+            status=DomainTxStatus.POSTED,
+        )
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 2),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("99.00"),
+            status=DomainTxStatus.PENDING,
+        )
+
+        repo = TransactionRepository(session, household.id)
+        posted = repo.list_headers(status=TransactionStatus.POSTED)
+        pending = repo.list_headers(status=TransactionStatus.PENDING)
+        assert len(posted) == 1 and posted[0].status is TransactionStatus.POSTED
+        assert len(pending) == 1 and pending[0].status is TransactionStatus.PENDING
+
+    def test_list_headers_respects_limit(self, session: Session, household: Household):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        for day in (1, 2, 3, 4, 5):
+            self._post_tx(
+                session,
+                household,
+                tx_date=date(2026, 6, day),
+                debit_account=food,
+                credit_account=cash,
+                amount=Decimal("1.00"),
+            )
+
+        repo = TransactionRepository(session, household.id)
+        # Limit returns the newest N (date desc).
+        top_two = repo.list_headers(limit=2)
+        assert [h.date for h in top_two] == [date(2026, 6, 5), date(2026, 6, 4)]
+
+    def test_list_headers_excludes_other_households(self, session: Session, household: Household):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("10.00"),
+        )
+
+        # A second household with its own accounts and transaction.
+        other = Household(id=uuid4(), name="Jones", base_currency="USD")
+        session.add(other)
+        session.commit()
+        other_repo = AccountRepository(session, other.id)
+        other_cash = other_repo.create(
+            code="1110", name="Cash", type=AccountType.ASSET, currency="USD"
+        )
+        other_food = other_repo.create(
+            code="5100", name="Food", type=AccountType.EXPENSE, currency="USD"
+        )
+        PeriodRepository(session, other.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        self._post_tx(
+            session,
+            other,
+            tx_date=date(2026, 6, 1),
+            debit_account=other_food,
+            credit_account=other_cash,
+            amount=Decimal("99.99"),
+        )
+
+        ours = TransactionRepository(session, household.id).list_headers()
+        theirs = TransactionRepository(session, other.id).list_headers()
+        assert len(ours) == 1
+        assert len(theirs) == 1
+        assert ours[0].id != theirs[0].id
+
     def test_save_unbalanced_posted_aborts_via_trigger(
         self, session: Session, household: Household
     ):


### PR DESCRIPTION
## Summary

Closes #54. Fills the "you can write but can't read your own data via CLI" gap before Phase 4 starts. Originally scoped as pure CLI work; the `GET /v1/transactions` endpoint had no filter params, so the slice grew a small repo + API extension as well.

- **Storage**: new `TransactionRepository.list_headers(account_id, from_date, to_date, status, limit)` replaces the inline SQL the API router used to do.
- **API**: `GET /v1/transactions` learns `account_id` / `from` / `to` / `status` / `limit` query params (validated and bounded; bad input → `validation.failed` 422).
- **CLI**: new `tulip transactions list` / `show`, `tulip accounts edit` (PATCH semantics, --parent reparent reuses #42.a validation), `tulip accounts deactivate` (confirmation prompt, --yes to skip). `TulipClient` learned `patch()` and `delete()`.

Transaction edit/delete/void deliberately not in scope — see #55, deferred to Phase 5 alongside reconciliation.

## Test plan

- [x] `uv run pytest` — 496 passing (net +36: 5 storage, 7 API, 24 CLI E2E)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy packages/tulip-storage/src packages/tulip-api/src packages/tulip-cli/src` — clean

### Optional manual smoke (E2E loop in one terminal)

```
export TULIP_MASTER_KEY="q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s="
export TULIP_JWT_SECRET="test-secret-32bytes-test-secret!!"
export TULIP_DATABASE_URL="sqlite:///./tulip-smoke.db"
export TULIP_API_URL="http://127.0.0.1:8000"
export TULIP_TOKEN_STORE="$(pwd)/tulip-smoke-tokens.json"
uv run alembic -c packages/tulip-storage/alembic.ini upgrade head
uv run uvicorn tulip_api.main:create_app --factory &
sleep 1
uv run tulip register --email smoke@example.com --display-name Smoke --household Smoke --password-stdin <<< "long-enough-password"
uv run tulip auth login --email smoke@example.com --password-stdin <<< "long-enough-password"
uv run tulip accounts add --name Checking --type asset --currency USD --code assets:checking
uv run tulip accounts add --name Food --type expense --currency USD --code expenses:food
uv run tulip add --date 2026-05-01 --description "Lunch" --post "expenses:food=12.50" --post "assets:checking=-12.50"
uv run tulip transactions list
uv run tulip transactions list --account expenses:food --from 2026-01-01 --status posted --limit 10
uv run tulip transactions show "$(uv run --quiet tulip --json transactions list --limit 1 | python3 -c 'import json,sys;print(json.load(sys.stdin)[0]["id"])')"
uv run tulip accounts edit assets:checking --name "Primary Checking"
uv run tulip accounts deactivate expenses:food --yes
uv run tulip accounts list
kill %1
rm -f tulip-smoke.db tulip-smoke-tokens.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)