### PR TITLE
P4.3.a — Scheduler runner primitive + ADR-0002 (closes #7)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-02 · `main` @ P4.0 + P4.1.a + P4.1.b + P4.2
+**Last updated:** 2026-05-02 · `main` @ P4.0 + P4.1.a + P4.1.b + P4.2 + P4.3.a
 
 ---
 
@@ -15,9 +15,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 3 (CLI):** ✅ complete — P3.1 through P3.4 + P3.6 shipped; P3.5 (toner-friendly print stylesheet) deferred to Phase 8 alongside the actual reports (#22)
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
 - **Pre-Phase-4 docs:** threat-model checkpoint shipped (#56, [docs/THREAT_MODEL.md](THREAT_MODEL.md)). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
-- **Phase 4 (envelopes + sinking funds):** in flight — P4.0 (storage + domain layer per [ADR-0001](adrs/0001-envelope-shadow-ledger.md)) shipped 2026-05-02 (#60); P4.1 split a/b — P4.1.a (writer chokepoint) shipped 2026-05-02 (#62); P4.1.b (envelope/sinking-fund/refill/transfer/budget-inflow endpoints) shipped 2026-05-02 (#63); P4.2 (CLI commands) shipped 2026-05-02 (#66); P4.3 (refill rules execution + scheduled-tx runner) queued.
+- **Phase 4 (envelopes + sinking funds):** in flight — P4.0 (#60), P4.1.a (#62), P4.1.b (#63), P4.2 (#66) shipped 2026-05-02. P4.3 split a/b/c — P4.3.a (scheduler runner primitive per [ADR-0002](adrs/0002-scheduler-primitive.md), closes #7) shipped 2026-05-02 (#68); P4.3.b (refill engine + handler, #69), P4.3.c (API + CLI for refill schedules, #70) queued.
 
-**Tests:** 702 passing · **CI:** green on `main`
+**Tests:** 713 passing · **CI:** green on `main`
 
 ---
 
@@ -340,9 +340,22 @@ Closes #66. Surfaces P4.1.b's API endpoints through the `tulip` CLI. Mirrors the
 - **Refill-rule editing** intentionally not in P4.2; the structured-only constraint from ADR-0001 needs an editor flow that lands as a follow-up.
 - **Tests**: 34 new E2E (15 envelope, 8 sinking-fund, 11 pool-action). Project total: **702 passing** (up from 668).
 
+### P4.3.a — Scheduler runner primitive + ADR-0002 — ✅ *(2026-05-02)*
+
+Closes #68 + #7. Implements the in-process scheduler that the rest of P4.3 (refill rules execution) sits on top of. Per [ADR-0002](adrs/0002-scheduler-primitive.md).
+
+- **ADR-0002**: records 8 design decisions — simple async loop in FastAPI lifespan (rejected apscheduler / rq / celery / cron); 4-method runner surface (`register_handler`, `schedule_one`, `schedule_recurring`, `cancel`) with idempotency keys from day one; two tables (`scheduled_jobs` + `scheduled_job_runs`, distinct from `audit_log`); single generic `scheduled_jobs` reconciles the architecture's `scheduled_transactions` sketch with #7's proposal; RRULE via `python-dateutil`; `Clock` injection (no `freezegun`); 1m / 5m / 30m retry then dead-letter; **single-worker assumption** documented loudly for v1.
+- **Schema**: new migration `b8a91c2f3d44` adding `scheduled_jobs` + `scheduled_job_runs`. `scheduled_jobs` has `dtstart` (RRULE anchor — needed so COUNT/UNTIL stays stable as `next_run_at` advances) + `next_run_at` (indexed) + `idempotency_key` (unique partial index per `(household_id, kind)`).
+- **Code** (new `tulip_storage/runner/` module): `Runner` class with the 4-method surface + the async poll loop; `Clock` type alias + default; `compute_next_fire` wrapper around `dateutil.rrule.rrulestr`. ~250 LOC core.
+- **FastAPI lifespan hook** in `create_app(enable_runner=True)` boots the runner on startup, drains it on shutdown. Tests pass `enable_runner=False` to skip the runner (their overridden `get_session` doesn't reach the runner's session factory).
+- **Architecture test** (`test_architecture_no_direct_scheduled_job_writes`): only `tulip_storage.runner.runner` may import the storage-layer `ScheduledJob` model. Mirrors P4.0's shadow-table guard.
+- **Tests**: 11 new in `tulip-storage` (TDD entry — schedule_one/run, schedule_recurring + advance, idempotency happy + cross-kind, cancel happy + unknown, retry + dead-letter, no-handler, RRULE-with-COUNT exhaustion, full async start/stop lifecycle). Project total: **713 passing** (up from 702).
+- **New deps**: `python-dateutil>=2.9` + `types-python-dateutil>=2.9` (added to `tulip-storage`).
+
 ### Phase 4 deferred to later slices
 
-- **P4.3 — Refill rules execution** + scheduled-tx runner.
+- **P4.3.b — Refill engine + handler** (#69): pure `evaluate_refill_rule` + `envelope_refill` runner consumer.
+- **P4.3.c — API + CLI for refill schedules** (#70).
 - **P4 follow-up — `--edit` flow for `tulip envelopes add` / `edit`** so users can author RefillRule structures interactively.
 
 ---

--- a/docs/adrs/0002-scheduler-primitive.md
+++ b/docs/adrs/0002-scheduler-primitive.md
@@ -1,0 +1,282 @@
+# ADR 0002 — In-process scheduler primitive (`scheduled_jobs`)
+
+**Status:** Accepted (2026-05-02) — adopted on P4.3.a merge.
+**Phase:** 4 (P4.3.a — runner primitive).
+**Supersedes:** None.
+
+---
+
+## Context
+
+[ARCHITECTURE.md §5.7](../ARCHITECTURE.md) and [issue #7](https://github.com/rmwarriner/tulip-accounting/issues/7) commit Tulip to a server-side scheduler. P4.3 (envelope refill execution) is the first consumer; future consumers will include reconciliation reminders (Phase 5), AI cost roll-ups (Phase 6), and report-pack generation (Phase 7).
+
+The architecture pre-commits to an **in-process** runner for v1 — single-household-on-a-Pi is the deployment target, and a separate worker process or external broker (Redis, RabbitMQ) is unjustified at that scale. Phase 9 will revisit when multi-tenant cloud requires worker-process separation.
+
+What §5.7 leaves open, and what this ADR settles:
+
+1. Which scheduler library — `apscheduler`, `rq`, `taskiq`, custom, or none?
+2. The public surface of the runner (handlers, scheduling, cancellation).
+3. The data model — one table or two? How does it relate to the `scheduled_transactions` schema sketch in §4.1?
+4. Cadence representation — RRULE, cron expression, custom DSL?
+5. How tests inject deterministic time.
+6. Failure handling — retry policy, dead-letter behavior.
+7. Concurrency — what does v1 assume about uvicorn worker count?
+
+ADR-0001 set the precedent of resolving these design questions explicitly before code lands. P4.3.a follows the same discipline.
+
+## Decision
+
+### 1. Runner architecture: simple async loop in a FastAPI lifespan task
+
+A `Runner` class spawned via `asyncio.create_task` in the FastAPI app's `lifespan` context. The loop polls `scheduled_jobs` for rows where `next_run_at <= clock()` and `is_active = true`, dispatches each to its registered handler, records the run in `scheduled_job_runs`, and re-schedules recurring jobs. ~80 LOC for the core loop.
+
+Rejected alternatives:
+
+- **`apscheduler`** — adds a 60+ KB code surface, ships threaded and asyncio modes that interact awkwardly with SQLAlchemy session lifecycles, and brings its own jobstore abstraction (which we'd then have to bridge to our DB anyway).
+- **`rq` / `taskiq` / `dramatiq`** — broker-backed; require Redis or similar, which violates v1's single-process target.
+- **`celery`** — heaviest of the bunch, and a notoriously sharp configuration edge.
+- **Pure cron (system-level)** — invisible to in-process observability, can't share the application's DB session, and complicates the deployment story.
+
+The simple async loop is small enough that maintaining it ourselves is cheaper than learning a library's quirks.
+
+### 2. Public surface
+
+The runner exposes four methods. Handlers are async; the runner construction is sync:
+
+```python
+def register_handler(
+    kind: str,
+    callback: Callable[[ScheduledJob, Clock], Awaitable[None]],
+) -> None: ...
+
+def schedule_one(
+    kind: str,
+    payload: dict,
+    fire_at: datetime,
+    *,
+    idempotency_key: str | None = None,
+) -> UUID: ...  # returns scheduled_job.id
+
+def schedule_recurring(
+    kind: str,
+    payload: dict,
+    rrule: str,
+    *,
+    start_at: datetime | None = None,
+    idempotency_key: str | None = None,
+) -> UUID: ...
+
+def cancel(job_id: UUID) -> None: ...  # flips is_active=False; no run rows touched
+```
+
+`idempotency_key` is included from day one — preventing the "envelope created twice creates two refill schedules" footgun is essentially free at table-create time (unique partial index per household). `register_handler` is sync because handler registration happens at import time, not in the event loop.
+
+There is deliberately no `list_jobs` method on the runner — that's a query, not a runner concern, and it lives on `ScheduledJobRepository`.
+
+### 3. Two-table data model
+
+- **`scheduled_jobs`** — the schedule itself. User-meaningful state: `kind`, `payload`, `rrule`, `next_run_at`, `last_run_at`, `is_active`, `idempotency_key`.
+- **`scheduled_job_runs`** — per-fire operational state: `scheduled_job_id`, `started_at`, `completed_at`, `status` (`success` | `failed` | `dead_letter`), `retry_count`, `last_error`.
+
+Both are distinct from `audit_log`. Audit answers "what changed to user-visible state" — one row per materialized shadow tx. Run records answer "did the runner fire, did it fail, retry count, last error" — operational state irrelevant to the user but essential for the operator. Folding them would conflate two readers and force `audit_log` to grow a `retry_count` column.
+
+### 4. Single generic `scheduled_jobs` (reconciles §4.1's `scheduled_transactions` sketch)
+
+ARCHITECTURE.md §4.1 sketches a domain-specific `scheduled_transactions` table; issue #7 sketches a generic `scheduled_jobs`. These are **not** the same thing, and we must reconcile.
+
+**Decision**: `scheduled_jobs` is the literal table. "Schedule a transaction" becomes `kind="materialize_transaction"` with `payload={template, household_id}`. P4.3.b's first consumer is `kind="envelope_refill"` with `payload={"envelope_id": ...}`. The §4.1 sketch becomes a documentation artifact — the literal table that ships is the generic one.
+
+This avoids parallel scheduling infrastructure and keeps the "one runner, many handlers" abstraction clean.
+
+### 5. RRULE via `python-dateutil`
+
+`scheduled_jobs.rrule` stores an RFC 5545 RRULE string (e.g., `"FREQ=MONTHLY;BYMONTHDAY=1"`). `python-dateutil`'s `rrulestr` parses it; `rrule.after(dtstart=last_run_at)` computes the next fire. After each successful run, the runner writes `next_run_at = rrule.after(now)` and updates the row. Rolling our own cadence DSL is the wrong build/buy call.
+
+`python-dateutil` is added to the root `pyproject.toml`. It's not currently a transitive dep of SQLAlchemy or pydantic v2 in this project.
+
+### 6. Clock injection
+
+`Clock = Callable[[], datetime]`, threaded through the `Runner` constructor (default `lambda: datetime.now(UTC)`) and into every handler invocation as the second positional argument.
+
+This is the only project-wide time-injection seam in v1. The refill-rule evaluation engine (P4.3.b) is pure and takes no clock — it accepts `current_balance: Money` and `recent_inflow: Money | None` as inputs, computed by the handler from a query at fire time.
+
+`freezegun` is **not** added. Tests that need to exercise the runner pass a fake `Clock` whose return value the test advances explicitly. Tests that don't exercise the runner don't need time injection.
+
+### 7. Retry policy
+
+On handler exception, the runner records a `scheduled_job_runs` row with `status="failed"` and `retry_count=N`, then schedules a retry at `now + backoff[N]` where `backoff = [60s, 300s, 1800s]`. After the third failure, the runner writes a row with `status="dead_letter"`, marks the parent `scheduled_jobs.is_active=false`, and stops attempting. Manual reactivation (CLI / admin endpoint) is required to resume.
+
+The user is notified of dead-lettering only via the operational log in v1 — in-app notifications are out of scope for Phase 4.
+
+### 8. Concurrency: single-worker assumption
+
+The poll loop does not lock rows. Running `uvicorn` with `--workers > 1` would race two pollers against the same `next_run_at <= now` query and double-fire jobs. v1 assumes single-worker deployment.
+
+**This is a known limitation, documented prominently.** Multi-worker safety lands in Phase 9 via either:
+- `SELECT … FOR UPDATE SKIP LOCKED` (PostgreSQL native; SQLite has no equivalent).
+- A leader-election layer (e.g., advisory locks or an external coordination service).
+
+The v1 deployment story (Docker compose, single uvicorn worker, single-household home server) does not encounter this constraint.
+
+## Consequences
+
+### Positive
+
+1. **Minimal new surface area.** The whole runner is ~150 LOC; handlers are pure functions of `(job, clock)`. Easy to audit, easy to test.
+2. **Single-loop, single-process** matches the deployment target and avoids any broker-style operational complexity.
+3. **Generic `scheduled_jobs` enables future consumers** without schema changes: Phase 5 reconciliation reminders, Phase 6 AI cost reports, Phase 7 weekly report packs all register a `kind` and reuse the same infra.
+4. **RRULE via dateutil** is stable, well-trodden, and compatible with calendar tools users already understand.
+5. **Clock injection** keeps tests deterministic without a global time-mocking dep.
+6. **Idempotency keys** prevent the most obvious schedule-duplication footgun.
+
+### Negative
+
+1. **Single-worker constraint** must be enforced operationally. If a deployer runs `uvicorn --workers 4`, the runner will misbehave silently. Documented in DEPLOYMENT.md (lands in Phase 8) and in the runner module's docstring.
+2. **Owning the loop** means we own its bugs. Unfair scheduling under heavy load, async-task cancellation edge cases, and SQLAlchemy session lifecycle around long-running handlers are all our responsibility.
+3. **Phase 9 worker-process extraction** will require a meaningful refactor. The runner module is colocated in `tulip-storage` for v1 (it's coupled to the SQLAlchemy session); extracting it means either pulling it into a new package or vendoring the SQLAlchemy bits into a worker.
+4. **No multi-tenant fairness in v1.** A household with thousands of scheduled jobs could starve another household's jobs in a future multi-tenant deployment. Addressed alongside the Phase 9 worker split.
+
+### Neutral
+
+1. **`python-dateutil` is a real new dep.** ~250 KB, zero-maintenance, gold standard for calendar arithmetic. Worth the cost.
+2. **The runner module is colocated in `tulip-storage`** because it's tightly coupled to the SQLAlchemy session via the repositories it calls. A standalone `tulip-runner` package would either need to import `tulip-storage` (defeating the separation) or duplicate the session machinery (worse). Revisit at Phase 9.
+3. **Handler responsibility for idempotency at the action level** — the runner guarantees at-most-once successful fire per `next_run_at` cycle, but the handler is responsible for not double-counting if the same job is replayed (e.g., after manual reactivation). For envelope refills (P4.3.b), the shadow tx's `idempotency` is already handled by the per-fire `started_at` boundary.
+
+## Alternatives considered (and why rejected)
+
+### apscheduler
+
+The most plausible alternative. Has good RRULE support, a sane API, and active maintenance. Rejected because:
+
+- 60+ KB code surface for what is fundamentally an in-process polling loop.
+- Threading and asyncio executor modes interact awkwardly with SQLAlchemy session scopes — handlers running in the threaded executor can't share the request-scoped session.
+- apscheduler's `SQLAlchemyJobStore` would persist *its* state model alongside ours, doubling the bookkeeping.
+
+The simple async loop is genuinely simpler at our scale.
+
+### `rq` / `taskiq` / `dramatiq`
+
+All require a broker (Redis or AMQP). Even the lightest broker is a deployment ask we don't want to make at single-household scale. Reconsidered when Phase 9 splits the runner into its own process.
+
+### Celery
+
+Strictly more configuration than `rq`, with a steeper learning curve. Same broker constraint.
+
+### System cron + a CLI handler
+
+Doable: cron triggers `tulip refills run-due` every N minutes. Rejected because:
+
+- Two coordination layers (cron + Tulip's own scheduling state) is a recipe for drift.
+- No in-process observability — the runner's internal state (next_run_at, dead-letter status) wouldn't be queryable from inside the API.
+- Deployment story complicates: every Tulip install needs a cron entry as well as the API process.
+
+### Pure event-loop scheduling (asyncio.call_at)
+
+Trivial for in-process scheduling but loses persistence. A restarted process forgets every scheduled job. The DB-backed design is non-negotiable for an accounting tool.
+
+## Implementation notes
+
+### Schema (P4.3.a migration sketch)
+
+```sql
+CREATE TABLE scheduled_jobs (
+  id                BLOB    NOT NULL,           -- UUID
+  household_id      BLOB    NOT NULL,
+  kind              TEXT    NOT NULL,
+  payload           TEXT    NOT NULL,           -- JSON
+  rrule             TEXT,                       -- nullable; schedule_one jobs have no rrule
+  next_run_at       TIMESTAMP NOT NULL,
+  last_run_at       TIMESTAMP,
+  idempotency_key   TEXT,                       -- nullable
+  is_active         BOOLEAN NOT NULL DEFAULT 1,
+  created_by_user_id BLOB,
+  created_at        TIMESTAMP NOT NULL,
+  updated_at        TIMESTAMP NOT NULL,
+  PRIMARY KEY (household_id, id),
+  FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
+);
+CREATE INDEX ix_scheduled_jobs_next_run ON scheduled_jobs(next_run_at)
+  WHERE is_active = 1;
+CREATE UNIQUE INDEX ix_scheduled_jobs_idempotency
+  ON scheduled_jobs(household_id, kind, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE TABLE scheduled_job_runs (
+  id                BLOB    NOT NULL,           -- UUID
+  household_id      BLOB    NOT NULL,
+  scheduled_job_id  BLOB    NOT NULL,
+  started_at        TIMESTAMP NOT NULL,
+  completed_at      TIMESTAMP,
+  status            TEXT    NOT NULL CHECK (status IN ('running', 'success', 'failed', 'dead_letter')),
+  retry_count       INTEGER NOT NULL DEFAULT 0,
+  last_error        TEXT,
+  PRIMARY KEY (household_id, id),
+  FOREIGN KEY (household_id, scheduled_job_id)
+    REFERENCES scheduled_jobs(household_id, id) ON DELETE CASCADE
+);
+CREATE INDEX ix_scheduled_job_runs_job
+  ON scheduled_job_runs(household_id, scheduled_job_id);
+```
+
+### Module layout (`tulip-storage`)
+
+```
+tulip_storage/runner/
+  __init__.py           — exports Runner, Clock, ScheduledJob (the model)
+  clock.py              — Clock type alias + default
+  rrule.py              — thin wrapper around dateutil.rrule.rrulestr
+  runner.py             — Runner class (the four-method surface + the loop)
+  handlers/             — first-party handlers (P4.3.b adds envelope_refill)
+```
+
+Repositories (`tulip_storage.repositories`):
+- `ScheduledJobRepository` — `create`, `get`, `due`, `cancel`, `update_next_run_at`.
+- `ScheduledJobRunRepository` — `record_start`, `record_completion`, `last_for_job`.
+
+### FastAPI lifespan integration
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from tulip_storage.runner import Runner
+
+def create_app() -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        runner = Runner(...)
+        app.state.runner = runner
+        await runner.start()
+        try:
+            yield
+        finally:
+            await runner.stop()
+    return FastAPI(..., lifespan=lifespan)
+```
+
+### Architecture test
+
+`tests/test_architecture_scheduled_job_writes.py` — AST scan rejects imports of `tulip_storage.models.ScheduledJob` outside `tulip_storage.runner.*` and the model module itself. Mirrors P4.0's `test_architecture_no_direct_shadow_writes.py`.
+
+## References
+
+- [ARCHITECTURE.md §5.7](../ARCHITECTURE.md) — scheduled-tx runner spec.
+- [ARCHITECTURE.md §4.1](../ARCHITECTURE.md) — `scheduled_transactions` schema sketch (reconciled here).
+- [ADR-0001](0001-envelope-shadow-ledger.md) — the shadow-ledger model that P4.3.b's first consumer materializes.
+- [docs/THREAT_MODEL.md §5.1](../THREAT_MODEL.md) — Phase 4 constraints (no eval; tenant scoping).
+- [Issue #7](https://github.com/rmwarriner/tulip-accounting/issues/7) — scheduler primitive ADR (closed by P4.3.a).
+- [Issue #68](https://github.com/rmwarriner/tulip-accounting/issues/68) — P4.3.a runner primitive (this ADR).
+- [Issue #69](https://github.com/rmwarriner/tulip-accounting/issues/69) — P4.3.b refill engine (first consumer).
+- [Issue #70](https://github.com/rmwarriner/tulip-accounting/issues/70) — P4.3.c API + CLI surface.
+
+## Decision log
+
+| Date | Decision | By |
+|---|---|---|
+| 2026-05-02 | Proposed: simple async loop over apscheduler / rq / celery / cron. | P4.3 planning |
+| 2026-05-02 | Decided: two tables (`scheduled_jobs` + `scheduled_job_runs`), distinct from `audit_log`. | P4.3 planning |
+| 2026-05-02 | Decided: `scheduled_jobs` is the literal generic table; §4.1's `scheduled_transactions` becomes a documentation artifact. | P4.3 planning |
+| 2026-05-02 | Decided: RRULE via `python-dateutil`; new dep accepted. | P4.3 planning |
+| 2026-05-02 | Decided: `Clock` injection; no `freezegun`. | P4.3 planning |
+| 2026-05-02 | Decided: 3 retries with 1m / 5m / 30m backoff, then `dead_letter` + recurring job paused. | P4.3 planning |
+| 2026-05-02 | Decided: single-worker assumption for v1. Multi-worker safety = Phase 9. | P4.3 planning |
+| 2026-05-02 | Accepted on P4.3.a merge (#68). Closes #7. | P4.3.a implementation |

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -3,12 +3,25 @@
 `create_app()` builds the app with all routers, middleware, and lifespan
 hooks attached. Tests construct fresh apps via this factory so each test
 runs against an isolated, predictable instance.
+
+The lifespan hook starts the scheduler runner (P4.3.a / ADR-0002) on
+app startup and stops it cleanly on shutdown. The runner picks up the
+session factory from the configured Settings, so tests that override
+``get_session`` should also call ``app.state.runner = None`` (or
+``disable_runner=True`` on construction) to avoid spinning up a real
+async loop alongside the in-process test session.
 """
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
+from fastapi import FastAPI
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from tulip_api.config import get_settings
 from tulip_api.errors import install_problem_handlers
 from tulip_api.logging_config import configure_logging
 from tulip_api.middleware import RequestIdMiddleware
@@ -23,14 +36,55 @@ from tulip_api.routers import (
     transactions,
     well_known_errors,
 )
+from tulip_storage.runner import Runner
 
 API_VERSION = "v1"
 API_TITLE = "Tulip Accounting API"
 
 
-def create_app() -> FastAPI:
-    """Build a fresh FastAPI app instance."""
+def _build_session_maker(database_url: str) -> sessionmaker[Session]:
+    """Mirror the deps.py factory but eager — the runner can't lazy-init."""
+    eng = create_engine(database_url, future=True)
+    if eng.dialect.name == "sqlite":
+
+        @event.listens_for(eng, "connect")
+        def _fk(dc: object, _r: object) -> None:
+            cur = dc.cursor()  # type: ignore[attr-defined]
+            cur.execute("PRAGMA foreign_keys=ON")
+            cur.close()
+
+    return sessionmaker(eng, expire_on_commit=False)
+
+
+def create_app(*, enable_runner: bool = True) -> FastAPI:
+    """Build a fresh FastAPI app instance.
+
+    Args:
+        enable_runner: When True (default), the FastAPI lifespan starts an
+            in-process scheduler runner per ADR-0002. Tests that override
+            ``get_session`` to point at an in-memory DB pass ``False`` to
+            skip the runner — its session factory wouldn't see the
+            test's overridden DB without extra plumbing.
+
+    """
     configure_logging()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        runner: Runner | None = None
+        if enable_runner:
+            settings = get_settings()
+            session_maker = _build_session_maker(settings.database_url)
+            runner = Runner(session_maker)
+            app.state.runner = runner
+            await runner.start()
+        else:
+            app.state.runner = None
+        try:
+            yield
+        finally:
+            if runner is not None:
+                await runner.stop()
 
     app = FastAPI(
         title=API_TITLE,
@@ -38,6 +92,7 @@ def create_app() -> FastAPI:
         description=(
             "Household-focused double-entry accounting API. See ARCHITECTURE.md for design notes."
         ),
+        lifespan=lifespan,
     )
 
     # Request-id stamping must run before any router-level logging so the

--- a/packages/tulip-api/tests/conftest.py
+++ b/packages/tulip-api/tests/conftest.py
@@ -71,7 +71,11 @@ def settings() -> Settings:
 
 @pytest.fixture
 def app(session_maker: sessionmaker[Session], settings: Settings) -> Iterator[FastAPI]:
-    a = create_app()
+    # Disable the scheduler runner per ADR-0002; tests run synchronously
+    # against TestClient and the runner's own session factory won't see
+    # the per-test overridden DB. Runner-specific tests opt back in via
+    # a separate fixture.
+    a = create_app(enable_runner=False)
 
     def _override_session() -> Iterator[Session]:
         with session_maker() as s:

--- a/packages/tulip-storage/pyproject.toml
+++ b/packages/tulip-storage/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     "sqlalchemy>=2.0",
     "alembic>=1.13",
     "cryptography>=42.0",
+    "python-dateutil>=2.9",
+    "types-python-dateutil>=2.9",
 ]
 
 [tool.uv.sources]

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260502_1600_b8a91c2f3d44_add_scheduled_jobs.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260502_1600_b8a91c2f3d44_add_scheduled_jobs.py
@@ -1,0 +1,141 @@
+"""Add scheduled_jobs and scheduled_job_runs tables (P4.3.a / ADR-0002).
+
+Two-table model:
+- ``scheduled_jobs``: the schedule itself (kind, payload, rrule, next_run_at,
+  is_active, idempotency_key). Distinct from ``audit_log`` — operational
+  state belongs in ``scheduled_job_runs``, not in audit.
+- ``scheduled_job_runs``: per-fire run records (status, retry_count,
+  last_error). Only the runner module writes here.
+
+Revision ID: b8a91c2f3d44
+Revises: a3f4d8e91b22
+Create Date: 2026-05-02 16:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from tulip_storage.models.base import GUID
+
+revision: str = "b8a91c2f3d44"
+down_revision: str | None = "a3f4d8e91b22"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create scheduled_jobs + scheduled_job_runs."""
+    op.create_table(
+        "scheduled_jobs",
+        sa.Column("household_id", GUID(length=36), nullable=False),
+        sa.Column("id", GUID(length=36), nullable=False),
+        sa.Column("kind", sa.String(length=50), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("rrule", sa.Text(), nullable=True),
+        # Original RRULE anchor; preserved across runs so COUNT / UNTIL
+        # semantics stay stable. See ADR-0002 §5.
+        sa.Column("dtstart", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("next_run_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=200), nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("created_by_user_id", GUID(length=36), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id"],
+            ["households.id"],
+            name=op.f("fk_scheduled_jobs_household_id_households"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("household_id", "id", name=op.f("pk_scheduled_jobs")),
+    )
+    with op.batch_alter_table("scheduled_jobs", schema=None) as batch_op:
+        # Polling index — runner queries WHERE is_active=1 AND next_run_at <= now.
+        batch_op.create_index(
+            "ix_scheduled_jobs_next_run",
+            ["next_run_at"],
+            unique=False,
+            sqlite_where=sa.text("is_active = 1"),
+        )
+        # Idempotency: per-household, per-kind. SQLite supports partial unique
+        # indexes — Postgres will use the same WHERE clause when we get there.
+        batch_op.create_index(
+            "ix_scheduled_jobs_idempotency",
+            ["household_id", "kind", "idempotency_key"],
+            unique=True,
+            sqlite_where=sa.text("idempotency_key IS NOT NULL"),
+        )
+
+    op.create_table(
+        "scheduled_job_runs",
+        sa.Column("household_id", GUID(length=36), nullable=False),
+        sa.Column("id", GUID(length=36), nullable=False),
+        sa.Column("scheduled_job_id", GUID(length=36), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "running",
+                "success",
+                "failed",
+                "dead_letter",
+                name="scheduledjobrunstatus",
+                native_enum=False,
+                length=20,
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "retry_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["household_id", "scheduled_job_id"],
+            ["scheduled_jobs.household_id", "scheduled_jobs.id"],
+            name="fk_scheduled_job_runs_job",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("household_id", "id", name=op.f("pk_scheduled_job_runs")),
+    )
+    with op.batch_alter_table("scheduled_job_runs", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_scheduled_job_runs_scheduled_job_id"),
+            ["scheduled_job_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Drop scheduled_job_runs + scheduled_jobs."""
+    with op.batch_alter_table("scheduled_job_runs", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_scheduled_job_runs_scheduled_job_id"))
+    op.drop_table("scheduled_job_runs")
+
+    with op.batch_alter_table("scheduled_jobs", schema=None) as batch_op:
+        batch_op.drop_index("ix_scheduled_jobs_idempotency")
+        batch_op.drop_index("ix_scheduled_jobs_next_run")
+    op.drop_table("scheduled_jobs")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -20,6 +20,11 @@ from tulip_storage.models.household import Household, MfaPolicy
 from tulip_storage.models.mfa_recovery_code import MfaRecoveryCode
 from tulip_storage.models.period import Period, PeriodStatus
 from tulip_storage.models.posting import Posting
+from tulip_storage.models.scheduled_job import (
+    ScheduledJob,
+    ScheduledJobRun,
+    ScheduledJobRunStatus,
+)
 from tulip_storage.models.session import Session
 from tulip_storage.models.shadow_posting import ShadowPosting
 from tulip_storage.models.shadow_transaction import (
@@ -48,6 +53,9 @@ __all__ = [
     "PoolType",
     "Posting",
     "RolloverPolicy",
+    "ScheduledJob",
+    "ScheduledJobRun",
+    "ScheduledJobRunStatus",
     "Session",
     "ShadowPosting",
     "ShadowTransaction",

--- a/packages/tulip-storage/src/tulip_storage/models/scheduled_job.py
+++ b/packages/tulip-storage/src/tulip_storage/models/scheduled_job.py
@@ -1,0 +1,139 @@
+"""ScheduledJob and ScheduledJobRun models — see ADR-0002.
+
+The runner reads ``scheduled_jobs`` for due rows and writes ``scheduled_job_runs``
+to record per-fire operational state. Both tables are distinct from
+``audit_log`` — audit captures user-visible side effects (one row per
+materialized shadow tx), runs capture runner internals (retry counts,
+last error, dead-letter status).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from tulip_storage.models.base import GUID, Base
+from tulip_storage.models.household import Household
+
+
+class ScheduledJobRunStatus(Enum):
+    """Outcome of a single fire of a ``scheduled_jobs`` row.
+
+    - ``RUNNING``: handler started but hasn't returned yet.
+    - ``SUCCESS``: handler returned without raising.
+    - ``FAILED``: handler raised; will retry per ADR-0002 §7.
+    - ``DEAD_LETTER``: third failure; parent job ``is_active`` flipped to False.
+    """
+
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+    DEAD_LETTER = "dead_letter"
+
+
+class ScheduledJob(Base):
+    """A scheduled job — the runner's polling target. See ADR-0002 §3."""
+
+    __tablename__ = "scheduled_jobs"
+    __table_args__ = (
+        # Partial unique index — idempotency-key collisions (per
+        # household, per kind) are rejected by the DB. Migrations create
+        # the same index; this declaration ensures Base.metadata.create_all
+        # in tests also creates it.
+        Index(
+            "ix_scheduled_jobs_idempotency",
+            "household_id",
+            "kind",
+            "idempotency_key",
+            unique=True,
+            sqlite_where=text("idempotency_key IS NOT NULL"),
+        ),
+        Index(
+            "ix_scheduled_jobs_next_run",
+            "next_run_at",
+            sqlite_where=text("is_active = 1"),
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("households.id", ondelete="CASCADE"), primary_key=True
+    )
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    kind: Mapped[str] = mapped_column(String(50), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    rrule: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # The original anchor for the RRULE — needed so COUNT/UNTIL semantics
+    # remain stable as ``next_run_at`` advances. Always equal to the
+    # ``start_at`` passed to ``schedule_recurring`` (or ``fire_at`` for
+    # one-shot jobs, where it's unused).
+    dtstart: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    next_run_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    idempotency_key: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_by_user_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    household: Mapped[Household] = relationship()
+
+
+class ScheduledJobRun(Base):
+    """One per-fire run record. See ADR-0002 §3."""
+
+    __tablename__ = "scheduled_job_runs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "scheduled_job_id"],
+            ["scheduled_jobs.household_id", "scheduled_jobs.id"],
+            ondelete="CASCADE",
+            name="fk_scheduled_job_runs_job",
+        ),
+        CheckConstraint(
+            "status IN ('running', 'success', 'failed', 'dead_letter')",
+            name="ck_scheduled_job_runs_status",
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    scheduled_job_id: Mapped[UUID] = mapped_column(GUID(), nullable=False, index=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    status: Mapped[ScheduledJobRunStatus] = mapped_column(
+        SAEnum(
+            ScheduledJobRunStatus,
+            native_enum=False,
+            length=20,
+            values_callable=lambda enum_cls: [m.value for m in enum_cls],
+        ),
+        nullable=False,
+    )
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/packages/tulip-storage/src/tulip_storage/runner/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/__init__.py
@@ -1,0 +1,29 @@
+"""Scheduler runner — see ADR-0002.
+
+Public surface:
+
+- :class:`Runner` — the four-method runner: ``register_handler``,
+  ``schedule_one``, ``schedule_recurring``, ``cancel``.
+- :data:`Clock` / :func:`default_clock` — the time-injection seam.
+- :func:`compute_next_fire` — RRULE wrapper.
+
+Handlers register at module-import time; the runner's loop is started
+from the FastAPI ``lifespan`` hook in :func:`tulip_api.main.create_app`.
+"""
+
+from tulip_storage.runner.clock import Clock, default_clock
+from tulip_storage.runner.rrule import compute_next_fire
+from tulip_storage.runner.runner import (
+    HandlerCallback,
+    IdempotencyKeyConflictError,
+    Runner,
+)
+
+__all__ = [
+    "Clock",
+    "HandlerCallback",
+    "IdempotencyKeyConflictError",
+    "Runner",
+    "compute_next_fire",
+    "default_clock",
+]

--- a/packages/tulip-storage/src/tulip_storage/runner/clock.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/clock.py
@@ -1,0 +1,21 @@
+"""Clock injection seam for the runner.
+
+Per ADR-0002 §6, the runner is the only place in the codebase that takes
+a ``Clock`` callable. Every other path uses real ``datetime.now(UTC)``;
+the runner is the only meaningful time-dependent component, so we
+constrain the injection seam to it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+#: A callable returning the current time. The runner threads this through
+#: the polling loop and into every handler invocation.
+Clock = Callable[[], datetime]
+
+
+def default_clock() -> datetime:
+    """Return the current UTC time. The default ``Clock`` for the runner."""
+    return datetime.now(UTC)

--- a/packages/tulip-storage/src/tulip_storage/runner/rrule.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/rrule.py
@@ -1,0 +1,61 @@
+"""RRULE helper — wraps ``dateutil.rrule.rrulestr`` for the runner.
+
+Per ADR-0002 §5, schedules are stored as RFC 5545 RRULE strings on
+``scheduled_jobs.rrule`` (e.g. ``"FREQ=MONTHLY;BYMONTHDAY=1"``). The runner
+calls :func:`compute_next_fire` after each successful run to advance
+``next_run_at``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from dateutil.rrule import rrulestr
+
+
+class InvalidRRuleError(ValueError):
+    """Raised when an RRULE string fails to parse."""
+
+
+def compute_next_fire(
+    rrule: str,
+    *,
+    dtstart: datetime,
+    after: datetime,
+    inclusive: bool = False,
+) -> datetime | None:
+    """Return the next datetime an RRULE fires after ``after``.
+
+    The RRULE's series is anchored at ``dtstart`` — important for
+    bounded rules (``COUNT=`` / ``UNTIL=``) where the count is from the
+    original schedule's start, not from the polling moment. ``after`` is
+    the cursor: occurrences strictly after ``after`` (or at-or-after
+    when ``inclusive=True``).
+
+    Returns ``None`` if the rule is bounded and has no occurrence after
+    ``after`` — i.e. the recurring job is exhausted and the runner
+    should deactivate it.
+
+    Args:
+        rrule: An RFC 5545 RRULE string (e.g. ``"FREQ=DAILY;COUNT=12"``).
+        dtstart: The original anchor of the recurrence series. For
+            ``schedule_recurring(start_at=X)``, this is X. Stays stable
+            across the job's lifetime.
+        after: The cursor; the next occurrence is after this.
+        inclusive: When True, ``after`` itself is a candidate.
+
+    Raises:
+        InvalidRRuleError: ``rrule`` could not be parsed.
+
+    """
+    try:
+        rule = rrulestr(rrule, dtstart=dtstart)
+    except (ValueError, TypeError) as exc:
+        msg = f"invalid RRULE {rrule!r}: {exc}"
+        raise InvalidRRuleError(msg) from exc
+    next_dt = rule.after(after, inc=inclusive)
+    if next_dt is None:
+        return None
+    # ``dateutil`` returns a tz-aware datetime when both ``dtstart`` and
+    # ``after`` are tz-aware.
+    return next_dt

--- a/packages/tulip-storage/src/tulip_storage/runner/runner.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/runner.py
@@ -1,0 +1,486 @@
+"""The Runner — see ADR-0002.
+
+Single async-loop poller. Reads ``scheduled_jobs`` for due rows, dispatches
+each to its registered handler, records the result in ``scheduled_job_runs``,
+and re-schedules recurring jobs. ~150 LOC of core logic; deliberately
+small enough to maintain ourselves rather than depend on apscheduler.
+
+ADR-0002 §8 documents the single-uvicorn-worker assumption. Running with
+``--workers > 1`` will race two pollers and double-fire jobs. v1
+deployment story is single-worker; multi-worker safety is Phase 9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from tulip_storage.models import ScheduledJob, ScheduledJobRun, ScheduledJobRunStatus
+from tulip_storage.runner.clock import Clock, default_clock
+from tulip_storage.runner.rrule import compute_next_fire
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+log = logging.getLogger("tulip_storage.runner")
+
+#: Backoff schedule per ADR-0002 §7. After the third failure (index 2 in
+#: this list), the next attempt promotes the run to ``dead_letter`` and
+#: deactivates the parent job.
+RETRY_BACKOFF: tuple[timedelta, ...] = (
+    timedelta(seconds=60),
+    timedelta(minutes=5),
+    timedelta(minutes=30),
+)
+MAX_RETRIES: int = len(RETRY_BACKOFF)
+
+#: Default poll cadence. Tests use a much smaller value or drive the loop
+#: manually via ``run_once``.
+DEFAULT_POLL_INTERVAL_SECONDS: float = 30.0
+
+
+HandlerCallback = Callable[[ScheduledJob, Clock], Awaitable[None]]
+
+
+class IdempotencyKeyConflictError(ValueError):
+    """Raised when ``schedule_one`` / ``schedule_recurring`` collides on idempotency_key.
+
+    The unique partial index on ``(household_id, kind, idempotency_key)``
+    rejects the insert; we surface a typed exception rather than letting
+    ``IntegrityError`` leak through. Caller decides whether to ignore
+    (the existing job is good enough) or surface to the user.
+    """
+
+
+class Runner:
+    """In-process scheduler. See ADR-0002 §1 for the architecture decision."""
+
+    def __init__(
+        self,
+        session_maker: sessionmaker[Session],
+        *,
+        clock: Clock = default_clock,
+        poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> None:
+        """Construct (without starting) the runner.
+
+        Args:
+            session_maker: SQLAlchemy session factory the runner uses for
+                its DB writes. Each poll tick opens a fresh session.
+            clock: Time injection per ADR-0002 §6. Tests pass a callable
+                whose return value they advance manually.
+            poll_interval_seconds: How often the loop polls when no jobs
+                are due. The loop fires immediately if jobs are already
+                due, regardless.
+
+        """
+        self._session_maker = session_maker
+        self._clock = clock
+        self._poll_interval = poll_interval_seconds
+        self._handlers: dict[str, HandlerCallback] = {}
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event: asyncio.Event | None = None
+
+    # ---- Public API per ADR-0002 §2 ----------------------------------
+
+    def register_handler(self, kind: str, callback: HandlerCallback) -> None:
+        """Register a handler for a job ``kind``.
+
+        Sync because handler registration happens at import time, not
+        inside the event loop. Re-registering replaces the prior handler
+        — useful for tests and live-reload.
+        """
+        self._handlers[kind] = callback
+
+    def schedule_one(
+        self,
+        *,
+        household_id: UUID,
+        kind: str,
+        payload: dict[str, Any],
+        fire_at: datetime,
+        idempotency_key: str | None = None,
+        created_by_user_id: UUID | None = None,
+    ) -> UUID:
+        """Insert a one-shot job. Returns the new ``scheduled_jobs.id``."""
+        job_id = uuid4()
+        with self._session_maker() as session:
+            session.add(
+                ScheduledJob(
+                    household_id=household_id,
+                    id=job_id,
+                    kind=kind,
+                    payload=payload,
+                    rrule=None,
+                    dtstart=fire_at,  # unused for one-shot; kept stable
+                    next_run_at=fire_at,
+                    idempotency_key=idempotency_key,
+                    is_active=True,
+                    created_by_user_id=created_by_user_id,
+                )
+            )
+            try:
+                session.commit()
+            except IntegrityError as exc:
+                session.rollback()
+                msg = (
+                    f"idempotency_key {idempotency_key!r} already in use for "
+                    f"kind={kind} in household {household_id}"
+                )
+                raise IdempotencyKeyConflictError(msg) from exc
+        return job_id
+
+    def schedule_recurring(
+        self,
+        *,
+        household_id: UUID,
+        kind: str,
+        payload: dict[str, Any],
+        rrule: str,
+        start_at: datetime | None = None,
+        idempotency_key: str | None = None,
+        created_by_user_id: UUID | None = None,
+    ) -> UUID:
+        """Insert a recurring job. Returns the new ``scheduled_jobs.id``."""
+        baseline = start_at or self._clock()
+        first_fire = compute_next_fire(rrule, dtstart=baseline, after=baseline, inclusive=True)
+        if first_fire is None:
+            msg = f"RRULE {rrule!r} has no occurrence at or after {baseline.isoformat()}"
+            raise ValueError(msg)
+        job_id = uuid4()
+        with self._session_maker() as session:
+            session.add(
+                ScheduledJob(
+                    household_id=household_id,
+                    id=job_id,
+                    kind=kind,
+                    payload=payload,
+                    rrule=rrule,
+                    dtstart=baseline,
+                    next_run_at=first_fire,
+                    idempotency_key=idempotency_key,
+                    is_active=True,
+                    created_by_user_id=created_by_user_id,
+                )
+            )
+            try:
+                session.commit()
+            except IntegrityError as exc:
+                session.rollback()
+                msg = (
+                    f"idempotency_key {idempotency_key!r} already in use for "
+                    f"kind={kind} in household {household_id}"
+                )
+                raise IdempotencyKeyConflictError(msg) from exc
+        return job_id
+
+    def cancel(self, household_id: UUID, job_id: UUID) -> None:
+        """Flip ``is_active=False``. Idempotent. Run rows untouched."""
+        with self._session_maker() as session:
+            job = session.execute(
+                select(ScheduledJob).where(
+                    ScheduledJob.household_id == household_id,
+                    ScheduledJob.id == job_id,
+                )
+            ).scalar_one_or_none()
+            if job is None:
+                return
+            job.is_active = False
+            session.commit()
+
+    # ---- Loop lifecycle -----------------------------------------------
+
+    async def start(self) -> None:
+        """Spawn the polling loop as an asyncio task.
+
+        Idempotent — calling twice does nothing extra. Cancel via :meth:`stop`.
+        """
+        if self._task is not None and not self._task.done():
+            return
+        self._stop_event = asyncio.Event()
+        self._task = asyncio.create_task(self._loop(), name="tulip_runner")
+
+    async def stop(self) -> None:
+        """Signal the loop to exit and wait for it to drain."""
+        if self._stop_event is None or self._task is None:
+            return
+        self._stop_event.set()
+        try:
+            await asyncio.wait_for(self._task, timeout=10.0)
+        except TimeoutError:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):  # noqa: S110
+                # Cancellation is expected; any other exception during
+                # shutdown is logged via the loop's own exception handling.
+                pass
+        self._task = None
+        self._stop_event = None
+
+    async def _loop(self) -> None:
+        assert self._stop_event is not None  # set by start()  # noqa: S101
+        while not self._stop_event.is_set():
+            try:
+                fired = await self.run_once()
+            except Exception:
+                log.exception("runner.poll_failed")
+                fired = 0
+            # If we fired anything, immediately poll again — the next batch
+            # may already be due. Otherwise wait the poll interval.
+            if fired > 0:
+                continue
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=self._poll_interval,
+                )
+            except TimeoutError:
+                continue
+
+    # ---- Polling --------------------------------------------------
+
+    async def run_once(self) -> int:
+        """Run all jobs whose ``next_run_at`` is at or before ``clock()`` once.
+
+        Returns the number of jobs dispatched (regardless of success /
+        failure). Tests call this directly to drive the loop without
+        starting / stopping.
+        """
+        now = self._clock()
+        due = self._fetch_due(now)
+        for job_snapshot in due:
+            await self._dispatch(job_snapshot, now)
+        return len(due)
+
+    def _fetch_due(self, now: datetime) -> list[ScheduledJob]:
+        """Return active jobs whose ``next_run_at <= now``.
+
+        Loaded into a fresh session and detached so each ``_dispatch`` can
+        open its own session. We avoid passing the loop's session into
+        handler code — handlers' DB writes need their own transaction
+        scope.
+        """
+        with self._session_maker() as session:
+            rows = (
+                session.execute(
+                    select(ScheduledJob).where(
+                        ScheduledJob.is_active.is_(True),
+                        ScheduledJob.next_run_at <= now,
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            # Detach so we can use these objects after the session closes.
+            for row in rows:
+                session.expunge(row)
+        return list(rows)
+
+    async def _dispatch(self, job: ScheduledJob, now: datetime) -> None:
+        """Run one job. Records start, calls handler, records outcome."""
+        handler = self._handlers.get(job.kind)
+        if handler is None:
+            log.warning(
+                "runner.no_handler",
+                extra={"job_id": str(job.id), "kind": job.kind},
+            )
+            self._record_outcome(
+                job,
+                started_at=now,
+                completed_at=now,
+                status=ScheduledJobRunStatus.FAILED,
+                last_error=f"no handler registered for kind={job.kind!r}",
+                advance_next_run_at=False,
+            )
+            return
+
+        run_id = uuid4()
+        start = self._clock()
+        self._record_start(job, run_id=run_id, started_at=start)
+
+        try:
+            await handler(job, self._clock)
+        except Exception as exc:
+            log.exception(
+                "runner.handler_failed",
+                extra={"job_id": str(job.id), "kind": job.kind},
+            )
+            self._on_failure(job, run_id=run_id, started_at=start, error=str(exc))
+            return
+
+        completed = self._clock()
+        self._record_completion(
+            job,
+            run_id=run_id,
+            started_at=start,
+            completed_at=completed,
+            status=ScheduledJobRunStatus.SUCCESS,
+        )
+        self._advance_after_success(job, completed_at=completed)
+
+    # ---- Per-fire bookkeeping ----------------------------------------
+
+    def _record_start(self, job: ScheduledJob, *, run_id: UUID, started_at: datetime) -> None:
+        with self._session_maker() as session:
+            session.add(
+                ScheduledJobRun(
+                    household_id=job.household_id,
+                    id=run_id,
+                    scheduled_job_id=job.id,
+                    started_at=started_at,
+                    status=ScheduledJobRunStatus.RUNNING,
+                    retry_count=0,
+                )
+            )
+            session.commit()
+
+    def _record_completion(
+        self,
+        job: ScheduledJob,
+        *,
+        run_id: UUID,
+        started_at: datetime,
+        completed_at: datetime,
+        status: ScheduledJobRunStatus,
+    ) -> None:
+        with self._session_maker() as session:
+            run = session.execute(
+                select(ScheduledJobRun).where(
+                    ScheduledJobRun.household_id == job.household_id,
+                    ScheduledJobRun.id == run_id,
+                )
+            ).scalar_one()
+            run.completed_at = completed_at
+            run.status = status
+            session.commit()
+
+    def _record_outcome(
+        self,
+        job: ScheduledJob,
+        *,
+        started_at: datetime,
+        completed_at: datetime,
+        status: ScheduledJobRunStatus,
+        last_error: str | None = None,
+        advance_next_run_at: bool,
+    ) -> None:
+        """One-shot insert of a completed run row (used for no-handler case)."""
+        with self._session_maker() as session:
+            session.add(
+                ScheduledJobRun(
+                    household_id=job.household_id,
+                    id=uuid4(),
+                    scheduled_job_id=job.id,
+                    started_at=started_at,
+                    completed_at=completed_at,
+                    status=status,
+                    retry_count=0,
+                    last_error=last_error,
+                )
+            )
+            if advance_next_run_at:
+                attached = session.execute(
+                    select(ScheduledJob).where(
+                        ScheduledJob.household_id == job.household_id,
+                        ScheduledJob.id == job.id,
+                    )
+                ).scalar_one()
+                attached.last_run_at = completed_at
+            session.commit()
+
+    def _on_failure(
+        self,
+        job: ScheduledJob,
+        *,
+        run_id: UUID,
+        started_at: datetime,
+        error: str,
+    ) -> None:
+        """Update the run row with ``failed`` + retry_count, schedule next attempt."""
+        with self._session_maker() as session:
+            run = session.execute(
+                select(ScheduledJobRun).where(
+                    ScheduledJobRun.household_id == job.household_id,
+                    ScheduledJobRun.id == run_id,
+                )
+            ).scalar_one()
+            attached_job = session.execute(
+                select(ScheduledJob).where(
+                    ScheduledJob.household_id == job.household_id,
+                    ScheduledJob.id == job.id,
+                )
+            ).scalar_one()
+
+            # Count prior failures for this job since the last success.
+            prior_failures = (
+                session.execute(
+                    select(ScheduledJobRun).where(
+                        ScheduledJobRun.household_id == job.household_id,
+                        ScheduledJobRun.scheduled_job_id == job.id,
+                        ScheduledJobRun.status == ScheduledJobRunStatus.FAILED,
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            retry_count = len(prior_failures)
+
+            now = self._clock()
+            run.completed_at = now
+            run.last_error = error
+            run.retry_count = retry_count
+
+            if retry_count >= MAX_RETRIES:
+                # Dead-letter: deactivate the job + flip the run status.
+                run.status = ScheduledJobRunStatus.DEAD_LETTER
+                attached_job.is_active = False
+                log.error(
+                    "runner.dead_letter",
+                    extra={"job_id": str(job.id), "kind": job.kind},
+                )
+            else:
+                run.status = ScheduledJobRunStatus.FAILED
+                # Schedule a retry; backoff index is the number of prior
+                # failures (0-indexed into RETRY_BACKOFF).
+                attached_job.next_run_at = now + RETRY_BACKOFF[retry_count]
+            session.commit()
+
+    def _advance_after_success(self, job: ScheduledJob, *, completed_at: datetime) -> None:
+        """Re-schedule a recurring job; deactivate a one-shot."""
+        with self._session_maker() as session:
+            attached = session.execute(
+                select(ScheduledJob).where(
+                    ScheduledJob.household_id == job.household_id,
+                    ScheduledJob.id == job.id,
+                )
+            ).scalar_one()
+            attached.last_run_at = completed_at
+            if attached.rrule is None:
+                # One-shot: done.
+                attached.is_active = False
+            else:
+                # SQLite drops tzinfo from DateTime(timezone=True) columns
+                # on read; normalize so dateutil can compare.
+                stored_dtstart = attached.dtstart
+                if stored_dtstart.tzinfo is None:
+                    stored_dtstart = stored_dtstart.replace(tzinfo=completed_at.tzinfo)
+                next_fire = compute_next_fire(
+                    attached.rrule,
+                    dtstart=stored_dtstart,
+                    after=completed_at,
+                )
+                if next_fire is None:
+                    # RRULE exhausted (COUNT/UNTIL boundary).
+                    attached.is_active = False
+                else:
+                    attached.next_run_at = next_fire
+            session.commit()

--- a/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
@@ -1,0 +1,86 @@
+"""Architecture test: scheduled_jobs writes go through the runner.
+
+Per ADR-0002 §3 the scheduler is the single chokepoint for inserting
+``scheduled_jobs`` rows. Direct construction of the ORM model anywhere
+else (a router, a CLI handler, a future migration helper) would let
+callers bypass the idempotency-key validation, the dtstart-anchoring
+contract, and the eventual multi-worker safety story.
+
+This test mirrors :mod:`test_architecture_no_direct_shadow_writes` —
+AST-scans all ``packages/*/src/`` files for imports of the storage-layer
+``ScheduledJob`` model and rejects any not in the allowlist.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
+_PACKAGES: Final[Path] = _REPO_ROOT / "packages"
+
+_BANNED_NAMES: Final[frozenset[str]] = frozenset({"ScheduledJob", "ScheduledJobRun"})
+
+#: Modules whose ``ScheduledJob``/``ScheduledJobRun`` are the storage-layer ORM models.
+_STORAGE_MODEL_MODULES: Final[frozenset[str]] = frozenset(
+    {
+        "tulip_storage.models",
+        "tulip_storage.models.scheduled_job",
+    }
+)
+
+#: Files allowed to import the storage-layer model classes.
+_ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
+    {
+        # Model definitions.
+        "tulip-storage/src/tulip_storage/models/scheduled_job.py",
+        # Re-exports.
+        "tulip-storage/src/tulip_storage/models/__init__.py",
+        # The runner — only legitimate writer.
+        "tulip-storage/src/tulip_storage/runner/runner.py",
+        "tulip-storage/src/tulip_storage/runner/__init__.py",
+    }
+)
+
+
+def _python_source_files() -> list[Path]:
+    """Yield every .py file under ``packages/*/src/``."""
+    out: list[Path] = []
+    for pkg in sorted(_PACKAGES.iterdir()):
+        src = pkg / "src"
+        if not src.is_dir():
+            continue
+        out.extend(sorted(src.rglob("*.py")))
+    return out
+
+
+def _illegal_storage_model_imports(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, name)`` pairs that import storage-layer ScheduledJob models."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in _STORAGE_MODEL_MODULES:
+            for alias in node.names:
+                if alias.name in _BANNED_NAMES:
+                    hits.append((node.lineno, alias.name))
+    return hits
+
+
+def test_no_direct_scheduled_job_writes_outside_runner() -> None:
+    """Every scheduler write must route through the Runner."""
+    offenders: dict[str, list[tuple[int, str]]] = {}
+    for path in _python_source_files():
+        rel = str(path.relative_to(_PACKAGES))
+        if rel in _ALLOWED_RELATIVE:
+            continue
+        hits = _illegal_storage_model_imports(path)
+        if hits:
+            offenders[rel] = hits
+
+    assert not offenders, (
+        "Direct imports of storage-layer ScheduledJob / ScheduledJobRun "
+        "outside the Runner — route through tulip_storage.runner.Runner so "
+        "the idempotency / dtstart / retry contract stays intact:\n"
+        + "\n".join(f"  {file}: {hits}" for file, hits in offenders.items())
+    )

--- a/packages/tulip-storage/tests/test_runner.py
+++ b/packages/tulip-storage/tests/test_runner.py
@@ -1,0 +1,430 @@
+"""Tests for the scheduler runner — see ADR-0002."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+
+from tulip_storage.models import (
+    Household,
+    ScheduledJob,
+    ScheduledJobRun,
+    ScheduledJobRunStatus,
+)
+from tulip_storage.runner import (
+    IdempotencyKeyConflictError,
+    Runner,
+)
+from tulip_storage.runner.runner import RETRY_BACKOFF
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+# ---- Fixtures + helpers -------------------------------------------------
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+class FakeClock:
+    """A controllable clock for the runner. Tests advance time explicitly."""
+
+    def __init__(self, *, now: datetime) -> None:
+        self._now = now
+
+    def __call__(self) -> datetime:
+        return self._now
+
+    def advance(self, delta: timedelta) -> None:
+        self._now += delta
+
+    def set(self, when: datetime) -> None:
+        self._now = when
+
+
+def _runner(session_maker: sessionmaker[Session], *, clock: FakeClock) -> Runner:
+    return Runner(session_maker, clock=clock, poll_interval_seconds=0.01)
+
+
+def _to_utc(dt: datetime) -> datetime:
+    """Normalize a possibly-naive datetime to UTC.
+
+    SQLite ignores the ``timezone=True`` flag on ``DateTime`` columns and
+    persists naive timestamps. Tests write tz-aware values; on read they
+    come back naive. Round-trip through this helper before subtracting.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _job(session: Session, household_id: UUID, job_id: UUID) -> ScheduledJob:
+    return session.execute(
+        select(ScheduledJob).where(
+            ScheduledJob.household_id == household_id,
+            ScheduledJob.id == job_id,
+        )
+    ).scalar_one()
+
+
+def _runs(session: Session, household_id: UUID, job_id: UUID) -> list[ScheduledJobRun]:
+    return list(
+        session.execute(
+            select(ScheduledJobRun).where(
+                ScheduledJobRun.household_id == household_id,
+                ScheduledJobRun.scheduled_job_id == job_id,
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+# ---- TDD entry tests ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_one_fires_handler_at_fire_at(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    fired: list[UUID] = []
+
+    async def handler(job: ScheduledJob, _clock):
+        fired.append(job.id)
+
+    runner.register_handler("test", handler)
+
+    job_id = runner.schedule_one(
+        household_id=household.id,
+        kind="test",
+        payload={},
+        fire_at=t0 + timedelta(seconds=10),
+    )
+
+    # Not yet due.
+    fired_count = await runner.run_once()
+    assert fired_count == 0
+    assert fired == []
+
+    clock.advance(timedelta(seconds=11))
+    fired_count = await runner.run_once()
+    assert fired_count == 1
+    assert fired == [job_id]
+
+    # One run row, status=success, advance once.
+    runs = _runs(session, household.id, job_id)
+    assert len(runs) == 1
+    assert runs[0].status is ScheduledJobRunStatus.SUCCESS
+
+    # One-shot job is deactivated after fire.
+    job = _job(session, household.id, job_id)
+    assert job.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_schedule_recurring_reschedules_after_fire(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    async def handler(job: ScheduledJob, _clock):
+        pass
+
+    runner.register_handler("daily_test", handler)
+    job_id = runner.schedule_recurring(
+        household_id=household.id,
+        kind="daily_test",
+        payload={},
+        rrule="FREQ=DAILY",
+        start_at=t0,
+    )
+
+    # Job's first fire is at or just after t0.
+    fired = await runner.run_once()
+    assert fired == 1
+
+    runs = _runs(session, household.id, job_id)
+    assert len(runs) == 1
+    assert runs[0].status is ScheduledJobRunStatus.SUCCESS
+
+    # Next run advanced by ~1 day. SQLite stores naive datetimes for
+    # DateTime(timezone=True) columns; normalize before comparing.
+    job = _job(session, household.id, job_id)
+    assert job.is_active is True
+    next_run = _to_utc(job.next_run_at)
+    delta = next_run - t0
+    assert timedelta(hours=23) < delta < timedelta(hours=25)
+
+
+# ---- Idempotency --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_rejects_duplicate(
+    session_maker: sessionmaker[Session],
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    runner.schedule_one(
+        household_id=household.id,
+        kind="test",
+        payload={},
+        fire_at=t0 + timedelta(minutes=10),
+        idempotency_key="envelope-123",
+    )
+    with pytest.raises(IdempotencyKeyConflictError):
+        runner.schedule_one(
+            household_id=household.id,
+            kind="test",
+            payload={},
+            fire_at=t0 + timedelta(minutes=20),
+            idempotency_key="envelope-123",
+        )
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_distinct_kinds_dont_collide(
+    session_maker: sessionmaker[Session],
+    household: Household,
+) -> None:
+    # Different kinds, same key — both succeed (per the unique partial
+    # index on (household_id, kind, idempotency_key)).
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    runner.schedule_one(
+        household_id=household.id,
+        kind="kind_a",
+        payload={},
+        fire_at=t0,
+        idempotency_key="shared",
+    )
+    runner.schedule_one(
+        household_id=household.id,
+        kind="kind_b",
+        payload={},
+        fire_at=t0,
+        idempotency_key="shared",
+    )
+
+
+# ---- Cancel -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_prevents_future_fires(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    async def handler(job: ScheduledJob, _clock):
+        pass
+
+    runner.register_handler("test", handler)
+    job_id = runner.schedule_one(
+        household_id=household.id,
+        kind="test",
+        payload={},
+        fire_at=t0,
+    )
+    runner.cancel(household.id, job_id)
+
+    fired = await runner.run_once()
+    assert fired == 0
+
+    runs = _runs(session, household.id, job_id)
+    assert runs == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_unknown_job_is_silent(
+    session_maker: sessionmaker[Session],
+    household: Household,
+) -> None:
+    runner = _runner(session_maker, clock=FakeClock(now=datetime.now(UTC)))
+    runner.cancel(household.id, uuid4())  # no exception
+
+
+# ---- Retry / dead-letter -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_retries_with_backoff(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    call_count = {"n": 0}
+
+    async def flaky_handler(job: ScheduledJob, _clock):
+        call_count["n"] += 1
+        raise RuntimeError(f"boom #{call_count['n']}")
+
+    runner.register_handler("flaky", flaky_handler)
+    job_id = runner.schedule_one(
+        household_id=household.id,
+        kind="flaky",
+        payload={},
+        fire_at=t0,
+    )
+
+    # First fire fails -> retry scheduled at +60s.
+    await runner.run_once()
+    job = _job(session, household.id, job_id)
+    assert job.is_active is True
+    assert (_to_utc(job.next_run_at) - t0) == RETRY_BACKOFF[0]
+
+    # Advance to the retry, fail again -> retry at +5m.
+    clock.set(t0 + RETRY_BACKOFF[0] + timedelta(seconds=1))
+    await runner.run_once()
+    session.expire_all()
+    job = _job(session, household.id, job_id)
+    next_t1 = clock()
+    assert job.is_active is True
+    assert (_to_utc(job.next_run_at) - next_t1) == RETRY_BACKOFF[1]
+
+    # Advance to the next retry, fail again -> retry at +30m.
+    clock.set(next_t1 + RETRY_BACKOFF[1] + timedelta(seconds=1))
+    await runner.run_once()
+    session.expire_all()
+    job = _job(session, household.id, job_id)
+    next_t2 = clock()
+    assert job.is_active is True
+    assert (_to_utc(job.next_run_at) - next_t2) == RETRY_BACKOFF[2]
+
+    # Fourth attempt: dead-letter, job deactivated.
+    clock.set(next_t2 + RETRY_BACKOFF[2] + timedelta(seconds=1))
+    await runner.run_once()
+    session.expire_all()
+    job = _job(session, household.id, job_id)
+    assert job.is_active is False
+
+    runs = _runs(session, household.id, job_id)
+    statuses = [r.status for r in runs]
+    assert statuses.count(ScheduledJobRunStatus.FAILED) == 3
+    assert statuses.count(ScheduledJobRunStatus.DEAD_LETTER) == 1
+
+
+# ---- Edge cases --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_handler_marks_run_failed(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    job_id = runner.schedule_one(
+        household_id=household.id,
+        kind="orphan",
+        payload={},
+        fire_at=t0,
+    )
+    fired = await runner.run_once()
+    assert fired == 1
+
+    runs = _runs(session, household.id, job_id)
+    assert len(runs) == 1
+    assert runs[0].status is ScheduledJobRunStatus.FAILED
+    assert "no handler" in (runs[0].last_error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_recurring_with_count_exhausts(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    async def handler(job: ScheduledJob, _clock):
+        pass
+
+    runner.register_handler("limited", handler)
+    job_id = runner.schedule_recurring(
+        household_id=household.id,
+        kind="limited",
+        payload={},
+        rrule="FREQ=DAILY;COUNT=2",
+        start_at=t0,
+    )
+
+    # Fire 1.
+    await runner.run_once()
+    clock.advance(timedelta(days=1, seconds=1))
+    # Fire 2.
+    await runner.run_once()
+    session.expire_all()
+    job = _job(session, household.id, job_id)
+    # COUNT=2 means two occurrences total; after both fire, no more
+    # occurrences and the job is deactivated.
+    assert job.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_start_stop_lifecycle(
+    session_maker: sessionmaker[Session],
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    fired: list[UUID] = []
+
+    async def handler(job: ScheduledJob, _clock):
+        fired.append(job.id)
+
+    runner.register_handler("test", handler)
+    job_id = runner.schedule_one(
+        household_id=household.id,
+        kind="test",
+        payload={},
+        fire_at=t0,
+    )
+
+    await runner.start()
+    # Give the loop a tick to fire.
+    await asyncio.sleep(0.05)
+    await runner.stop()
+
+    assert fired == [job_id]

--- a/uv.lock
+++ b/uv.lock
@@ -1279,6 +1279,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1794,16 +1806,20 @@ source = { editable = "packages/tulip-storage" }
 dependencies = [
     { name = "alembic" },
     { name = "cryptography" },
+    { name = "python-dateutil" },
     { name = "sqlalchemy" },
     { name = "tulip-core" },
+    { name = "types-python-dateutil" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "cryptography", specifier = ">=42.0" },
+    { name = "python-dateutil", specifier = ">=2.9" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "tulip-core", editable = "packages/tulip-core" },
+    { name = "types-python-dateutil", specifier = ">=2.9" },
 ]
 
 [[package]]
@@ -1819,6 +1835,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/f3/2427775f80cd5e19a0a71ba8e5ab7645a01a852f43a5fd0ffc24f66338e0/types_python_dateutil-2.9.0.20260408.tar.gz", hash = "sha256:8b056ec01568674235f64ecbcef928972a5fac412f5aab09c516dfa2acfbb582", size = 16981, upload-time = "2026-04-08T04:28:10.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c6/eeba37bfee282a6a97f889faef9352d6172c6a5088eb9a4daf570d9d748d/types_python_dateutil-2.9.0.20260408-py3-none-any.whl", hash = "sha256:473139d514a71c9d1fbd8bb328974bedcb1cc3dba57aad04ffa4157f483c216f", size = 18437, upload-time = "2026-04-08T04:28:10.095Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #68 + #7. First slice of P4.3 — implements the in-process scheduler runner that the rest of P4.3 (refill rules execution) sits on top of. Per [ADR-0002](docs/adrs/0002-scheduler-primitive.md).

P4.3.b (#69) ships the refill-rule evaluation engine + the \`envelope_refill\` runner handler. P4.3.c (#70) ships the API + CLI surface for managing refill schedules.

## Summary

**[ADR-0002](docs/adrs/0002-scheduler-primitive.md)** records eight design decisions for the scheduler primitive:

1. **Simple async loop in a FastAPI lifespan task** — rejected \`apscheduler\` (60+ KB code surface, threading model that interacts awkwardly with SQLAlchemy session scopes), \`rq\` / \`taskiq\` (broker dep), \`celery\` (heavyweight), pure cron (no in-process visibility).
2. **Public surface**: \`register_handler\` + \`schedule_one\` + \`schedule_recurring\` + \`cancel\`. Idempotency keys included from day one to prevent duplicate-schedule footguns.
3. **Two tables**: \`scheduled_jobs\` (the schedule itself) + \`scheduled_job_runs\` (per-fire operational state). Distinct from \`audit_log\` — operational state ≠ user-visible side effects.
4. **Single generic \`scheduled_jobs\`** reconciles ARCHITECTURE.md §4.1's \`scheduled_transactions\` sketch with #7's proposal. The first consumer is \`kind=\"envelope_refill\"\` (P4.3.b); future consumers (Phase 5 reconciliation, Phase 6 AI cost reports) reuse the same surface.
5. **RRULE via \`python-dateutil\`** — new dep accepted (~250 KB, gold standard, zero-maintenance). Rolling our own cadence DSL was the wrong build/buy.
6. **\`Clock\` injection** in the runner (no \`freezegun\`). The runner is the only project-wide time-injection seam.
7. **Retry policy**: 3 retries with 1m / 5m / 30m backoff, then \`status=\"dead_letter\"\` and the parent job is paused until manually resumed.
8. **Single-worker assumption** for v1 — documented loudly. Multi-worker safety is a Phase 9 concern that requires either \`SELECT … FOR UPDATE SKIP LOCKED\` (PostgreSQL-only) or external leader election.

**Schema**: new migration \`b8a91c2f3d44\` adding two tables. \`scheduled_jobs\` has \`dtstart\` (stable RRULE anchor — needed so COUNT/UNTIL stays correct as \`next_run_at\` advances), \`next_run_at\` (indexed for polling), \`idempotency_key\` (unique partial index per \`(household_id, kind)\`), \`is_active\`.

**Code** (new \`tulip_storage/runner/\` module): \`Runner\` class with the 4-method surface + the async poll loop; \`Clock\` type alias + default; \`compute_next_fire\` wrapper around \`dateutil.rrule.rrulestr\`. ~250 LOC core.

**FastAPI lifespan hook** in \`create_app(enable_runner=True)\` boots the runner on startup and drains it cleanly on shutdown. Tests opt out via \`enable_runner=False\` to keep their overridden sessions intact.

**Architecture test** (\`test_architecture_no_direct_scheduled_job_writes\`): only \`tulip_storage.runner.runner\` may import the storage-layer \`ScheduledJob\` model. Mirrors P4.0's shadow-table guard.

**11 new tests** in \`tulip-storage\` covering: \`schedule_one\` + run, \`schedule_recurring\` + advance after fire, idempotency-key happy + cross-kind-don't-collide, cancel happy + unknown-job-silent, retry+dead-letter (full backoff sequence), no-handler-marks-failed, RRULE \`COUNT=2\` exhaustion, full async \`start\` / \`stop\` lifecycle.

**Project total**: **713 passing** (up from 702). Lint + mypy --strict clean (122 source files).

## Subagent retrospective

Used **two parallel Explore agents** at slice start (one on design intent across ADR-0001 / ARCHITECTURE.md / THREAT_MODEL.md / open issue #7; one on current code state — refill-rule plumbing, FastAPI lifecycle, scheduler deps, period model, audit log shape, time-mocking precedent, biggest-unknown flagging). The Plan agent then folded both digests into a 3-slice split recommendation (P4.3.a/b/c) with eight design decisions and four open questions. The dual-Explore approach paid off — the design and code surveys are genuinely orthogonal here, and combining them in one Plan prompt produced a sharper result than sequencing would have.

The biggest-unknown flag from the code-state Explore (\"how does the runner know the next refill date?\") prompted the \`dtstart\` design decision in advance, avoiding what would otherwise have been mid-implementation rework.

## Test plan

- [x] Full pytest run: 713 passing
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy packages/\` — clean (122 source files)
- [x] Runner: schedule one + recurring + idempotency + cancel + retry/dead-letter + no-handler + RRULE COUNT exhaustion + start/stop lifecycle (11 tests)
- [x] Architecture test passes — only the runner module imports the storage-layer ScheduledJob
- [x] FastAPI lifespan hook boots/drains the runner without leaking the test's session factory
- [x] Migration round-trips (forward + downgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)