### PR TITLE
P4.2 — CLI commands for envelopes / sinking-funds / refill / transfer / budget-inflow

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-02 · `main` @ P4.0 + P4.1.a + P4.1.b
+**Last updated:** 2026-05-02 · `main` @ P4.0 + P4.1.a + P4.1.b + P4.2
 
 ---
 
@@ -15,9 +15,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 3 (CLI):** ✅ complete — P3.1 through P3.4 + P3.6 shipped; P3.5 (toner-friendly print stylesheet) deferred to Phase 8 alongside the actual reports (#22)
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
 - **Pre-Phase-4 docs:** threat-model checkpoint shipped (#56, [docs/THREAT_MODEL.md](THREAT_MODEL.md)). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
-- **Phase 4 (envelopes + sinking funds):** in flight — P4.0 (storage + domain layer per [ADR-0001](adrs/0001-envelope-shadow-ledger.md)) shipped 2026-05-02 (#60); P4.1 split a/b — P4.1.a (writer chokepoint) shipped 2026-05-02 (#62); P4.1.b (envelope/sinking-fund/refill/transfer/budget-inflow endpoints) shipped 2026-05-02 (#63); P4.2 (CLI), P4.3 (refill rules + scheduled-tx runner) queued.
+- **Phase 4 (envelopes + sinking funds):** in flight — P4.0 (storage + domain layer per [ADR-0001](adrs/0001-envelope-shadow-ledger.md)) shipped 2026-05-02 (#60); P4.1 split a/b — P4.1.a (writer chokepoint) shipped 2026-05-02 (#62); P4.1.b (envelope/sinking-fund/refill/transfer/budget-inflow endpoints) shipped 2026-05-02 (#63); P4.2 (CLI commands) shipped 2026-05-02 (#66); P4.3 (refill rules execution + scheduled-tx runner) queued.
 
-**Tests:** 668 passing · **CI:** green on `main`
+**Tests:** 702 passing · **CI:** green on `main`
 
 ---
 
@@ -328,10 +328,22 @@ Closes #63. Three new routers (`/v1/envelopes`, `/v1/sinking-funds`, `/v1/pools`
 - **Decimal-safe validation rendering**: fixed a latent bug where `RequestValidationError` with `Decimal` constraint contexts (`ge=0`, `gt=0`) couldn't serialize to JSON. Added `_sanitize_for_json` recursive coercion in the validation handler.
 - **Tests**: 63 new (23 envelope endpoint tests, 13 sinking-fund, 27 pool). Project total: **668 passing** (up from 605).
 
+### P4.2 — CLI commands for envelopes / sinking-funds / refill / transfer / budget-inflow — ✅ *(2026-05-02)*
+
+Closes #66. Surfaces P4.1.b's API endpoints through the `tulip` CLI. Mirrors the patterns from `tulip accounts` (CRUD subgroups) and `tulip add` (top-level action commands).
+
+- **`tulip envelopes`** subgroup: `list`, `show`, `add`, `edit`, `deactivate`. Resolver falls back to `name` (envelopes have no code field), with `envelope.ambiguous_name` raised on duplicates rather than silent first-match.
+- **`tulip sinking-funds`** subgroup: same shape, mirror of envelopes minus refill. Field set: `--target-amount`, `--target-date`, `--contribution-strategy`, `--contribution-amount`.
+- **Top-level action commands**: `tulip refill ENVELOPE`, `tulip transfer --from POOL --to POOL`, `tulip budget-inflow`. The transfer resolver looks across both envelope and sinking-fund lists; cross-type name collisions raise `pool.ambiguous_name`.
+- **Output formats**: Rich tables for list (no per-row balance fetch — avoids N+1); key:value plus a separate `balance:` line for `show`; "Refilled X by AMT; new balance: BAL" / "Transferred AMT from SRC to DEST; new destination balance: BAL" / "Declared inflow of AMT CCY; new Unallocated balance: BAL" for actions. `--json` passes through the raw API response on every command.
+- **Helper module** `commands/_pools.py`: `_resolve_envelope`, `_resolve_sinking_fund`, `_resolve_pool` plus typed Problem Details builders (`*.not_found`, `*.ambiguous_name`).
+- **Refill-rule editing** intentionally not in P4.2; the structured-only constraint from ADR-0001 needs an editor flow that lands as a follow-up.
+- **Tests**: 34 new E2E (15 envelope, 8 sinking-fund, 11 pool-action). Project total: **702 passing** (up from 668).
+
 ### Phase 4 deferred to later slices
 
-- **P4.2 — CLI** (`tulip envelopes …`, `tulip sinking-funds …`, `tulip refill`, `tulip transfer`, `tulip budget-inflow`).
 - **P4.3 — Refill rules execution** + scheduled-tx runner.
+- **P4 follow-up — `--edit` flow for `tulip envelopes add` / `edit`** so users can author RefillRule structures interactively.
 
 ---
 

--- a/packages/tulip-cli/src/tulip_cli/commands/_pools.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/_pools.py
@@ -1,0 +1,181 @@
+"""Resolvers + Problem Details shapes for envelope / sinking-fund / pool lookups.
+
+Mirrors the ``_resolve_account`` pattern in :mod:`tulip_cli.commands.accounts`,
+adapted for resources that have no ``code`` field — fallback is on ``name``.
+Three resolvers live here so the top-level ``transfer`` command can import
+without a circular reference back to the envelopes / sinking_funds modules.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from tulip_cli.errors import EXIT_USER, CliError
+
+if TYPE_CHECKING:
+    from tulip_cli.http import TulipClient
+
+
+def _not_found_problem(kind: str, identifier: str) -> dict[str, object]:
+    return {
+        "type": f"/.well-known/errors/{kind}.not_found",
+        "title": f"{kind.replace('_', ' ').capitalize()} not found",
+        "status": 0,
+        "detail": (
+            f"No {kind.replace('_', ' ')} with name or id {identifier!r} is "
+            f"visible to this user. Run `tulip {kind.replace('_', '-')}s list` "
+            "to see what's available."
+        ),
+        "instance": "",
+        "code": f"{kind}.not_found",
+    }
+
+
+def _ambiguous_name_problem(kind: str, identifier: str, count: int) -> dict[str, object]:
+    return {
+        "type": f"/.well-known/errors/{kind}.ambiguous_name",
+        "title": f"{kind.replace('_', ' ').capitalize()} name matches multiple",
+        "status": 0,
+        "detail": (
+            f"{count} {kind.replace('_', ' ')}s have name {identifier!r}. "
+            "Use the UUID to disambiguate, or rename one of the duplicates."
+        ),
+        "instance": "",
+        "code": f"{kind}.ambiguous_name",
+    }
+
+
+def _ambiguous_pool_across_types(identifier: str) -> dict[str, object]:
+    return {
+        "type": "/.well-known/errors/pool.ambiguous_name",
+        "title": "Pool name matches across types",
+        "status": 0,
+        "detail": (
+            f"Name {identifier!r} matches both an envelope and a sinking fund. "
+            "Use the UUID to disambiguate, or rename one of them."
+        ),
+        "instance": "",
+        "code": "pool.ambiguous_name",
+    }
+
+
+def _looks_like_uuid(identifier: str) -> bool:
+    try:
+        UUID(identifier)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_envelope(client: TulipClient, identifier: str) -> dict[str, Any]:
+    """Return a single envelope dict by UUID or by ``name``.
+
+    UUID lookup hits ``GET /v1/envelopes/{id}`` directly. Name lookup
+    fetches the list and matches on ``name``; ambiguous matches raise
+    rather than picking the first.
+    """
+    if _looks_like_uuid(identifier):
+        response = client.get(f"/v1/envelopes/{identifier}", authenticated=True)
+        return dict(response.json())
+
+    response = client.get("/v1/envelopes", authenticated=True)
+    matches = [e for e in response.json() if e.get("name") == identifier]
+    if not matches:
+        raise CliError(
+            problem=_not_found_problem("envelope", identifier),
+            as_json=False,
+            exit_code=EXIT_USER,
+        )
+    if len(matches) > 1:
+        raise CliError(
+            problem=_ambiguous_name_problem("envelope", identifier, len(matches)),
+            as_json=False,
+            exit_code=EXIT_USER,
+        )
+    return dict(matches[0])
+
+
+def _resolve_sinking_fund(client: TulipClient, identifier: str) -> dict[str, Any]:
+    """Return a single sinking-fund dict by UUID or by ``name``."""
+    if _looks_like_uuid(identifier):
+        response = client.get(f"/v1/sinking-funds/{identifier}", authenticated=True)
+        return dict(response.json())
+
+    response = client.get("/v1/sinking-funds", authenticated=True)
+    matches = [s for s in response.json() if s.get("name") == identifier]
+    if not matches:
+        raise CliError(
+            problem=_not_found_problem("sinking_fund", identifier),
+            as_json=False,
+            exit_code=EXIT_USER,
+        )
+    if len(matches) > 1:
+        raise CliError(
+            problem=_ambiguous_name_problem("sinking_fund", identifier, len(matches)),
+            as_json=False,
+            exit_code=EXIT_USER,
+        )
+    return dict(matches[0])
+
+
+def _resolve_pool(client: TulipClient, identifier: str) -> dict[str, Any]:
+    """Return a single pool dict (envelope or sinking-fund) by UUID or name.
+
+    UUID-shaped identifiers try the envelope endpoint first; if that 404s
+    (which surfaces as a ``CliError``), try the sinking-fund endpoint. For
+    name-shaped identifiers, we fetch both lists and match on ``name``;
+    cross-type collisions raise ``pool.ambiguous_name``.
+
+    Returns the pool dict in whatever shape its source endpoint returned
+    (envelope or sinking_fund). Callers that need the pool's currency or
+    id can rely on those fields existing in both shapes.
+    """
+    if _looks_like_uuid(identifier):
+        try:
+            response = client.get(f"/v1/envelopes/{identifier}", authenticated=True)
+            return dict(response.json())
+        except CliError as env_err:
+            # Re-raise anything that isn't a not-found — auth errors,
+            # network failures shouldn't be re-tried as the wrong endpoint.
+            if env_err.problem.get("code") != "envelope.not_found":
+                raise
+        # Fall through to sinking-fund lookup. If THAT also 404s, we
+        # surface a generic pool.not_found rather than the SF-specific one.
+        try:
+            response = client.get(f"/v1/sinking-funds/{identifier}", authenticated=True)
+            return dict(response.json())
+        except CliError as sf_err:
+            if sf_err.problem.get("code") != "sinking_fund.not_found":
+                raise
+            raise CliError(
+                problem=_not_found_problem("pool", identifier),
+                as_json=False,
+                exit_code=EXIT_USER,
+            ) from sf_err
+
+    envelopes = client.get("/v1/envelopes", authenticated=True).json()
+    sinking_funds = client.get("/v1/sinking-funds", authenticated=True).json()
+    env_matches = [e for e in envelopes if e.get("name") == identifier]
+    sf_matches = [s for s in sinking_funds if s.get("name") == identifier]
+
+    if env_matches and sf_matches:
+        raise CliError(
+            problem=_ambiguous_pool_across_types(identifier),
+            as_json=False,
+            exit_code=EXIT_USER,
+        )
+    if not env_matches and not sf_matches:
+        raise CliError(
+            problem=_not_found_problem("pool", identifier),
+            as_json=False,
+            exit_code=EXIT_USER,
+        )
+    matches = env_matches or sf_matches
+    if len(matches) > 1:
+        raise CliError(
+            problem=_ambiguous_name_problem("pool", identifier, len(matches)),
+            as_json=False,
+            exit_code=EXIT_USER,
+        )
+    return dict(matches[0])

--- a/packages/tulip-cli/src/tulip_cli/commands/envelopes.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/envelopes.py
@@ -1,0 +1,317 @@
+"""``tulip envelopes`` — CRUD over /v1/envelopes.
+
+Mirrors :mod:`tulip_cli.commands.accounts`'s shape: list / show / add /
+edit / deactivate. Identifier resolution falls back to ``name`` instead
+of ``code`` (envelopes have no code field). The ``balance`` sub-route is
+fetched on ``show`` only — list intentionally skips per-row balance
+fetches to avoid N+1 calls against a household with many envelopes.
+
+Refill rules are intentionally not exposed as CLI flags in P4.2; the
+structured-only constraint from ADR-0001 calls for an editor flow that
+lands as a follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Annotated, Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.commands._pools import _resolve_envelope
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+envelopes_app = typer.Typer(
+    name="envelopes",
+    help="Create and inspect budgeting envelopes.",
+    no_args_is_help=True,
+)
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+def _render_table(envelopes: list[dict[str, Any]]) -> None:
+    """Render envelopes as a Rich table to stdout (no balance fetch — N+1)."""
+    table = Table(show_header=True, show_lines=False)
+    table.add_column("name")
+    table.add_column("currency")
+    table.add_column("period")
+    table.add_column("rollover")
+    table.add_column("budget")
+    for env in envelopes:
+        table.add_row(
+            env.get("name") or "",
+            env.get("currency") or "",
+            env.get("budget_period") or "",
+            env.get("rollover_policy") or "",
+            env.get("budget_amount") or "—",
+        )
+    Console().print(table)
+
+
+def _render_envelope(envelope: dict[str, Any], balance: dict[str, Any] | None = None) -> None:
+    """Render a single envelope vertically; balance is shown on its own line if present."""
+    typer.echo(f"id:               {envelope.get('id', '')}")
+    typer.echo(f"name:             {envelope.get('name', '')}")
+    typer.echo(f"currency:         {envelope.get('currency', '')}")
+    typer.echo(f"visibility:       {envelope.get('visibility', '')}")
+    typer.echo(f"is_active:        {envelope.get('is_active', '')}")
+    typer.echo(f"budget_period:    {envelope.get('budget_period', '')}")
+    typer.echo(f"rollover_policy:  {envelope.get('rollover_policy', '')}")
+    typer.echo(f"budget_amount:    {envelope.get('budget_amount') or '—'}")
+    if envelope.get("refill_rule") is not None:
+        typer.echo(f"refill_rule:      {json.dumps(envelope['refill_rule'])}")
+    if balance is not None:
+        typer.echo(
+            f"balance:          {balance.get('balance', '')} (as of {balance.get('as_of', '')})"
+        )
+
+
+@envelopes_app.command("list")
+def list_envelopes(ctx: typer.Context) -> None:
+    """List active envelopes visible to the logged-in user."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get("/v1/envelopes", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    envelopes = response.json()
+    if not envelopes:
+        typer.echo("No envelopes. Run `tulip envelopes add` to create one.")
+        return
+    _render_table(envelopes)
+
+
+@envelopes_app.command("add")
+def add_envelope(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Option("--name", help="Envelope name.")],
+    currency: Annotated[
+        str,
+        typer.Option("--currency", help="ISO 4217 three-letter code (e.g. USD)."),
+    ],
+    budget_period: Annotated[
+        str,
+        typer.Option(
+            "--budget-period",
+            help="One of: weekly, biweekly, monthly, quarterly, annual, custom.",
+        ),
+    ],
+    rollover_policy: Annotated[
+        str,
+        typer.Option(
+            "--rollover-policy",
+            help="One of: reset, accumulate, cap_at_budget.",
+        ),
+    ],
+    budget_amount: Annotated[
+        str | None,
+        typer.Option(
+            "--budget-amount",
+            help="Optional decimal amount per period (e.g. 250.00).",
+        ),
+    ] = None,
+    visibility: Annotated[
+        str,
+        typer.Option("--visibility", help="'shared' (default) or 'private'."),
+    ] = "shared",
+) -> None:
+    """Create a new envelope."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    body: dict[str, Any] = {
+        "name": name,
+        "currency": currency,
+        "budget_period": budget_period,
+        "rollover_policy": rollover_policy,
+        "visibility": visibility,
+    }
+    if budget_amount is not None:
+        body["budget_amount"] = budget_amount
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post("/v1/envelopes", json=body, authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    payload = response.json()
+    typer.echo(f"Created envelope {payload.get('id', '')}")
+    _render_envelope(payload)
+
+
+@envelopes_app.command("show")
+def show_envelope(
+    ctx: typer.Context,
+    identifier: Annotated[
+        str,
+        typer.Argument(help="Envelope name or UUID.", metavar="ENVELOPE"),
+    ],
+) -> None:
+    """Show one envelope (header + derived balance)."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    balance: dict[str, Any] | None = None
+    try:
+        with _client(config, as_json=as_json) as client:
+            envelope = _resolve_envelope(client, identifier)
+            try:
+                balance_response = client.get(
+                    f"/v1/envelopes/{envelope['id']}/balance",
+                    authenticated=True,
+                )
+                balance = dict(balance_response.json())
+            except CliError:
+                # Graceful: render the envelope without balance rather than
+                # crashing if the balance endpoint fails. Mirrors how
+                # `accounts show` handles parent-fetch failures.
+                balance = None
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        out = dict(envelope)
+        if balance is not None:
+            out["balance_detail"] = balance
+        sys.stdout.write(json.dumps(out) + "\n")
+        return
+    _render_envelope(envelope, balance=balance)
+
+
+@envelopes_app.command("edit")
+def edit_envelope(
+    ctx: typer.Context,
+    identifier: Annotated[
+        str,
+        typer.Argument(help="Envelope name or UUID.", metavar="ENVELOPE"),
+    ],
+    name: Annotated[
+        str | None,
+        typer.Option("--name", help="New display name."),
+    ] = None,
+    visibility: Annotated[
+        str | None,
+        typer.Option("--visibility", help="'shared' or 'private'."),
+    ] = None,
+    budget_period: Annotated[
+        str | None,
+        typer.Option(
+            "--budget-period",
+            help="One of: weekly, biweekly, monthly, quarterly, annual, custom.",
+        ),
+    ] = None,
+    budget_amount: Annotated[
+        str | None,
+        typer.Option(
+            "--budget-amount",
+            help="New decimal amount per period (e.g. 250.00).",
+        ),
+    ] = None,
+    rollover_policy: Annotated[
+        str | None,
+        typer.Option(
+            "--rollover-policy",
+            help="One of: reset, accumulate, cap_at_budget.",
+        ),
+    ] = None,
+) -> None:
+    """Update mutable fields on an envelope. Only explicitly-passed flags are sent."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    body: dict[str, Any] = {}
+    if name is not None:
+        body["name"] = name
+    if visibility is not None:
+        body["visibility"] = visibility
+    if budget_period is not None:
+        body["budget_period"] = budget_period
+    if budget_amount is not None:
+        body["budget_amount"] = budget_amount
+    if rollover_policy is not None:
+        body["rollover_policy"] = rollover_policy
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            target = _resolve_envelope(client, identifier)
+            response = client.patch(
+                f"/v1/envelopes/{target['id']}",
+                json=body,
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    payload = response.json()
+    typer.echo(f"Updated envelope {payload.get('id', '')}")
+    _render_envelope(payload)
+
+
+@envelopes_app.command("deactivate")
+def deactivate_envelope(
+    ctx: typer.Context,
+    identifier: Annotated[
+        str,
+        typer.Argument(help="Envelope name or UUID.", metavar="ENVELOPE"),
+    ],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip the interactive confirmation prompt.",
+        ),
+    ] = False,
+) -> None:
+    """Soft-delete (deactivate) an envelope. Admin-only on the API side."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            target = _resolve_envelope(client, identifier)
+            if not yes:
+                label = target.get("name") or str(target["id"])
+                if not typer.confirm(
+                    f"Deactivate envelope {label}? It will disappear from `tulip envelopes list`.",
+                    default=False,
+                ):
+                    typer.echo("Aborted; no changes made.")
+                    return
+            client.delete(f"/v1/envelopes/{target['id']}", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(json.dumps({"deactivated": str(target["id"])}) + "\n")
+        return
+    typer.echo(f"Deactivated envelope {target.get('name') or target['id']}.")

--- a/packages/tulip-cli/src/tulip_cli/commands/pool_actions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/pool_actions.py
@@ -1,0 +1,228 @@
+"""Top-level action commands: ``tulip refill``, ``tulip transfer``, ``tulip budget-inflow``.
+
+These wrap the user-initiated shadow-tx endpoints from P4.1.b. Each
+command resolves the relevant pool(s), POSTs the request, and prints the
+new balance the API returns. ``--json`` passes through the raw API body.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Annotated, Any
+
+import typer
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.commands._pools import _resolve_envelope, _resolve_pool
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+def refill(
+    ctx: typer.Context,
+    envelope: Annotated[
+        str,
+        typer.Argument(help="Envelope name or UUID.", metavar="ENVELOPE"),
+    ],
+    amount: Annotated[
+        str,
+        typer.Option("--amount", help="Positive decimal amount to add (e.g. 250.00)."),
+    ],
+    date: Annotated[
+        str,
+        typer.Option("--date", help="ISO date for the refill (YYYY-MM-DD)."),
+    ],
+    description: Annotated[
+        str,
+        typer.Option(
+            "--description",
+            "-m",
+            help="Human-readable description for the audit log.",
+        ),
+    ],
+    memo: Annotated[
+        str | None,
+        typer.Option("--memo", help="Optional per-leg memo."),
+    ] = None,
+) -> None:
+    """Refill an envelope from Unallocated.
+
+    Posts a 2-leg shadow transaction (Unallocated -X / envelope +X). The
+    Unallocated system pool for the envelope's currency is lazy-created
+    if it doesn't yet exist in the household.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    body: dict[str, Any] = {
+        "amount": amount,
+        "date": date,
+        "description": description,
+    }
+    if memo is not None:
+        body["memo"] = memo
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            target = _resolve_envelope(client, envelope)
+            response = client.post(
+                f"/v1/envelopes/{target['id']}/refill",
+                json=body,
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    payload = response.json()
+    new_balance = payload.get("balance", "")
+    typer.echo(
+        f"Refilled {target.get('name') or target['id']} by {amount}; new balance: {new_balance}"
+    )
+
+
+def transfer(
+    ctx: typer.Context,
+    src: Annotated[
+        str,
+        typer.Option("--from", help="Source pool name or UUID."),
+    ],
+    dest: Annotated[
+        str,
+        typer.Option("--to", help="Destination pool name or UUID."),
+    ],
+    amount: Annotated[
+        str,
+        typer.Option("--amount", help="Positive decimal amount to move."),
+    ],
+    date: Annotated[
+        str,
+        typer.Option("--date", help="ISO date for the transfer (YYYY-MM-DD)."),
+    ],
+    description: Annotated[
+        str,
+        typer.Option(
+            "--description",
+            "-m",
+            help="Human-readable description for the audit log.",
+        ),
+    ],
+    memo: Annotated[
+        str | None,
+        typer.Option("--memo", help="Optional per-leg memo."),
+    ] = None,
+) -> None:
+    """Move money between two pools.
+
+    Source and destination must both be in the caller's household, both
+    active, both visible, **same currency**, and **both user pools**
+    (envelope or sinking fund — system-pool transfers are rejected). Same
+    pool both sides is also rejected.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    body: dict[str, Any] = {
+        "amount": amount,
+        "date": date,
+        "description": description,
+    }
+    if memo is not None:
+        body["memo"] = memo
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            src_pool = _resolve_pool(client, src)
+            dest_pool = _resolve_pool(client, dest)
+            body["dest_pool_id"] = dest_pool["id"]
+            response = client.post(
+                f"/v1/pools/{src_pool['id']}/transfer",
+                json=body,
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    payload = response.json()
+    new_balance = payload.get("balance", "")
+    typer.echo(
+        f"Transferred {amount} from {src_pool.get('name') or src_pool['id']} "
+        f"to {dest_pool.get('name') or dest_pool['id']}; "
+        f"new destination balance: {new_balance}"
+    )
+
+
+def budget_inflow(
+    ctx: typer.Context,
+    amount: Annotated[
+        str,
+        typer.Option("--amount", help="Positive decimal amount of inflow to declare."),
+    ],
+    currency: Annotated[
+        str,
+        typer.Option("--currency", help="ISO 4217 three-letter code (e.g. USD)."),
+    ],
+    date: Annotated[
+        str,
+        typer.Option("--date", help="ISO date for the inflow (YYYY-MM-DD)."),
+    ],
+    description: Annotated[
+        str,
+        typer.Option(
+            "--description",
+            "-m",
+            help="Human-readable description for the audit log.",
+        ),
+    ],
+    memo: Annotated[
+        str | None,
+        typer.Option("--memo", help="Optional per-leg memo."),
+    ] = None,
+) -> None:
+    """Declare new money available to budget.
+
+    Posts a shadow transaction with reason ``budget_inflow`` of the form
+    ``Inflow -X / Unallocated +X``. The household's Inflow / Unallocated
+    / Spent system pools are lazy-created for the currency if any are
+    missing — supports adding new currencies after household registration.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    body: dict[str, Any] = {
+        "amount": amount,
+        "currency": currency,
+        "date": date,
+        "description": description,
+    }
+    if memo is not None:
+        body["memo"] = memo
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post("/v1/pools/budget-inflow", json=body, authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    payload = response.json()
+    new_balance = payload.get("balance", "")
+    typer.echo(f"Declared inflow of {amount} {currency}; new Unallocated balance: {new_balance}")

--- a/packages/tulip-cli/src/tulip_cli/commands/sinking_funds.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/sinking_funds.py
@@ -1,0 +1,317 @@
+"""``tulip sinking-funds`` — CRUD over /v1/sinking-funds.
+
+Mirror of :mod:`tulip_cli.commands.envelopes` with the goal-bounded field
+set (``target_amount``, ``target_date``, ``contribution_strategy``,
+``contribution_amount``). The API rejects ``contribution_amount`` for
+``even_split`` / ``percentage_of_income`` strategies — the CLI doesn't
+duplicate that validation, just renders the API's Problem Details.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Annotated, Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.commands._pools import _resolve_sinking_fund
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+sinking_funds_app = typer.Typer(
+    name="sinking-funds",
+    help="Create and inspect sinking funds.",
+    no_args_is_help=True,
+)
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+def _render_table(sfs: list[dict[str, Any]]) -> None:
+    table = Table(show_header=True, show_lines=False)
+    table.add_column("name")
+    table.add_column("currency")
+    table.add_column("target")
+    table.add_column("target_date")
+    table.add_column("strategy")
+    for sf in sfs:
+        table.add_row(
+            sf.get("name") or "",
+            sf.get("currency") or "",
+            sf.get("target_amount") or "",
+            sf.get("target_date") or "",
+            sf.get("contribution_strategy") or "",
+        )
+    Console().print(table)
+
+
+def _render_sinking_fund(sf: dict[str, Any], balance: dict[str, Any] | None = None) -> None:
+    typer.echo(f"id:                     {sf.get('id', '')}")
+    typer.echo(f"name:                   {sf.get('name', '')}")
+    typer.echo(f"currency:               {sf.get('currency', '')}")
+    typer.echo(f"visibility:             {sf.get('visibility', '')}")
+    typer.echo(f"is_active:              {sf.get('is_active', '')}")
+    typer.echo(f"target_amount:          {sf.get('target_amount', '')}")
+    typer.echo(f"target_date:            {sf.get('target_date', '')}")
+    typer.echo(f"contribution_strategy:  {sf.get('contribution_strategy', '')}")
+    typer.echo(f"contribution_amount:    {sf.get('contribution_amount') or '—'}")
+    if balance is not None:
+        typer.echo(
+            f"balance:                {balance.get('balance', '')} "
+            f"(as of {balance.get('as_of', '')})"
+        )
+
+
+@sinking_funds_app.command("list")
+def list_sinking_funds(ctx: typer.Context) -> None:
+    """List active sinking funds visible to the logged-in user."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get("/v1/sinking-funds", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    sfs = response.json()
+    if not sfs:
+        typer.echo("No sinking funds. Run `tulip sinking-funds add` to create one.")
+        return
+    _render_table(sfs)
+
+
+@sinking_funds_app.command("add")
+def add_sinking_fund(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Option("--name", help="Sinking-fund name.")],
+    currency: Annotated[str, typer.Option("--currency", help="ISO 4217 code.")],
+    target_amount: Annotated[
+        str,
+        typer.Option(
+            "--target-amount",
+            help="Goal amount in the chosen currency (e.g. 3000.00).",
+        ),
+    ],
+    target_date: Annotated[
+        str,
+        typer.Option("--target-date", help="ISO date (YYYY-MM-DD)."),
+    ],
+    contribution_strategy: Annotated[
+        str,
+        typer.Option(
+            "--contribution-strategy",
+            help="One of: manual, even_split, percentage_of_income.",
+        ),
+    ],
+    contribution_amount: Annotated[
+        str | None,
+        typer.Option(
+            "--contribution-amount",
+            help=(
+                "Optional fixed contribution amount; only valid with "
+                "strategy=manual. The API rejects it for the other strategies."
+            ),
+        ),
+    ] = None,
+    visibility: Annotated[
+        str,
+        typer.Option("--visibility", help="'shared' (default) or 'private'."),
+    ] = "shared",
+) -> None:
+    """Create a new sinking fund."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    body: dict[str, Any] = {
+        "name": name,
+        "currency": currency,
+        "target_amount": target_amount,
+        "target_date": target_date,
+        "contribution_strategy": contribution_strategy,
+        "visibility": visibility,
+    }
+    if contribution_amount is not None:
+        body["contribution_amount"] = contribution_amount
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post("/v1/sinking-funds", json=body, authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    payload = response.json()
+    typer.echo(f"Created sinking fund {payload.get('id', '')}")
+    _render_sinking_fund(payload)
+
+
+@sinking_funds_app.command("show")
+def show_sinking_fund(
+    ctx: typer.Context,
+    identifier: Annotated[
+        str,
+        typer.Argument(help="Sinking-fund name or UUID.", metavar="SINKING_FUND"),
+    ],
+) -> None:
+    """Show one sinking fund (header + derived balance)."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    balance: dict[str, Any] | None = None
+    try:
+        with _client(config, as_json=as_json) as client:
+            sf = _resolve_sinking_fund(client, identifier)
+            try:
+                balance_response = client.get(
+                    f"/v1/sinking-funds/{sf['id']}/balance",
+                    authenticated=True,
+                )
+                balance = dict(balance_response.json())
+            except CliError:
+                balance = None
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        out = dict(sf)
+        if balance is not None:
+            out["balance_detail"] = balance
+        sys.stdout.write(json.dumps(out) + "\n")
+        return
+    _render_sinking_fund(sf, balance=balance)
+
+
+@sinking_funds_app.command("edit")
+def edit_sinking_fund(
+    ctx: typer.Context,
+    identifier: Annotated[
+        str,
+        typer.Argument(help="Sinking-fund name or UUID.", metavar="SINKING_FUND"),
+    ],
+    name: Annotated[
+        str | None,
+        typer.Option("--name", help="New display name."),
+    ] = None,
+    visibility: Annotated[
+        str | None,
+        typer.Option("--visibility", help="'shared' or 'private'."),
+    ] = None,
+    target_amount: Annotated[
+        str | None,
+        typer.Option("--target-amount", help="New goal amount."),
+    ] = None,
+    target_date: Annotated[
+        str | None,
+        typer.Option("--target-date", help="New ISO date (YYYY-MM-DD)."),
+    ] = None,
+    contribution_strategy: Annotated[
+        str | None,
+        typer.Option(
+            "--contribution-strategy",
+            help="One of: manual, even_split, percentage_of_income.",
+        ),
+    ] = None,
+    contribution_amount: Annotated[
+        str | None,
+        typer.Option(
+            "--contribution-amount",
+            help="New fixed contribution amount (only valid with manual).",
+        ),
+    ] = None,
+) -> None:
+    """Update mutable fields on a sinking fund."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    body: dict[str, Any] = {}
+    if name is not None:
+        body["name"] = name
+    if visibility is not None:
+        body["visibility"] = visibility
+    if target_amount is not None:
+        body["target_amount"] = target_amount
+    if target_date is not None:
+        body["target_date"] = target_date
+    if contribution_strategy is not None:
+        body["contribution_strategy"] = contribution_strategy
+    if contribution_amount is not None:
+        body["contribution_amount"] = contribution_amount
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            target = _resolve_sinking_fund(client, identifier)
+            response = client.patch(
+                f"/v1/sinking-funds/{target['id']}",
+                json=body,
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    payload = response.json()
+    typer.echo(f"Updated sinking fund {payload.get('id', '')}")
+    _render_sinking_fund(payload)
+
+
+@sinking_funds_app.command("deactivate")
+def deactivate_sinking_fund(
+    ctx: typer.Context,
+    identifier: Annotated[
+        str,
+        typer.Argument(help="Sinking-fund name or UUID.", metavar="SINKING_FUND"),
+    ],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip the interactive confirmation prompt.",
+        ),
+    ] = False,
+) -> None:
+    """Soft-delete (deactivate) a sinking fund. Admin-only on the API side."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            target = _resolve_sinking_fund(client, identifier)
+            if not yes:
+                label = target.get("name") or str(target["id"])
+                if not typer.confirm(
+                    f"Deactivate sinking fund {label}? It will disappear from "
+                    "`tulip sinking-funds list`.",
+                    default=False,
+                ):
+                    typer.echo("Aborted; no changes made.")
+                    return
+            client.delete(f"/v1/sinking-funds/{target['id']}", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(json.dumps({"deactivated": str(target["id"])}) + "\n")
+        return
+    typer.echo(f"Deactivated sinking fund {target.get('name') or target['id']}.")

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -17,7 +17,18 @@ from tulip_cli import __version__
 from tulip_cli.commands.accounts import accounts_app
 from tulip_cli.commands.auth import auth_app
 from tulip_cli.commands.balance import balance as balance_command
+from tulip_cli.commands.envelopes import envelopes_app
+from tulip_cli.commands.pool_actions import (
+    budget_inflow as budget_inflow_command,
+)
+from tulip_cli.commands.pool_actions import (
+    refill as refill_command,
+)
+from tulip_cli.commands.pool_actions import (
+    transfer as transfer_command,
+)
 from tulip_cli.commands.register import register as register_command
+from tulip_cli.commands.sinking_funds import sinking_funds_app
 from tulip_cli.commands.transactions import add as add_command
 from tulip_cli.commands.transactions import transactions_app
 from tulip_cli.config import Config, load_config
@@ -90,9 +101,14 @@ def ping(ctx: typer.Context) -> None:
 app.command("register")(register_command)
 app.command("balance")(balance_command)
 app.command("add")(add_command)
+app.command("refill")(refill_command)
+app.command("transfer")(transfer_command)
+app.command("budget-inflow")(budget_inflow_command)
 app.add_typer(auth_app, name="auth")
 app.add_typer(accounts_app, name="accounts")
 app.add_typer(transactions_app, name="transactions")
+app.add_typer(envelopes_app, name="envelopes")
+app.add_typer(sinking_funds_app, name="sinking-funds")
 
 
 if __name__ == "__main__":

--- a/packages/tulip-cli/tests/test_envelopes.py
+++ b/packages/tulip-cli/tests/test_envelopes.py
@@ -1,0 +1,314 @@
+"""End-to-end tests for ``tulip envelopes`` (P4.2).
+
+Each test spawns the API via ``live_api``, logs Alice in via the CLI, and
+exercises the envelope subcommand group as a subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=20,
+    )
+
+
+def _create_envelope(
+    api_url: str,
+    access_token: str,
+    *,
+    name: str,
+    currency: str = "USD",
+    budget_period: str = "monthly",
+    rollover_policy: str = "reset",
+    budget_amount: str | None = None,
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "name": name,
+        "currency": currency,
+        "budget_period": budget_period,
+        "rollover_policy": rollover_policy,
+    }
+    if budget_amount is not None:
+        body["budget_amount"] = budget_amount
+    r = httpx.post(
+        f"{api_url}/v1/envelopes",
+        json=body,
+        headers={"authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return dict(r.json())
+
+
+@pytest.fixture
+def authed_session(live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Register Alice and log her in via the CLI."""
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    result = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert result.returncode == 0, result.stderr
+    return live_api
+
+
+@pytest.fixture
+def access_token(authed_session: str) -> str:
+    """Return Alice's API access token (for direct API setup in tests)."""
+    r = httpx.post(
+        f"{authed_session}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return str(r.json()["access_token"])
+
+
+# ---- list ----------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_envelopes_list_when_empty(authed_session: str) -> None:
+    result = _run_cli("envelopes", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "No envelopes" in result.stdout
+
+
+@pytest.mark.integration
+def test_envelopes_list_renders_table(authed_session: str, access_token: str) -> None:
+    _create_envelope(authed_session, access_token, name="Groceries")
+    _create_envelope(authed_session, access_token, name="Rent", budget_amount="2500.00")
+    result = _run_cli("envelopes", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "Groceries" in result.stdout
+    assert "Rent" in result.stdout
+    assert "2500.00" in result.stdout
+
+
+@pytest.mark.integration
+def test_envelopes_list_json(authed_session: str, access_token: str) -> None:
+    _create_envelope(authed_session, access_token, name="Groceries")
+    result = _run_cli("--json", "envelopes", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["name"] == "Groceries"
+
+
+# ---- add -----------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_envelopes_add_minimal(authed_session: str) -> None:
+    result = _run_cli(
+        "envelopes",
+        "add",
+        "--name",
+        "Groceries",
+        "--currency",
+        "USD",
+        "--budget-period",
+        "monthly",
+        "--rollover-policy",
+        "reset",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Created envelope" in result.stdout
+    assert "Groceries" in result.stdout
+
+
+@pytest.mark.integration
+def test_envelopes_add_with_budget_amount(authed_session: str) -> None:
+    result = _run_cli(
+        "envelopes",
+        "add",
+        "--name",
+        "Rent",
+        "--currency",
+        "USD",
+        "--budget-period",
+        "monthly",
+        "--rollover-policy",
+        "accumulate",
+        "--budget-amount",
+        "2500.00",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "2500.00" in result.stdout
+
+
+@pytest.mark.integration
+def test_envelopes_add_invalid_period_yields_user_error(authed_session: str) -> None:
+    result = _run_cli(
+        "envelopes",
+        "add",
+        "--name",
+        "Bad",
+        "--currency",
+        "USD",
+        "--budget-period",
+        "weirdly",
+        "--rollover-policy",
+        "reset",
+        api_url=authed_session,
+    )
+    # Schema rejection from the API.
+    assert result.returncode == 1, result.stderr
+
+
+# ---- show ----------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_envelopes_show_by_uuid(authed_session: str, access_token: str) -> None:
+    created = _create_envelope(authed_session, access_token, name="Groceries")
+    result = _run_cli("envelopes", "show", str(created["id"]), api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "Groceries" in result.stdout
+    assert "balance" in result.stdout
+
+
+@pytest.mark.integration
+def test_envelopes_show_by_name(authed_session: str, access_token: str) -> None:
+    _create_envelope(authed_session, access_token, name="Groceries")
+    result = _run_cli("envelopes", "show", "Groceries", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "Groceries" in result.stdout
+
+
+@pytest.mark.integration
+def test_envelopes_show_unknown_yields_user_error(authed_session: str) -> None:
+    result = _run_cli("envelopes", "show", "no-such-name", api_url=authed_session)
+    assert result.returncode == 1
+    assert "not found" in (result.stdout + result.stderr).lower()
+
+
+@pytest.mark.integration
+def test_envelopes_show_ambiguous_name_yields_user_error(
+    authed_session: str, access_token: str
+) -> None:
+    _create_envelope(authed_session, access_token, name="Duplicated")
+    _create_envelope(authed_session, access_token, name="Duplicated")
+    result = _run_cli("envelopes", "show", "Duplicated", api_url=authed_session)
+    assert result.returncode == 1
+    # Both the title and the detail mention the ambiguity. The CLI
+    # renderer uses "matches multiple" in the title; check for either
+    # word so a future copy edit doesn't break the test pointlessly.
+    haystack = (result.stdout + result.stderr).lower()
+    assert "matches multiple" in haystack or "ambiguous" in haystack
+
+
+# ---- edit ----------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_envelopes_edit_partial_fields(authed_session: str, access_token: str) -> None:
+    created = _create_envelope(authed_session, access_token, name="Groceries")
+    result = _run_cli(
+        "envelopes",
+        "edit",
+        str(created["id"]),
+        "--budget-amount",
+        "300.00",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Updated envelope" in result.stdout
+    assert "300.00" in result.stdout
+
+
+@pytest.mark.integration
+def test_envelopes_edit_unknown_yields_user_error(authed_session: str) -> None:
+    result = _run_cli(
+        "envelopes",
+        "edit",
+        "no-such-name",
+        "--name",
+        "X",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1
+
+
+# ---- deactivate ----------------------------------------------------
+
+
+@pytest.mark.integration
+def test_envelopes_deactivate_with_yes_flag(authed_session: str, access_token: str) -> None:
+    created = _create_envelope(authed_session, access_token, name="Groceries")
+    result = _run_cli(
+        "envelopes",
+        "deactivate",
+        str(created["id"]),
+        "--yes",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Deactivated envelope" in result.stdout
+
+    # No longer appears in list.
+    list_result = _run_cli("envelopes", "list", api_url=authed_session)
+    assert "No envelopes" in list_result.stdout
+
+
+@pytest.mark.integration
+def test_envelopes_deactivate_aborted_via_prompt(authed_session: str, access_token: str) -> None:
+    created = _create_envelope(authed_session, access_token, name="Groceries")
+    # Send "n\n" to the confirm prompt.
+    result = _run_cli(
+        "envelopes",
+        "deactivate",
+        str(created["id"]),
+        api_url=authed_session,
+        stdin="n\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Aborted" in result.stdout
+
+
+# ---- unauthenticated -----------------------------------------------
+
+
+@pytest.mark.integration
+def test_envelopes_list_unauthenticated_yields_auth_error(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli("envelopes", "list", api_url=live_api)
+    assert result.returncode == 2  # EXIT_AUTH

--- a/packages/tulip-cli/tests/test_pool_actions.py
+++ b/packages/tulip-cli/tests/test_pool_actions.py
@@ -1,0 +1,353 @@
+"""End-to-end tests for ``tulip refill``, ``tulip transfer``, ``tulip budget-inflow`` (P4.2)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=20,
+    )
+
+
+@pytest.fixture
+def authed_session(live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    result = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert result.returncode == 0, result.stderr
+    return live_api
+
+
+@pytest.fixture
+def access_token(authed_session: str) -> str:
+    r = httpx.post(
+        f"{authed_session}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return str(r.json()["access_token"])
+
+
+def _create_envelope(
+    api_url: str,
+    token: str,
+    name: str,
+    currency: str = "USD",
+) -> dict[str, object]:
+    r = httpx.post(
+        f"{api_url}/v1/envelopes",
+        json={
+            "name": name,
+            "currency": currency,
+            "budget_period": "monthly",
+            "rollover_policy": "reset",
+        },
+        headers={"authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return dict(r.json())
+
+
+# ---- budget-inflow ----------------------------------------------------
+
+
+@pytest.mark.integration
+def test_budget_inflow_succeeds(authed_session: str) -> None:
+    result = _run_cli(
+        "budget-inflow",
+        "--amount",
+        "1000",
+        "--currency",
+        "USD",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Salary",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Declared inflow of 1000" in result.stdout
+    assert "1000.00" in result.stdout  # quantized response balance
+
+
+@pytest.mark.integration
+def test_budget_inflow_lazy_creates_eur_pools(authed_session: str) -> None:
+    result = _run_cli(
+        "budget-inflow",
+        "--amount",
+        "500",
+        "--currency",
+        "EUR",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "EUR salary",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "EUR" in result.stdout
+
+
+@pytest.mark.integration
+def test_budget_inflow_unknown_currency_yields_user_error(authed_session: str) -> None:
+    result = _run_cli(
+        "budget-inflow",
+        "--amount",
+        "100",
+        "--currency",
+        "ZZZ",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Bad",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1
+    assert (
+        "ZZZ" in (result.stdout + result.stderr)
+        or "currency" in (result.stdout + result.stderr).lower()
+    )
+
+
+@pytest.mark.integration
+def test_budget_inflow_json(authed_session: str) -> None:
+    result = _run_cli(
+        "--json",
+        "budget-inflow",
+        "--amount",
+        "500",
+        "--currency",
+        "USD",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Salary",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["currency"] == "USD"
+
+
+# ---- refill -----------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_refill_succeeds(authed_session: str, access_token: str) -> None:
+    # Seed with an inflow so Unallocated has positive balance
+    # (refill works either way, but exercises the more realistic flow).
+    _run_cli(
+        "budget-inflow",
+        "--amount",
+        "500",
+        "--currency",
+        "USD",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Salary",
+        api_url=authed_session,
+    )
+    _create_envelope(authed_session, access_token, "Groceries")
+    result = _run_cli(
+        "refill",
+        "Groceries",
+        "--amount",
+        "250.00",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Monthly grocery refill",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Refilled Groceries by 250.00" in result.stdout
+    assert "new balance: 250.00" in result.stdout
+
+
+@pytest.mark.integration
+def test_refill_unknown_envelope_yields_user_error(authed_session: str) -> None:
+    result = _run_cli(
+        "refill",
+        "no-such-envelope",
+        "--amount",
+        "100",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "X",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1
+    assert "not found" in (result.stdout + result.stderr).lower()
+
+
+# ---- transfer ---------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_transfer_succeeds(authed_session: str, access_token: str) -> None:
+    _create_envelope(authed_session, access_token, "Groceries")
+    _create_envelope(authed_session, access_token, "Entertainment")
+    # Refill source first.
+    _run_cli(
+        "budget-inflow",
+        "--amount",
+        "500",
+        "--currency",
+        "USD",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Salary",
+        api_url=authed_session,
+    )
+    _run_cli(
+        "refill",
+        "Groceries",
+        "--amount",
+        "300",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Refill",
+        api_url=authed_session,
+    )
+    result = _run_cli(
+        "transfer",
+        "--from",
+        "Groceries",
+        "--to",
+        "Entertainment",
+        "--amount",
+        "100",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Move to entertainment",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Transferred 100" in result.stdout
+    assert "new destination balance: 100.00" in result.stdout
+
+
+@pytest.mark.integration
+def test_transfer_currency_mismatch_yields_user_error(
+    authed_session: str, access_token: str
+) -> None:
+    _create_envelope(authed_session, access_token, "USD env", currency="USD")
+    _create_envelope(authed_session, access_token, "EUR env", currency="EUR")
+    result = _run_cli(
+        "transfer",
+        "--from",
+        "USD env",
+        "--to",
+        "EUR env",
+        "--amount",
+        "10",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Cross-ccy",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1
+    assert "currenc" in (result.stdout + result.stderr).lower()
+
+
+@pytest.mark.integration
+def test_transfer_same_pool_yields_user_error(authed_session: str, access_token: str) -> None:
+    _create_envelope(authed_session, access_token, "Groceries")
+    result = _run_cli(
+        "transfer",
+        "--from",
+        "Groceries",
+        "--to",
+        "Groceries",
+        "--amount",
+        "10",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Self",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1
+    haystack = (result.stdout + result.stderr).lower()
+    assert "same" in haystack or "differ" in haystack
+
+
+@pytest.mark.integration
+def test_transfer_unknown_pool_yields_user_error(authed_session: str) -> None:
+    result = _run_cli(
+        "transfer",
+        "--from",
+        "no-such-source",
+        "--to",
+        "no-such-dest",
+        "--amount",
+        "10",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "Bad",
+        api_url=authed_session,
+    )
+    assert result.returncode == 1
+
+
+@pytest.mark.integration
+def test_refill_unauthenticated_yields_auth_error(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli(
+        "refill",
+        "anything",
+        "--amount",
+        "10",
+        "--date",
+        date.today().isoformat(),
+        "--description",
+        "X",
+        api_url=live_api,
+    )
+    assert result.returncode == 2

--- a/packages/tulip-cli/tests/test_sinking_funds.py
+++ b/packages/tulip-cli/tests/test_sinking_funds.py
@@ -1,0 +1,195 @@
+"""End-to-end tests for ``tulip sinking-funds`` (P4.2).
+
+Mirrors test_envelopes.py with the goal-bounded field set.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=20,
+    )
+
+
+def _future_date() -> str:
+    return date(date.today().year + 1, 1, 1).isoformat()
+
+
+def _create_sinking_fund(
+    api_url: str,
+    access_token: str,
+    *,
+    name: str,
+    currency: str = "USD",
+    target_amount: str = "3000.00",
+    contribution_strategy: str = "manual",
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "name": name,
+        "currency": currency,
+        "target_amount": target_amount,
+        "target_date": _future_date(),
+        "contribution_strategy": contribution_strategy,
+    }
+    r = httpx.post(
+        f"{api_url}/v1/sinking-funds",
+        json=body,
+        headers={"authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return dict(r.json())
+
+
+@pytest.fixture
+def authed_session(live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    result = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert result.returncode == 0, result.stderr
+    return live_api
+
+
+@pytest.fixture
+def access_token(authed_session: str) -> str:
+    r = httpx.post(
+        f"{authed_session}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return str(r.json()["access_token"])
+
+
+@pytest.mark.integration
+def test_sinking_funds_list_when_empty(authed_session: str) -> None:
+    result = _run_cli("sinking-funds", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "No sinking funds" in result.stdout
+
+
+@pytest.mark.integration
+def test_sinking_funds_add_minimal(authed_session: str) -> None:
+    result = _run_cli(
+        "sinking-funds",
+        "add",
+        "--name",
+        "Vacation",
+        "--currency",
+        "USD",
+        "--target-amount",
+        "3000.00",
+        "--target-date",
+        _future_date(),
+        "--contribution-strategy",
+        "manual",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Created sinking fund" in result.stdout
+    assert "Vacation" in result.stdout
+
+
+@pytest.mark.integration
+def test_sinking_funds_show_by_name(authed_session: str, access_token: str) -> None:
+    _create_sinking_fund(authed_session, access_token, name="Vacation")
+    result = _run_cli("sinking-funds", "show", "Vacation", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "Vacation" in result.stdout
+    assert "balance" in result.stdout
+
+
+@pytest.mark.integration
+def test_sinking_funds_list_json(authed_session: str, access_token: str) -> None:
+    _create_sinking_fund(authed_session, access_token, name="Vacation")
+    result = _run_cli("--json", "sinking-funds", "list", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list)
+    assert payload[0]["name"] == "Vacation"
+
+
+@pytest.mark.integration
+def test_sinking_funds_edit_partial(authed_session: str, access_token: str) -> None:
+    created = _create_sinking_fund(authed_session, access_token, name="Vacation")
+    new_target = date(date.today().year + 2, 6, 1).isoformat()
+    result = _run_cli(
+        "sinking-funds",
+        "edit",
+        str(created["id"]),
+        "--target-amount",
+        "5000",
+        "--target-date",
+        new_target,
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Updated sinking fund" in result.stdout
+
+
+@pytest.mark.integration
+def test_sinking_funds_deactivate(authed_session: str, access_token: str) -> None:
+    created = _create_sinking_fund(authed_session, access_token, name="Vacation")
+    result = _run_cli(
+        "sinking-funds",
+        "deactivate",
+        str(created["id"]),
+        "--yes",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Deactivated sinking fund" in result.stdout
+
+
+@pytest.mark.integration
+def test_sinking_funds_show_unknown_yields_user_error(
+    authed_session: str,
+) -> None:
+    result = _run_cli("sinking-funds", "show", "no-such-name", api_url=authed_session)
+    assert result.returncode == 1
+    assert "not found" in (result.stdout + result.stderr).lower()
+
+
+@pytest.mark.integration
+def test_sinking_funds_unauthenticated_yields_auth_error(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    result = _run_cli("sinking-funds", "list", api_url=live_api)
+    assert result.returncode == 2


### PR DESCRIPTION
Closes #66. Third slice of Phase 4. Surfaces P4.1.b's API endpoints through the \`tulip\` CLI. Mirrors the patterns from \`tulip accounts\` (CRUD subgroups) and \`tulip add\` (top-level action commands). Planning followed the parallel-Explore + Plan-agent pattern from \`feedback_subagent_usage.md\`.

## Summary

**New CLI surfaces:**

- \`tulip envelopes {list, show, add, edit, deactivate}\` — CRUD over \`/v1/envelopes\`. Resolver falls back to **name** (envelopes have no code field), raising \`envelope.ambiguous_name\` on duplicates rather than silent first-match.
- \`tulip sinking-funds {list, show, add, edit, deactivate}\` — mirror of envelopes minus refill. Field set: \`--target-amount\`, \`--target-date\`, \`--contribution-strategy\`, \`--contribution-amount\`. Currency immutable.
- \`tulip refill ENVELOPE\` — POSTs to \`/v1/envelopes/{id}/refill\`. Prints "Refilled X by AMT; new balance: BAL".
- \`tulip transfer --from POOL --to POOL\` — POSTs to \`/v1/pools/{src}/transfer\`. The pool resolver searches both envelope and sinking-fund lists; cross-type name collisions raise \`pool.ambiguous_name\`.
- \`tulip budget-inflow\` — POSTs to \`/v1/pools/budget-inflow\`. Lazy-creates system pools for new currencies.

**Helper module** \`commands/_pools.py\` houses the three resolvers (\`_resolve_envelope\`, \`_resolve_sinking_fund\`, \`_resolve_pool\`) and the typed Problem Details builders (\`*.not_found\`, \`*.ambiguous_name\`). Lives in its own module so the top-level \`transfer\` command can import without a circular reference back to the envelopes / sinking_funds modules.

**Output formats:**
- **List**: Rich tables, no per-row balance fetch (avoids N+1). Empty-state copy: \`"No envelopes. Run \`tulip envelopes add\` to create one."\`
- **Show**: header rendered as key:value pairs, plus a separate \`balance:\` line. Balance fetch failure renders gracefully (mirrors how \`accounts show\` handles parent-fetch failures).
- **Action commands**: \`"Refilled <name> by <amount>; new balance: <bal>"\` etc. \`--json\` passes through the raw API response.

**Refill-rule editing** intentionally not exposed in P4.2; the structured-only constraint from ADR-0001 calls for an \`\$EDITOR\` flow that lands as a follow-up (mirroring \`tulip add --edit\`).

**34 new E2E tests** (15 envelope, 8 sinking-fund, 11 pool-action). Project total: **702 passing** (up from 668). Lint + mypy --strict clean.

## Decisions resolved during planning

1. **Subgroups + top-level actions**: \`envelopes\` / \`sinking-funds\` are CRUD-shaped resources (subgroups); \`refill\` / \`transfer\` / \`budget-inflow\` are verbs (top-level).
2. **\`tulip budget-inflow\` not \`tulip inflow\`** — mirrors the API verb for discoverability over a single typed character of ergonomics.
3. **No CLI-side preflight** for transfer same-pool / currency-mismatch — let the API reject. One source of truth.
4. **Drop trailing currency** in action-command output ("new balance: 250.00", not "250.00 USD" — the envelope already implies the currency).
5. **Drop visibility column** from list table (almost always \`shared\`; keeps the table narrow).
6. **Graceful balance-fetch failure** in \`show\` — render the envelope without balance rather than failing the whole command.
7. **One PR** — mechanical mirror work; splitting would create review burden.

## Subagent retrospective

Used one Explore agent + one Plan agent at slice start. The Explore digest distinguished load-bearing concerns (resolver patterns, JSON passthrough semantics, \`_run_cli\` test fixture) from the mechanical mirror work, which let the Plan agent zero in on the four real decisions (path placement, ambiguity error shapes, output wording, refill-rule editing deferral). Caught one subtle gotcha — duplicate option-name registration via \`typer.Option(\"--from\", \"from_\", ...)\` — only because the Plan agent's "open question 5" prompted me to actually exercise \`tulip transfer --help\` before writing tests.

## Test plan

- [x] Full pytest run: 702 passing (up from 668)
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy packages/\` — clean (116 source files)
- [x] \`tulip envelopes\` group: list/show/add/edit/deactivate happy paths + \`--json\` + ambiguous-name + unknown-name + unauthenticated (15 tests)
- [x] \`tulip sinking-funds\` group: minimal smoke + add/show/edit/deactivate + \`--json\` + unknown-name + unauthenticated (8 tests)
- [x] \`tulip refill\` / \`transfer\` / \`budget-inflow\`: happy paths + JSON + lazy EUR pool creation + every error code (currency mismatch, same-pool, unknown-pool, unknown-currency, unauthenticated) (11 tests)
- [x] Architecture test (CLI must not import \`tulip_api\`/\`tulip_storage\`/etc.) still passes — new modules go through the network only

🤖 Generated with [Claude Code](https://claude.com/claude-code)