### PR TITLE
P4.0 — envelope/sinking-fund storage + domain layer (shadow ledger)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -392,20 +392,21 @@ Standard double-entry. The accounting engine module (`tulip.core.accounting`) is
 
 ### 5.3 Refill Rules (envelope `refill_rule` JSON)
 
-Three supported strategies:
+Three supported strategies, persisted as structured JSON only (no expression
+language, no string-to-eval — see [docs/THREAT_MODEL.md §5.1](THREAT_MODEL.md)).
+The shape is round-trippable through `tulip_core.allocation.RefillRule.{to,from}_dict`:
 
 ```json
-{ "strategy": "fixed", "amount": "500.00", "currency": "USD" }
+{ "strategy": "fixed_amount", "amount": "500.00", "currency": "USD" }
 
-{ "strategy": "percentage_of_income",
-  "percentage": "10.0",
-  "income_account_id": "...",
-  "lookback_period": "month" }
+{ "strategy": "fill_to_amount", "amount": "500.00", "currency": "USD" }
 
-{ "strategy": "fill_to_target",
-  "target_balance": "500.00",
-  "currency": "USD" }
+{ "strategy": "percentage_of_income", "percentage": "0.10" }
 ```
+
+`fixed_amount` contributes `amount` per period. `fill_to_amount` tops the
+envelope up to `amount` per period. `percentage_of_income` contributes
+`percentage` (a fraction in (0, 1]) of the next inflow.
 
 ### 5.4 Sinking Funds
 

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-01 · `main` @ `7e724a6`
+**Last updated:** 2026-05-02 · `main` @ `24353dd`
 
 ---
 
@@ -15,9 +15,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 3 (CLI):** ✅ complete — P3.1 through P3.4 + P3.6 shipped; P3.5 (toner-friendly print stylesheet) deferred to Phase 8 alongside the actual reports (#22)
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
 - **Pre-Phase-4 docs:** threat-model checkpoint shipped (#56, [docs/THREAT_MODEL.md](THREAT_MODEL.md)). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
-- **Phase 4 (envelopes + sinking funds):** not started
+- **Phase 4 (envelopes + sinking funds):** in flight — P4.0 (storage + domain layer per [ADR-0001](adrs/0001-envelope-shadow-ledger.md)) shipped 2026-05-02 (#60); P4.1 (API endpoints), P4.2 (CLI), P4.3 (refill rules + scheduled-tx runner) queued.
 
-**Tests:** 496 passing · **CI:** green on `main`
+**Tests:** 580 passing · **CI:** green on `main`
 
 ---
 
@@ -281,6 +281,31 @@ PR #48. Editor-driven transaction entry as an alternative to the flag mode.
 
 ---
 
+## Phase 4 — Envelopes + sinking funds — in flight
+
+Per [ADR-0001](adrs/0001-envelope-shadow-ledger.md). Envelope and sinking-fund balances are tracked through a parallel double-entry **shadow ledger** whose accounts are `allocation_pools`. Spending against an envelope = a main-ledger posting carrying `pool_id`, which auto-pairs a shadow transaction at write time. Refills, transfers, rollovers, and ad-hoc allocations are user-initiated shadow transactions. Pool balances are derived from `sum(shadow_postings)` — never stored.
+
+### P4.0 — Storage + domain layer — ✅ *(2026-05-02)*
+
+Closes #60. Pure storage + domain slice; no API, no CLI, no refill execution. Migration + value objects + engine + repositories + system-pool auto-creation + architecture test.
+
+- **Migration** (`a3f4d8e91b22`): new tables `allocation_pools`, `envelopes`, `sinking_funds`, `shadow_transactions`, `shadow_postings`. Four shadow-ledger balance triggers mirror the main-ledger triggers from migration 0001 — sum-to-zero per `(shadow_transaction_id, currency)` is enforced on transitions into `posted` and on `INSERT` / `UPDATE` / `DELETE` of postings while a shadow tx is `posted`. The long-deferred FK on `postings.pool_id → allocation_pools` lands here too (the column has existed since the initial schema as a nullable BLOB without referential integrity).
+- **Domain types** (`tulip_core.allocation`): `Pool` (frozen value object, equality by id), `PoolType` (5 values: `envelope`, `sinking_fund`, `inflow`, `unallocated`, `spent`), `Envelope` (with `BudgetPeriod` and `RolloverPolicy`), `SinkingFund` (with `ContributionStrategy`), `ShadowPosting`, `ShadowTransaction` (sum-to-zero invariant on POSTED, multi-currency segregated), `ShadowTxReason` (6 values), `ShadowTxStatus` (`pending` / `posted` / `voided`), `RefillRule` value object (3 strategies, structured shape, JSON round-trip — no expression eval).
+- **Engine** (`tulip_core.allocation.engine.post_shadow_transaction`): validates pool existence + tenant scope + active flag + currency match + balance, then promotes to POSTED. Idempotent on already-POSTED; rejects re-post of VOIDED. Period validation deliberately deferred to P4.1 — shadow tx record intent and the period gate is enforced where the main tx that triggered them lives.
+- **Repositories** (`tulip-storage`): `AllocationPoolRepository` (CRUD + `get_or_create_system_pools(currency)` resolver, idempotent, system pools rejected from `deactivate`); `ShadowTransactionRepository.save_balanced` (PENDING-then-UPDATE-to-POSTED save flow, trigger fires on the UPDATE) + `balance_for_pool(pool_id, *, currency=None, as_of=None)` returning `{currency: net amount}`; pending and voided shadow txs excluded from balance sums.
+- **System-pool auto-creation**: `Inflow` / `Unallocated` / `Spent` per `(household, currency)`, eagerly created on `POST /v1/auth/register` for the household's `base_currency`. The resolver is idempotent so lazy creation in P4.1's API layer (on first use of a new currency) Just Works.
+- **Architecture test** (`test_architecture_no_direct_shadow_writes.py`): AST scan rejecting imports of the storage-layer `ShadowTransaction` / `ShadowPosting` model classes outside `repositories/shadow_transaction.py`. Domain-layer value objects of the same name are deliberately not banned — that's the type the rest of the codebase uses to *describe* a shadow tx before handing it to the repo.
+- **Doc updates**: ARCHITECTURE.md §5.3 refill_rule JSON shape brought in line with the structured `RefillRule` value object (`fixed_amount` / `fill_to_amount` / `percentage_of_income`). ADR-0001 status flipped to Accepted.
+- **Tests**: 84 new tests (49 core, 23 storage, 1 API). Project total: 580 passing.
+
+### Phase 4 deferred to later slices
+
+- **P4.1 — API endpoints** (`POST /v1/envelopes`, `POST /v1/sinking-funds`, refill, transfer, balance) and the writer chokepoint that auto-pairs a shadow tx whenever a main-ledger posting carries `pool_id`.
+- **P4.2 — CLI** (`tulip envelopes …`, `tulip sinking-funds …`).
+- **P4.3 — Refill rules execution** + scheduled-tx runner.
+
+---
+
 ## Other shipped fixes
 
 ### P2.x.4 — catch-all unhandled-exception handler — ✅ *(2026-05-01)*
@@ -291,4 +316,4 @@ PR #30. Closed #26. Surfaced during P3.2.a smoke testing when a SQLAlchemy URL p
 
 ## Reference: full phase roadmap
 
-See [ARCHITECTURE.md §10](ARCHITECTURE.md). Phases 4 through 9 (envelopes, importers, AI, reports, ops, pre-cloud) are not in flight.
+See [ARCHITECTURE.md §10](ARCHITECTURE.md). Phases 5 through 9 (importers, AI, reports, ops, pre-cloud) are not in flight.

--- a/docs/adrs/0001-envelope-shadow-ledger.md
+++ b/docs/adrs/0001-envelope-shadow-ledger.md
@@ -1,6 +1,6 @@
 # ADR 0001 — Envelope and sinking-fund tracking via shadow ledger
 
-**Status:** Proposed (2026-05-01) — pending user sign-off, then becomes Accepted on P4.0 merge.
+**Status:** Accepted (2026-05-02) — adopted on P4.0 merge.
 **Phase:** 4 (Envelopes + sinking funds).
 **Supersedes:** None.
 
@@ -337,3 +337,4 @@ P4.0 explicitly does **not** ship the API endpoints, CLI, refill rules execution
 | 2026-05-01 | Decided: 3 system pool types (Inflow, Unallocated, Spent), per-currency. | P4 kickoff Q1+Q2 |
 | 2026-05-01 | Decided: auto-pairing on every main posting with `pool_id`. | P4 kickoff Q3 |
 | 2026-05-01 | Pairing rule: one main-ledger tx → at most one paired shadow tx (composite, multi-leg as needed). Worked examples added. | clarifying question on multi-envelope paychecks |
+| 2026-05-02 | Accepted on P4.0 merge (#60). Refill-rule JSON shape finalized as `fixed_amount` / `fill_to_amount` / `percentage_of_income` to match the structured value object. | P4.0 implementation |

--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -77,7 +77,11 @@ from tulip_api.schemas.auth import (
 )
 from tulip_storage.models import Household, MfaPolicy, MfaRecoveryCode, User, UserRole
 from tulip_storage.models import Session as SessionRow
-from tulip_storage.repositories import AuditLogWriter, PeriodRepository
+from tulip_storage.repositories import (
+    AllocationPoolRepository,
+    AuditLogWriter,
+    PeriodRepository,
+)
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -134,6 +138,13 @@ def register(
     PeriodRepository(session, household.id).create(
         start_date=date(today.year, 1, 1),
         end_date=date(today.year, 12, 31),
+    )
+
+    # Seed the three system pools (Inflow / Unallocated / Spent) for the
+    # household's base currency. Other currencies are created lazily on
+    # first use; see ADR-0001.
+    AllocationPoolRepository(session, household.id).get_or_create_system_pools(
+        currency=household.base_currency,
     )
 
     AuditLogWriter(session, household.id).write(

--- a/packages/tulip-api/tests/test_auth_endpoints.py
+++ b/packages/tulip-api/tests/test_auth_endpoints.py
@@ -68,6 +68,43 @@ class TestRegister:
         )
         assert r.status_code == 422
 
+    def test_register_seeds_system_pools_for_base_currency(self, client, session_maker):
+        # ADR-0001: Inflow / Unallocated / Spent per (household, currency)
+        # are auto-created at household creation for the base currency.
+        r = client.post(
+            "/v1/auth/register",
+            json={
+                "email": "alice@example.com",
+                "password": "correct horse battery staple",
+                "display_name": "Alice",
+                "household_name": "Smith",
+            },
+        )
+        assert r.status_code == 201
+        household_id = r.json()["household_id"]
+
+        from uuid import UUID
+
+        from tulip_storage.models import AllocationPool, PoolType
+
+        with session_maker() as s:
+            from sqlalchemy import select
+
+            rows = list(
+                s.execute(
+                    select(AllocationPool).where(
+                        AllocationPool.household_id == UUID(household_id),
+                        AllocationPool.is_system.is_(True),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            types = {p.pool_type for p in rows}
+            assert types == {PoolType.INFLOW, PoolType.UNALLOCATED, PoolType.SPENT}
+            assert all(p.currency == "USD" for p in rows)
+            assert all(p.is_active for p in rows)
+
 
 class TestLogin:
     def test_returns_access_and_refresh(self, client: TestClient, registered: dict[str, str]):

--- a/packages/tulip-core/src/tulip_core/allocation/__init__.py
+++ b/packages/tulip-core/src/tulip_core/allocation/__init__.py
@@ -1,0 +1,46 @@
+"""Allocation pools (envelopes + sinking funds) and the shadow-ledger engine.
+
+Per ADR-0001, envelope and sinking-fund balances are tracked in a parallel
+double-entry ledger whose accounts are :class:`Pool` instances. This package
+holds the pure-domain types. Persistence and repositories live in
+``tulip_storage.models`` / ``tulip_storage.repositories``.
+"""
+
+from tulip_core.allocation.engine import (
+    InactivePoolError,
+    PoolCurrencyMismatchError,
+    UnbalancedShadowTransactionError,
+    UnknownPoolError,
+    post_shadow_transaction,
+)
+from tulip_core.allocation.envelope import BudgetPeriod, Envelope, RolloverPolicy
+from tulip_core.allocation.pool import Pool, PoolType
+from tulip_core.allocation.refill_rule import RefillRule, RefillStrategy
+from tulip_core.allocation.shadow_posting import ShadowPosting
+from tulip_core.allocation.shadow_transaction import (
+    ShadowTransaction,
+    ShadowTxReason,
+    ShadowTxStatus,
+)
+from tulip_core.allocation.sinking_fund import ContributionStrategy, SinkingFund
+
+__all__ = [
+    "BudgetPeriod",
+    "ContributionStrategy",
+    "Envelope",
+    "InactivePoolError",
+    "Pool",
+    "PoolCurrencyMismatchError",
+    "PoolType",
+    "RefillRule",
+    "RefillStrategy",
+    "RolloverPolicy",
+    "ShadowPosting",
+    "ShadowTransaction",
+    "ShadowTxReason",
+    "ShadowTxStatus",
+    "SinkingFund",
+    "UnbalancedShadowTransactionError",
+    "UnknownPoolError",
+    "post_shadow_transaction",
+]

--- a/packages/tulip-core/src/tulip_core/allocation/engine.py
+++ b/packages/tulip-core/src/tulip_core/allocation/engine.py
@@ -1,0 +1,107 @@
+"""Shadow-ledger engine.
+
+Single public operation: :func:`post_shadow_transaction`. Validates the
+balance invariant, the per-pool currency match, and pool activeness, and
+returns a copy of the transaction with status ``POSTED``.
+
+Period validation is deliberately out of scope for v1 — shadow transactions
+record *intent* (refills, transfers, rollovers) rather than real money
+movement, and the period gate is enforced where the main-ledger transaction
+that triggered the shadow tx lives. User-initiated shadow transactions can
+have whatever date the user picks; the period rules around them will land
+in P4.1 alongside the API surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from tulip_core.allocation.shadow_transaction import ShadowTransaction, ShadowTxStatus
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from tulip_core.allocation.pool import Pool
+
+
+class UnbalancedShadowTransactionError(ValueError):
+    """Raised when a shadow transaction's postings don't sum to zero per currency."""
+
+
+class UnknownPoolError(ValueError):
+    """Raised when a posting references a pool that doesn't exist in the household."""
+
+
+class PoolCurrencyMismatchError(ValueError):
+    """Raised when a posting's currency doesn't match its pool's currency."""
+
+
+class InactivePoolError(ValueError):
+    """Raised when a posting writes to a deactivated pool."""
+
+
+def post_shadow_transaction(
+    tx: ShadowTransaction,
+    *,
+    pools: Iterable[Pool],
+) -> ShadowTransaction:
+    """Promote a shadow transaction to POSTED after validation.
+
+    Already-posted transactions are returned unchanged (idempotent). Voided
+    transactions cannot be re-posted and raise ``ValueError``.
+
+    Validation order:
+
+    1. Every posting's ``pool_id`` resolves to a pool in the same household.
+    2. Every referenced pool is active.
+    3. Every posting's currency matches its pool's currency.
+    4. Per-currency sums are zero.
+
+    Args:
+        tx: The shadow transaction to post.
+        pools: Candidate pools to validate against; only those whose
+            ``household_id`` matches the transaction's are considered.
+
+    Returns:
+        A ShadowTransaction with status POSTED. If the input was already
+        POSTED, the same instance is returned.
+
+    Raises:
+        UnknownPoolError: a posting's pool_id is not in the candidate set.
+        InactivePoolError: a referenced pool is deactivated.
+        PoolCurrencyMismatchError: a posting's currency differs from its pool's.
+        UnbalancedShadowTransactionError: postings don't sum to zero per currency.
+        ValueError: the transaction is already VOIDED.
+
+    """
+    if tx.status is ShadowTxStatus.POSTED:
+        return tx
+    if tx.status is ShadowTxStatus.VOIDED:
+        raise ValueError(f"cannot post voided shadow transaction {tx.id}")
+
+    pools_by_id = {p.id: p for p in pools if p.household_id == tx.household_id}
+
+    for posting in tx.postings:
+        pool = pools_by_id.get(posting.pool_id)
+        if pool is None:
+            raise UnknownPoolError(
+                f"posting {posting.id} references unknown pool {posting.pool_id} "
+                f"in household {tx.household_id}"
+            )
+        if not pool.is_active:
+            raise InactivePoolError(
+                f"posting {posting.id} writes to inactive pool {pool.id} ({pool.name!r})"
+            )
+        if pool.currency != posting.amount.currency:
+            raise PoolCurrencyMismatchError(
+                f"posting {posting.id} currency {posting.amount.currency!r} "
+                f"does not match pool {pool.id} currency {pool.currency!r}"
+            )
+
+    if not tx.is_balanced():
+        raise UnbalancedShadowTransactionError(
+            f"shadow transaction {tx.id} does not balance: {tx.balance_per_currency()}"
+        )
+
+    return replace(tx, status=ShadowTxStatus.POSTED)

--- a/packages/tulip-core/src/tulip_core/allocation/envelope.py
+++ b/packages/tulip-core/src/tulip_core/allocation/envelope.py
@@ -1,0 +1,71 @@
+"""Envelope: a periodic-budget pool with rollover policy and optional refill rule."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from tulip_core.allocation.pool import Pool, PoolType
+
+if TYPE_CHECKING:
+    from tulip_core.allocation.refill_rule import RefillRule
+    from tulip_core.money import Money
+
+
+class BudgetPeriod(Enum):
+    """The cadence on which an envelope's budget renews."""
+
+    WEEKLY = "weekly"
+    BIWEEKLY = "biweekly"
+    MONTHLY = "monthly"
+    QUARTERLY = "quarterly"
+    ANNUAL = "annual"
+    CUSTOM = "custom"
+
+
+class RolloverPolicy(Enum):
+    """What happens to an envelope's unused balance at period end.
+
+    - ``RESET``: balance returns to budget_amount at next period start.
+    - ``ACCUMULATE``: balance carries over (savings-style envelope).
+    - ``CAP_AT_BUDGET``: carry over up to budget_amount; trim the excess.
+    """
+
+    RESET = "reset"
+    ACCUMULATE = "accumulate"
+    CAP_AT_BUDGET = "cap_at_budget"
+
+
+@dataclass(frozen=True, slots=True)
+class Envelope:
+    """An envelope (period-bounded budget) on top of a :class:`Pool`."""
+
+    pool: Pool
+    budget_period: BudgetPeriod
+    rollover_policy: RolloverPolicy
+    budget_amount: Money | None = field(default=None)
+    refill_rule: RefillRule | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        """Validate the envelope's pool type and currency consistency."""
+        if self.pool.pool_type is not PoolType.ENVELOPE:
+            raise ValueError(
+                f"Envelope must wrap a pool of type 'envelope', got {self.pool.pool_type.value!r}"
+            )
+        if self.budget_amount is not None and self.budget_amount.currency != self.pool.currency:
+            raise ValueError(
+                f"budget_amount currency {self.budget_amount.currency!r} "
+                f"does not match pool currency {self.pool.currency!r}"
+            )
+        if self.budget_amount is not None and self.budget_amount.amount < 0:
+            raise ValueError(f"budget_amount must be non-negative, got {self.budget_amount.amount}")
+        if (
+            self.refill_rule is not None
+            and self.refill_rule.amount is not None
+            and self.refill_rule.amount.currency != self.pool.currency
+        ):
+            raise ValueError(
+                f"refill_rule.amount currency {self.refill_rule.amount.currency!r} "
+                f"does not match pool currency {self.pool.currency!r}"
+            )

--- a/packages/tulip-core/src/tulip_core/allocation/pool.py
+++ b/packages/tulip-core/src/tulip_core/allocation/pool.py
@@ -1,0 +1,90 @@
+"""Pool: an account in the shadow ledger.
+
+A Pool is the polymorphic base for envelopes, sinking funds, and the three
+system pools (``Inflow``, ``Unallocated``, ``Spent``). Per ADR-0001, pool
+balances are *never* stored — they are derived from the sum of associated
+:class:`ShadowPosting` rows. The Pool value object therefore carries identity
+and metadata only, no balance field.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from tulip_core.currency import Currency
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+
+class PoolType(Enum):
+    """Polymorphic discriminator for an :class:`AllocationPool` row.
+
+    Five variants:
+
+    - ``ENVELOPE`` / ``SINKING_FUND``: user-created, visible in the user's
+      pool list.
+    - ``INFLOW`` / ``UNALLOCATED`` / ``SPENT``: system pools auto-created
+      per ``(household, currency)``. Plumbing for the ledger; not editable.
+    """
+
+    ENVELOPE = "envelope"
+    SINKING_FUND = "sinking_fund"
+    INFLOW = "inflow"
+    UNALLOCATED = "unallocated"
+    SPENT = "spent"
+
+
+SYSTEM_POOL_TYPES: frozenset[PoolType] = frozenset(
+    {PoolType.INFLOW, PoolType.UNALLOCATED, PoolType.SPENT}
+)
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class Pool:
+    """An account in the shadow ledger.
+
+    Equality is by ``id`` only; mirrors :class:`tulip_core.account.Account`.
+    """
+
+    id: UUID
+    household_id: UUID
+    pool_type: PoolType
+    name: str
+    currency: str
+    visibility: str = field(default="shared")
+    is_active: bool = field(default=True)
+    is_system: bool = field(default=False)
+
+    def __post_init__(self) -> None:
+        """Validate currency code and the system-pool flag invariant."""
+        Currency.from_code(self.currency)
+        if not self.name:
+            raise ValueError("Pool name must be non-empty")
+        if self.visibility not in ("shared", "private"):
+            raise ValueError(
+                f"Pool visibility must be 'shared' or 'private', got {self.visibility!r}"
+            )
+        # System-pool flag must agree with the type discriminator. Everywhere
+        # else in the system trusts is_system as the boolean predicate, so we
+        # reject inconsistent constructions at the seam.
+        type_is_system = self.pool_type in SYSTEM_POOL_TYPES
+        if type_is_system and not self.is_system:
+            raise ValueError(f"Pool of type {self.pool_type.value!r} must have is_system=True")
+        if not type_is_system and self.is_system:
+            raise ValueError(f"Pool of type {self.pool_type.value!r} cannot have is_system=True")
+        # System pools are global plumbing — visibility doesn't apply.
+        if self.is_system and self.visibility != "shared":
+            raise ValueError("System pools must have visibility='shared'")
+
+    def __eq__(self, other: object) -> bool:
+        """Two Pools are equal iff their ids match."""
+        if not isinstance(other, Pool):
+            return NotImplemented
+        return self.id == other.id
+
+    def __hash__(self) -> int:
+        """Hash by id, consistent with equality."""
+        return hash(self.id)

--- a/packages/tulip-core/src/tulip_core/allocation/refill_rule.py
+++ b/packages/tulip-core/src/tulip_core/allocation/refill_rule.py
@@ -1,0 +1,88 @@
+"""RefillRule: a structured value object describing how an envelope refills.
+
+Three strategies are supported. The shape is **structured** — no expression
+language, no string-to-execute — to keep refill execution off any
+code-execution path. Per the threat-model checkpoint
+(docs/THREAT_MODEL.md §5.1), refill rules persisted as JSON must never be
+passed to a Python expression evaluator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tulip_core.money import Money
+
+
+class RefillStrategy(Enum):
+    """Three refill strategies. See ADR-0001 / ARCHITECTURE §5.3."""
+
+    FIXED_AMOUNT = "fixed_amount"
+    FILL_TO_AMOUNT = "fill_to_amount"
+    PERCENTAGE_OF_INCOME = "percentage_of_income"
+
+
+@dataclass(frozen=True, slots=True)
+class RefillRule:
+    """How (and how much) an envelope receives at the next refill event.
+
+    - ``FIXED_AMOUNT``: contribute ``amount`` per period. ``percentage`` unset.
+    - ``FILL_TO_AMOUNT``: top up the envelope to ``amount`` per period.
+      ``percentage`` unset.
+    - ``PERCENTAGE_OF_INCOME``: contribute ``percentage`` of the next inflow.
+      ``amount`` unset; ``percentage`` is a fraction in (0, 1].
+    """
+
+    strategy: RefillStrategy
+    amount: Money | None = field(default=None)
+    percentage: Decimal | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        """Validate the per-strategy field shape."""
+        if self.strategy in (RefillStrategy.FIXED_AMOUNT, RefillStrategy.FILL_TO_AMOUNT):
+            if self.amount is None:
+                raise ValueError(f"strategy={self.strategy.value} requires amount; got None")
+            if self.percentage is not None:
+                raise ValueError(f"strategy={self.strategy.value} forbids percentage")
+            if self.amount.amount <= 0:
+                raise ValueError(f"strategy={self.strategy.value} requires positive amount")
+        elif self.strategy is RefillStrategy.PERCENTAGE_OF_INCOME:
+            if self.percentage is None:
+                raise ValueError("strategy=percentage_of_income requires percentage; got None")
+            if self.amount is not None:
+                raise ValueError("strategy=percentage_of_income forbids amount")
+            if not (Decimal(0) < self.percentage <= Decimal(1)):
+                raise ValueError(f"percentage must be in (0, 1], got {self.percentage}")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe dict for storage in ``envelopes.refill_rule_json``.
+
+        The shape is intentionally simple and round-trips through
+        :meth:`from_dict`. No code, no callables, no references — just
+        primitives.
+        """
+        out: dict[str, Any] = {"strategy": self.strategy.value}
+        if self.amount is not None:
+            out["amount"] = str(self.amount.amount)
+            out["currency"] = self.amount.currency
+        if self.percentage is not None:
+            out["percentage"] = str(self.percentage)
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RefillRule:
+        """Deserialize from the dict shape produced by :meth:`to_dict`."""
+        from tulip_core.money import Money
+
+        strategy = RefillStrategy(data["strategy"])
+        amount: Money | None = None
+        percentage: Decimal | None = None
+        if "amount" in data:
+            amount = Money(Decimal(data["amount"]), data["currency"])
+        if "percentage" in data:
+            percentage = Decimal(data["percentage"])
+        return cls(strategy=strategy, amount=amount, percentage=percentage)

--- a/packages/tulip-core/src/tulip_core/allocation/shadow_posting.py
+++ b/packages/tulip-core/src/tulip_core/allocation/shadow_posting.py
@@ -1,0 +1,26 @@
+"""ShadowPosting: one leg of a shadow-ledger transaction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from tulip_core.money import Money
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowPosting:
+    """One leg of a :class:`ShadowTransaction`.
+
+    Sign convention mirrors the main ledger's: positive amount = into the
+    pool, negative = out of the pool. The sum of every posting in a shadow
+    transaction must be zero per currency for the transaction to balance.
+    """
+
+    id: UUID
+    pool_id: UUID
+    amount: Money
+    memo: str | None = field(default=None)

--- a/packages/tulip-core/src/tulip_core/allocation/shadow_transaction.py
+++ b/packages/tulip-core/src/tulip_core/allocation/shadow_transaction.py
@@ -1,0 +1,86 @@
+"""ShadowTransaction: a balanced set of shadow postings.
+
+Mirrors :class:`tulip_core.transactions.Transaction` but operates on the
+parallel ledger whose accounts are :class:`Pool` instances. The balance
+invariant (sum-to-zero per currency) is enforced on construction when the
+status is ``POSTED``; ``PENDING`` is allowed to be unbalanced for
+in-progress shapes.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import date
+    from uuid import UUID
+
+    from tulip_core.allocation.shadow_posting import ShadowPosting
+
+
+class ShadowTxStatus(Enum):
+    """Workflow status for a shadow transaction.
+
+    Three states:
+
+    - ``PENDING``: provisionally constructed; may be unbalanced.
+    - ``POSTED``: committed to the shadow ledger; postings balance.
+    - ``VOIDED``: reversed via the void/reversal mechanic landing in Phase 5.
+    """
+
+    PENDING = "pending"
+    POSTED = "posted"
+    VOIDED = "voided"
+
+
+class ShadowTxReason(Enum):
+    """Why this shadow transaction exists. See ADR-0001."""
+
+    BUDGET_INFLOW = "budget_inflow"
+    REFILL = "refill"
+    SPEND = "spend"
+    TRANSFER = "transfer"
+    ROLLOVER = "rollover"
+    MANUAL = "manual"
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowTransaction:
+    """A double-entry transaction in the shadow ledger."""
+
+    id: UUID
+    household_id: UUID
+    date: date
+    description: str
+    reason: ShadowTxReason
+    postings: tuple[ShadowPosting, ...]
+    status: ShadowTxStatus
+    paired_main_tx_id: UUID | None = field(default=None)
+    created_by_user_id: UUID | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        """Validate posting count and per-currency balance for POSTED status."""
+        if len(self.postings) < 2:
+            raise ValueError(
+                f"shadow transaction must have at least two postings, got {len(self.postings)}"
+            )
+        if self.status is ShadowTxStatus.POSTED:
+            balances = self.balance_per_currency()
+            unbalanced = {ccy: bal for ccy, bal in balances.items() if bal != 0}
+            if unbalanced:
+                raise ValueError(f"shadow transaction does not balance per currency: {unbalanced}")
+
+    def balance_per_currency(self) -> dict[str, Decimal]:
+        """Return a {currency: net amount} dict over all postings."""
+        sums: dict[str, Decimal] = defaultdict(lambda: Decimal(0))
+        for posting in self.postings:
+            sums[posting.amount.currency] += posting.amount.amount
+        return dict(sums)
+
+    def is_balanced(self) -> bool:
+        """Return True iff every currency's postings sum to zero."""
+        return all(b == 0 for b in self.balance_per_currency().values())

--- a/packages/tulip-core/src/tulip_core/allocation/sinking_fund.py
+++ b/packages/tulip-core/src/tulip_core/allocation/sinking_fund.py
@@ -1,0 +1,67 @@
+"""SinkingFund: a goal-bounded pool with target amount/date and contribution strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from tulip_core.allocation.pool import Pool, PoolType
+
+if TYPE_CHECKING:
+    from datetime import date
+
+    from tulip_core.money import Money
+
+
+class ContributionStrategy(Enum):
+    """How a sinking fund's scheduled contribution is computed."""
+
+    MANUAL = "manual"
+    EVEN_SPLIT = "even_split"
+    PERCENTAGE_OF_INCOME = "percentage_of_income"
+
+
+@dataclass(frozen=True, slots=True)
+class SinkingFund:
+    """A goal-bounded savings pool on top of a :class:`Pool`."""
+
+    pool: Pool
+    target_amount: Money
+    target_date: date
+    contribution_strategy: ContributionStrategy
+    contribution_amount: Money | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        """Validate pool type, currency consistency, and per-strategy fields."""
+        if self.pool.pool_type is not PoolType.SINKING_FUND:
+            raise ValueError(
+                f"SinkingFund must wrap a pool of type 'sinking_fund', got "
+                f"{self.pool.pool_type.value!r}"
+            )
+        if self.target_amount.currency != self.pool.currency:
+            raise ValueError(
+                f"target_amount currency {self.target_amount.currency!r} "
+                f"does not match pool currency {self.pool.currency!r}"
+            )
+        if self.target_amount.amount <= 0:
+            raise ValueError(f"target_amount must be positive, got {self.target_amount.amount}")
+        if (
+            self.contribution_amount is not None
+            and self.contribution_amount.currency != self.pool.currency
+        ):
+            raise ValueError(
+                f"contribution_amount currency {self.contribution_amount.currency!r} "
+                f"does not match pool currency {self.pool.currency!r}"
+            )
+        if self.contribution_strategy is ContributionStrategy.MANUAL:
+            # Manual strategy: contribution_amount is optional, no further checks.
+            pass
+        elif self.contribution_strategy is ContributionStrategy.EVEN_SPLIT:
+            if self.contribution_amount is not None:
+                raise ValueError("contribution_amount is derived for EVEN_SPLIT; do not set it")
+        elif self.contribution_strategy is ContributionStrategy.PERCENTAGE_OF_INCOME:
+            if self.contribution_amount is not None:
+                raise ValueError(
+                    "contribution_amount is derived for PERCENTAGE_OF_INCOME; do not set it"
+                )

--- a/packages/tulip-core/tests/test_allocation_engine.py
+++ b/packages/tulip-core/tests/test_allocation_engine.py
@@ -1,0 +1,251 @@
+"""Tests for tulip_core.allocation.engine.post_shadow_transaction."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from tulip_core.allocation import (
+    InactivePoolError,
+    Pool,
+    PoolCurrencyMismatchError,
+    PoolType,
+    ShadowPosting,
+    ShadowTransaction,
+    ShadowTxReason,
+    ShadowTxStatus,
+    UnbalancedShadowTransactionError,
+    UnknownPoolError,
+    post_shadow_transaction,
+)
+from tulip_core.money import Money
+
+
+def _pool(
+    *,
+    pool_id: UUID,
+    household_id: UUID,
+    currency: str = "USD",
+    pool_type: PoolType = PoolType.ENVELOPE,
+    is_system: bool = False,
+    is_active: bool = True,
+) -> Pool:
+    return Pool(
+        id=pool_id,
+        household_id=household_id,
+        pool_type=pool_type,
+        name=f"pool-{pool_id}",
+        currency=currency,
+        is_system=is_system,
+        is_active=is_active,
+    )
+
+
+def _build_tx(
+    *,
+    household_id: UUID,
+    postings: tuple[ShadowPosting, ...],
+    status: ShadowTxStatus = ShadowTxStatus.PENDING,
+) -> ShadowTransaction:
+    return ShadowTransaction(
+        id=uuid4(),
+        household_id=household_id,
+        date=date(2026, 6, 1),
+        description="x",
+        reason=ShadowTxReason.REFILL,
+        postings=postings,
+        status=status,
+    )
+
+
+def test_post_promotes_pending_to_posted() -> None:
+    household_id = uuid4()
+    src = uuid4()
+    dst = uuid4()
+    pools = [
+        _pool(
+            pool_id=src,
+            household_id=household_id,
+            pool_type=PoolType.UNALLOCATED,
+            is_system=True,
+        ),
+        _pool(pool_id=dst, household_id=household_id),
+    ]
+    tx = _build_tx(
+        household_id=household_id,
+        postings=(
+            ShadowPosting(id=uuid4(), pool_id=src, amount=Money(Decimal("-250"), "USD")),
+            ShadowPosting(id=uuid4(), pool_id=dst, amount=Money(Decimal("250"), "USD")),
+        ),
+    )
+    posted = post_shadow_transaction(tx, pools=pools)
+    assert posted.status is ShadowTxStatus.POSTED
+
+
+def test_idempotent_for_already_posted() -> None:
+    household_id = uuid4()
+    src = uuid4()
+    dst = uuid4()
+    pools = [
+        _pool(
+            pool_id=src,
+            household_id=household_id,
+            pool_type=PoolType.UNALLOCATED,
+            is_system=True,
+        ),
+        _pool(pool_id=dst, household_id=household_id),
+    ]
+    tx = _build_tx(
+        household_id=household_id,
+        postings=(
+            ShadowPosting(id=uuid4(), pool_id=src, amount=Money(Decimal("-250"), "USD")),
+            ShadowPosting(id=uuid4(), pool_id=dst, amount=Money(Decimal("250"), "USD")),
+        ),
+        status=ShadowTxStatus.POSTED,
+    )
+    again = post_shadow_transaction(tx, pools=pools)
+    assert again is tx
+
+
+def test_voided_cannot_be_re_posted() -> None:
+    household_id = uuid4()
+    src = uuid4()
+    dst = uuid4()
+    pools = [
+        _pool(
+            pool_id=src,
+            household_id=household_id,
+            pool_type=PoolType.UNALLOCATED,
+            is_system=True,
+        ),
+        _pool(pool_id=dst, household_id=household_id),
+    ]
+    # Build via PENDING then mutate status via dataclass replace would require
+    # the engine; for the test we construct directly with VOIDED.
+    # ShadowTransaction.__post_init__ skips balance check for non-POSTED status.
+    tx = _build_tx(
+        household_id=household_id,
+        postings=(
+            ShadowPosting(id=uuid4(), pool_id=src, amount=Money(Decimal("-250"), "USD")),
+            ShadowPosting(id=uuid4(), pool_id=dst, amount=Money(Decimal("250"), "USD")),
+        ),
+        status=ShadowTxStatus.VOIDED,
+    )
+    with pytest.raises(ValueError, match="voided"):
+        post_shadow_transaction(tx, pools=pools)
+
+
+def test_unknown_pool_rejected() -> None:
+    household_id = uuid4()
+    known = uuid4()
+    unknown = uuid4()
+    pools = [_pool(pool_id=known, household_id=household_id)]
+    tx = _build_tx(
+        household_id=household_id,
+        postings=(
+            ShadowPosting(id=uuid4(), pool_id=known, amount=Money(Decimal("-250"), "USD")),
+            ShadowPosting(id=uuid4(), pool_id=unknown, amount=Money(Decimal("250"), "USD")),
+        ),
+    )
+    with pytest.raises(UnknownPoolError):
+        post_shadow_transaction(tx, pools=pools)
+
+
+def test_pool_in_other_household_rejected() -> None:
+    household_id = uuid4()
+    other_household = uuid4()
+    p1 = uuid4()
+    p2 = uuid4()
+    pools = [
+        _pool(pool_id=p1, household_id=household_id),
+        _pool(pool_id=p2, household_id=other_household),
+    ]
+    tx = _build_tx(
+        household_id=household_id,
+        postings=(
+            ShadowPosting(id=uuid4(), pool_id=p1, amount=Money(Decimal("-250"), "USD")),
+            ShadowPosting(id=uuid4(), pool_id=p2, amount=Money(Decimal("250"), "USD")),
+        ),
+    )
+    with pytest.raises(UnknownPoolError):
+        post_shadow_transaction(tx, pools=pools)
+
+
+def test_inactive_pool_rejected() -> None:
+    household_id = uuid4()
+    src = uuid4()
+    dst = uuid4()
+    pools = [
+        _pool(
+            pool_id=src,
+            household_id=household_id,
+            pool_type=PoolType.UNALLOCATED,
+            is_system=True,
+        ),
+        _pool(pool_id=dst, household_id=household_id, is_active=False),
+    ]
+    tx = _build_tx(
+        household_id=household_id,
+        postings=(
+            ShadowPosting(id=uuid4(), pool_id=src, amount=Money(Decimal("-250"), "USD")),
+            ShadowPosting(id=uuid4(), pool_id=dst, amount=Money(Decimal("250"), "USD")),
+        ),
+    )
+    with pytest.raises(InactivePoolError):
+        post_shadow_transaction(tx, pools=pools)
+
+
+def test_pool_currency_mismatch_rejected() -> None:
+    household_id = uuid4()
+    src = uuid4()
+    dst = uuid4()
+    pools = [
+        _pool(
+            pool_id=src,
+            household_id=household_id,
+            currency="USD",
+            pool_type=PoolType.UNALLOCATED,
+            is_system=True,
+        ),
+        _pool(pool_id=dst, household_id=household_id, currency="USD"),
+    ]
+    tx = _build_tx(
+        household_id=household_id,
+        postings=(
+            ShadowPosting(id=uuid4(), pool_id=src, amount=Money(Decimal("-250"), "USD")),
+            ShadowPosting(id=uuid4(), pool_id=dst, amount=Money(Decimal("250"), "EUR")),
+        ),
+    )
+    # The transaction's per-currency sum is also unbalanced (USD: -250, EUR: 250),
+    # but the currency-mismatch check fires first.
+    with pytest.raises(PoolCurrencyMismatchError):
+        post_shadow_transaction(tx, pools=pools)
+
+
+def test_unbalanced_rejected() -> None:
+    # Constructed as PENDING (which permits imbalance) and then handed to the
+    # engine. The engine then rejects the imbalance.
+    household_id = uuid4()
+    src = uuid4()
+    dst = uuid4()
+    pools = [
+        _pool(
+            pool_id=src,
+            household_id=household_id,
+            pool_type=PoolType.UNALLOCATED,
+            is_system=True,
+        ),
+        _pool(pool_id=dst, household_id=household_id),
+    ]
+    tx = _build_tx(
+        household_id=household_id,
+        postings=(
+            ShadowPosting(id=uuid4(), pool_id=src, amount=Money(Decimal("-100"), "USD")),
+            ShadowPosting(id=uuid4(), pool_id=dst, amount=Money(Decimal("250"), "USD")),
+        ),
+    )
+    with pytest.raises(UnbalancedShadowTransactionError):
+        post_shadow_transaction(tx, pools=pools)

--- a/packages/tulip-core/tests/test_allocation_envelope.py
+++ b/packages/tulip-core/tests/test_allocation_envelope.py
@@ -1,0 +1,119 @@
+"""Tests for the Envelope value object."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from tulip_core.allocation import (
+    BudgetPeriod,
+    Envelope,
+    Pool,
+    PoolType,
+    RefillRule,
+    RefillStrategy,
+    RolloverPolicy,
+)
+from tulip_core.money import Money
+
+
+def _envelope_pool(currency: str = "USD") -> Pool:
+    return Pool(
+        id=uuid4(),
+        household_id=uuid4(),
+        pool_type=PoolType.ENVELOPE,
+        name="Groceries",
+        currency=currency,
+    )
+
+
+def test_envelope_minimal() -> None:
+    env = Envelope(
+        pool=_envelope_pool(),
+        budget_period=BudgetPeriod.MONTHLY,
+        rollover_policy=RolloverPolicy.RESET,
+    )
+    assert env.budget_amount is None
+    assert env.refill_rule is None
+
+
+def test_envelope_with_budget_and_refill() -> None:
+    pool = _envelope_pool("USD")
+    env = Envelope(
+        pool=pool,
+        budget_period=BudgetPeriod.MONTHLY,
+        rollover_policy=RolloverPolicy.ACCUMULATE,
+        budget_amount=Money(Decimal("400"), "USD"),
+        refill_rule=RefillRule(
+            strategy=RefillStrategy.FIXED_AMOUNT,
+            amount=Money(Decimal("100"), "USD"),
+        ),
+    )
+    assert env.budget_amount is not None
+    assert env.refill_rule is not None
+
+
+def test_envelope_rejects_non_envelope_pool() -> None:
+    sf_pool = Pool(
+        id=uuid4(),
+        household_id=uuid4(),
+        pool_type=PoolType.SINKING_FUND,
+        name="Vacation",
+        currency="USD",
+    )
+    with pytest.raises(ValueError, match="type 'envelope'"):
+        Envelope(
+            pool=sf_pool,
+            budget_period=BudgetPeriod.MONTHLY,
+            rollover_policy=RolloverPolicy.RESET,
+        )
+
+
+def test_envelope_budget_currency_must_match_pool() -> None:
+    pool = _envelope_pool("USD")
+    with pytest.raises(ValueError, match="budget_amount currency"):
+        Envelope(
+            pool=pool,
+            budget_period=BudgetPeriod.MONTHLY,
+            rollover_policy=RolloverPolicy.RESET,
+            budget_amount=Money(Decimal("400"), "EUR"),
+        )
+
+
+def test_envelope_budget_must_be_non_negative() -> None:
+    pool = _envelope_pool("USD")
+    with pytest.raises(ValueError, match="non-negative"):
+        Envelope(
+            pool=pool,
+            budget_period=BudgetPeriod.MONTHLY,
+            rollover_policy=RolloverPolicy.RESET,
+            budget_amount=Money(Decimal("-1"), "USD"),
+        )
+
+
+def test_envelope_refill_currency_must_match_pool() -> None:
+    pool = _envelope_pool("USD")
+    with pytest.raises(ValueError, match=r"refill_rule\.amount currency"):
+        Envelope(
+            pool=pool,
+            budget_period=BudgetPeriod.MONTHLY,
+            rollover_policy=RolloverPolicy.RESET,
+            refill_rule=RefillRule(
+                strategy=RefillStrategy.FIXED_AMOUNT,
+                amount=Money(Decimal("100"), "EUR"),
+            ),
+        )
+
+
+def test_envelope_zero_budget_allowed() -> None:
+    pool = _envelope_pool("USD")
+    env = Envelope(
+        pool=pool,
+        budget_period=BudgetPeriod.MONTHLY,
+        rollover_policy=RolloverPolicy.RESET,
+        budget_amount=Money(Decimal("0"), "USD"),
+    )
+    assert env.budget_amount is not None
+    assert env.budget_amount.amount == Decimal("0")

--- a/packages/tulip-core/tests/test_allocation_pool.py
+++ b/packages/tulip-core/tests/test_allocation_pool.py
@@ -1,0 +1,139 @@
+"""Tests for the Pool value object and PoolType enum."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from tulip_core.allocation import Pool, PoolType
+
+
+def test_pool_construction_minimal() -> None:
+    p = Pool(
+        id=uuid4(),
+        household_id=uuid4(),
+        pool_type=PoolType.ENVELOPE,
+        name="Groceries",
+        currency="USD",
+    )
+    assert p.is_active is True
+    assert p.is_system is False
+    assert p.visibility == "shared"
+
+
+def test_pool_unknown_currency_rejected() -> None:
+    with pytest.raises(ValueError):
+        Pool(
+            id=uuid4(),
+            household_id=uuid4(),
+            pool_type=PoolType.ENVELOPE,
+            name="Groceries",
+            currency="ZZZ",
+        )
+
+
+def test_pool_empty_name_rejected() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        Pool(
+            id=uuid4(),
+            household_id=uuid4(),
+            pool_type=PoolType.ENVELOPE,
+            name="",
+            currency="USD",
+        )
+
+
+def test_pool_unknown_visibility_rejected() -> None:
+    with pytest.raises(ValueError, match="visibility"):
+        Pool(
+            id=uuid4(),
+            household_id=uuid4(),
+            pool_type=PoolType.ENVELOPE,
+            name="Groceries",
+            currency="USD",
+            visibility="public",
+        )
+
+
+@pytest.mark.parametrize("system_type", [PoolType.INFLOW, PoolType.UNALLOCATED, PoolType.SPENT])
+def test_system_pool_type_requires_is_system(system_type: PoolType) -> None:
+    with pytest.raises(ValueError, match="is_system=True"):
+        Pool(
+            id=uuid4(),
+            household_id=uuid4(),
+            pool_type=system_type,
+            name="x",
+            currency="USD",
+            is_system=False,
+        )
+
+
+@pytest.mark.parametrize("user_type", [PoolType.ENVELOPE, PoolType.SINKING_FUND])
+def test_user_pool_type_forbids_is_system(user_type: PoolType) -> None:
+    with pytest.raises(ValueError, match="cannot have is_system=True"):
+        Pool(
+            id=uuid4(),
+            household_id=uuid4(),
+            pool_type=user_type,
+            name="x",
+            currency="USD",
+            is_system=True,
+        )
+
+
+def test_system_pool_must_be_shared() -> None:
+    with pytest.raises(ValueError, match="visibility='shared'"):
+        Pool(
+            id=uuid4(),
+            household_id=uuid4(),
+            pool_type=PoolType.INFLOW,
+            name="Inflow USD",
+            currency="USD",
+            is_system=True,
+            visibility="private",
+        )
+
+
+def test_pool_equality_by_id() -> None:
+    pool_id = uuid4()
+    a = Pool(
+        id=pool_id,
+        household_id=uuid4(),
+        pool_type=PoolType.ENVELOPE,
+        name="Groceries",
+        currency="USD",
+    )
+    b = Pool(
+        id=pool_id,
+        household_id=uuid4(),
+        pool_type=PoolType.SINKING_FUND,
+        name="Different",
+        currency="EUR",
+    )
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_pool_inequality_with_other_types() -> None:
+    p = Pool(
+        id=uuid4(),
+        household_id=uuid4(),
+        pool_type=PoolType.ENVELOPE,
+        name="Groceries",
+        currency="USD",
+    )
+    assert p != "not a pool"
+    assert p != 42
+
+
+def test_pool_is_frozen() -> None:
+    p = Pool(
+        id=uuid4(),
+        household_id=uuid4(),
+        pool_type=PoolType.ENVELOPE,
+        name="Groceries",
+        currency="USD",
+    )
+    with pytest.raises(AttributeError):
+        p.name = "Renamed"  # type: ignore[misc]

--- a/packages/tulip-core/tests/test_allocation_refill_rule.py
+++ b/packages/tulip-core/tests/test_allocation_refill_rule.py
@@ -1,0 +1,117 @@
+"""Tests for the RefillRule structured value object."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from tulip_core.allocation import RefillRule, RefillStrategy
+from tulip_core.money import Money
+
+
+def test_fixed_amount_minimal() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("250.00"), "USD"),
+    )
+    assert rule.amount is not None
+    assert rule.amount.amount == Decimal("250.00")
+    assert rule.percentage is None
+
+
+def test_fixed_amount_requires_amount() -> None:
+    with pytest.raises(ValueError, match="requires amount"):
+        RefillRule(strategy=RefillStrategy.FIXED_AMOUNT)
+
+
+def test_fixed_amount_forbids_percentage() -> None:
+    with pytest.raises(ValueError, match="forbids percentage"):
+        RefillRule(
+            strategy=RefillStrategy.FIXED_AMOUNT,
+            amount=Money(Decimal("250.00"), "USD"),
+            percentage=Decimal("0.5"),
+        )
+
+
+def test_fixed_amount_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        RefillRule(
+            strategy=RefillStrategy.FIXED_AMOUNT,
+            amount=Money(Decimal("0.00"), "USD"),
+        )
+
+
+def test_fill_to_amount_minimal() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FILL_TO_AMOUNT,
+        amount=Money(Decimal("500.00"), "EUR"),
+    )
+    assert rule.amount is not None
+    assert rule.amount.currency == "EUR"
+
+
+def test_fill_to_amount_requires_amount() -> None:
+    with pytest.raises(ValueError, match="requires amount"):
+        RefillRule(strategy=RefillStrategy.FILL_TO_AMOUNT)
+
+
+def test_percentage_of_income_minimal() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("0.10"),
+    )
+    assert rule.percentage == Decimal("0.10")
+    assert rule.amount is None
+
+
+def test_percentage_requires_percentage() -> None:
+    with pytest.raises(ValueError, match="requires percentage"):
+        RefillRule(strategy=RefillStrategy.PERCENTAGE_OF_INCOME)
+
+
+def test_percentage_forbids_amount() -> None:
+    with pytest.raises(ValueError, match="forbids amount"):
+        RefillRule(
+            strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+            amount=Money(Decimal("100"), "USD"),
+            percentage=Decimal("0.10"),
+        )
+
+
+@pytest.mark.parametrize("p", [Decimal("0"), Decimal("-0.10"), Decimal("1.01"), Decimal("2")])
+def test_percentage_out_of_range_rejected(p: Decimal) -> None:
+    with pytest.raises(ValueError, match=r"\(0, 1\]"):
+        RefillRule(strategy=RefillStrategy.PERCENTAGE_OF_INCOME, percentage=p)
+
+
+def test_round_trip_fixed_amount() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("250.00"), "USD"),
+    )
+    restored = RefillRule.from_dict(rule.to_dict())
+    assert restored == rule
+
+
+def test_round_trip_percentage() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("0.15"),
+    )
+    restored = RefillRule.from_dict(rule.to_dict())
+    assert restored == rule
+
+
+def test_to_dict_shape_is_jsonable_primitives() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("250.00"), "USD"),
+    )
+    out = rule.to_dict()
+    # Every value must be a JSON-safe primitive: str / int / float / bool / None.
+    # No Money, no Decimal, no Enum.
+    for k, v in out.items():
+        assert isinstance(v, (str, int, float, bool, type(None))), (
+            f"{k}={v!r} is not a JSON primitive"
+        )

--- a/packages/tulip-core/tests/test_allocation_shadow_transaction.py
+++ b/packages/tulip-core/tests/test_allocation_shadow_transaction.py
@@ -1,0 +1,141 @@
+"""Tests for ShadowTransaction's balance-invariant enforcement."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from tulip_core.allocation import (
+    ShadowPosting,
+    ShadowTransaction,
+    ShadowTxReason,
+    ShadowTxStatus,
+)
+from tulip_core.money import Money
+
+
+def _balanced_postings(currency: str = "USD") -> tuple[ShadowPosting, ShadowPosting]:
+    return (
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("250"), currency)),
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("-250"), currency)),
+    )
+
+
+def test_pending_can_be_unbalanced() -> None:
+    postings = (
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("100"), "USD")),
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("-50"), "USD")),
+    )
+    tx = ShadowTransaction(
+        id=uuid4(),
+        household_id=uuid4(),
+        date=date(2026, 6, 1),
+        description="WIP",
+        reason=ShadowTxReason.MANUAL,
+        postings=postings,
+        status=ShadowTxStatus.PENDING,
+    )
+    assert tx.is_balanced() is False
+
+
+def test_posted_must_be_balanced() -> None:
+    postings = (
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("100"), "USD")),
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("-50"), "USD")),
+    )
+    with pytest.raises(ValueError, match="balance per currency"):
+        ShadowTransaction(
+            id=uuid4(),
+            household_id=uuid4(),
+            date=date(2026, 6, 1),
+            description="Bad",
+            reason=ShadowTxReason.MANUAL,
+            postings=postings,
+            status=ShadowTxStatus.POSTED,
+        )
+
+
+def test_balanced_posted_succeeds() -> None:
+    tx = ShadowTransaction(
+        id=uuid4(),
+        household_id=uuid4(),
+        date=date(2026, 6, 1),
+        description="Refill",
+        reason=ShadowTxReason.REFILL,
+        postings=_balanced_postings(),
+        status=ShadowTxStatus.POSTED,
+    )
+    assert tx.is_balanced()
+    assert tx.status is ShadowTxStatus.POSTED
+
+
+def test_must_have_two_postings() -> None:
+    only_one = (ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("0"), "USD")),)
+    with pytest.raises(ValueError, match="at least two"):
+        ShadowTransaction(
+            id=uuid4(),
+            household_id=uuid4(),
+            date=date(2026, 6, 1),
+            description="x",
+            reason=ShadowTxReason.MANUAL,
+            postings=only_one,
+            status=ShadowTxStatus.PENDING,
+        )
+
+
+def test_balance_per_currency_segregates_currencies() -> None:
+    # USD legs must zero; EUR legs must zero. Cross-currency net does NOT balance.
+    postings = (
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("100"), "USD")),
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("-100"), "USD")),
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("80"), "EUR")),
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("-80"), "EUR")),
+    )
+    tx = ShadowTransaction(
+        id=uuid4(),
+        household_id=uuid4(),
+        date=date(2026, 6, 1),
+        description="Multi-ccy",
+        reason=ShadowTxReason.TRANSFER,
+        postings=postings,
+        status=ShadowTxStatus.POSTED,
+    )
+    assert tx.balance_per_currency() == {"USD": Decimal("0"), "EUR": Decimal("0")}
+
+
+def test_posted_rejects_cross_currency_imbalance() -> None:
+    # USD nets to zero, EUR doesn't.
+    postings = (
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("100"), "USD")),
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("-100"), "USD")),
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("80"), "EUR")),
+        ShadowPosting(id=uuid4(), pool_id=uuid4(), amount=Money(Decimal("-50"), "EUR")),
+    )
+    with pytest.raises(ValueError, match="EUR"):
+        ShadowTransaction(
+            id=uuid4(),
+            household_id=uuid4(),
+            date=date(2026, 6, 1),
+            description="Bad",
+            reason=ShadowTxReason.TRANSFER,
+            postings=postings,
+            status=ShadowTxStatus.POSTED,
+        )
+
+
+def test_paired_main_tx_id_optional() -> None:
+    paired_id = uuid4()
+    tx = ShadowTransaction(
+        id=uuid4(),
+        household_id=uuid4(),
+        date=date(2026, 6, 1),
+        description="Costco shadow",
+        reason=ShadowTxReason.SPEND,
+        postings=_balanced_postings(),
+        status=ShadowTxStatus.POSTED,
+        paired_main_tx_id=paired_id,
+    )
+    assert tx.paired_main_tx_id == paired_id

--- a/packages/tulip-core/tests/test_allocation_sinking_fund.py
+++ b/packages/tulip-core/tests/test_allocation_sinking_fund.py
@@ -1,0 +1,116 @@
+"""Tests for the SinkingFund value object."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from tulip_core.allocation import ContributionStrategy, Pool, PoolType, SinkingFund
+from tulip_core.money import Money
+
+
+def _sf_pool(currency: str = "USD") -> Pool:
+    return Pool(
+        id=uuid4(),
+        household_id=uuid4(),
+        pool_type=PoolType.SINKING_FUND,
+        name="Vacation",
+        currency=currency,
+    )
+
+
+def test_manual_minimal() -> None:
+    sf = SinkingFund(
+        pool=_sf_pool(),
+        target_amount=Money(Decimal("3000"), "USD"),
+        target_date=date(2027, 6, 1),
+        contribution_strategy=ContributionStrategy.MANUAL,
+    )
+    assert sf.contribution_amount is None
+
+
+def test_manual_with_contribution_amount_allowed() -> None:
+    sf = SinkingFund(
+        pool=_sf_pool(),
+        target_amount=Money(Decimal("3000"), "USD"),
+        target_date=date(2027, 6, 1),
+        contribution_strategy=ContributionStrategy.MANUAL,
+        contribution_amount=Money(Decimal("250"), "USD"),
+    )
+    assert sf.contribution_amount is not None
+    assert sf.contribution_amount.amount == Decimal("250")
+
+
+def test_even_split_forbids_explicit_contribution_amount() -> None:
+    with pytest.raises(ValueError, match="EVEN_SPLIT"):
+        SinkingFund(
+            pool=_sf_pool(),
+            target_amount=Money(Decimal("3000"), "USD"),
+            target_date=date(2027, 6, 1),
+            contribution_strategy=ContributionStrategy.EVEN_SPLIT,
+            contribution_amount=Money(Decimal("250"), "USD"),
+        )
+
+
+def test_percentage_of_income_forbids_explicit_contribution_amount() -> None:
+    with pytest.raises(ValueError, match="PERCENTAGE_OF_INCOME"):
+        SinkingFund(
+            pool=_sf_pool(),
+            target_amount=Money(Decimal("3000"), "USD"),
+            target_date=date(2027, 6, 1),
+            contribution_strategy=ContributionStrategy.PERCENTAGE_OF_INCOME,
+            contribution_amount=Money(Decimal("250"), "USD"),
+        )
+
+
+def test_rejects_non_sinking_fund_pool() -> None:
+    env_pool = Pool(
+        id=uuid4(),
+        household_id=uuid4(),
+        pool_type=PoolType.ENVELOPE,
+        name="Groceries",
+        currency="USD",
+    )
+    with pytest.raises(ValueError, match="type 'sinking_fund'"):
+        SinkingFund(
+            pool=env_pool,
+            target_amount=Money(Decimal("3000"), "USD"),
+            target_date=date(2027, 6, 1),
+            contribution_strategy=ContributionStrategy.MANUAL,
+        )
+
+
+def test_target_currency_must_match_pool() -> None:
+    pool = _sf_pool("USD")
+    with pytest.raises(ValueError, match="target_amount currency"):
+        SinkingFund(
+            pool=pool,
+            target_amount=Money(Decimal("3000"), "EUR"),
+            target_date=date(2027, 6, 1),
+            contribution_strategy=ContributionStrategy.MANUAL,
+        )
+
+
+def test_target_amount_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        SinkingFund(
+            pool=_sf_pool(),
+            target_amount=Money(Decimal("0"), "USD"),
+            target_date=date(2027, 6, 1),
+            contribution_strategy=ContributionStrategy.MANUAL,
+        )
+
+
+def test_contribution_currency_must_match_pool() -> None:
+    pool = _sf_pool("USD")
+    with pytest.raises(ValueError, match="contribution_amount currency"):
+        SinkingFund(
+            pool=pool,
+            target_amount=Money(Decimal("3000"), "USD"),
+            target_date=date(2027, 6, 1),
+            contribution_strategy=ContributionStrategy.MANUAL,
+            contribution_amount=Money(Decimal("250"), "EUR"),
+        )

--- a/packages/tulip-storage/src/tulip_storage/migrations/_triggers.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/_triggers.py
@@ -110,3 +110,114 @@ INITIAL_TRIGGER_NAMES: Final[tuple[str, ...]] = (
     "trg_postings_balanced_on_update",
     "trg_postings_balanced_on_delete",
 )
+
+
+# ---- P4.0 shadow-ledger balance triggers --------------------------------
+#
+# Mirror the main-ledger triggers above. Pool balances are derived from
+# `sum(shadow_postings)`, so the invariant we enforce at the trigger layer
+# is that every `shadow_transactions` row in `posted` status has its
+# `shadow_postings` summing to zero per currency. Pending and voided rows
+# are exempt — they don't contribute to derived balances.
+
+_SHADOW_TX_STATUS_BALANCE = """
+CREATE TRIGGER trg_shadow_transactions_balanced_on_post
+AFTER UPDATE OF status ON shadow_transactions
+WHEN NEW.status = 'posted'
+  AND (OLD.status IS NULL OR OLD.status != NEW.status)
+BEGIN
+  SELECT CASE
+    WHEN EXISTS (
+      SELECT 1 FROM shadow_postings
+      WHERE household_id = NEW.household_id
+        AND shadow_transaction_id = NEW.id
+      GROUP BY currency
+      HAVING SUM(amount) != 0
+    )
+    THEN RAISE(ABORT, 'shadow transaction postings do not balance per currency')
+  END;
+END;
+"""
+
+_SHADOW_POSTING_INSERT_BALANCE = """
+CREATE TRIGGER trg_shadow_postings_balanced_on_insert
+AFTER INSERT ON shadow_postings
+WHEN EXISTS (
+  SELECT 1 FROM shadow_transactions
+  WHERE household_id = NEW.household_id
+    AND id = NEW.shadow_transaction_id
+    AND status = 'posted'
+)
+BEGIN
+  SELECT CASE
+    WHEN EXISTS (
+      SELECT 1 FROM shadow_postings
+      WHERE household_id = NEW.household_id
+        AND shadow_transaction_id = NEW.shadow_transaction_id
+      GROUP BY currency
+      HAVING SUM(amount) != 0
+    )
+    THEN RAISE(ABORT, 'shadow posting insert breaks balance on a posted shadow tx')
+  END;
+END;
+"""
+
+_SHADOW_POSTING_UPDATE_BALANCE = """
+CREATE TRIGGER trg_shadow_postings_balanced_on_update
+AFTER UPDATE ON shadow_postings
+WHEN EXISTS (
+  SELECT 1 FROM shadow_transactions
+  WHERE household_id = NEW.household_id
+    AND id = NEW.shadow_transaction_id
+    AND status = 'posted'
+)
+BEGIN
+  SELECT CASE
+    WHEN EXISTS (
+      SELECT 1 FROM shadow_postings
+      WHERE household_id = NEW.household_id
+        AND shadow_transaction_id = NEW.shadow_transaction_id
+      GROUP BY currency
+      HAVING SUM(amount) != 0
+    )
+    THEN RAISE(ABORT, 'shadow posting update breaks balance on a posted shadow tx')
+  END;
+END;
+"""
+
+_SHADOW_POSTING_DELETE_BALANCE = """
+CREATE TRIGGER trg_shadow_postings_balanced_on_delete
+AFTER DELETE ON shadow_postings
+WHEN EXISTS (
+  SELECT 1 FROM shadow_transactions
+  WHERE household_id = OLD.household_id
+    AND id = OLD.shadow_transaction_id
+    AND status = 'posted'
+)
+BEGIN
+  SELECT CASE
+    WHEN EXISTS (
+      SELECT 1 FROM shadow_postings
+      WHERE household_id = OLD.household_id
+        AND shadow_transaction_id = OLD.shadow_transaction_id
+      GROUP BY currency
+      HAVING SUM(amount) != 0
+    )
+    THEN RAISE(ABORT, 'shadow posting delete breaks balance on a posted shadow tx')
+  END;
+END;
+"""
+
+P4_0_SHADOW_TRIGGERS: Final[tuple[str, ...]] = (
+    _SHADOW_TX_STATUS_BALANCE,
+    _SHADOW_POSTING_INSERT_BALANCE,
+    _SHADOW_POSTING_UPDATE_BALANCE,
+    _SHADOW_POSTING_DELETE_BALANCE,
+)
+
+P4_0_SHADOW_TRIGGER_NAMES: Final[tuple[str, ...]] = (
+    "trg_shadow_transactions_balanced_on_post",
+    "trg_shadow_postings_balanced_on_insert",
+    "trg_shadow_postings_balanced_on_update",
+    "trg_shadow_postings_balanced_on_delete",
+)

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260502_1200_a3f4d8e91b22_add_allocation_shadow_ledger.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260502_1200_a3f4d8e91b22_add_allocation_shadow_ledger.py
@@ -1,0 +1,363 @@
+"""Add allocation_pools, envelopes, sinking_funds, shadow_transactions, shadow_postings.
+
+Implements ADR-0001's shadow-ledger model for envelope and sinking-fund
+tracking. Pool balances are derived from `sum(shadow_postings)`; the
+balance trigger on `shadow_postings` mirrors the main-ledger triggers in
+the initial migration. Also adds the long-deferred FK constraint on
+`postings.pool_id` (the column existed since the initial schema as a
+nullable BLOB without a referential integrity constraint).
+
+Revision ID: a3f4d8e91b22
+Revises: 735bfd334b06
+Create Date: 2026-05-02 12:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from tulip_storage.migrations._triggers import (
+    INITIAL_TRIGGER_NAMES,
+    INITIAL_TRIGGERS,
+    P4_0_SHADOW_TRIGGER_NAMES,
+    P4_0_SHADOW_TRIGGERS,
+)
+from tulip_storage.models.base import GUID
+
+revision: str = "a3f4d8e91b22"
+down_revision: str | None = "735bfd334b06"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create allocation/shadow-ledger tables, indexes, triggers, and the postings.pool_id FK."""
+    op.create_table(
+        "allocation_pools",
+        sa.Column("household_id", GUID(length=36), nullable=False),
+        sa.Column("id", GUID(length=36), nullable=False),
+        sa.Column(
+            "pool_type",
+            sa.Enum(
+                "envelope",
+                "sinking_fund",
+                "inflow",
+                "unallocated",
+                "spent",
+                name="pooltype",
+                native_enum=False,
+                length=20,
+            ),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column(
+            "visibility",
+            sa.String(length=10),
+            nullable=False,
+            server_default="shared",
+        ),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "is_system",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("created_by_user_id", GUID(length=36), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id"],
+            ["households.id"],
+            name=op.f("fk_allocation_pools_household_id_households"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("household_id", "id", name=op.f("pk_allocation_pools")),
+    )
+    with op.batch_alter_table("allocation_pools", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_allocation_pools_household_active",
+            ["household_id", "is_active"],
+            unique=False,
+        )
+        # One Inflow / Unallocated / Spent row per (household, currency).
+        batch_op.create_index(
+            "ix_allocation_pools_system_per_currency",
+            ["household_id", "pool_type", "currency"],
+            unique=True,
+            sqlite_where=sa.text("is_system = 1"),
+        )
+
+    op.create_table(
+        "envelopes",
+        sa.Column("household_id", GUID(length=36), nullable=False),
+        sa.Column("pool_id", GUID(length=36), nullable=False),
+        sa.Column(
+            "budget_period",
+            sa.Enum(
+                "weekly",
+                "biweekly",
+                "monthly",
+                "quarterly",
+                "annual",
+                "custom",
+                name="budgetperiod",
+                native_enum=False,
+                length=20,
+            ),
+            nullable=False,
+        ),
+        sa.Column("budget_amount", sa.Numeric(precision=20, scale=8), nullable=True),
+        sa.Column(
+            "rollover_policy",
+            sa.Enum(
+                "reset",
+                "accumulate",
+                "cap_at_budget",
+                name="rolloverpolicy",
+                native_enum=False,
+                length=20,
+            ),
+            nullable=False,
+        ),
+        sa.Column("refill_rule_json", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["household_id", "pool_id"],
+            ["allocation_pools.household_id", "allocation_pools.id"],
+            name="fk_envelopes_pool",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("household_id", "pool_id", name=op.f("pk_envelopes")),
+    )
+
+    op.create_table(
+        "sinking_funds",
+        sa.Column("household_id", GUID(length=36), nullable=False),
+        sa.Column("pool_id", GUID(length=36), nullable=False),
+        sa.Column("target_amount", sa.Numeric(precision=20, scale=8), nullable=False),
+        sa.Column("target_date", sa.Date(), nullable=False),
+        sa.Column(
+            "contribution_strategy",
+            sa.Enum(
+                "manual",
+                "even_split",
+                "percentage_of_income",
+                name="contributionstrategy",
+                native_enum=False,
+                length=30,
+            ),
+            nullable=False,
+        ),
+        sa.Column("contribution_amount", sa.Numeric(precision=20, scale=8), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["household_id", "pool_id"],
+            ["allocation_pools.household_id", "allocation_pools.id"],
+            name="fk_sinking_funds_pool",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("household_id", "pool_id", name=op.f("pk_sinking_funds")),
+    )
+
+    op.create_table(
+        "shadow_transactions",
+        sa.Column("household_id", GUID(length=36), nullable=False),
+        sa.Column("id", GUID(length=36), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("description", sa.String(length=500), nullable=False),
+        sa.Column(
+            "reason",
+            sa.Enum(
+                "budget_inflow",
+                "refill",
+                "spend",
+                "transfer",
+                "rollover",
+                "manual",
+                name="shadowtxreason",
+                native_enum=False,
+                length=20,
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "posted",
+                "voided",
+                name="shadowtxstatus",
+                native_enum=False,
+                length=20,
+            ),
+            nullable=False,
+        ),
+        sa.Column("paired_main_tx_id", GUID(length=36), nullable=True),
+        sa.Column("voided_by_shadow_tx_id", GUID(length=36), nullable=True),
+        sa.Column("voided_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("posted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_by_user_id", GUID(length=36), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id"],
+            ["households.id"],
+            name=op.f("fk_shadow_transactions_household_id_households"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id", "paired_main_tx_id"],
+            ["transactions.household_id", "transactions.id"],
+            name="fk_shadow_transactions_paired_main_tx",
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id", "voided_by_shadow_tx_id"],
+            ["shadow_transactions.household_id", "shadow_transactions.id"],
+            name="fk_shadow_transactions_voided_by",
+            use_alter=True,
+        ),
+        sa.PrimaryKeyConstraint("household_id", "id", name=op.f("pk_shadow_transactions")),
+    )
+    with op.batch_alter_table("shadow_transactions", schema=None) as batch_op:
+        # Plain ascending index on (household_id, date). DESC scans use the
+        # same index in SQLite without needing the explicit DESC modifier.
+        batch_op.create_index(
+            "ix_shadow_tx_household_date",
+            ["household_id", "date"],
+            unique=False,
+        )
+        batch_op.create_index(
+            "ix_shadow_tx_paired_main",
+            ["household_id", "paired_main_tx_id"],
+            unique=False,
+            sqlite_where=sa.text("paired_main_tx_id IS NOT NULL"),
+        )
+
+    op.create_table(
+        "shadow_postings",
+        sa.Column("id", GUID(length=36), nullable=False),
+        sa.Column("household_id", GUID(length=36), nullable=False),
+        sa.Column("shadow_transaction_id", GUID(length=36), nullable=False),
+        sa.Column("pool_id", GUID(length=36), nullable=False),
+        sa.Column("amount", sa.Numeric(precision=20, scale=8), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("memo", sa.String(length=500), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["household_id", "shadow_transaction_id"],
+            ["shadow_transactions.household_id", "shadow_transactions.id"],
+            name="fk_shadow_postings_shadow_transaction",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id", "pool_id"],
+            ["allocation_pools.household_id", "allocation_pools.id"],
+            name="fk_shadow_postings_pool",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_shadow_postings")),
+    )
+    with op.batch_alter_table("shadow_postings", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_shadow_postings_household_id"), ["household_id"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_shadow_postings_shadow_transaction_id"),
+            ["shadow_transaction_id"],
+            unique=False,
+        )
+        batch_op.create_index(batch_op.f("ix_shadow_postings_pool_id"), ["pool_id"], unique=False)
+
+    # Add the long-deferred FK on postings.pool_id. The column has existed
+    # since the initial migration as a nullable GUID without referential
+    # integrity. SQLite requires a table rebuild to add an FK; batch_alter_table
+    # handles it.
+    #
+    # The main-ledger balance triggers reference `postings` by name. SQLite's
+    # rebuild-rename dance briefly leaves no `postings` table in the database,
+    # which makes the trigger bodies unresolvable and aborts the ALTER. Drop
+    # the triggers around the rebuild and recreate them afterwards.
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        for trigger_name in reversed(INITIAL_TRIGGER_NAMES):
+            op.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+
+    with op.batch_alter_table("postings", schema=None) as batch_op:
+        batch_op.create_foreign_key(
+            "fk_postings_pool",
+            "allocation_pools",
+            ["household_id", "pool_id"],
+            ["household_id", "id"],
+            ondelete="RESTRICT",
+        )
+
+    if bind.dialect.name == "sqlite":
+        for ddl in INITIAL_TRIGGERS:
+            op.execute(ddl)
+        for ddl in P4_0_SHADOW_TRIGGERS:
+            op.execute(ddl)
+
+
+def downgrade() -> None:
+    """Drop allocation/shadow-ledger tables, the postings.pool_id FK, and triggers."""
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        for trigger_name in reversed(P4_0_SHADOW_TRIGGER_NAMES):
+            op.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+        # Same trigger / batch_alter dance as upgrade(): drop the
+        # main-ledger triggers, rebuild the table, recreate the triggers.
+        for trigger_name in reversed(INITIAL_TRIGGER_NAMES):
+            op.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+
+    with op.batch_alter_table("postings", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_postings_pool", type_="foreignkey")
+
+    if bind.dialect.name == "sqlite":
+        for ddl in INITIAL_TRIGGERS:
+            op.execute(ddl)
+
+    with op.batch_alter_table("shadow_postings", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_shadow_postings_pool_id"))
+        batch_op.drop_index(batch_op.f("ix_shadow_postings_shadow_transaction_id"))
+        batch_op.drop_index(batch_op.f("ix_shadow_postings_household_id"))
+    op.drop_table("shadow_postings")
+
+    with op.batch_alter_table("shadow_transactions", schema=None) as batch_op:
+        batch_op.drop_index("ix_shadow_tx_paired_main")
+        batch_op.drop_index("ix_shadow_tx_household_date")
+    op.drop_table("shadow_transactions")
+    op.drop_table("sinking_funds")
+    op.drop_table("envelopes")
+
+    with op.batch_alter_table("allocation_pools", schema=None) as batch_op:
+        batch_op.drop_index("ix_allocation_pools_system_per_currency")
+        batch_op.drop_index("ix_allocation_pools_household_active")
+    op.drop_table("allocation_pools")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -12,28 +12,48 @@ architecture test in tulip-core enforces this.
 """
 
 from tulip_storage.models.account import Account, AccountType
+from tulip_storage.models.allocation_pool import AllocationPool, PoolType
 from tulip_storage.models.audit_log import AuditLog
 from tulip_storage.models.base import Base
+from tulip_storage.models.envelope import BudgetPeriod, Envelope, RolloverPolicy
 from tulip_storage.models.household import Household, MfaPolicy
 from tulip_storage.models.mfa_recovery_code import MfaRecoveryCode
 from tulip_storage.models.period import Period, PeriodStatus
 from tulip_storage.models.posting import Posting
 from tulip_storage.models.session import Session
+from tulip_storage.models.shadow_posting import ShadowPosting
+from tulip_storage.models.shadow_transaction import (
+    ShadowTransaction,
+    ShadowTxReason,
+    ShadowTxStatus,
+)
+from tulip_storage.models.sinking_fund import ContributionStrategy, SinkingFund
 from tulip_storage.models.transaction import Transaction, TransactionStatus
 from tulip_storage.models.user import User, UserRole
 
 __all__ = [
     "Account",
     "AccountType",
+    "AllocationPool",
     "AuditLog",
     "Base",
+    "BudgetPeriod",
+    "ContributionStrategy",
+    "Envelope",
     "Household",
     "MfaPolicy",
     "MfaRecoveryCode",
     "Period",
     "PeriodStatus",
+    "PoolType",
     "Posting",
+    "RolloverPolicy",
     "Session",
+    "ShadowPosting",
+    "ShadowTransaction",
+    "ShadowTxReason",
+    "ShadowTxStatus",
+    "SinkingFund",
     "Transaction",
     "TransactionStatus",
     "User",

--- a/packages/tulip-storage/src/tulip_storage/models/allocation_pool.py
+++ b/packages/tulip-storage/src/tulip_storage/models/allocation_pool.py
@@ -1,0 +1,71 @@
+"""AllocationPool model — the polymorphic base for envelopes / sinking funds / system pools.
+
+See ADR-0001. Pool balances are derived from :mod:`shadow_postings`; this
+table carries identity, type discriminator, currency, and is_active /
+is_system flags.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, func
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from tulip_storage.models.base import GUID, Base
+from tulip_storage.models.household import Household
+
+
+class PoolType(Enum):
+    """Polymorphic discriminator for an :class:`AllocationPool`.
+
+    Mirrors :class:`tulip_core.allocation.PoolType` exactly. The two enums
+    live in different layers (storage vs. domain) by convention; the values
+    must remain identical so converters at the seam are trivial.
+    """
+
+    ENVELOPE = "envelope"
+    SINKING_FUND = "sinking_fund"
+    INFLOW = "inflow"
+    UNALLOCATED = "unallocated"
+    SPENT = "spent"
+
+
+class AllocationPool(Base):
+    """An account in the shadow ledger."""
+
+    __tablename__ = "allocation_pools"
+
+    household_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("households.id", ondelete="CASCADE"), primary_key=True
+    )
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    pool_type: Mapped[PoolType] = mapped_column(
+        SAEnum(
+            PoolType,
+            native_enum=False,
+            length=20,
+            values_callable=lambda enum_cls: [m.value for m in enum_cls],
+        ),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    visibility: Mapped[str] = mapped_column(String(10), nullable=False, default="shared")
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    is_system: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_by_user_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    household: Mapped[Household] = relationship()

--- a/packages/tulip-storage/src/tulip_storage/models/envelope.py
+++ b/packages/tulip-storage/src/tulip_storage/models/envelope.py
@@ -1,0 +1,81 @@
+"""Envelope model — joined to AllocationPool via composite (household_id, pool_id) FK."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import Enum
+from uuid import UUID
+
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy import ForeignKeyConstraint, Numeric, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from tulip_storage.models.allocation_pool import AllocationPool
+from tulip_storage.models.base import GUID, Base
+
+
+class BudgetPeriod(Enum):
+    """Budget refresh cadence for an envelope."""
+
+    WEEKLY = "weekly"
+    BIWEEKLY = "biweekly"
+    MONTHLY = "monthly"
+    QUARTERLY = "quarterly"
+    ANNUAL = "annual"
+    CUSTOM = "custom"
+
+
+class RolloverPolicy(Enum):
+    """End-of-period rollover behavior for an envelope."""
+
+    RESET = "reset"
+    ACCUMULATE = "accumulate"
+    CAP_AT_BUDGET = "cap_at_budget"
+
+
+class Envelope(Base):
+    """Envelope detail rows joined to allocation_pools."""
+
+    __tablename__ = "envelopes"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "pool_id"],
+            ["allocation_pools.household_id", "allocation_pools.id"],
+            ondelete="CASCADE",
+            name="fk_envelopes_pool",
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    pool_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    budget_period: Mapped[BudgetPeriod] = mapped_column(
+        SAEnum(
+            BudgetPeriod,
+            native_enum=False,
+            length=20,
+            values_callable=lambda enum_cls: [m.value for m in enum_cls],
+        ),
+        nullable=False,
+    )
+    budget_amount: Mapped[Decimal | None] = mapped_column(Numeric(20, 8), nullable=True)
+    rollover_policy: Mapped[RolloverPolicy] = mapped_column(
+        SAEnum(
+            RolloverPolicy,
+            native_enum=False,
+            length=20,
+            values_callable=lambda enum_cls: [m.value for m in enum_cls],
+        ),
+        nullable=False,
+    )
+    refill_rule_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    pool: Mapped[AllocationPool] = relationship(
+        primaryjoin=(
+            "and_("
+            "Envelope.household_id == AllocationPool.household_id, "
+            "Envelope.pool_id == AllocationPool.id"
+            ")"
+        ),
+        foreign_keys="[Envelope.household_id, Envelope.pool_id]",
+        viewonly=True,
+    )

--- a/packages/tulip-storage/src/tulip_storage/models/shadow_posting.py
+++ b/packages/tulip-storage/src/tulip_storage/models/shadow_posting.py
@@ -1,0 +1,55 @@
+"""ShadowPosting model — one leg of a shadow-ledger transaction."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import ForeignKeyConstraint, Numeric, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from tulip_storage.models.allocation_pool import AllocationPool
+from tulip_storage.models.base import GUID, Base
+from tulip_storage.models.shadow_transaction import ShadowTransaction
+
+
+class ShadowPosting(Base):
+    """One leg of a :class:`ShadowTransaction`.
+
+    Composite FKs to ``shadow_transactions`` and ``allocation_pools`` mirror
+    the main-ledger ``Posting`` design. Sum-to-zero per shadow_transaction_id
+    per currency is enforced by trigger on transitions into ``posted``.
+    """
+
+    __tablename__ = "shadow_postings"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "shadow_transaction_id"],
+            ["shadow_transactions.household_id", "shadow_transactions.id"],
+            ondelete="CASCADE",
+            name="fk_shadow_postings_shadow_transaction",
+        ),
+        ForeignKeyConstraint(
+            ["household_id", "pool_id"],
+            ["allocation_pools.household_id", "allocation_pools.id"],
+            ondelete="RESTRICT",
+            name="fk_shadow_postings_pool",
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    household_id: Mapped[UUID] = mapped_column(GUID(), nullable=False, index=True)
+    shadow_transaction_id: Mapped[UUID] = mapped_column(GUID(), nullable=False, index=True)
+    pool_id: Mapped[UUID] = mapped_column(GUID(), nullable=False, index=True)
+    amount: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    memo: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    shadow_transaction: Mapped[ShadowTransaction] = relationship(
+        foreign_keys="[ShadowPosting.household_id, ShadowPosting.shadow_transaction_id]",
+        overlaps="pool",
+    )
+    pool: Mapped[AllocationPool] = relationship(
+        foreign_keys="[ShadowPosting.household_id, ShadowPosting.pool_id]",
+        overlaps="shadow_transaction",
+    )

--- a/packages/tulip-storage/src/tulip_storage/models/shadow_transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/models/shadow_transaction.py
@@ -1,0 +1,94 @@
+"""ShadowTransaction model — header for a balanced set of shadow postings."""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from sqlalchemy import Date, DateTime, ForeignKey, ForeignKeyConstraint, String, func
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from tulip_storage.models.base import GUID, Base
+from tulip_storage.models.household import Household
+
+
+class ShadowTxStatus(Enum):
+    """Workflow status — see tulip_core.allocation.ShadowTxStatus."""
+
+    PENDING = "pending"
+    POSTED = "posted"
+    VOIDED = "voided"
+
+
+class ShadowTxReason(Enum):
+    """Why this shadow tx exists. See ADR-0001."""
+
+    BUDGET_INFLOW = "budget_inflow"
+    REFILL = "refill"
+    SPEND = "spend"
+    TRANSFER = "transfer"
+    ROLLOVER = "rollover"
+    MANUAL = "manual"
+
+
+class ShadowTransaction(Base):
+    """A shadow-ledger transaction header. Postings live in `shadow_postings`."""
+
+    __tablename__ = "shadow_transactions"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "paired_main_tx_id"],
+            ["transactions.household_id", "transactions.id"],
+            name="fk_shadow_transactions_paired_main_tx",
+        ),
+        ForeignKeyConstraint(
+            ["household_id", "voided_by_shadow_tx_id"],
+            ["shadow_transactions.household_id", "shadow_transactions.id"],
+            name="fk_shadow_transactions_voided_by",
+            use_alter=True,
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("households.id", ondelete="CASCADE"), primary_key=True
+    )
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    date: Mapped[date_type] = mapped_column(Date, nullable=False)
+    description: Mapped[str] = mapped_column(String(500), nullable=False)
+    reason: Mapped[ShadowTxReason] = mapped_column(
+        SAEnum(
+            ShadowTxReason,
+            native_enum=False,
+            length=20,
+            values_callable=lambda enum_cls: [m.value for m in enum_cls],
+        ),
+        nullable=False,
+    )
+    status: Mapped[ShadowTxStatus] = mapped_column(
+        SAEnum(
+            ShadowTxStatus,
+            native_enum=False,
+            length=20,
+            values_callable=lambda enum_cls: [m.value for m in enum_cls],
+        ),
+        nullable=False,
+    )
+    paired_main_tx_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    voided_by_shadow_tx_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    voided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    posted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_by_user_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    household: Mapped[Household] = relationship()

--- a/packages/tulip-storage/src/tulip_storage/models/sinking_fund.py
+++ b/packages/tulip-storage/src/tulip_storage/models/sinking_fund.py
@@ -1,0 +1,63 @@
+"""SinkingFund model — joined to AllocationPool via composite (household_id, pool_id) FK."""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from decimal import Decimal
+from enum import Enum
+from uuid import UUID
+
+from sqlalchemy import Date, ForeignKeyConstraint, Numeric
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from tulip_storage.models.allocation_pool import AllocationPool
+from tulip_storage.models.base import GUID, Base
+
+
+class ContributionStrategy(Enum):
+    """How a sinking fund's per-period contribution is computed."""
+
+    MANUAL = "manual"
+    EVEN_SPLIT = "even_split"
+    PERCENTAGE_OF_INCOME = "percentage_of_income"
+
+
+class SinkingFund(Base):
+    """Sinking-fund detail rows joined to allocation_pools."""
+
+    __tablename__ = "sinking_funds"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "pool_id"],
+            ["allocation_pools.household_id", "allocation_pools.id"],
+            ondelete="CASCADE",
+            name="fk_sinking_funds_pool",
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    pool_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    target_amount: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    target_date: Mapped[date_type] = mapped_column(Date, nullable=False)
+    contribution_strategy: Mapped[ContributionStrategy] = mapped_column(
+        SAEnum(
+            ContributionStrategy,
+            native_enum=False,
+            length=30,
+            values_callable=lambda enum_cls: [m.value for m in enum_cls],
+        ),
+        nullable=False,
+    )
+    contribution_amount: Mapped[Decimal | None] = mapped_column(Numeric(20, 8), nullable=True)
+
+    pool: Mapped[AllocationPool] = relationship(
+        primaryjoin=(
+            "and_("
+            "SinkingFund.household_id == AllocationPool.household_id, "
+            "SinkingFund.pool_id == AllocationPool.id"
+            ")"
+        ),
+        foreign_keys="[SinkingFund.household_id, SinkingFund.pool_id]",
+        viewonly=True,
+    )

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -10,14 +10,18 @@ higher layers (the API) call it on every business mutation.
 """
 
 from tulip_storage.repositories.account import AccountRepository
+from tulip_storage.repositories.allocation_pool import AllocationPoolRepository
 from tulip_storage.repositories.audit_log import AuditLogWriter
 from tulip_storage.repositories.period import PeriodRepository
+from tulip_storage.repositories.shadow_transaction import ShadowTransactionRepository
 from tulip_storage.repositories.transaction import TransactionRepository, TrialBalanceRow
 
 __all__ = [
     "AccountRepository",
+    "AllocationPoolRepository",
     "AuditLogWriter",
     "PeriodRepository",
+    "ShadowTransactionRepository",
     "TransactionRepository",
     "TrialBalanceRow",
 ]

--- a/packages/tulip-storage/src/tulip_storage/repositories/allocation_pool.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/allocation_pool.py
@@ -1,0 +1,137 @@
+"""AllocationPoolRepository — household-scoped CRUD over the allocation_pools table.
+
+Includes the system-pool resolver: ``get_or_create_system_pools(currency)``
+returns the household's ``Inflow`` / ``Unallocated`` / ``Spent`` pools for the
+given currency, creating the row(s) if missing. Wired into household
+creation by the API layer; called lazily by the shadow-ledger writer the
+first time a new currency shows up in budgeting.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+
+from tulip_storage.models import AllocationPool, PoolType
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+_SYSTEM_POOL_TYPES: tuple[PoolType, ...] = (
+    PoolType.INFLOW,
+    PoolType.UNALLOCATED,
+    PoolType.SPENT,
+)
+
+_SYSTEM_POOL_NAMES: dict[PoolType, str] = {
+    PoolType.INFLOW: "Inflow",
+    PoolType.UNALLOCATED: "Unallocated",
+    PoolType.SPENT: "Spent",
+}
+
+
+class AllocationPoolRepository:
+    """CRUD + system-pool resolution for one household's allocation_pools."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the repository to a session and a tenant scope."""
+        self._session = session
+        self._household_id = household_id
+
+    def create(
+        self,
+        *,
+        pool_type: PoolType,
+        name: str,
+        currency: str,
+        visibility: str = "shared",
+        is_system: bool = False,
+        created_by_user_id: UUID | None = None,
+    ) -> AllocationPool:
+        """Insert a new AllocationPool into this repository's household."""
+        p = AllocationPool(
+            household_id=self._household_id,
+            id=uuid4(),
+            pool_type=pool_type,
+            name=name,
+            currency=currency,
+            visibility=visibility,
+            is_active=True,
+            is_system=is_system,
+            created_by_user_id=created_by_user_id,
+        )
+        self._session.add(p)
+        self._session.flush()
+        return p
+
+    def get(self, pool_id: UUID) -> AllocationPool | None:
+        """Return the AllocationPool with the given id, or None."""
+        return self._session.execute(
+            select(AllocationPool).where(
+                AllocationPool.household_id == self._household_id,
+                AllocationPool.id == pool_id,
+            )
+        ).scalar_one_or_none()
+
+    def list_active(self) -> list[AllocationPool]:
+        """Return all active pools in this household, including system pools."""
+        return list(
+            self._session.execute(
+                select(AllocationPool)
+                .where(
+                    AllocationPool.household_id == self._household_id,
+                    AllocationPool.is_active.is_(True),
+                )
+                .order_by(AllocationPool.is_system, AllocationPool.name)
+            )
+            .scalars()
+            .all()
+        )
+
+    def deactivate(self, pool_id: UUID) -> AllocationPool:
+        """Mark a pool inactive (soft delete). Raises if missing or system."""
+        p = self.get(pool_id)
+        if p is None:
+            raise LookupError(f"pool {pool_id} not found in household {self._household_id}")
+        if p.is_system:
+            raise ValueError(f"system pool {pool_id} ({p.name!r}) cannot be deactivated")
+        p.is_active = False
+        self._session.flush()
+        return p
+
+    def get_system_pool(self, *, pool_type: PoolType, currency: str) -> AllocationPool | None:
+        """Return the system pool for ``(household, pool_type, currency)``, or None."""
+        if pool_type not in _SYSTEM_POOL_TYPES:
+            raise ValueError(f"pool_type {pool_type.value!r} is not a system pool type")
+        return self._session.execute(
+            select(AllocationPool).where(
+                AllocationPool.household_id == self._household_id,
+                AllocationPool.pool_type == pool_type,
+                AllocationPool.currency == currency,
+                AllocationPool.is_system.is_(True),
+            )
+        ).scalar_one_or_none()
+
+    def get_or_create_system_pools(self, *, currency: str) -> dict[PoolType, AllocationPool]:
+        """Return the three system pools for ``(household, currency)``.
+
+        Creates any rows that are missing. Idempotent: calling twice with
+        the same currency returns the same rows. Used both eagerly at
+        household creation and lazily by the shadow-ledger writer when a
+        new currency first appears in budgeting.
+        """
+        out: dict[PoolType, AllocationPool] = {}
+        for pool_type in _SYSTEM_POOL_TYPES:
+            existing = self.get_system_pool(pool_type=pool_type, currency=currency)
+            if existing is None:
+                existing = self.create(
+                    pool_type=pool_type,
+                    name=f"{_SYSTEM_POOL_NAMES[pool_type]} {currency}",
+                    currency=currency,
+                    is_system=True,
+                )
+            out[pool_type] = existing
+        return out

--- a/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
@@ -1,0 +1,179 @@
+"""ShadowTransactionRepository — persists balanced shadow transactions and queries balances.
+
+Mirrors :class:`tulip_storage.repositories.TransactionRepository` for the
+parallel ledger. The save flow inserts the header as PENDING, adds every
+shadow posting, then UPDATEs the header to POSTED — the trigger validates
+balance on the status transition. ``balance_for_pool`` sums the postings
+on a single pool; voided shadow transactions are excluded.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from datetime import date as date_type
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import func, select, update
+
+from tulip_storage.models import (
+    ShadowPosting,
+    ShadowTransaction,
+    ShadowTxStatus,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_core.allocation import ShadowTransaction as DomainShadowTx
+    from tulip_core.allocation import ShadowTxStatus as DomainShadowStatus
+
+
+_DOMAIN_TO_STORAGE_STATUS: dict[str, ShadowTxStatus] = {
+    "pending": ShadowTxStatus.PENDING,
+    "posted": ShadowTxStatus.POSTED,
+    "voided": ShadowTxStatus.VOIDED,
+}
+
+#: Statuses whose postings count toward derived balances. Pending shadow
+#: transactions are workflow state; voided are reversed; both are excluded
+#: from balance sums.
+_BALANCE_STATUSES = (ShadowTxStatus.POSTED,)
+
+
+class ShadowTransactionRepository:
+    """Persists shadow transactions and queries pool balances, scoped to a household."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the repository to a session and a tenant scope."""
+        self._session = session
+        self._household_id = household_id
+
+    def get(self, tx_id: UUID) -> ShadowTransaction | None:
+        """Return the ShadowTransaction header by id, or None."""
+        return self._session.execute(
+            select(ShadowTransaction).where(
+                ShadowTransaction.household_id == self._household_id,
+                ShadowTransaction.id == tx_id,
+            )
+        ).scalar_one_or_none()
+
+    def list_postings(self, tx_id: UUID) -> list[ShadowPosting]:
+        """Return all shadow postings belonging to a shadow transaction."""
+        return list(
+            self._session.execute(
+                select(ShadowPosting).where(
+                    ShadowPosting.household_id == self._household_id,
+                    ShadowPosting.shadow_transaction_id == tx_id,
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    def balance_for_pool(
+        self,
+        pool_id: UUID,
+        *,
+        currency: str | None = None,
+        as_of: date_type | None = None,
+    ) -> dict[str, Decimal]:
+        """Return ``{currency: net amount}`` over POSTED shadow postings for ``pool_id``.
+
+        - ``currency=None`` (the default) returns one row per currency
+          touching the pool. Pools are single-currency, so the map will
+          almost always have one entry.
+        - ``currency="USD"`` filters to that one currency; the map will be
+          empty if the pool has no postings in that currency.
+        - ``as_of=YYYY-MM-DD`` filters to shadow transactions on or before
+          that date.
+        """
+        query = (
+            select(
+                ShadowPosting.currency,
+                func.coalesce(func.sum(ShadowPosting.amount), 0).label("balance"),
+            )
+            .join(
+                ShadowTransaction,
+                ShadowTransaction.id == ShadowPosting.shadow_transaction_id,
+            )
+            .where(
+                ShadowPosting.household_id == self._household_id,
+                ShadowPosting.pool_id == pool_id,
+                ShadowTransaction.status.in_(_BALANCE_STATUSES),
+            )
+            .group_by(ShadowPosting.currency)
+        )
+        if currency is not None:
+            query = query.where(ShadowPosting.currency == currency)
+        if as_of is not None:
+            query = query.where(ShadowTransaction.date <= as_of)
+        rows = self._session.execute(query).all()
+        return {ccy: Decimal(str(bal)) for ccy, bal in rows}
+
+    def save_balanced(self, domain_tx: DomainShadowTx) -> ShadowTransaction:
+        """Persist a balanced domain ShadowTransaction.
+
+        Inserts the header as PENDING, then every shadow posting, then
+        UPDATEs the header to the requested final status. The shadow-ledger
+        balance trigger validates on the UPDATE.
+        """
+        target_status = self._domain_to_storage(domain_tx.status)
+        return self._save(domain_tx, target_status)
+
+    def _save(
+        self,
+        domain_tx: DomainShadowTx,
+        target_status: ShadowTxStatus,
+    ) -> ShadowTransaction:
+        # Header inserted as PENDING so the trigger doesn't fire before
+        # postings exist. Storage enum values match domain enum values
+        # by construction, so we round-trip via .value across the seam.
+        from tulip_storage.models import ShadowTxReason as StorageReason
+
+        header = ShadowTransaction(
+            household_id=self._household_id,
+            id=domain_tx.id,
+            date=domain_tx.date,
+            description=domain_tx.description,
+            reason=StorageReason(domain_tx.reason.value),
+            status=ShadowTxStatus.PENDING,
+            paired_main_tx_id=domain_tx.paired_main_tx_id,
+            created_by_user_id=domain_tx.created_by_user_id,
+            posted_at=datetime.now(tz=UTC) if target_status is ShadowTxStatus.POSTED else None,
+        )
+        self._session.add(header)
+        self._session.flush()
+
+        for p in domain_tx.postings:
+            self._session.add(
+                ShadowPosting(
+                    id=p.id,
+                    household_id=self._household_id,
+                    shadow_transaction_id=header.id,
+                    pool_id=p.pool_id,
+                    amount=p.amount.amount,
+                    currency=p.amount.currency,
+                    memo=p.memo,
+                )
+            )
+        self._session.flush()
+
+        if target_status is not ShadowTxStatus.PENDING:
+            # Trigger fires on the UPDATE; aborts if postings don't balance.
+            self._session.execute(
+                update(ShadowTransaction)
+                .where(
+                    ShadowTransaction.household_id == self._household_id,
+                    ShadowTransaction.id == header.id,
+                )
+                .values(status=target_status.value)
+            )
+            header.status = target_status
+
+        return header
+
+    @staticmethod
+    def _domain_to_storage(status: DomainShadowStatus) -> ShadowTxStatus:
+        return _DOMAIN_TO_STORAGE_STATUS[status.value]

--- a/packages/tulip-storage/tests/conftest.py
+++ b/packages/tulip-storage/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import Engine, create_engine, event, text
 from sqlalchemy.orm import Session, sessionmaker
 
-from tulip_storage.migrations._triggers import INITIAL_TRIGGERS
+from tulip_storage.migrations._triggers import INITIAL_TRIGGERS, P4_0_SHADOW_TRIGGERS
 from tulip_storage.models import Base
 
 
@@ -31,6 +31,8 @@ def engine() -> Iterator[Engine]:
     Base.metadata.create_all(eng)
     with eng.begin() as conn:
         for ddl in INITIAL_TRIGGERS:
+            conn.execute(text(ddl))
+        for ddl in P4_0_SHADOW_TRIGGERS:
             conn.execute(text(ddl))
     yield eng
     eng.dispose()

--- a/packages/tulip-storage/tests/test_allocation_repositories.py
+++ b/packages/tulip-storage/tests/test_allocation_repositories.py
@@ -1,0 +1,262 @@
+"""Tests for AllocationPoolRepository and ShadowTransactionRepository."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_core.allocation import (
+    ShadowPosting as DomainShadowPosting,
+)
+from tulip_core.allocation import (
+    ShadowTransaction as DomainShadowTransaction,
+)
+from tulip_core.allocation import (
+    ShadowTxReason as DomainShadowTxReason,
+)
+from tulip_core.allocation import (
+    ShadowTxStatus as DomainShadowTxStatus,
+)
+from tulip_core.money import Money
+from tulip_storage.models import (
+    AllocationPool,
+    Household,
+    PoolType,
+    ShadowTxStatus,
+)
+from tulip_storage.repositories import (
+    AllocationPoolRepository,
+    ShadowTransactionRepository,
+)
+
+
+def _seed_household(session: Session, *, base_currency: str = "USD") -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency=base_currency)
+    session.add(h)
+    session.commit()
+    return h
+
+
+# ---- AllocationPoolRepository ------------------------------------------
+
+
+class TestPoolCreate:
+    def test_create_envelope(self, session: Session) -> None:
+        h = _seed_household(session)
+        repo = AllocationPoolRepository(session, h.id)
+        p = repo.create(pool_type=PoolType.ENVELOPE, name="Groceries", currency="USD")
+        session.commit()
+        assert p.is_system is False
+        assert p.is_active is True
+
+    def test_create_system_pool_idempotent(self, session: Session) -> None:
+        h = _seed_household(session)
+        repo = AllocationPoolRepository(session, h.id)
+        first = repo.get_or_create_system_pools(currency="USD")
+        session.commit()
+        second = repo.get_or_create_system_pools(currency="USD")
+        session.commit()
+        assert {p.id for p in first.values()} == {p.id for p in second.values()}
+        assert set(first.keys()) == {PoolType.INFLOW, PoolType.UNALLOCATED, PoolType.SPENT}
+
+    def test_system_pools_are_per_currency(self, session: Session) -> None:
+        h = _seed_household(session)
+        repo = AllocationPoolRepository(session, h.id)
+        usd = repo.get_or_create_system_pools(currency="USD")
+        eur = repo.get_or_create_system_pools(currency="EUR")
+        session.commit()
+        # Six pool rows total (3 system types x 2 currencies).
+        assert {p.id for p in usd.values()}.isdisjoint({p.id for p in eur.values()})
+
+    def test_get_system_pool_rejects_non_system_type(self, session: Session) -> None:
+        h = _seed_household(session)
+        repo = AllocationPoolRepository(session, h.id)
+        with pytest.raises(ValueError, match="not a system pool type"):
+            repo.get_system_pool(pool_type=PoolType.ENVELOPE, currency="USD")
+
+
+class TestPoolListAndDeactivate:
+    def test_list_active_includes_system(self, session: Session) -> None:
+        h = _seed_household(session)
+        repo = AllocationPoolRepository(session, h.id)
+        repo.get_or_create_system_pools(currency="USD")
+        repo.create(pool_type=PoolType.ENVELOPE, name="Groceries", currency="USD")
+        session.commit()
+        pools = repo.list_active()
+        assert len(pools) == 4
+        assert sum(1 for p in pools if p.is_system) == 3
+
+    def test_deactivate_user_pool(self, session: Session) -> None:
+        h = _seed_household(session)
+        repo = AllocationPoolRepository(session, h.id)
+        p = repo.create(pool_type=PoolType.ENVELOPE, name="Groceries", currency="USD")
+        session.commit()
+        repo.deactivate(p.id)
+        session.commit()
+        again = repo.get(p.id)
+        assert again is not None
+        assert again.is_active is False
+
+    def test_deactivate_system_pool_rejected(self, session: Session) -> None:
+        h = _seed_household(session)
+        repo = AllocationPoolRepository(session, h.id)
+        pools = repo.get_or_create_system_pools(currency="USD")
+        session.commit()
+        with pytest.raises(ValueError, match="system pool"):
+            repo.deactivate(pools[PoolType.UNALLOCATED].id)
+
+    def test_deactivate_missing_raises(self, session: Session) -> None:
+        h = _seed_household(session)
+        repo = AllocationPoolRepository(session, h.id)
+        with pytest.raises(LookupError):
+            repo.deactivate(uuid4())
+
+
+# ---- ShadowTransactionRepository ---------------------------------------
+
+
+def _build_balanced_domain_tx(
+    *,
+    household_id: UUID,
+    src_pool_id: UUID,
+    dst_pool_id: UUID,
+    amount: Decimal = Decimal("250"),
+    currency: str = "USD",
+    tx_date: date = date(2026, 6, 1),
+    paired_main_tx_id: UUID | None = None,
+) -> DomainShadowTransaction:
+    return DomainShadowTransaction(
+        id=uuid4(),
+        household_id=household_id,
+        date=tx_date,
+        description="Refill Groceries",
+        reason=DomainShadowTxReason.REFILL,
+        postings=(
+            DomainShadowPosting(id=uuid4(), pool_id=src_pool_id, amount=Money(-amount, currency)),
+            DomainShadowPosting(id=uuid4(), pool_id=dst_pool_id, amount=Money(amount, currency)),
+        ),
+        status=DomainShadowTxStatus.POSTED,
+        paired_main_tx_id=paired_main_tx_id,
+    )
+
+
+def _seed_pools_for_balance_test(
+    session: Session, household: Household
+) -> tuple[AllocationPool, AllocationPool]:
+    pool_repo = AllocationPoolRepository(session, household.id)
+    sys_pools = pool_repo.get_or_create_system_pools(currency="USD")
+    src = sys_pools[PoolType.UNALLOCATED]
+    dst = pool_repo.create(pool_type=PoolType.ENVELOPE, name="Groceries", currency="USD")
+    session.commit()
+    return src, dst
+
+
+class TestSavePostedShadowTx:
+    def test_save_balanced(self, session: Session) -> None:
+        h = _seed_household(session)
+        src, dst = _seed_pools_for_balance_test(session, h)
+        stx_repo = ShadowTransactionRepository(session, h.id)
+        domain_tx = _build_balanced_domain_tx(
+            household_id=h.id, src_pool_id=src.id, dst_pool_id=dst.id
+        )
+        stx = stx_repo.save_balanced(domain_tx)
+        session.commit()
+        assert stx.status is ShadowTxStatus.POSTED
+        assert stx.posted_at is not None
+        postings = stx_repo.list_postings(stx.id)
+        assert len(postings) == 2
+
+    def test_balance_for_pool_after_refill(self, session: Session) -> None:
+        h = _seed_household(session)
+        src, dst = _seed_pools_for_balance_test(session, h)
+        stx_repo = ShadowTransactionRepository(session, h.id)
+        domain_tx = _build_balanced_domain_tx(
+            household_id=h.id, src_pool_id=src.id, dst_pool_id=dst.id, amount=Decimal("250")
+        )
+        stx_repo.save_balanced(domain_tx)
+        session.commit()
+        assert stx_repo.balance_for_pool(dst.id) == {"USD": Decimal("250")}
+        assert stx_repo.balance_for_pool(src.id) == {"USD": Decimal("-250")}
+
+    def test_balance_for_empty_pool(self, session: Session) -> None:
+        h = _seed_household(session)
+        _, dst = _seed_pools_for_balance_test(session, h)
+        stx_repo = ShadowTransactionRepository(session, h.id)
+        # No shadow tx posted to dst yet.
+        assert stx_repo.balance_for_pool(dst.id) == {}
+
+    def test_balance_for_pool_currency_filter(self, session: Session) -> None:
+        h = _seed_household(session)
+        src, dst = _seed_pools_for_balance_test(session, h)
+        stx_repo = ShadowTransactionRepository(session, h.id)
+        stx_repo.save_balanced(
+            _build_balanced_domain_tx(
+                household_id=h.id, src_pool_id=src.id, dst_pool_id=dst.id, amount=Decimal("250")
+            )
+        )
+        session.commit()
+        # Filter to a currency the pool has no postings in.
+        assert stx_repo.balance_for_pool(dst.id, currency="EUR") == {}
+        assert stx_repo.balance_for_pool(dst.id, currency="USD") == {"USD": Decimal("250")}
+
+    def test_balance_for_pool_as_of(self, session: Session) -> None:
+        h = _seed_household(session)
+        src, dst = _seed_pools_for_balance_test(session, h)
+        stx_repo = ShadowTransactionRepository(session, h.id)
+        # Two refills on different dates.
+        stx_repo.save_balanced(
+            _build_balanced_domain_tx(
+                household_id=h.id,
+                src_pool_id=src.id,
+                dst_pool_id=dst.id,
+                amount=Decimal("100"),
+                tx_date=date(2026, 6, 1),
+            )
+        )
+        stx_repo.save_balanced(
+            _build_balanced_domain_tx(
+                household_id=h.id,
+                src_pool_id=src.id,
+                dst_pool_id=dst.id,
+                amount=Decimal("250"),
+                tx_date=date(2026, 7, 1),
+            )
+        )
+        session.commit()
+        # As-of June 30 — only the first refill counts.
+        assert stx_repo.balance_for_pool(dst.id, as_of=date(2026, 6, 30)) == {"USD": Decimal("100")}
+        # As-of July 31 — both refills count.
+        assert stx_repo.balance_for_pool(dst.id, as_of=date(2026, 7, 31)) == {"USD": Decimal("350")}
+
+
+class TestPendingShadowTxExcludedFromBalance:
+    def test_pending_does_not_contribute(self, session: Session) -> None:
+        h = _seed_household(session)
+        src, dst = _seed_pools_for_balance_test(session, h)
+        stx_repo = ShadowTransactionRepository(session, h.id)
+        # Build a domain tx in PENDING status (which is permitted to exist
+        # even unbalanced); save it and check it doesn't affect balance.
+        domain_tx = DomainShadowTransaction(
+            id=uuid4(),
+            household_id=h.id,
+            date=date(2026, 6, 1),
+            description="WIP",
+            reason=DomainShadowTxReason.MANUAL,
+            postings=(
+                DomainShadowPosting(
+                    id=uuid4(), pool_id=src.id, amount=Money(Decimal("-100"), "USD")
+                ),
+                DomainShadowPosting(
+                    id=uuid4(), pool_id=dst.id, amount=Money(Decimal("100"), "USD")
+                ),
+            ),
+            status=DomainShadowTxStatus.PENDING,
+        )
+        stx_repo.save_balanced(domain_tx)
+        session.commit()
+        # Pending shouldn't show up in derived balances.
+        assert stx_repo.balance_for_pool(dst.id) == {}

--- a/packages/tulip-storage/tests/test_architecture_no_direct_shadow_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_shadow_writes.py
@@ -1,0 +1,101 @@
+"""Architecture test: shadow-ledger writes go through ShadowTransactionRepository.
+
+Per ADR-0001, the shadow ledger and the main ledger must stay in lockstep.
+The single chokepoint is :class:`tulip_storage.repositories.ShadowTransactionRepository`,
+which co-ordinates the header insert, the postings insert, and the balance
+trigger fire on the status transition. Direct construction of
+``tulip_storage.models.ShadowTransaction`` / ``ShadowPosting`` model
+instances elsewhere in the codebase would let a caller bypass that flow
+and emit invalid shadow rows.
+
+The domain-layer value objects with the same names
+(``tulip_core.allocation.ShadowTransaction``) are pure value objects with
+no DB attachment and are deliberately not banned — that's the type the
+rest of the codebase uses to *describe* a shadow tx before handing it to
+the repo.
+
+This test scans every source file under ``packages/*/src/`` (tests are
+excluded; tests legitimately construct rows for setup) and rejects any
+import of the storage-layer model classes outside the allowlist.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
+_PACKAGES: Final[Path] = _REPO_ROOT / "packages"
+
+_BANNED_NAMES: Final[frozenset[str]] = frozenset({"ShadowTransaction", "ShadowPosting"})
+
+#: Modules whose ``ShadowTransaction``/``ShadowPosting`` are the storage-layer ORM models.
+_STORAGE_MODEL_MODULES: Final[frozenset[str]] = frozenset(
+    {
+        "tulip_storage.models",
+        "tulip_storage.models.shadow_transaction",
+        "tulip_storage.models.shadow_posting",
+    }
+)
+
+#: Files allowed to reference the storage-layer model classes. Paths are relative to ``packages/``.
+_ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
+    {
+        # The model classes themselves.
+        "tulip-storage/src/tulip_storage/models/shadow_transaction.py",
+        "tulip-storage/src/tulip_storage/models/shadow_posting.py",
+        # Re-exports.
+        "tulip-storage/src/tulip_storage/models/__init__.py",
+        # The repository — the only legitimate place that constructs them.
+        "tulip-storage/src/tulip_storage/repositories/shadow_transaction.py",
+        "tulip-storage/src/tulip_storage/repositories/__init__.py",
+    }
+)
+
+
+def _python_source_files() -> list[Path]:
+    """Yield every .py file under packages/*/src/."""
+    out: list[Path] = []
+    for pkg in sorted(_PACKAGES.iterdir()):
+        src = pkg / "src"
+        if not src.is_dir():
+            continue
+        out.extend(sorted(src.rglob("*.py")))
+    return out
+
+
+def _illegal_storage_model_imports(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, name)`` pairs that import storage-layer Shadow models.
+
+    Only ``from tulip_storage.models[.X] import ShadowTransaction|ShadowPosting``
+    counts. Imports of the same names from ``tulip_core.allocation`` are
+    fine — those are pure domain value objects.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in _STORAGE_MODEL_MODULES:
+            for alias in node.names:
+                if alias.name in _BANNED_NAMES:
+                    hits.append((node.lineno, alias.name))
+    return hits
+
+
+def test_no_direct_storage_shadow_model_use_outside_allowlist() -> None:
+    """Storage-layer ShadowTransaction/ShadowPosting only used by the repo."""
+    offenders: dict[str, list[tuple[int, str]]] = {}
+    for path in _python_source_files():
+        rel = str(path.relative_to(_PACKAGES))
+        if rel in _ALLOWED_RELATIVE:
+            continue
+        hits = _illegal_storage_model_imports(path)
+        if hits:
+            offenders[rel] = hits
+
+    assert not offenders, (
+        "Direct imports of storage-layer ShadowTransaction / ShadowPosting "
+        "outside the ShadowTransactionRepository — route through the repo "
+        "so the balance trigger and the main↔shadow pairing stay correct:\n"
+        + "\n".join(f"  {file}: {hits}" for file, hits in offenders.items())
+    )

--- a/packages/tulip-storage/tests/test_p40_migration.py
+++ b/packages/tulip-storage/tests/test_p40_migration.py
@@ -1,0 +1,466 @@
+"""Tests for the P4.0 allocation/shadow-ledger migration.
+
+Verifies that the migration adds the new tables, the shadow-ledger balance
+trigger fires on POSTED transitions, and the long-deferred FK on
+``postings.pool_id`` actually rejects orphan references.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from alembic.command import downgrade, upgrade
+from alembic.config import Config
+from sqlalchemy import event, inspect
+from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.orm import Session, sessionmaker
+
+from tulip_storage.models import (
+    Account,
+    AccountType,
+    AllocationPool,
+    Household,
+    PoolType,
+    Posting,
+    ShadowPosting,
+    ShadowTransaction,
+    ShadowTxReason,
+    ShadowTxStatus,
+    Transaction,
+    TransactionStatus,
+)
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+
+
+def _make_alembic_cfg(db_url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    cfg.set_main_option(
+        "script_location",
+        str(ALEMBIC_INI.parent / "src" / "tulip_storage" / "migrations"),
+    )
+    return cfg
+
+
+@pytest.fixture
+def migrated_db(tmp_path):
+    db_path = tmp_path / "tulip.db"
+    db_url = f"sqlite:///{db_path}"
+    cfg = _make_alembic_cfg(db_url)
+    upgrade(cfg, "head")
+
+    from sqlalchemy import create_engine
+
+    eng = create_engine(db_url, future=True)
+
+    @event.listens_for(eng, "connect")
+    def _enable_fk(dc, _r):  # type: ignore[no-untyped-def]
+        cur = dc.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    yield db_url, sessionmaker(eng, expire_on_commit=False)
+    eng.dispose()
+
+
+def _seed_household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+def _seed_envelope_pool(session: Session, household_id) -> AllocationPool:
+    p = AllocationPool(
+        household_id=household_id,
+        id=uuid4(),
+        pool_type=PoolType.ENVELOPE,
+        name="Groceries",
+        currency="USD",
+        is_active=True,
+        is_system=False,
+    )
+    session.add(p)
+    session.commit()
+    return p
+
+
+def _seed_unallocated_system_pool(session: Session, household_id) -> AllocationPool:
+    p = AllocationPool(
+        household_id=household_id,
+        id=uuid4(),
+        pool_type=PoolType.UNALLOCATED,
+        name="Unallocated USD",
+        currency="USD",
+        is_active=True,
+        is_system=True,
+    )
+    session.add(p)
+    session.commit()
+    return p
+
+
+class TestSchemaShape:
+    def test_new_tables_exist_after_upgrade(self, migrated_db):
+        db_url, _ = migrated_db
+        from sqlalchemy import create_engine
+
+        eng = create_engine(db_url)
+        names = set(inspect(eng).get_table_names())
+        assert {
+            "allocation_pools",
+            "envelopes",
+            "sinking_funds",
+            "shadow_transactions",
+            "shadow_postings",
+        } <= names
+        eng.dispose()
+
+    def test_postings_pool_id_fk_added(self, migrated_db):
+        db_url, _ = migrated_db
+        from sqlalchemy import create_engine
+
+        eng = create_engine(db_url)
+        fks = inspect(eng).get_foreign_keys("postings")
+        # The FK is composite (household_id, pool_id) → allocation_pools.
+        pool_fks = [fk for fk in fks if "pool_id" in fk["constrained_columns"]]
+        assert pool_fks, f"expected FK on postings.pool_id, got {fks}"
+        eng.dispose()
+
+    def test_round_trip_upgrade_downgrade(self, tmp_path):
+        db_path = tmp_path / "tulip.db"
+        cfg = _make_alembic_cfg(f"sqlite:///{db_path}")
+        upgrade(cfg, "head")
+        downgrade(cfg, "base")
+        from sqlalchemy import create_engine
+
+        eng = create_engine(f"sqlite:///{db_path}")
+        names = set(inspect(eng).get_table_names())
+        assert names <= {"alembic_version"}
+        eng.dispose()
+
+
+class TestShadowBalanceTrigger:
+    def test_balanced_shadow_post_succeeds(self, migrated_db):
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            h = _seed_household(s)
+            src = _seed_unallocated_system_pool(s, h.id)
+            dst = _seed_envelope_pool(s, h.id)
+
+            stx = ShadowTransaction(
+                household_id=h.id,
+                id=uuid4(),
+                date=date(2026, 6, 1),
+                description="Refill Groceries",
+                reason=ShadowTxReason.REFILL,
+                status=ShadowTxStatus.PENDING,
+            )
+            s.add(stx)
+            s.flush()
+            s.add_all(
+                [
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=src.id,
+                        amount=Decimal("-250"),
+                        currency="USD",
+                    ),
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=dst.id,
+                        amount=Decimal("250"),
+                        currency="USD",
+                    ),
+                ]
+            )
+            s.flush()
+            stx.status = ShadowTxStatus.POSTED
+            s.commit()
+
+    def test_unbalanced_shadow_post_aborts(self, migrated_db):
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            h = _seed_household(s)
+            src = _seed_unallocated_system_pool(s, h.id)
+            dst = _seed_envelope_pool(s, h.id)
+
+            stx = ShadowTransaction(
+                household_id=h.id,
+                id=uuid4(),
+                date=date(2026, 6, 1),
+                description="Bad",
+                reason=ShadowTxReason.REFILL,
+                status=ShadowTxStatus.PENDING,
+            )
+            s.add(stx)
+            s.flush()
+            s.add_all(
+                [
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=src.id,
+                        amount=Decimal("-100"),
+                        currency="USD",
+                    ),
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=dst.id,
+                        amount=Decimal("250"),
+                        currency="USD",
+                    ),
+                ]
+            )
+            s.flush()
+            stx.status = ShadowTxStatus.POSTED
+            with pytest.raises((IntegrityError, OperationalError), match="balance"):
+                s.commit()
+
+    def test_inserting_unbalanced_posting_into_posted_shadow_tx_aborts(self, migrated_db):
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            h = _seed_household(s)
+            src = _seed_unallocated_system_pool(s, h.id)
+            dst = _seed_envelope_pool(s, h.id)
+
+            stx = ShadowTransaction(
+                household_id=h.id,
+                id=uuid4(),
+                date=date(2026, 6, 1),
+                description="Refill",
+                reason=ShadowTxReason.REFILL,
+                status=ShadowTxStatus.PENDING,
+            )
+            s.add(stx)
+            s.flush()
+            s.add_all(
+                [
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=src.id,
+                        amount=Decimal("-250"),
+                        currency="USD",
+                    ),
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=dst.id,
+                        amount=Decimal("250"),
+                        currency="USD",
+                    ),
+                ]
+            )
+            s.flush()
+            stx.status = ShadowTxStatus.POSTED
+            s.commit()
+
+            with Smaker() as s2:
+                bad = ShadowPosting(
+                    id=uuid4(),
+                    household_id=h.id,
+                    shadow_transaction_id=stx.id,
+                    pool_id=dst.id,
+                    amount=Decimal("1"),
+                    currency="USD",
+                )
+                s2.add(bad)
+                with pytest.raises((IntegrityError, OperationalError), match="balance"):
+                    s2.commit()
+
+    def test_pending_shadow_tx_can_be_unbalanced(self, migrated_db):
+        # PENDING is exempt from the balance trigger; only the transition
+        # into POSTED enforces zero-sum.
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            h = _seed_household(s)
+            src = _seed_unallocated_system_pool(s, h.id)
+            dst = _seed_envelope_pool(s, h.id)
+
+            stx = ShadowTransaction(
+                household_id=h.id,
+                id=uuid4(),
+                date=date(2026, 6, 1),
+                description="WIP",
+                reason=ShadowTxReason.MANUAL,
+                status=ShadowTxStatus.PENDING,
+            )
+            s.add(stx)
+            s.flush()
+            s.add_all(
+                [
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=src.id,
+                        amount=Decimal("-100"),
+                        currency="USD",
+                    ),
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=dst.id,
+                        amount=Decimal("50"),
+                        currency="USD",
+                    ),
+                ]
+            )
+            s.commit()
+
+    def test_per_currency_balance_segregated(self, migrated_db):
+        # USD legs zero, EUR legs zero. Mixed currencies in one shadow tx
+        # are valid as long as each currency individually balances.
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            h = _seed_household(s)
+            usd_src = _seed_unallocated_system_pool(s, h.id)
+            usd_dst = _seed_envelope_pool(s, h.id)
+            eur_src = AllocationPool(
+                household_id=h.id,
+                id=uuid4(),
+                pool_type=PoolType.UNALLOCATED,
+                name="Unallocated EUR",
+                currency="EUR",
+                is_active=True,
+                is_system=True,
+            )
+            eur_dst = AllocationPool(
+                household_id=h.id,
+                id=uuid4(),
+                pool_type=PoolType.ENVELOPE,
+                name="Travel",
+                currency="EUR",
+                is_active=True,
+                is_system=False,
+            )
+            s.add_all([eur_src, eur_dst])
+            s.commit()
+
+            stx = ShadowTransaction(
+                household_id=h.id,
+                id=uuid4(),
+                date=date(2026, 6, 1),
+                description="Multi-ccy",
+                reason=ShadowTxReason.MANUAL,
+                status=ShadowTxStatus.PENDING,
+            )
+            s.add(stx)
+            s.flush()
+            s.add_all(
+                [
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=usd_src.id,
+                        amount=Decimal("-100"),
+                        currency="USD",
+                    ),
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=usd_dst.id,
+                        amount=Decimal("100"),
+                        currency="USD",
+                    ),
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=eur_src.id,
+                        amount=Decimal("-50"),
+                        currency="EUR",
+                    ),
+                    ShadowPosting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        shadow_transaction_id=stx.id,
+                        pool_id=eur_dst.id,
+                        amount=Decimal("50"),
+                        currency="EUR",
+                    ),
+                ]
+            )
+            s.flush()
+            stx.status = ShadowTxStatus.POSTED
+            s.commit()
+
+
+class TestPoolIdForeignKeyOnPostings:
+    def test_orphan_pool_id_on_posting_rejected(self, migrated_db):
+        # Insert an account, a transaction, and a posting that points its
+        # `pool_id` at a pool UUID that doesn't exist in `allocation_pools`.
+        # The FK added by P4.0 must reject the posting.
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            h = _seed_household(s)
+            cash = Account(
+                household_id=h.id,
+                id=uuid4(),
+                code="1110",
+                name="Checking",
+                type=AccountType.ASSET,
+                currency="USD",
+                visibility="shared",
+            )
+            food = Account(
+                household_id=h.id,
+                id=uuid4(),
+                code="5100",
+                name="Food",
+                type=AccountType.EXPENSE,
+                currency="USD",
+                visibility="shared",
+            )
+            s.add_all([cash, food])
+            s.commit()
+            tx = Transaction(
+                household_id=h.id,
+                id=uuid4(),
+                date=date(2026, 6, 1),
+                description="Lunch",
+                status=TransactionStatus.PENDING,
+            )
+            s.add(tx)
+            s.flush()
+            s.add_all(
+                [
+                    Posting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        transaction_id=tx.id,
+                        account_id=food.id,
+                        amount=Decimal("12.50"),
+                        currency="USD",
+                        pool_id=uuid4(),  # orphan — no matching allocation_pool
+                    ),
+                    Posting(
+                        id=uuid4(),
+                        household_id=h.id,
+                        transaction_id=tx.id,
+                        account_id=cash.id,
+                        amount=Decimal("-12.50"),
+                        currency="USD",
+                    ),
+                ]
+            )
+            with pytest.raises(IntegrityError):
+                s.commit()


### PR DESCRIPTION
Closes #60. First slice of Phase 4. Implements the storage and domain layer for envelopes and sinking funds via the shadow-ledger model adopted in [ADR-0001](docs/adrs/0001-envelope-shadow-ledger.md). Pure storage + domain — **no API endpoints, no CLI, no refill execution, no scheduler** in this slice (those are P4.1 / P4.2 / P4.3).

## Summary

- **Migration `a3f4d8e91b22`**: new tables \`allocation_pools\`, \`envelopes\`, \`sinking_funds\`, \`shadow_transactions\`, \`shadow_postings\`. Four shadow-ledger balance triggers mirror the main-ledger triggers from migration 0001 — sum-to-zero per \`(shadow_transaction_id, currency)\` is enforced on the transition into \`posted\` and on \`INSERT\` / \`UPDATE\` / \`DELETE\` of postings while a shadow tx is \`posted\`. Long-deferred FK on \`postings.pool_id → allocation_pools\` lands here too.
- **Domain types** (\`tulip_core.allocation\`): \`Pool\` (frozen, equality-by-id), \`PoolType\` (\`envelope\` / \`sinking_fund\` / \`inflow\` / \`unallocated\` / \`spent\`), \`Envelope\` (with \`BudgetPeriod\` + \`RolloverPolicy\`), \`SinkingFund\` (with \`ContributionStrategy\`), \`ShadowPosting\`, \`ShadowTransaction\` (sum-to-zero invariant, multi-currency segregated), \`ShadowTxReason\` (6 reasons), \`ShadowTxStatus\` (3 states), \`RefillRule\` (3 strategies, structured value object, JSON round-trip — no expression eval).
- **Engine** (\`post_shadow_transaction\`): validates pool existence, tenant scope, active flag, currency match, balance — then promotes to POSTED. Idempotent on already-POSTED; rejects re-post of VOIDED.
- **Repositories**: \`AllocationPoolRepository\` (CRUD + idempotent \`get_or_create_system_pools(currency)\`); \`ShadowTransactionRepository.save_balanced\` (PENDING-then-UPDATE-to-POSTED save flow that fires the trigger) + \`balance_for_pool\` returning \`{currency: net amount}\`.
- **System pools** (\`Inflow\` / \`Unallocated\` / \`Spent\`) eagerly created at household registration for the base currency; lazy resolver in place for P4.1's first-use-of-new-currency path.
- **Architecture test** bans imports of the storage-layer \`ShadowTransaction\` / \`ShadowPosting\` ORM classes outside the repository — same AST-scan pattern as \`test_architecture_no_http_exception.py\`. Domain-layer value objects of the same name are deliberately not banned (different package).
- **Doc updates**: ARCHITECTURE.md §5.3 refill_rule JSON shape brought in line with the structured \`RefillRule\` value object. ADR-0001 status flipped to Accepted. PHASE_STATUS.md gets a P4.0 entry.

84 new tests (49 core, 23 storage, 1 API). Project total: **580 passing** (up from 496). Lint + mypy --strict clean. CI should be green.

## Explicitly out of scope (queued for later P4 slices)

- **P4.1**: API endpoints (\`POST /v1/envelopes\`, \`POST /v1/sinking-funds\`, refill / transfer / balance) and the writer chokepoint that auto-pairs a shadow tx whenever a main-ledger posting carries \`pool_id\`.
- **P4.2**: CLI (\`tulip envelopes …\`, \`tulip sinking-funds …\`).
- **P4.3**: Refill rules execution + scheduled-tx runner.

## Test plan

- [x] Full pytest run: 580 passing
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy packages/\` — clean (103 source files)
- [x] Migration round-trip (\`alembic upgrade head\` then \`alembic downgrade base\`) — covered by \`test_p40_migration.py::TestSchemaShape::test_round_trip_upgrade_downgrade\`
- [x] Shadow balance trigger fires on POSTED transition — covered by \`test_p40_migration.py::TestShadowBalanceTrigger\`
- [x] Orphan \`postings.pool_id\` rejected by FK — covered by \`test_p40_migration.py::TestPoolIdForeignKeyOnPostings\`
- [x] System pools auto-seeded on \`POST /v1/auth/register\` — covered by \`test_auth_endpoints.py::TestRegister::test_register_seeds_system_pools_for_base_currency\`

### Manual smoke test — register-then-inspect

Confirms a fresh household ends up with the three system pools wired up for its base currency. Requires the API server running locally:

\`\`\`bash
cd /tmp && rm -f smoke-p40.db
DATABASE_URL=\"sqlite:////tmp/smoke-p40.db\" \\
  uv --project /Users/robert/Projects/tulip-accounting run alembic \\
  -c /Users/robert/Projects/tulip-accounting/packages/tulip-storage/alembic.ini \\
  upgrade head

DATABASE_URL=\"sqlite:////tmp/smoke-p40.db\" \\
TULIP_MASTER_KEY=\"\$(python3 -c 'import base64,os; print(base64.b64encode(os.urandom(32)).decode())')\" \\
TULIP_JWT_SECRET=\"smoke-test-32-byte-secret-here-ok\" \\
  uv --project /Users/robert/Projects/tulip-accounting run uvicorn tulip_api.main:create_app --factory --port 8765 &
sleep 2

curl -s -X POST http://localhost:8765/v1/auth/register \\
  -H 'content-type: application/json' \\
  -d '{\"email\":\"alice@example.com\",\"password\":\"correct horse battery staple\",\"display_name\":\"Alice\",\"household_name\":\"Smith\"}' \\
  | python3 -m json.tool

sqlite3 /tmp/smoke-p40.db 'SELECT pool_type, name, currency, is_system FROM allocation_pools'

kill %1
\`\`\`

Expected: the curl output shows a created household_id; the sqlite3 output shows three rows: \`(inflow, Inflow USD, USD, 1)\`, \`(unallocated, Unallocated USD, USD, 1)\`, \`(spent, Spent USD, USD, 1)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)