### PR TITLE
P4.1.a — Auto-pair shadow tx when posting carries pool_id

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-02 · `main` @ `24353dd`
+**Last updated:** 2026-05-02 · `main` @ P4.0 + P4.1.a
 
 ---
 
@@ -15,9 +15,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 3 (CLI):** ✅ complete — P3.1 through P3.4 + P3.6 shipped; P3.5 (toner-friendly print stylesheet) deferred to Phase 8 alongside the actual reports (#22)
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
 - **Pre-Phase-4 docs:** threat-model checkpoint shipped (#56, [docs/THREAT_MODEL.md](THREAT_MODEL.md)). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
-- **Phase 4 (envelopes + sinking funds):** in flight — P4.0 (storage + domain layer per [ADR-0001](adrs/0001-envelope-shadow-ledger.md)) shipped 2026-05-02 (#60); P4.1 (API endpoints), P4.2 (CLI), P4.3 (refill rules + scheduled-tx runner) queued.
+- **Phase 4 (envelopes + sinking funds):** in flight — P4.0 (storage + domain layer per [ADR-0001](adrs/0001-envelope-shadow-ledger.md)) shipped 2026-05-02 (#60); P4.1 split a/b — P4.1.a (writer chokepoint) shipped 2026-05-02 (#62); P4.1.b (envelope/sinking-fund/refill/transfer/balance endpoints, #63), P4.2 (CLI), P4.3 (refill rules + scheduled-tx runner) queued.
 
-**Tests:** 580 passing · **CI:** green on `main`
+**Tests:** 605 passing · **CI:** green on `main`
 
 ---
 
@@ -298,9 +298,23 @@ Closes #60. Pure storage + domain slice; no API, no CLI, no refill execution. Mi
 - **Doc updates**: ARCHITECTURE.md §5.3 refill_rule JSON shape brought in line with the structured `RefillRule` value object (`fixed_amount` / `fill_to_amount` / `percentage_of_income`). ADR-0001 status flipped to Accepted.
 - **Tests**: 84 new tests (49 core, 23 storage, 1 API). Project total: 580 passing.
 
+### P4.1.a — Writer chokepoint (auto-pair shadow tx on pool_id postings) — ✅ *(2026-05-02)*
+
+Closes #62. Extends `POST /v1/transactions`: when any posting carries `pool_id`, the handler atomically writes a paired shadow-ledger transaction in the same `session.commit()` per ADR-0001's pairing rule.
+
+- **Schema**: `PostingCreate` learns optional `pool_id: UUID | None`; `PostingRead` and `TransactionRead` surface it (plus `paired_shadow_tx_id` on the response).
+- **Pre-flight validation** (in this order, before any DB write): pool exists in household → pool active → account type permits pool-tagging (**EXPENSE only in v1**) → pool currency matches posting currency. Each maps to a typed Problem Details code: `pool.not_found`, `pool.inactive`, `pool.invalid_account_type_pairing`, `pool.currency_mismatch` (all 400). Cross-tenant pool refs surface as `pool.not_found`.
+- **Lazy system-pool creation**: for each distinct currency among pool-tagged postings, the handler calls `AllocationPoolRepository.get_or_create_system_pools(currency=...)` before either ledger writes. Idempotent. No separate audit row — system pools are plumbing.
+- **Auto-pairing engine**: new `tulip_core.allocation.engine.derive_paired_shadow_tx(main_tx, *, account_types_by_id, spent_pool_by_currency)` returning `ShadowTransaction | None`. Sign rule for v1: `EXPENSE → +1`. One absorbing leg in the household's `Spent` system pool of the appropriate currency. Multi-currency pool-tags within one main tx → `MultiCurrencyPoolTaggingError` (rejected in v1). Refund-shaped (positive net pool effect) → `UnsupportedRefundShapedShadowTxError` (rejected in v1; needs an ADR amendment to add a `REFUND` reason).
+- **Atomic rollback**: existing handler boundary handles it — both `save_balanced` calls + the audit write share one session, one commit. If anything raises, FastAPI's request lifecycle rolls back the session via `get_session` and neither ledger persists.
+- **Audit log**: extended the main tx's `after_snapshot` with `paired_shadow_tx_id` when present. One user action = one audit row; the shadow row is queryable via `paired_main_tx_id`.
+- **GET / list endpoints** also surface `paired_shadow_tx_id` via a new `ShadowTransactionRepository.get_paired_id_for_main_tx`. Architecture test (P4.0) still bans direct shadow-table writes outside the repo.
+- **New error codes**: `pool.not_found`, `pool.inactive`, `pool.currency_mismatch`, `pool.invalid_account_type_pairing` (400) and `pool.shadow_unbalanced` (500, defense in depth — only fires on a Tulip bug).
+- **Tests**: 25 new (8 engine unit + 17 API integration). Project total: **605 passing** (up from 580).
+
 ### Phase 4 deferred to later slices
 
-- **P4.1 — API endpoints** (`POST /v1/envelopes`, `POST /v1/sinking-funds`, refill, transfer, balance) and the writer chokepoint that auto-pairs a shadow tx whenever a main-ledger posting carries `pool_id`.
+- **P4.1.b — API endpoints** (`/v1/envelopes` CRUD, `/v1/sinking-funds` CRUD, refill / transfer / balance) — tracked as #63.
 - **P4.2 — CLI** (`tulip envelopes …`, `tulip sinking-funds …`).
 - **P4.3 — Refill rules execution** + scheduled-tx runner.
 

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -511,6 +511,104 @@ class TransactionNotFoundError(TulipProblem):
         )
 
 
+class PoolNotFoundError(TulipProblem):
+    """A posting carries a pool_id that doesn't exist in this household."""
+
+    def __init__(self, pool_id: str) -> None:
+        """Build the pool.not_found problem.
+
+        ``pool_id`` is included in ``detail`` so the user can identify the
+        offending posting. Visibility is uniform across all household pools
+        for now — there's no information leak from echoing the bad UUID.
+        """
+        super().__init__(
+            code="pool.not_found",
+            title="Unknown pool in posting",
+            status=400,
+            detail=(
+                f"Posting references pool {pool_id}, which does not exist "
+                "in this household. Check the pool ID and resubmit."
+            ),
+        )
+
+
+class PoolInactiveError(TulipProblem):
+    """A posting's pool_id resolves to a deactivated pool."""
+
+    def __init__(self, pool_id: str) -> None:
+        """Build the pool.inactive problem."""
+        super().__init__(
+            code="pool.inactive",
+            title="Pool is deactivated",
+            status=400,
+            detail=(
+                f"Pool {pool_id} is deactivated and cannot accept new "
+                "postings. Reactivate it or remove the pool_id from the "
+                "posting and resubmit."
+            ),
+        )
+
+
+class PoolCurrencyMismatchError(TulipProblem):
+    """A posting's currency does not match its pool's currency."""
+
+    def __init__(self, *, pool_id: str, pool_currency: str, posting_currency: str) -> None:
+        """Build the pool.currency_mismatch problem."""
+        super().__init__(
+            code="pool.currency_mismatch",
+            title="Pool currency does not match posting currency",
+            status=400,
+            detail=(
+                f"Pool {pool_id} is denominated in {pool_currency}, but the "
+                f"posting is in {posting_currency}. Pool tagging requires "
+                "the pool and the posting to share a currency."
+            ),
+        )
+
+
+class PoolInvalidAccountTypePairingError(TulipProblem):
+    """A posting carries pool_id but its account type forbids pairing.
+
+    v1 permits pool-tagging on EXPENSE accounts only.
+    """
+
+    def __init__(self, *, account_type: str) -> None:
+        """Build the pool.invalid_account_type_pairing problem."""
+        super().__init__(
+            code="pool.invalid_account_type_pairing",
+            title="Pool tagging not permitted for this account type",
+            status=400,
+            detail=(
+                f"This posting is on a {account_type} account; only EXPENSE "
+                "accounts may carry pool_id in v1. Remove the pool_id and "
+                "resubmit, or move the posting to an expense account."
+            ),
+        )
+
+
+class ShadowLedgerInternalError(TulipProblem):
+    """The auto-paired shadow tx failed an internal invariant.
+
+    Defense-in-depth: the engine's checks should catch every malformed
+    pairing case before it gets here. Reaching this branch indicates a
+    Tulip bug, not a user error. The body deliberately surfaces no
+    detail beyond a request-id correlation hint.
+    """
+
+    def __init__(self) -> None:
+        """Build the pool.shadow_unbalanced problem."""
+        super().__init__(
+            code="pool.shadow_unbalanced",
+            title="Shadow-ledger pairing failed",
+            status=500,
+            detail=(
+                "The server could not derive a valid shadow-ledger "
+                "transaction for this main transaction. Please report "
+                "this incident with the request_id."
+            ),
+        )
+
+
 class ValidationFailedError(TulipProblem):
     """FastAPI / Pydantic input validation rejected the request body or params."""
 

--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -14,6 +14,11 @@ from tulip_api.deps import get_session
 from tulip_api.errors import (
     AccountUnknownError,
     PeriodClosedError,
+    PoolCurrencyMismatchError,
+    PoolInactiveError,
+    PoolInvalidAccountTypePairingError,
+    PoolNotFoundError,
+    ShadowLedgerInternalError,
     TransactionInvalidError,
     TransactionNotFoundError,
     TransactionUnbalancedError,
@@ -24,10 +29,17 @@ from tulip_api.schemas.transaction import (
     TransactionCreate,
     TransactionRead,
 )
+from tulip_core.account import AccountType as DomainAccountType
 from tulip_core.accounting import (
     ClosedPeriodError,
     UnbalancedTransactionError,
     post_transaction,
+)
+from tulip_core.allocation import (
+    InvalidAccountTypePairingError,
+    MultiCurrencyPoolTaggingError,
+    UnsupportedRefundShapedShadowTxError,
+    derive_paired_shadow_tx,
 )
 from tulip_core.money import Money
 from tulip_core.periods import Period as DomainPeriod
@@ -41,11 +53,14 @@ from tulip_core.transactions import (
 from tulip_core.transactions import (
     TransactionStatus as DomainTxStatus,
 )
+from tulip_storage.models import PoolType as StoragePoolType
 from tulip_storage.models import TransactionStatus as StorageTxStatus
 from tulip_storage.repositories import (
     AccountRepository,
+    AllocationPoolRepository,
     AuditLogWriter,
     PeriodRepository,
+    ShadowTransactionRepository,
     TransactionRepository,
 )
 
@@ -69,11 +84,16 @@ log = structlog.get_logger("tulip_api.transactions")
             "transaction.invalid",
             "transaction.unbalanced",
             "period.closed",
+            "pool.not_found",
+            "pool.inactive",
+            "pool.currency_mismatch",
+            "pool.invalid_account_type_pairing",
             "request.body_invalid",
         ),
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
         422: problem_response("validation.failed"),
+        500: problem_response("pool.shadow_unbalanced"),
     },
 )
 def create_transaction(
@@ -82,18 +102,63 @@ def create_transaction(
     claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> TransactionRead:
-    """Build a domain Transaction, post it through the engine, persist."""
-    accounts_repo = AccountRepository(session, claims.household_id)
-    for p in body.postings:
-        if accounts_repo.get(p.account_id) is None:
-            raise AccountUnknownError(account_id=str(p.account_id))
+    """Build a domain Transaction, post it through the engine, persist.
 
+    When any posting carries ``pool_id``, this handler also writes a
+    paired shadow-ledger transaction in the same session per ADR-0001.
+    Both ledgers commit atomically — the shadow side rolls back the main
+    tx if it fails an invariant.
+    """
+    accounts_repo = AccountRepository(session, claims.household_id)
+    accounts_by_id = {}
+    for p in body.postings:
+        a = accounts_repo.get(p.account_id)
+        if a is None:
+            raise AccountUnknownError(account_id=str(p.account_id))
+        accounts_by_id[p.account_id] = a
+
+    # ---- Pool pre-flight checks ------------------------------------
+    # Order: not_found → inactive → invalid_account_type → currency_mismatch.
+    # All four run before any DB write so a malformed request can't
+    # leave an orphan main-ledger row.
+    pool_repo = AllocationPoolRepository(session, claims.household_id)
+    pool_tagged_currencies: set[str] = set()
+    for p in body.postings:
+        if p.pool_id is None:
+            continue
+        pool = pool_repo.get(p.pool_id)
+        if pool is None:
+            raise PoolNotFoundError(pool_id=str(p.pool_id))
+        if not pool.is_active:
+            raise PoolInactiveError(pool_id=str(p.pool_id))
+        account = accounts_by_id[p.account_id]
+        if account.type.value != "expense":
+            raise PoolInvalidAccountTypePairingError(account_type=account.type.value)
+        if pool.currency != p.currency:
+            raise PoolCurrencyMismatchError(
+                pool_id=str(p.pool_id),
+                pool_currency=pool.currency,
+                posting_currency=p.currency,
+            )
+        pool_tagged_currencies.add(p.currency)
+
+    # ---- Lazy system-pool creation ---------------------------------
+    # For each currency that touches a pool-tagged posting, ensure the
+    # household has its three system pools. The resolver is idempotent
+    # (P4.0); calling it for an already-materialized currency is a noop.
+    spent_pool_by_currency: dict[str, UUID] = {}
+    for ccy in pool_tagged_currencies:
+        sys_pools = pool_repo.get_or_create_system_pools(currency=ccy)
+        spent_pool_by_currency[ccy] = sys_pools[StoragePoolType.SPENT].id
+
+    # ---- Domain construction ---------------------------------------
     domain_postings: tuple[DomainPosting, ...] = tuple(
         DomainPosting(
             id=uuid4(),
             account_id=p.account_id,
             amount=Money(p.amount, p.currency),
             memo=p.memo,
+            pool_id=p.pool_id,
         )
         for p in body.postings
     )
@@ -123,8 +188,50 @@ def create_transaction(
     except ClosedPeriodError as exc:
         raise PeriodClosedError(reason=str(exc)) from exc
 
+    # ---- Auto-pair shadow tx ---------------------------------------
+    # derive_paired_shadow_tx returns None when no posting carries pool_id.
+    # InvalidAccountTypePairingError + MultiCurrencyPoolTaggingError +
+    # UnsupportedRefundShapedShadowTxError all map to user-facing 400s.
+    # Other engine errors (no Spent pool, balance check) are bugs → 500.
+    account_types_by_id = {
+        aid: DomainAccountType(a.type.value) for aid, a in accounts_by_id.items()
+    }
+    try:
+        shadow_tx = derive_paired_shadow_tx(
+            posted,
+            account_types_by_id=account_types_by_id,
+            spent_pool_by_currency=spent_pool_by_currency,
+        )
+    except InvalidAccountTypePairingError as exc:
+        # Pre-flight should already have caught this, but keep the
+        # mapping so the engine remains a complete contract.
+        raise PoolInvalidAccountTypePairingError(
+            account_type="non-expense",
+        ) from exc
+    except MultiCurrencyPoolTaggingError as exc:
+        raise TransactionInvalidError(reason=str(exc)) from exc
+    except UnsupportedRefundShapedShadowTxError as exc:
+        raise TransactionInvalidError(reason=str(exc)) from exc
+    except ValueError as exc:
+        # Engine raised a non-typed error: missing system pool, internal
+        # invariant. Always a Tulip bug, not user input.
+        raise ShadowLedgerInternalError() from exc
+
     tx_repo = TransactionRepository(session, claims.household_id)
     saved = tx_repo.save_balanced(posted)
+
+    paired_shadow_tx_id: UUID | None = None
+    if shadow_tx is not None:
+        shadow_repo = ShadowTransactionRepository(session, claims.household_id)
+        saved_shadow = shadow_repo.save_balanced(shadow_tx)
+        paired_shadow_tx_id = saved_shadow.id
+
+    audit_after: dict[str, str] = {
+        "description": saved.description,
+        "date": saved.date.isoformat(),
+    }
+    if paired_shadow_tx_id is not None:
+        audit_after["paired_shadow_tx_id"] = str(paired_shadow_tx_id)
 
     AuditLogWriter(session, claims.household_id).write(
         action="create",
@@ -132,12 +239,21 @@ def create_transaction(
         actor_user_id=claims.user_id,
         entity_type="transaction",
         entity_id=saved.id,
-        after={"description": saved.description, "date": saved.date.isoformat()},
+        after=audit_after,
         request_id=_request_uuid(request),
     )
     session.commit()
-    log.info("transaction.created", tx_id=str(saved.id))
-    return _read_response(saved.id, claims.household_id, session)
+    log.info(
+        "transaction.created",
+        tx_id=str(saved.id),
+        paired_shadow_tx_id=str(paired_shadow_tx_id) if paired_shadow_tx_id else None,
+    )
+    return _read_response(
+        saved.id,
+        claims.household_id,
+        session,
+        paired_shadow_tx_id=paired_shadow_tx_id,
+    )
 
 
 @router.get(
@@ -236,11 +352,22 @@ def _domain_periods(repo: PeriodRepository) -> list[DomainPeriod]:
     ]
 
 
-def _read_response(tx_id: UUID, household_id: UUID, session: Session) -> TransactionRead:
+def _read_response(
+    tx_id: UUID,
+    household_id: UUID,
+    session: Session,
+    *,
+    paired_shadow_tx_id: UUID | None = None,
+) -> TransactionRead:
     repo = TransactionRepository(session, household_id)
     header = repo.get(tx_id)
     assert header is not None  # caller verifies before invoking  # noqa: S101
     postings = repo.list_postings(tx_id)
+    if paired_shadow_tx_id is None:
+        # GET / list paths don't have it pre-resolved; look it up.
+        paired_shadow_tx_id = ShadowTransactionRepository(
+            session, household_id
+        ).get_paired_id_for_main_tx(tx_id)
     return TransactionRead(
         id=header.id,
         date=header.date,
@@ -254,9 +381,11 @@ def _read_response(tx_id: UUID, household_id: UUID, session: Session) -> Transac
                 amount=p.amount,
                 currency=p.currency,
                 memo=p.memo,
+                pool_id=p.pool_id,
             )
             for p in postings
         ],
+        paired_shadow_tx_id=paired_shadow_tx_id,
     )
 
 

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -42,6 +42,14 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
         "reason": "Transaction does not balance: USD postings sum to 1.00 instead of 0."
     },
     "PeriodClosedError": {"reason": "Period 2025-12-31 is closed."},
+    "PoolNotFoundError": {"pool_id": "<pool-uuid>"},
+    "PoolInactiveError": {"pool_id": "<pool-uuid>"},
+    "PoolCurrencyMismatchError": {
+        "pool_id": "<pool-uuid>",
+        "pool_currency": "USD",
+        "posting_currency": "EUR",
+    },
+    "PoolInvalidAccountTypePairingError": {"account_type": "asset"},
     "ValidationFailedError": {
         "errors": [
             {

--- a/packages/tulip-api/src/tulip_api/schemas/transaction.py
+++ b/packages/tulip-api/src/tulip_api/schemas/transaction.py
@@ -16,6 +16,13 @@ class PostingCreate(BaseModel):
     amount: Decimal
     currency: str = Field(min_length=3, max_length=3)
     memo: str | None = Field(default=None, max_length=500)
+    pool_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Optional allocation pool (envelope or sinking fund). When set, "
+            "the server auto-pairs a shadow-ledger transaction; see ADR-0001."
+        ),
+    )
 
 
 class TransactionCreate(BaseModel):
@@ -35,6 +42,7 @@ class PostingRead(BaseModel):
     amount: Decimal
     currency: str
     memo: str | None
+    pool_id: UUID | None = None
 
 
 class TransactionRead(BaseModel):
@@ -46,3 +54,4 @@ class TransactionRead(BaseModel):
     reference: str | None
     status: str
     postings: list[PostingRead]
+    paired_shadow_tx_id: UUID | None = None

--- a/packages/tulip-api/tests/test_transactions_pool_pairing.py
+++ b/packages/tulip-api/tests/test_transactions_pool_pairing.py
@@ -1,0 +1,735 @@
+"""Integration tests for the writer-chokepoint extension (P4.1.a).
+
+Tests that ``POST /v1/transactions``, when given a body whose postings carry
+``pool_id``, atomically writes a paired shadow-ledger transaction per
+ADR-0001's pairing rule. Covers the full handler chain: pre-flight
+validation, lazy system-pool creation, the auto-pairing engine, atomic
+commit / rollback, and the audit-log extension.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session, sessionmaker
+
+from _problem_details import assert_problem
+from tulip_storage.models import PoolType, ShadowTxStatus
+from tulip_storage.repositories import (
+    AllocationPoolRepository,
+    ShadowTransactionRepository,
+)
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> tuple[str, str]:
+    """Register a household + admin and return (token, household_id)."""
+    r = client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    household_id = r.json()["household_id"]
+    r2 = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r2.json()["access_token"], household_id
+
+
+@pytest.fixture
+def auth_h(admin_token: tuple[str, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token[0]}"}
+
+
+@pytest.fixture
+def household_id(admin_token: tuple[str, str]) -> UUID:
+    return UUID(admin_token[1])
+
+
+@pytest.fixture
+def cash_and_food(client: TestClient, auth_h: dict[str, str]) -> tuple[str, str]:
+    cash = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Cash", "type": "asset", "currency": "USD", "code": "1110"},
+    ).json()
+    food = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Food", "type": "expense", "currency": "USD", "code": "5100"},
+    ).json()
+    return cash["id"], food["id"]
+
+
+def _create_envelope_pool(
+    session_maker: sessionmaker[Session],
+    household_id: UUID,
+    *,
+    name: str = "Groceries",
+    currency: str = "USD",
+) -> UUID:
+    """Create an envelope pool directly via the repo (CRUD endpoints land in P4.1.b)."""
+    with session_maker() as s:
+        pool = AllocationPoolRepository(s, household_id).create(
+            pool_type=PoolType.ENVELOPE,
+            name=name,
+            currency=currency,
+        )
+        s.commit()
+        return pool.id
+
+
+def _deactivate_pool(session_maker: sessionmaker[Session], household_id: UUID, pool_id: UUID):
+    with session_maker() as s:
+        AllocationPoolRepository(s, household_id).deactivate(pool_id)
+        s.commit()
+
+
+# ---- Happy path -------------------------------------------------------
+
+
+class TestSinglePoolSpend:
+    def test_creates_paired_shadow_with_two_legs(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        cash, food = cash_and_food
+        groceries_pool = _create_envelope_pool(session_maker, household_id)
+        body = {
+            "date": date.today().isoformat(),
+            "description": "Costco",
+            "postings": [
+                {
+                    "account_id": food,
+                    "amount": "50",
+                    "currency": "USD",
+                    "pool_id": str(groceries_pool),
+                },
+                {"account_id": cash, "amount": "-50", "currency": "USD"},
+            ],
+        }
+        r = client.post("/v1/transactions", headers=auth_h, json=body)
+        assert r.status_code == 201, r.text
+        out = r.json()
+        # Paired shadow tx id is returned in the response.
+        assert out["paired_shadow_tx_id"] is not None
+        # Pool id round-trips on the response posting.
+        food_posting = next(p for p in out["postings"] if p["account_id"] == food)
+        assert food_posting["pool_id"] == str(groceries_pool)
+        cash_posting = next(p for p in out["postings"] if p["account_id"] == cash)
+        assert cash_posting["pool_id"] is None
+
+        # Inspect the shadow side directly.
+        shadow_id = UUID(out["paired_shadow_tx_id"])
+        with session_maker() as s:
+            shadow_repo = ShadowTransactionRepository(s, household_id)
+            header = shadow_repo.get(shadow_id)
+            assert header is not None
+            assert header.status is ShadowTxStatus.POSTED
+            assert header.paired_main_tx_id == UUID(out["id"])
+            assert header.description == "Costco (envelope effects)"
+            assert header.date == date.today()
+
+            postings = shadow_repo.list_postings(shadow_id)
+            assert len(postings) == 2
+            by_pool = {p.pool_id: p.amount for p in postings}
+            assert by_pool[groceries_pool] == Decimal("-50")
+            # The Spent USD pool was lazy-materialized and got the absorbing leg.
+            spent_pool_id = (
+                AllocationPoolRepository(s, household_id)
+                .get_system_pool(pool_type=PoolType.SPENT, currency="USD")
+                .id  # type: ignore[union-attr]
+            )
+            assert by_pool[spent_pool_id] == Decimal("50")
+
+    def test_get_returns_paired_shadow_tx_id(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        # Round-trip through GET — paired_shadow_tx_id must surface there too.
+        cash, food = cash_and_food
+        groceries_pool = _create_envelope_pool(session_maker, household_id)
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Costco",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "50",
+                        "currency": "USD",
+                        "pool_id": str(groceries_pool),
+                    },
+                    {"account_id": cash, "amount": "-50", "currency": "USD"},
+                ],
+            },
+        )
+        tx_id = r.json()["id"]
+        get = client.get(f"/v1/transactions/{tx_id}", headers=auth_h)
+        assert get.status_code == 200
+        assert get.json()["paired_shadow_tx_id"] is not None
+
+
+class TestMultiPoolSpend:
+    def test_one_paired_shadow_with_three_legs(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        # ADR-0001 §B: $50 groceries + $30 entertainment + -$80 cash.
+        cash = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Cash", "type": "asset", "currency": "USD", "code": "1110"},
+        ).json()["id"]
+        food = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Food", "type": "expense", "currency": "USD", "code": "5100"},
+        ).json()["id"]
+        ent = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Entertainment", "type": "expense", "currency": "USD", "code": "5200"},
+        ).json()["id"]
+        groceries_pool = _create_envelope_pool(session_maker, household_id, name="Groceries")
+        ent_pool = _create_envelope_pool(session_maker, household_id, name="Entertainment")
+        body = {
+            "date": date.today().isoformat(),
+            "description": "Costco",
+            "postings": [
+                {
+                    "account_id": food,
+                    "amount": "50",
+                    "currency": "USD",
+                    "pool_id": str(groceries_pool),
+                },
+                {
+                    "account_id": ent,
+                    "amount": "30",
+                    "currency": "USD",
+                    "pool_id": str(ent_pool),
+                },
+                {"account_id": cash, "amount": "-80", "currency": "USD"},
+            ],
+        }
+        r = client.post("/v1/transactions", headers=auth_h, json=body)
+        assert r.status_code == 201, r.text
+        shadow_id = UUID(r.json()["paired_shadow_tx_id"])
+        with session_maker() as s:
+            shadow_repo = ShadowTransactionRepository(s, household_id)
+            postings = shadow_repo.list_postings(shadow_id)
+            assert len(postings) == 3
+            by_pool = {p.pool_id: p.amount for p in postings}
+            assert by_pool[groceries_pool] == Decimal("-50")
+            assert by_pool[ent_pool] == Decimal("-30")
+            spent_pool_id = (
+                AllocationPoolRepository(s, household_id)
+                .get_system_pool(pool_type=PoolType.SPENT, currency="USD")
+                .id  # type: ignore[union-attr]
+            )
+            assert by_pool[spent_pool_id] == Decimal("80")
+
+
+class TestLazySystemPoolCreation:
+    def test_eur_pool_lazy_creates_system_pools(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        # Household registers as USD (default), so only USD system pools
+        # exist. Posting an EUR transaction with pool_id should lazy-
+        # materialize Inflow/Unallocated/Spent EUR.
+        cash = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "EUR Cash", "type": "asset", "currency": "EUR", "code": "1120"},
+        ).json()["id"]
+        travel = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Travel", "type": "expense", "currency": "EUR", "code": "5300"},
+        ).json()["id"]
+        travel_pool = _create_envelope_pool(
+            session_maker, household_id, name="Travel", currency="EUR"
+        )
+
+        # Pre-condition: EUR system pools don't exist yet.
+        with session_maker() as s:
+            assert (
+                AllocationPoolRepository(s, household_id).get_system_pool(
+                    pool_type=PoolType.SPENT, currency="EUR"
+                )
+                is None
+            )
+
+        body = {
+            "date": date.today().isoformat(),
+            "description": "Paris dinner",
+            "postings": [
+                {
+                    "account_id": travel,
+                    "amount": "40",
+                    "currency": "EUR",
+                    "pool_id": str(travel_pool),
+                },
+                {"account_id": cash, "amount": "-40", "currency": "EUR"},
+            ],
+        }
+        r = client.post("/v1/transactions", headers=auth_h, json=body)
+        assert r.status_code == 201, r.text
+
+        # Post-condition: all three EUR system pools materialized.
+        with session_maker() as s:
+            repo = AllocationPoolRepository(s, household_id)
+            for pt in (PoolType.INFLOW, PoolType.UNALLOCATED, PoolType.SPENT):
+                p = repo.get_system_pool(pool_type=pt, currency="EUR")
+                assert p is not None
+                assert p.is_active
+
+
+# ---- Pre-flight error matrix ----------------------------------------
+
+
+class TestPreflightErrors:
+    def test_unknown_pool_id_returns_pool_not_found(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        bogus = uuid4()
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Bad pool",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "50",
+                        "currency": "USD",
+                        "pool_id": str(bogus),
+                    },
+                    {"account_id": cash, "amount": "-50", "currency": "USD"},
+                ],
+            },
+        )
+        body_json = assert_problem(r, code="pool.not_found", status=400)
+        assert str(bogus) in body_json["detail"]
+
+    def test_inactive_pool_returns_pool_inactive(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        cash, food = cash_and_food
+        pool = _create_envelope_pool(session_maker, household_id)
+        _deactivate_pool(session_maker, household_id, pool)
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Inactive pool",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "50",
+                        "currency": "USD",
+                        "pool_id": str(pool),
+                    },
+                    {"account_id": cash, "amount": "-50", "currency": "USD"},
+                ],
+            },
+        )
+        assert_problem(r, code="pool.inactive", status=400)
+
+    def test_pool_currency_mismatch_returns_400(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        cash, food = cash_and_food
+        # USD account, EUR pool — currency mismatch.
+        eur_pool = _create_envelope_pool(
+            session_maker, household_id, name="EUR Pool", currency="EUR"
+        )
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Wrong ccy",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "50",
+                        "currency": "USD",
+                        "pool_id": str(eur_pool),
+                    },
+                    {"account_id": cash, "amount": "-50", "currency": "USD"},
+                ],
+            },
+        )
+        assert_problem(r, code="pool.currency_mismatch", status=400)
+
+    @pytest.mark.parametrize("acct_type", ["asset", "liability", "income", "equity"])
+    def test_non_expense_account_with_pool_id_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+        acct_type: str,
+    ):
+        cash, food = cash_and_food
+        pool = _create_envelope_pool(session_maker, household_id)
+        # Build a posting with pool_id on an account whose type is NOT expense.
+        wrong = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": f"Wrong {acct_type}",
+                "type": acct_type,
+                "currency": "USD",
+                "code": f"X{acct_type[:3].upper()}",
+            },
+        ).json()["id"]
+        # Build a balanced 2-leg main tx — note we still need it balanced
+        # to even reach the pool pre-flight, so we put the bad pool_id
+        # on the wrong-type account but balance it against another acct.
+        if acct_type in ("income",):
+            # Income posting is credit-shaped (negative); offset with food.
+            postings = [
+                {
+                    "account_id": wrong,
+                    "amount": "-50",
+                    "currency": "USD",
+                    "pool_id": str(pool),
+                },
+                {"account_id": food, "amount": "50", "currency": "USD"},
+            ]
+        elif acct_type == "liability":
+            # Liability is credit-shaped too.
+            postings = [
+                {
+                    "account_id": wrong,
+                    "amount": "-50",
+                    "currency": "USD",
+                    "pool_id": str(pool),
+                },
+                {"account_id": food, "amount": "50", "currency": "USD"},
+            ]
+        else:
+            # asset / equity: debit-shaped (positive).
+            postings = [
+                {
+                    "account_id": wrong,
+                    "amount": "50",
+                    "currency": "USD",
+                    "pool_id": str(pool),
+                },
+                {"account_id": cash, "amount": "-50", "currency": "USD"},
+            ]
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": f"Pool on {acct_type}",
+                "postings": postings,
+            },
+        )
+        assert_problem(r, code="pool.invalid_account_type_pairing", status=400)
+
+    def test_pool_in_other_household_returns_pool_not_found(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        # Tenant scoping: a pool in some OTHER household must surface as
+        # pool.not_found from this household's perspective (not as the
+        # generic 500).
+        cash, food = cash_and_food
+        other_household_id = uuid4()
+        with session_maker() as s:
+            from tulip_storage.models import Household
+
+            s.add(Household(id=other_household_id, name="Other", base_currency="USD"))
+            s.commit()
+        other_pool = _create_envelope_pool(session_maker, other_household_id)
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Cross-tenant",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "50",
+                        "currency": "USD",
+                        "pool_id": str(other_pool),
+                    },
+                    {"account_id": cash, "amount": "-50", "currency": "USD"},
+                ],
+            },
+        )
+        assert_problem(r, code="pool.not_found", status=400)
+
+
+# ---- Engine-side rejections (route through transaction.invalid) ------
+
+
+class TestEngineRejections:
+    def test_refund_shaped_pool_effect_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        # A negative-amount EXPENSE posting (refund shape) yields a positive
+        # net pool effect, which v1 rejects until the REFUND reason ships.
+        cash, food = cash_and_food
+        pool = _create_envelope_pool(session_maker, household_id)
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Refund",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "-50",
+                        "currency": "USD",
+                        "pool_id": str(pool),
+                    },
+                    {"account_id": cash, "amount": "50", "currency": "USD"},
+                ],
+            },
+        )
+        assert_problem(r, code="transaction.invalid", status=400)
+
+
+# ---- Period gate ordering -------------------------------------------
+
+
+class TestPeriodGate:
+    def test_pool_tagged_tx_in_closed_period_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        # Period gate fires inside post_transaction, which runs AFTER
+        # pool pre-flight but BEFORE shadow build. Result: period.closed
+        # surfaces, no shadow tx is written.
+        cash, food = cash_and_food
+        pool = _create_envelope_pool(session_maker, household_id)
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": "1999-01-01",  # outside the seeded current-year period
+                "description": "Time travel",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "50",
+                        "currency": "USD",
+                        "pool_id": str(pool),
+                    },
+                    {"account_id": cash, "amount": "-50", "currency": "USD"},
+                ],
+            },
+        )
+        assert_problem(r, code="period.closed", status=400)
+        # Belt-and-braces: no shadow tx exists for this household.
+        with session_maker() as s:
+            from sqlalchemy import select
+
+            from tulip_storage.models import ShadowTransaction
+
+            count = (
+                s.execute(
+                    select(ShadowTransaction).where(
+                        ShadowTransaction.household_id == household_id,
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(count) == 0
+
+
+# ---- Mixed / regression ---------------------------------------------
+
+
+class TestMixedAndRegression:
+    def test_mixed_tagged_and_untagged_postings(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        # Two food postings, only one tagged. Shadow tx has 1 pool leg + 1 absorbing.
+        cash, food = cash_and_food
+        pool = _create_envelope_pool(session_maker, household_id)
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Mixed",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "30",
+                        "currency": "USD",
+                        "pool_id": str(pool),
+                    },
+                    {
+                        "account_id": food,
+                        "amount": "20",
+                        "currency": "USD",
+                        # untagged
+                    },
+                    {"account_id": cash, "amount": "-50", "currency": "USD"},
+                ],
+            },
+        )
+        assert r.status_code == 201, r.text
+        shadow_id = UUID(r.json()["paired_shadow_tx_id"])
+        with session_maker() as s:
+            postings = ShadowTransactionRepository(s, household_id).list_postings(shadow_id)
+            assert len(postings) == 2  # only the tagged leg → shadow leg, plus absorbing
+            by_pool = {p.pool_id: p.amount for p in postings}
+            assert by_pool[pool] == Decimal("-30")
+
+    def test_no_pool_tagged_postings_writes_no_shadow_tx(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        # Regression: existing behavior unchanged when no pool_id.
+        cash, food = cash_and_food
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Plain",
+                "postings": [
+                    {"account_id": food, "amount": "12.50", "currency": "USD"},
+                    {"account_id": cash, "amount": "-12.50", "currency": "USD"},
+                ],
+            },
+        )
+        assert r.status_code == 201
+        out = r.json()
+        assert out["paired_shadow_tx_id"] is None
+        # Confirm no shadow tx exists.
+        with session_maker() as s:
+            assert (
+                ShadowTransactionRepository(s, household_id).get_paired_id_for_main_tx(
+                    UUID(out["id"])
+                )
+                is None
+            )
+
+
+# ---- Audit log ------------------------------------------------------
+
+
+class TestAuditLog:
+    def test_paired_shadow_tx_id_captured_in_audit_after(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        household_id: UUID,
+        session_maker: sessionmaker[Session],
+    ):
+        cash, food = cash_and_food
+        pool = _create_envelope_pool(session_maker, household_id)
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Audit",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "50",
+                        "currency": "USD",
+                        "pool_id": str(pool),
+                    },
+                    {"account_id": cash, "amount": "-50", "currency": "USD"},
+                ],
+            },
+        )
+        tx_id = UUID(r.json()["id"])
+        shadow_tx_id = r.json()["paired_shadow_tx_id"]
+
+        with session_maker() as s:
+            from sqlalchemy import select
+
+            from tulip_storage.models import AuditLog
+
+            row = s.execute(
+                select(AuditLog).where(
+                    AuditLog.household_id == household_id,
+                    AuditLog.entity_type == "transaction",
+                    AuditLog.entity_id == tx_id,
+                )
+            ).scalar_one_or_none()
+            assert row is not None
+            assert row.action == "create"
+            assert row.after_snapshot is not None
+            assert row.after_snapshot["paired_shadow_tx_id"] == shadow_tx_id

--- a/packages/tulip-core/src/tulip_core/allocation/__init__.py
+++ b/packages/tulip-core/src/tulip_core/allocation/__init__.py
@@ -8,9 +8,13 @@ holds the pure-domain types. Persistence and repositories live in
 
 from tulip_core.allocation.engine import (
     InactivePoolError,
+    InvalidAccountTypePairingError,
+    MultiCurrencyPoolTaggingError,
     PoolCurrencyMismatchError,
     UnbalancedShadowTransactionError,
     UnknownPoolError,
+    UnsupportedRefundShapedShadowTxError,
+    derive_paired_shadow_tx,
     post_shadow_transaction,
 )
 from tulip_core.allocation.envelope import BudgetPeriod, Envelope, RolloverPolicy
@@ -29,6 +33,8 @@ __all__ = [
     "ContributionStrategy",
     "Envelope",
     "InactivePoolError",
+    "InvalidAccountTypePairingError",
+    "MultiCurrencyPoolTaggingError",
     "Pool",
     "PoolCurrencyMismatchError",
     "PoolType",
@@ -42,5 +48,7 @@ __all__ = [
     "SinkingFund",
     "UnbalancedShadowTransactionError",
     "UnknownPoolError",
+    "UnsupportedRefundShapedShadowTxError",
+    "derive_paired_shadow_tx",
     "post_shadow_transaction",
 ]

--- a/packages/tulip-core/src/tulip_core/allocation/engine.py
+++ b/packages/tulip-core/src/tulip_core/allocation/engine.py
@@ -15,14 +15,25 @@ in P4.1 alongside the API surface.
 from __future__ import annotations
 
 from dataclasses import replace
+from decimal import Decimal
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
-from tulip_core.allocation.shadow_transaction import ShadowTransaction, ShadowTxStatus
+from tulip_core.account import AccountType
+from tulip_core.allocation.shadow_posting import ShadowPosting
+from tulip_core.allocation.shadow_transaction import (
+    ShadowTransaction,
+    ShadowTxReason,
+    ShadowTxStatus,
+)
+from tulip_core.money import Money
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
+    from uuid import UUID
 
     from tulip_core.allocation.pool import Pool
+    from tulip_core.transactions import Transaction
 
 
 class UnbalancedShadowTransactionError(ValueError):
@@ -39,6 +50,174 @@ class PoolCurrencyMismatchError(ValueError):
 
 class InactivePoolError(ValueError):
     """Raised when a posting writes to a deactivated pool."""
+
+
+class InvalidAccountTypePairingError(ValueError):
+    """Raised when a pool-tagged main posting is on an account whose type forbids pairing.
+
+    v1 permits pool-tagging on EXPENSE accounts only. The account-type
+    table can be widened in a later slice if a real use case lands; for
+    now anything else is rejected so the auto-pairing semantics stay
+    pinned to the worked examples in ADR-0001.
+    """
+
+
+class MultiCurrencyPoolTaggingError(ValueError):
+    """Raised when pool-tagged postings on a single main tx span multiple currencies.
+
+    Multi-currency main transactions are legal in general (FX flows), but
+    the absorbing-leg sign rule and the per-currency balance interaction
+    haven't been worked out for cross-currency shadow pairing in v1.
+    """
+
+
+class UnsupportedRefundShapedShadowTxError(ValueError):
+    """Raised when the inferred shadow tx would have a non-negative net pool effect.
+
+    "Spending-shaped" main transactions produce a negative net pool effect
+    (money out of envelopes, absorbed by Spent). The mirror case — money
+    into envelopes via a refund-shaped main tx — needs an Inflow-side
+    absorbing leg with reason ``REFUND``, which isn't in the
+    ``ShadowTxReason`` enum yet. Out of scope for v1; deferred to an ADR
+    amendment.
+    """
+
+
+# v1 sign rule: only EXPENSE accounts may carry pool_id. Other types
+# can be added when a real use case lands; until then anything else is
+# rejected at this layer (and at the API pre-flight check too).
+_PAIRABLE_ACCOUNT_TYPES: frozenset[AccountType] = frozenset({AccountType.EXPENSE})
+
+# For an EXPENSE leg with positive amount (the spending side of a
+# debit-shaped expense posting), the shadow leg's amount is
+# `-sign * main_amount = -1 * +amount = -amount` — money out of envelope.
+# Documented as the worked example in ADR-0001 §B.
+_SIGN_FOR_ACCOUNT_TYPE: dict[AccountType, int] = {
+    AccountType.EXPENSE: 1,
+}
+
+
+def derive_paired_shadow_tx(
+    main_tx: Transaction,
+    *,
+    account_types_by_id: Mapping[UUID, AccountType],
+    spent_pool_by_currency: Mapping[str, UUID],
+) -> ShadowTransaction | None:
+    """Build the shadow tx paired to ``main_tx`` when its postings carry ``pool_id``.
+
+    Returns ``None`` when no posting carries ``pool_id`` — caller skips the
+    shadow-ledger write entirely. Otherwise returns a POSTED shadow tx
+    with one leg per pool-tagged main posting plus an absorbing leg in
+    the household's ``Spent`` system pool of the appropriate currency.
+    Per ADR-0001's pairing rule: one main tx → at most one paired shadow
+    tx; multi-pool effects are bundled as additional legs.
+
+    Args:
+        main_tx: The already-balanced main-ledger transaction.
+        account_types_by_id: Resolver from ``account_id`` to ``AccountType``.
+            The router builds this once from the AccountRepository before
+            calling.
+        spent_pool_by_currency: Resolver from currency to the household's
+            ``Spent`` system-pool UUID. The router obtains it via
+            ``AllocationPoolRepository.get_or_create_system_pools`` and
+            extracts the ``PoolType.SPENT`` entry.
+
+    Returns:
+        A POSTED ShadowTransaction with ``paired_main_tx_id`` set and
+        ``description`` suffixed with " (envelope effects)". The shadow
+        tx's per-currency sums are zero by construction.
+
+    Raises:
+        InvalidAccountTypePairingError: a pool-tagged posting is on an
+            account whose type is not EXPENSE.
+        MultiCurrencyPoolTaggingError: pool-tagged postings span more
+            than one currency on this main tx.
+        UnsupportedRefundShapedShadowTxError: the net pool effect would
+            be non-negative (refund-shaped); v1 only supports negative
+            (spending-shaped) effects.
+
+    """
+    pool_tagged = [p for p in main_tx.postings if p.pool_id is not None]
+    if not pool_tagged:
+        return None
+
+    currencies = {p.amount.currency for p in pool_tagged}
+    if len(currencies) > 1:
+        raise MultiCurrencyPoolTaggingError(
+            f"pool-tagged postings span multiple currencies "
+            f"({sorted(currencies)}) on main tx {main_tx.id}; "
+            "rejected in v1 — see ADR-0001"
+        )
+    currency = next(iter(currencies))
+
+    for p in pool_tagged:
+        atype = account_types_by_id.get(p.account_id)
+        if atype is None or atype not in _PAIRABLE_ACCOUNT_TYPES:
+            raise InvalidAccountTypePairingError(
+                f"posting {p.id} is on account {p.account_id} of type "
+                f"{atype.value if atype else 'unknown'!r}; only EXPENSE "
+                "accounts may carry pool_id in v1"
+            )
+
+    shadow_postings: list[ShadowPosting] = []
+    net_pool_effect = Decimal(0)
+    for p in pool_tagged:
+        # mypy knows account_types_by_id.get is Optional; the loop above
+        # already raised on None, so a non-None lookup is safe here.
+        atype = account_types_by_id[p.account_id]
+        sign = _SIGN_FOR_ACCOUNT_TYPE[atype]
+        shadow_amount = -sign * p.amount.amount
+        net_pool_effect += shadow_amount
+        # mypy: pool_id is Optional[UUID] on Posting but we filtered to
+        # non-None above; assert via cast.
+        assert p.pool_id is not None  # noqa: S101 - filtered above
+        shadow_postings.append(
+            ShadowPosting(
+                id=uuid4(),
+                pool_id=p.pool_id,
+                amount=Money(shadow_amount, currency),
+            )
+        )
+
+    if net_pool_effect >= 0:
+        # Net positive (or zero) shadow effect = money flowing INTO
+        # envelopes. Refund-shaped pairing requires an Inflow absorbing
+        # leg + a REFUND reason that isn't in ShadowTxReason yet.
+        raise UnsupportedRefundShapedShadowTxError(
+            f"main tx {main_tx.id} has net pool effect "
+            f"{net_pool_effect} {currency}; v1 only supports "
+            "spending-shaped (negative net effect) auto-pairing"
+        )
+
+    spent_pool_id = spent_pool_by_currency.get(currency)
+    if spent_pool_id is None:
+        # Caller is responsible for ensuring system pools exist for
+        # every pool-tagged currency. Reaching this branch is a Tulip
+        # bug, not a user error.
+        raise ValueError(
+            f"no Spent system pool registered for currency {currency!r} "
+            "— caller must materialize system pools before pairing"
+        )
+
+    shadow_postings.append(
+        ShadowPosting(
+            id=uuid4(),
+            pool_id=spent_pool_id,
+            amount=Money(-net_pool_effect, currency),
+        )
+    )
+
+    return ShadowTransaction(
+        id=uuid4(),
+        household_id=main_tx.household_id,
+        date=main_tx.date,
+        description=f"{main_tx.description} (envelope effects)",
+        reason=ShadowTxReason.SPEND,
+        postings=tuple(shadow_postings),
+        status=ShadowTxStatus.POSTED,
+        paired_main_tx_id=main_tx.id,
+        created_by_user_id=main_tx.created_by_user_id,
+    )
 
 
 def post_shadow_transaction(

--- a/packages/tulip-core/tests/test_allocation_derive_paired.py
+++ b/packages/tulip-core/tests/test_allocation_derive_paired.py
@@ -1,0 +1,293 @@
+"""Unit tests for derive_paired_shadow_tx (the auto-pairing engine)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from tulip_core.account import AccountType
+from tulip_core.allocation import (
+    InvalidAccountTypePairingError,
+    MultiCurrencyPoolTaggingError,
+    ShadowTxReason,
+    ShadowTxStatus,
+    UnsupportedRefundShapedShadowTxError,
+    derive_paired_shadow_tx,
+)
+from tulip_core.money import Money
+from tulip_core.transactions import Posting, Transaction, TransactionStatus
+
+
+def _build_main_tx(
+    *,
+    household_id: UUID,
+    postings: tuple[Posting, ...],
+    description: str = "Costco run",
+    tx_date: date = date(2026, 6, 1),
+) -> Transaction:
+    return Transaction(
+        id=uuid4(),
+        household_id=household_id,
+        date=tx_date,
+        description=description,
+        postings=postings,
+        status=TransactionStatus.POSTED,
+    )
+
+
+def test_no_pool_tagged_postings_returns_none() -> None:
+    household_id = uuid4()
+    food_id = uuid4()
+    cash_id = uuid4()
+    main_tx = _build_main_tx(
+        household_id=household_id,
+        postings=(
+            Posting(id=uuid4(), account_id=food_id, amount=Money(Decimal("12.50"), "USD")),
+            Posting(id=uuid4(), account_id=cash_id, amount=Money(Decimal("-12.50"), "USD")),
+        ),
+    )
+    result = derive_paired_shadow_tx(
+        main_tx,
+        account_types_by_id={food_id: AccountType.EXPENSE, cash_id: AccountType.ASSET},
+        spent_pool_by_currency={"USD": uuid4()},
+    )
+    assert result is None
+
+
+def test_single_pool_spend_yields_two_legs() -> None:
+    household_id = uuid4()
+    food_id = uuid4()
+    cash_id = uuid4()
+    pool_id = uuid4()
+    spent_pool_id = uuid4()
+    main_tx = _build_main_tx(
+        household_id=household_id,
+        description="Costco",
+        postings=(
+            Posting(
+                id=uuid4(),
+                account_id=food_id,
+                amount=Money(Decimal("50"), "USD"),
+                pool_id=pool_id,
+            ),
+            Posting(id=uuid4(), account_id=cash_id, amount=Money(Decimal("-50"), "USD")),
+        ),
+    )
+    shadow = derive_paired_shadow_tx(
+        main_tx,
+        account_types_by_id={food_id: AccountType.EXPENSE, cash_id: AccountType.ASSET},
+        spent_pool_by_currency={"USD": spent_pool_id},
+    )
+    assert shadow is not None
+    assert shadow.status is ShadowTxStatus.POSTED
+    assert shadow.reason is ShadowTxReason.SPEND
+    assert shadow.paired_main_tx_id == main_tx.id
+    assert shadow.household_id == household_id
+    assert shadow.date == main_tx.date
+    assert shadow.description == "Costco (envelope effects)"
+    assert len(shadow.postings) == 2
+    pool_leg = next(p for p in shadow.postings if p.pool_id == pool_id)
+    spent_leg = next(p for p in shadow.postings if p.pool_id == spent_pool_id)
+    assert pool_leg.amount == Money(Decimal("-50"), "USD")
+    assert spent_leg.amount == Money(Decimal("50"), "USD")
+
+
+def test_multi_pool_spend_yields_one_paired_with_three_legs() -> None:
+    """ADR-0001 section B verbatim: $50 groceries + $30 entertainment + -$80 cash."""
+    household_id = uuid4()
+    food_id = uuid4()
+    ent_id = uuid4()
+    cash_id = uuid4()
+    groceries_pool = uuid4()
+    ent_pool = uuid4()
+    spent_pool_id = uuid4()
+    main_tx = _build_main_tx(
+        household_id=household_id,
+        postings=(
+            Posting(
+                id=uuid4(),
+                account_id=food_id,
+                amount=Money(Decimal("50"), "USD"),
+                pool_id=groceries_pool,
+            ),
+            Posting(
+                id=uuid4(),
+                account_id=ent_id,
+                amount=Money(Decimal("30"), "USD"),
+                pool_id=ent_pool,
+            ),
+            Posting(id=uuid4(), account_id=cash_id, amount=Money(Decimal("-80"), "USD")),
+        ),
+    )
+    shadow = derive_paired_shadow_tx(
+        main_tx,
+        account_types_by_id={
+            food_id: AccountType.EXPENSE,
+            ent_id: AccountType.EXPENSE,
+            cash_id: AccountType.ASSET,
+        },
+        spent_pool_by_currency={"USD": spent_pool_id},
+    )
+    assert shadow is not None
+    assert len(shadow.postings) == 3
+    by_pool = {p.pool_id: p.amount for p in shadow.postings}
+    assert by_pool[groceries_pool] == Money(Decimal("-50"), "USD")
+    assert by_pool[ent_pool] == Money(Decimal("-30"), "USD")
+    assert by_pool[spent_pool_id] == Money(Decimal("80"), "USD")
+    # Per-currency balance must be zero (it's the trigger invariant too).
+    assert shadow.balance_per_currency() == {"USD": Decimal("0")}
+
+
+def test_non_expense_account_type_rejected() -> None:
+    household_id = uuid4()
+    food_id = uuid4()
+    cash_id = uuid4()
+    pool_id = uuid4()
+    main_tx = _build_main_tx(
+        household_id=household_id,
+        postings=(
+            Posting(
+                id=uuid4(),
+                account_id=cash_id,
+                amount=Money(Decimal("50"), "USD"),
+                pool_id=pool_id,
+            ),
+            Posting(id=uuid4(), account_id=food_id, amount=Money(Decimal("-50"), "USD")),
+        ),
+    )
+    with pytest.raises(InvalidAccountTypePairingError, match="EXPENSE"):
+        derive_paired_shadow_tx(
+            main_tx,
+            account_types_by_id={cash_id: AccountType.ASSET, food_id: AccountType.EXPENSE},
+            spent_pool_by_currency={"USD": uuid4()},
+        )
+
+
+def test_multi_currency_pool_tagging_rejected() -> None:
+    household_id = uuid4()
+    food_id = uuid4()
+    travel_id = uuid4()
+    cash_id = uuid4()
+    main_tx = Transaction(
+        id=uuid4(),
+        household_id=household_id,
+        date=date(2026, 6, 1),
+        description="Mixed currency",
+        postings=(
+            Posting(
+                id=uuid4(),
+                account_id=food_id,
+                amount=Money(Decimal("50"), "USD"),
+                pool_id=uuid4(),
+            ),
+            Posting(
+                id=uuid4(),
+                account_id=travel_id,
+                amount=Money(Decimal("30"), "EUR"),
+                pool_id=uuid4(),
+            ),
+            Posting(id=uuid4(), account_id=cash_id, amount=Money(Decimal("-50"), "USD")),
+            Posting(id=uuid4(), account_id=cash_id, amount=Money(Decimal("-30"), "EUR")),
+        ),
+        # PENDING because the multi-currency tx is balanced per currency
+        # but we don't want post-init to enforce; PENDING is exempt and
+        # the engine doesn't care about main-tx status.
+        status=TransactionStatus.PENDING,
+    )
+    with pytest.raises(MultiCurrencyPoolTaggingError):
+        derive_paired_shadow_tx(
+            main_tx,
+            account_types_by_id={
+                food_id: AccountType.EXPENSE,
+                travel_id: AccountType.EXPENSE,
+                cash_id: AccountType.ASSET,
+            },
+            spent_pool_by_currency={"USD": uuid4(), "EUR": uuid4()},
+        )
+
+
+def test_refund_shaped_pool_effect_rejected() -> None:
+    """A negative-amount EXPENSE posting (refund in) gives positive net pool effect."""
+    household_id = uuid4()
+    food_id = uuid4()
+    cash_id = uuid4()
+    pool_id = uuid4()
+    main_tx = Transaction(
+        id=uuid4(),
+        household_id=household_id,
+        date=date(2026, 6, 1),
+        description="Refund",
+        postings=(
+            Posting(
+                id=uuid4(),
+                account_id=food_id,
+                amount=Money(Decimal("-50"), "USD"),  # refund: negative expense
+                pool_id=pool_id,
+            ),
+            Posting(id=uuid4(), account_id=cash_id, amount=Money(Decimal("50"), "USD")),
+        ),
+        status=TransactionStatus.POSTED,
+    )
+    with pytest.raises(UnsupportedRefundShapedShadowTxError):
+        derive_paired_shadow_tx(
+            main_tx,
+            account_types_by_id={food_id: AccountType.EXPENSE, cash_id: AccountType.ASSET},
+            spent_pool_by_currency={"USD": uuid4()},
+        )
+
+
+def test_missing_spent_pool_for_currency_raises() -> None:
+    """Caller is responsible for materializing system pools — engine raises if missing."""
+    household_id = uuid4()
+    food_id = uuid4()
+    cash_id = uuid4()
+    pool_id = uuid4()
+    main_tx = _build_main_tx(
+        household_id=household_id,
+        postings=(
+            Posting(
+                id=uuid4(),
+                account_id=food_id,
+                amount=Money(Decimal("50"), "USD"),
+                pool_id=pool_id,
+            ),
+            Posting(id=uuid4(), account_id=cash_id, amount=Money(Decimal("-50"), "USD")),
+        ),
+    )
+    with pytest.raises(ValueError, match="Spent system pool"):
+        derive_paired_shadow_tx(
+            main_tx,
+            account_types_by_id={food_id: AccountType.EXPENSE, cash_id: AccountType.ASSET},
+            spent_pool_by_currency={},  # no Spent pool registered
+        )
+
+
+def test_unknown_account_id_in_resolver_treated_as_invalid_type() -> None:
+    household_id = uuid4()
+    food_id = uuid4()
+    cash_id = uuid4()
+    pool_id = uuid4()
+    main_tx = _build_main_tx(
+        household_id=household_id,
+        postings=(
+            Posting(
+                id=uuid4(),
+                account_id=food_id,
+                amount=Money(Decimal("50"), "USD"),
+                pool_id=pool_id,
+            ),
+            Posting(id=uuid4(), account_id=cash_id, amount=Money(Decimal("-50"), "USD")),
+        ),
+    )
+    # food_id missing from account_types_by_id — engine treats it as
+    # "unknown type" → InvalidAccountTypePairingError. The router's
+    # responsibility is to populate the resolver from a real repo.
+    with pytest.raises(InvalidAccountTypePairingError, match="unknown"):
+        derive_paired_shadow_tx(
+            main_tx,
+            account_types_by_id={cash_id: AccountType.ASSET},
+            spent_pool_by_currency={"USD": uuid4()},
+        )

--- a/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
@@ -59,6 +59,20 @@ class ShadowTransactionRepository:
             )
         ).scalar_one_or_none()
 
+    def get_paired_id_for_main_tx(self, main_tx_id: UUID) -> UUID | None:
+        """Return the id of the shadow tx paired to ``main_tx_id``, or None.
+
+        Lookup keyed on ``paired_main_tx_id``. The pairing rule (ADR-0001)
+        guarantees at most one row per main tx, so ``scalar_one_or_none``
+        is the right shape.
+        """
+        return self._session.execute(
+            select(ShadowTransaction.id).where(
+                ShadowTransaction.household_id == self._household_id,
+                ShadowTransaction.paired_main_tx_id == main_tx_id,
+            )
+        ).scalar_one_or_none()
+
     def list_postings(self, tx_id: UUID) -> list[ShadowPosting]:
         """Return all shadow postings belonging to a shadow transaction."""
         return list(


### PR DESCRIPTION
Closes #62. First half of P4.1, split out for review size. Implements the writer chokepoint that auto-pairs a shadow-ledger transaction whenever a main-ledger posting carries \`pool_id\`. Per [ADR-0001](docs/adrs/0001-envelope-shadow-ledger.md). Builds on P4.0 (#60). The CRUD endpoints + refill/transfer/balance ship as P4.1.b (#63), which is unblocked once this merges.

## Summary

- **Schema**: \`PostingCreate\` learns optional \`pool_id: UUID | None\`; \`PostingRead\` exposes it on responses; \`TransactionRead\` gets a new \`paired_shadow_tx_id\` field.
- **Pre-flight validation** (in this order, before any DB write): pool exists in household → active → account type permits (**EXPENSE-only in v1**) → pool currency matches posting currency. Cross-tenant pool refs surface as \`pool.not_found\`.
- **Lazy system-pool creation**: for each distinct currency among pool-tagged postings, the handler calls \`AllocationPoolRepository.get_or_create_system_pools(currency=...)\` before either ledger writes. Idempotent. No separate audit row — system pools are plumbing.
- **Auto-pairing engine**: new pure \`tulip_core.allocation.engine.derive_paired_shadow_tx(main_tx, *, account_types_by_id, spent_pool_by_currency)\` returning \`ShadowTransaction | None\`. Sign rule for v1: \`EXPENSE → +1\`. One absorbing leg in the household's \`Spent\` system pool of the appropriate currency. Multi-currency pool-tags within one main tx rejected with typed \`MultiCurrencyPoolTaggingError\`. Refund-shaped (positive net pool effect) rejected with \`UnsupportedRefundShapedShadowTxError\` — needs an ADR amendment to add \`REFUND\` reason.
- **Atomic rollback**: existing handler boundary handles it — both \`save_balanced\` calls + the audit write share one session, one commit. If anything raises, FastAPI's request lifecycle rolls back the session via \`get_session\`.
- **Audit log**: extended the main tx's \`after_snapshot\` with \`paired_shadow_tx_id\` when present. One user action = one audit row; the shadow row is queryable via \`paired_main_tx_id\`.
- **GET / list endpoints** also surface \`paired_shadow_tx_id\` via a new \`ShadowTransactionRepository.get_paired_id_for_main_tx\` (architecture test from P4.0 still bans direct shadow-table writes outside the repo).
- **New Problem Details codes**: \`pool.not_found\` / \`pool.inactive\` / \`pool.currency_mismatch\` / \`pool.invalid_account_type_pairing\` (400) and \`pool.shadow_unbalanced\` (500, defense-in-depth — only fires on a Tulip bug). Documented at \`/.well-known/errors/{code}\`.
- **Tests**: 25 new (8 engine unit + 17 API integration). Project total: **605 passing** (up from 580).

## Decisions resolved during planning

1. **EXPENSE-only pool-tagging in v1.** Other types rejected at pre-flight + engine. Widen later if a real use case lands.
2. **Refund-shaped (positive net pool effect) rejected in v1.** Needs an ADR amendment to add a \`REFUND\` reason and an \`Inflow\` absorbing-leg path.
3. **Multi-currency pool-tags in a single main tx rejected in v1.** Sign rule across currencies is hairy; punt to a follow-up ADR.
4. **Shadow tx description** = main tx description + \`\" (envelope effects)\"\` (per ADR §B).
5. **Shadow tx date** mirrors main tx date (preserves time-travel semantics).

## Subagent retrospective

Used parallel Explore agents + a Plan agent at slice start (per memory \`feedback_subagent_usage.md\`). The Explore digests collapsed ~12 file reads into two ~500-word summaries; the Plan agent's output was sharper than ad-hoc inline thinking would have been because every decision had to be made explicit. Time cost: ~2 min wall time for ~10-15 min of saved sequential reading + drift. Validated the approach.

## Test plan

- [x] Full pytest run: 605 passing
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy packages/\` — clean (103 source files)
- [x] Engine unit tests cover happy path, multi-pool, all four rejection cases (engine.py)
- [x] API integration tests cover the full TDD plan from #62 (single-pool, multi-pool, lazy EUR, all four pre-flight error codes, EQUITY/ASSET/LIABILITY/INCOME rejection, period-gate ordering, mixed tagged/untagged, no-tag regression, audit-log shape)
- [x] Cross-tenant pool ref surfaces as \`pool.not_found\` (no info leak)
- [x] Architecture test (P4.0) still passes — no direct shadow-table writes outside the repo

### Manual smoke test — register, create envelope, post tagged transaction

\`\`\`bash
cd /tmp && rm -f smoke-p41a.db
DATABASE_URL=\"sqlite:////tmp/smoke-p41a.db\" \\
  uv --project /Users/robert/Projects/tulip-accounting run alembic \\
  -c /Users/robert/Projects/tulip-accounting/packages/tulip-storage/alembic.ini \\
  upgrade head

DATABASE_URL=\"sqlite:////tmp/smoke-p41a.db\" \\
TULIP_MASTER_KEY=\"\$(python3 -c 'import base64,os; print(base64.b64encode(os.urandom(32)).decode())')\" \\
TULIP_JWT_SECRET=\"smoke-test-32-byte-secret-here-ok\" \\
  uv --project /Users/robert/Projects/tulip-accounting run uvicorn tulip_api.main:create_app --factory --port 8765 &
sleep 2

REG=\$(curl -s -X POST http://localhost:8765/v1/auth/register \\
  -H 'content-type: application/json' \\
  -d '{\"email\":\"alice@example.com\",\"password\":\"correct horse battery staple\",\"display_name\":\"Alice\",\"household_name\":\"Smith\"}')
HOUSEHOLD=\$(echo \"\$REG\" | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"household_id\"])')

TOK=\$(curl -s -X POST http://localhost:8765/v1/auth/login \\
  -H 'content-type: application/json' \\
  -d '{\"email\":\"alice@example.com\",\"password\":\"correct horse battery staple\"}' \\
  | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"access_token\"])')

CASH=\$(curl -s -X POST http://localhost:8765/v1/accounts \\
  -H \"Authorization: Bearer \$TOK\" -H 'content-type: application/json' \\
  -d '{\"name\":\"Cash\",\"type\":\"asset\",\"currency\":\"USD\",\"code\":\"1110\"}' \\
  | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"id\"])')
FOOD=\$(curl -s -X POST http://localhost:8765/v1/accounts \\
  -H \"Authorization: Bearer \$TOK\" -H 'content-type: application/json' \\
  -d '{\"name\":\"Food\",\"type\":\"expense\",\"currency\":\"USD\",\"code\":\"5100\"}' \\
  | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"id\"])')

POOL=\$(sqlite3 /tmp/smoke-p41a.db \"INSERT INTO allocation_pools (household_id, id, pool_type, name, visibility, currency, is_active, is_system, created_at, updated_at) VALUES ('\$HOUSEHOLD', lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(6))), 'envelope', 'Groceries', 'shared', 'USD', 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id;\")

curl -s -X POST http://localhost:8765/v1/transactions \\
  -H \"Authorization: Bearer \$TOK\" -H 'content-type: application/json' \\
  -d '{\"date\":\"'\$(date -u +%Y-%m-%d)'\",\"description\":\"Costco\",\"postings\":[{\"account_id\":\"'\$FOOD'\",\"amount\":\"50\",\"currency\":\"USD\",\"pool_id\":\"'\$POOL'\"},{\"account_id\":\"'\$CASH'\",\"amount\":\"-50\",\"currency\":\"USD\"}]}' \\
  | python3 -m json.tool

sqlite3 /tmp/smoke-p41a.db 'SELECT pool_id, amount FROM shadow_postings;'

kill %1
\`\`\`

Expected: the curl output shows \`\"paired_shadow_tx_id\": \"<uuid>\"\` in the response. The \`shadow_postings\` query shows two rows: \`(<groceries-pool>, -50)\` and \`(<spent-USD-pool>, 50)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)