### PR TITLE
P4.3.b — Refill-rule engine + envelope_refill handler

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-02 · `main` @ P4.0 + P4.1.a + P4.1.b + P4.2 + P4.3.a
+**Last updated:** 2026-05-02 · `main` @ P4.0 + P4.1.a + P4.1.b + P4.2 + P4.3.a + P4.3.b
 
 ---
 
@@ -15,9 +15,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 3 (CLI):** ✅ complete — P3.1 through P3.4 + P3.6 shipped; P3.5 (toner-friendly print stylesheet) deferred to Phase 8 alongside the actual reports (#22)
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
 - **Pre-Phase-4 docs:** threat-model checkpoint shipped (#56, [docs/THREAT_MODEL.md](THREAT_MODEL.md)). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
-- **Phase 4 (envelopes + sinking funds):** in flight — P4.0 (#60), P4.1.a (#62), P4.1.b (#63), P4.2 (#66) shipped 2026-05-02. P4.3 split a/b/c — P4.3.a (scheduler runner primitive per [ADR-0002](adrs/0002-scheduler-primitive.md), closes #7) shipped 2026-05-02 (#68); P4.3.b (refill engine + handler, #69), P4.3.c (API + CLI for refill schedules, #70) queued.
+- **Phase 4 (envelopes + sinking funds):** in flight — P4.0 (#60), P4.1.a (#62), P4.1.b (#63), P4.2 (#66) shipped 2026-05-02. P4.3 split a/b/c — P4.3.a (scheduler runner primitive per [ADR-0002](adrs/0002-scheduler-primitive.md), closes #7) shipped 2026-05-02 (#68); P4.3.b (refill engine + envelope_refill handler) shipped 2026-05-02 (#69); P4.3.c (API + CLI for refill schedules, #70) queued.
 
-**Tests:** 713 passing · **CI:** green on `main`
+**Tests:** 739 passing · **CI:** green on `main`
 
 ---
 
@@ -352,9 +352,20 @@ Closes #68 + #7. Implements the in-process scheduler that the rest of P4.3 (refi
 - **Tests**: 11 new in `tulip-storage` (TDD entry — schedule_one/run, schedule_recurring + advance, idempotency happy + cross-kind, cancel happy + unknown, retry + dead-letter, no-handler, RRULE-with-COUNT exhaustion, full async start/stop lifecycle). Project total: **713 passing** (up from 702).
 - **New deps**: `python-dateutil>=2.9` + `types-python-dateutil>=2.9` (added to `tulip-storage`).
 
+### P4.3.b — Refill-rule evaluation engine + envelope_refill handler — ✅ *(2026-05-02)*
+
+Closes #69. Sits on top of P4.3.a's runner primitive and P4.1.b's API surface; consumes the storage layer P4.0 shipped.
+
+- **Pure engine** (`tulip_core.allocation.evaluate_refill_rule`): given a `RefillRule`, the envelope's `current_balance`, and (for `PERCENTAGE_OF_INCOME`) the household's `recent_inflow`, returns the `Money` amount to contribute. Always non-negative; returns `Money.zero(...)` when the rule produces no contribution (e.g., `FILL_TO_AMOUNT` already at target, no recent inflow). Raises `CurrencyMismatchError` on cross-currency inputs.
+- **`envelope_refill` runner handler** (`tulip_storage.runner.handlers.envelope_refill`): factory pattern — `make_envelope_refill_handler(session_maker)` returns the `(job, clock) -> None` callback that the runner registers. Handler loads envelope → lazy-creates `Unallocated` system pool for envelope's currency → computes `current_balance` via `ShadowTransactionRepository.balance_for_pool` → for `PERCENTAGE_OF_INCOME`, sums `BUDGET_INFLOW` shadow tx since `last_run_at` (or 30 days for first fire) → calls the engine → posts a 2-leg `REFILL` shadow tx if amount > 0 → writes audit row with `actor_kind="system"`.
+- **Inactive envelope / no-rule envelope** are silent no-ops (don't error → don't retry; the schedule remains active in case the envelope reactivates).
+- **Unknown envelope** raises `EnvelopeRefillError` → runner marks the run failed and retries per the backoff policy.
+- **New repo method** `ShadowTransactionRepository.inflow_since(currency, since)` — sums positive `Unallocated` postings where `reason=BUDGET_INFLOW` and date ≥ since. Used by the handler; refactored out of the handler to keep the architecture-test boundary clean (handlers don't directly query shadow_transactions).
+- **Architecture test** (P4.0's no-direct-shadow-writes) still passes — the handler routes all shadow access through the repo. The P4.3.a no-direct-scheduled-job-writes allowlist gets one new entry for the handler module (it has a TYPE_CHECKING-only `ScheduledJob` import for typing).
+- **Tests**: 26 new (14 engine pure-function tests + 12 handler integration tests covering FIXED_AMOUNT happy path, FILL_TO_AMOUNT with gap and at-target, PERCENTAGE_OF_INCOME with and without inflow, no-rule no-op, inactive-envelope no-op, unknown-envelope error, payload-missing-key error, audit row shape with `actor_kind="system"`, recurring monthly schedule with two fires, full async start/stop pipeline). Project total: **739 passing** (up from 713).
+
 ### Phase 4 deferred to later slices
 
-- **P4.3.b — Refill engine + handler** (#69): pure `evaluate_refill_rule` + `envelope_refill` runner consumer.
 - **P4.3.c — API + CLI for refill schedules** (#70).
 - **P4 follow-up — `--edit` flow for `tulip envelopes add` / `edit`** so users can author RefillRule structures interactively.
 

--- a/packages/tulip-core/src/tulip_core/allocation/__init__.py
+++ b/packages/tulip-core/src/tulip_core/allocation/__init__.py
@@ -19,6 +19,7 @@ from tulip_core.allocation.engine import (
 )
 from tulip_core.allocation.envelope import BudgetPeriod, Envelope, RolloverPolicy
 from tulip_core.allocation.pool import Pool, PoolType
+from tulip_core.allocation.refill_engine import evaluate_refill_rule
 from tulip_core.allocation.refill_rule import RefillRule, RefillStrategy
 from tulip_core.allocation.shadow_posting import ShadowPosting
 from tulip_core.allocation.shadow_transaction import (
@@ -50,5 +51,6 @@ __all__ = [
     "UnknownPoolError",
     "UnsupportedRefundShapedShadowTxError",
     "derive_paired_shadow_tx",
+    "evaluate_refill_rule",
     "post_shadow_transaction",
 ]

--- a/packages/tulip-core/src/tulip_core/allocation/refill_engine.py
+++ b/packages/tulip-core/src/tulip_core/allocation/refill_engine.py
@@ -1,0 +1,97 @@
+"""Pure refill-rule evaluation engine — see ADR-0002 §7.
+
+Given an envelope's :class:`RefillRule`, the envelope's current balance,
+and (for ``PERCENTAGE_OF_INCOME``) the household's recent inflow,
+returns the ``Money`` amount the runner should refill into the envelope.
+
+Pure function: no DB, no clock, no I/O. The runner handler in
+``tulip_storage`` builds the inputs and consumes the output. This
+separation keeps the math in :mod:`tulip_core` testable without
+infrastructure and keeps the no-eval guarantee (per
+``docs/THREAT_MODEL.md §5.1``) trivially provable.
+"""
+
+from __future__ import annotations
+
+from tulip_core.allocation.refill_rule import RefillRule, RefillStrategy
+from tulip_core.money import CurrencyMismatchError, Money
+
+
+def evaluate_refill_rule(
+    rule: RefillRule,
+    *,
+    current_balance: Money,
+    recent_inflow: Money | None = None,
+) -> Money:
+    """Compute the amount to add to an envelope on this refill cycle.
+
+    The returned amount is always non-negative: a rule that produces a
+    zero or negative contribution (e.g. ``FILL_TO_AMOUNT`` when the
+    envelope is already at or above target) yields ``Money.zero(...)``.
+    The runner skips the shadow-tx write when amount is zero.
+
+    Args:
+        rule: The envelope's stored refill rule.
+        current_balance: The envelope's balance in the envelope's
+            currency. The result is always returned in this currency
+            (envelopes are single-currency by construction).
+        recent_inflow: For ``PERCENTAGE_OF_INCOME``, the household's
+            recent inflow in the envelope's currency. ``None`` (or zero)
+            means no inflow since the last evaluation; the rule
+            contributes nothing.
+
+    Returns:
+        ``Money`` in ``current_balance.currency``. Always non-negative.
+
+    Raises:
+        CurrencyMismatchError: A rule input's currency disagrees with
+            ``current_balance.currency``. Indicates an upstream bug — the
+            envelope's storage layer should already enforce that
+            ``rule.amount.currency == envelope.currency``.
+
+    """
+    target_ccy = current_balance.currency
+
+    if rule.strategy is RefillStrategy.FIXED_AMOUNT:
+        # Pre-validated by RefillRule.__post_init__: amount is non-None
+        # and positive. Currency must match the envelope.
+        assert rule.amount is not None  # noqa: S101 - validated by __post_init__
+        if rule.amount.currency != target_ccy:
+            raise CurrencyMismatchError(
+                f"FIXED_AMOUNT rule currency {rule.amount.currency!r} "
+                f"differs from envelope currency {target_ccy!r}"
+            )
+        return rule.amount
+
+    if rule.strategy is RefillStrategy.FILL_TO_AMOUNT:
+        assert rule.amount is not None  # noqa: S101 - validated by __post_init__
+        if rule.amount.currency != target_ccy:
+            raise CurrencyMismatchError(
+                f"FILL_TO_AMOUNT rule currency {rule.amount.currency!r} "
+                f"differs from envelope currency {target_ccy!r}"
+            )
+        gap = rule.amount.amount - current_balance.amount
+        if gap <= 0:
+            # Envelope already at or above target — no contribution.
+            return Money.zero(target_ccy)
+        return Money(gap, target_ccy)
+
+    # PERCENTAGE_OF_INCOME — validated by __post_init__: percentage is
+    # non-None and in (0, 1]. amount is None.
+    assert rule.strategy is RefillStrategy.PERCENTAGE_OF_INCOME  # noqa: S101
+    assert rule.percentage is not None  # noqa: S101 - validated by __post_init__
+
+    if recent_inflow is None or recent_inflow.amount <= 0:
+        return Money.zero(target_ccy)
+    if recent_inflow.currency != target_ccy:
+        raise CurrencyMismatchError(
+            f"recent_inflow currency {recent_inflow.currency!r} differs "
+            f"from envelope currency {target_ccy!r}"
+        )
+    contribution = recent_inflow.amount * rule.percentage
+    if contribution <= 0:
+        return Money.zero(target_ccy)
+    return Money(contribution, target_ccy)
+
+
+__all__ = ["evaluate_refill_rule"]

--- a/packages/tulip-core/tests/test_refill_engine.py
+++ b/packages/tulip-core/tests/test_refill_engine.py
@@ -1,0 +1,175 @@
+"""Unit tests for evaluate_refill_rule (P4.3.b)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from tulip_core.allocation import (
+    RefillRule,
+    RefillStrategy,
+    evaluate_refill_rule,
+)
+from tulip_core.money import CurrencyMismatchError, Money
+
+# ---- FIXED_AMOUNT --------------------------------------------------
+
+
+def test_fixed_amount_returns_rule_amount() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("250"), "USD"),
+    )
+    result = evaluate_refill_rule(rule, current_balance=Money(Decimal("0"), "USD"))
+    assert result == Money(Decimal("250"), "USD")
+
+
+def test_fixed_amount_ignores_current_balance() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("250"), "USD"),
+    )
+    # Even if envelope already has plenty, fixed contributes the same.
+    result = evaluate_refill_rule(rule, current_balance=Money(Decimal("1000"), "USD"))
+    assert result == Money(Decimal("250"), "USD")
+
+
+def test_fixed_amount_currency_mismatch_raises() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("250"), "USD"),
+    )
+    with pytest.raises(CurrencyMismatchError):
+        evaluate_refill_rule(rule, current_balance=Money(Decimal("0"), "EUR"))
+
+
+# ---- FILL_TO_AMOUNT ------------------------------------------------
+
+
+def test_fill_to_amount_returns_gap() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FILL_TO_AMOUNT,
+        amount=Money(Decimal("500"), "USD"),
+    )
+    result = evaluate_refill_rule(rule, current_balance=Money(Decimal("200"), "USD"))
+    assert result == Money(Decimal("300"), "USD")
+
+
+def test_fill_to_amount_zero_when_at_target() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FILL_TO_AMOUNT,
+        amount=Money(Decimal("500"), "USD"),
+    )
+    result = evaluate_refill_rule(rule, current_balance=Money(Decimal("500"), "USD"))
+    assert result == Money.zero("USD")
+
+
+def test_fill_to_amount_zero_when_above_target() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FILL_TO_AMOUNT,
+        amount=Money(Decimal("500"), "USD"),
+    )
+    result = evaluate_refill_rule(rule, current_balance=Money(Decimal("750"), "USD"))
+    assert result == Money.zero("USD")
+
+
+def test_fill_to_amount_full_when_negative_balance() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FILL_TO_AMOUNT,
+        amount=Money(Decimal("500"), "USD"),
+    )
+    # Negative balance is permitted (over-spent envelope). Top-up fills
+    # the gap including the deficit.
+    result = evaluate_refill_rule(rule, current_balance=Money(Decimal("-50"), "USD"))
+    assert result == Money(Decimal("550"), "USD")
+
+
+def test_fill_to_amount_currency_mismatch_raises() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FILL_TO_AMOUNT,
+        amount=Money(Decimal("500"), "USD"),
+    )
+    with pytest.raises(CurrencyMismatchError):
+        evaluate_refill_rule(rule, current_balance=Money(Decimal("0"), "EUR"))
+
+
+# ---- PERCENTAGE_OF_INCOME ------------------------------------------
+
+
+def test_percentage_returns_pct_of_inflow() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("0.10"),
+    )
+    result = evaluate_refill_rule(
+        rule,
+        current_balance=Money(Decimal("0"), "USD"),
+        recent_inflow=Money(Decimal("3000"), "USD"),
+    )
+    assert result == Money(Decimal("300.00"), "USD")
+
+
+def test_percentage_returns_zero_with_no_inflow() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("0.10"),
+    )
+    result = evaluate_refill_rule(
+        rule, current_balance=Money(Decimal("0"), "USD"), recent_inflow=None
+    )
+    assert result == Money.zero("USD")
+
+
+def test_percentage_returns_zero_with_zero_inflow() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("0.10"),
+    )
+    result = evaluate_refill_rule(
+        rule,
+        current_balance=Money(Decimal("0"), "USD"),
+        recent_inflow=Money(Decimal("0"), "USD"),
+    )
+    assert result == Money.zero("USD")
+
+
+def test_percentage_returns_zero_with_negative_inflow() -> None:
+    # Negative inflow shouldn't happen in practice (it would be a refund
+    # shape), but the engine should be robust to it.
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("0.10"),
+    )
+    result = evaluate_refill_rule(
+        rule,
+        current_balance=Money(Decimal("0"), "USD"),
+        recent_inflow=Money(Decimal("-100"), "USD"),
+    )
+    assert result == Money.zero("USD")
+
+
+def test_percentage_currency_mismatch_raises() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("0.10"),
+    )
+    with pytest.raises(CurrencyMismatchError):
+        evaluate_refill_rule(
+            rule,
+            current_balance=Money(Decimal("0"), "USD"),
+            recent_inflow=Money(Decimal("3000"), "EUR"),
+        )
+
+
+def test_percentage_full_inflow_at_100_percent() -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("1.0"),
+    )
+    result = evaluate_refill_rule(
+        rule,
+        current_balance=Money(Decimal("0"), "USD"),
+        recent_inflow=Money(Decimal("500"), "USD"),
+    )
+    assert result == Money(Decimal("500.0"), "USD")

--- a/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
@@ -59,6 +59,45 @@ class ShadowTransactionRepository:
             )
         ).scalar_one_or_none()
 
+    def inflow_since(
+        self,
+        *,
+        currency: str,
+        since: date_type,
+    ) -> Decimal:
+        """Sum POSTED ``BUDGET_INFLOW`` shadow tx for ``currency`` since ``since``.
+
+        Used by the envelope-refill handler (P4.3.b) to compute
+        ``recent_inflow`` for ``PERCENTAGE_OF_INCOME`` rules. Sums the
+        positive (Unallocated) leg of every BUDGET_INFLOW shadow tx
+        whose date is on or after ``since``. Pending and voided shadow
+        txs don't contribute.
+
+        Returns 0 if no inflow has been declared in the window.
+        """
+        from tulip_storage.models import (
+            ShadowPosting,
+            ShadowTxReason,
+        )
+
+        query = (
+            select(func.coalesce(func.sum(ShadowPosting.amount), 0))
+            .join(
+                ShadowTransaction,
+                ShadowTransaction.id == ShadowPosting.shadow_transaction_id,
+            )
+            .where(
+                ShadowPosting.household_id == self._household_id,
+                ShadowPosting.currency == currency,
+                ShadowPosting.amount > 0,  # Unallocated leg
+                ShadowTransaction.reason == ShadowTxReason.BUDGET_INFLOW,
+                ShadowTransaction.status.in_(_BALANCE_STATUSES),
+                ShadowTransaction.date >= since,
+            )
+        )
+        result = self._session.execute(query).scalar_one()
+        return Decimal(str(result))
+
     def get_paired_id_for_main_tx(self, main_tx_id: UUID) -> UUID | None:
         """Return the id of the shadow tx paired to ``main_tx_id``, or None.
 

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/__init__.py
@@ -1,0 +1,16 @@
+"""First-party scheduler handlers — see ADR-0002.
+
+Handlers are registered with a :class:`Runner` instance via
+``register_handler(kind, callback)``. They consume :class:`ScheduledJob`
+rows the runner has dispatched and produce side effects (shadow-ledger
+writes, audit rows, etc.) within their own session scopes.
+
+P4.3.b ships ``envelope_refill`` — the handler that materializes an
+envelope's ``refill_rule`` into a ``REFILL`` shadow transaction on each
+fire. Future handlers (reconciliation reminders, AI cost reports) will
+register the same way.
+"""
+
+from tulip_storage.runner.handlers.envelope_refill import make_envelope_refill_handler
+
+__all__ = ["make_envelope_refill_handler"]

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/envelope_refill.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/envelope_refill.py
@@ -1,0 +1,259 @@
+"""``envelope_refill`` runner handler — see ADR-0002 §4 and P4.3.b (#69).
+
+Materializes an envelope's ``refill_rule`` into a ``REFILL`` shadow
+transaction each time the scheduler fires. The runner passes the
+:class:`ScheduledJob` (whose ``payload`` carries the envelope id) and the
+runner's ``Clock``; the handler does the rest:
+
+1. Loads the envelope and its ``refill_rule``.
+2. Lazy-creates the household's ``Unallocated`` system pool for the
+   envelope's currency if missing.
+3. Computes ``current_balance`` from the shadow ledger.
+4. Computes ``recent_inflow`` for ``PERCENTAGE_OF_INCOME`` strategies
+   (sum of ``BUDGET_INFLOW`` shadow tx since the job's ``last_run_at``,
+   or the last 30 days if first run).
+5. Calls :func:`tulip_core.allocation.evaluate_refill_rule` (pure).
+6. If the engine returns a non-zero amount, posts a 2-leg shadow tx
+   (``Unallocated -X`` / envelope ``+X``) with reason ``REFILL`` and
+   ``actor_kind="system"`` audit metadata.
+
+The handler is constructed via :func:`make_envelope_refill_handler` —
+the factory captures the runner's ``session_maker`` in a closure so the
+handler signature stays the simple ``(job, clock)`` shape ADR-0002 §2
+specifies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from tulip_core.allocation import (
+    RefillRule,
+    RefillStrategy,
+    evaluate_refill_rule,
+)
+from tulip_core.allocation import (
+    ShadowPosting as DomainShadowPosting,
+)
+from tulip_core.allocation import (
+    ShadowTransaction as DomainShadowTransaction,
+)
+from tulip_core.allocation import (
+    ShadowTxReason as DomainShadowTxReason,
+)
+from tulip_core.allocation import (
+    ShadowTxStatus as DomainShadowTxStatus,
+)
+from tulip_core.money import Money
+from tulip_storage.models import PoolType
+from tulip_storage.repositories import (
+    AllocationPoolRepository,
+    AuditLogWriter,
+    EnvelopeRepository,
+    ShadowTransactionRepository,
+)
+from tulip_storage.runner.clock import Clock
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session, sessionmaker
+
+    from tulip_storage.models import ScheduledJob
+    from tulip_storage.runner.runner import HandlerCallback
+
+
+log = logging.getLogger("tulip_storage.runner.handlers.envelope_refill")
+
+
+#: Lookback window for ``PERCENTAGE_OF_INCOME`` rules on the first fire
+#: (when ``ScheduledJob.last_run_at`` is None). Subsequent fires use the
+#: actual last run as the lower bound. 30 days matches the typical
+#: "monthly" budgeting cadence.
+FIRST_FIRE_INFLOW_LOOKBACK = timedelta(days=30)
+
+
+class EnvelopeRefillError(RuntimeError):
+    """Raised by the handler when the refill cannot proceed.
+
+    Surfaces to the runner as a regular exception → the run is marked
+    ``failed`` and retried per the runner's backoff policy. See ADR-0002
+    §7. Distinct from ``ValueError`` so the runner's catch-all logging
+    can differentiate handler-domain errors from generic bugs.
+    """
+
+
+def make_envelope_refill_handler(
+    session_maker: sessionmaker[Session],
+) -> HandlerCallback:
+    """Build the ``envelope_refill`` handler bound to a session factory.
+
+    Returns a callable matching :data:`HandlerCallback`. Call once at
+    runner-construction time::
+
+        runner = Runner(session_maker)
+        runner.register_handler(
+            "envelope_refill",
+            make_envelope_refill_handler(session_maker),
+        )
+
+    The factory shape keeps the handler's signature ``(job, clock)``
+    while still giving it access to a session — per ADR-0002 §2, handlers
+    can't accept extra args without changing the runner's surface.
+    """
+
+    async def handle(job: ScheduledJob, clock: Clock) -> None:
+        envelope_id_raw = job.payload.get("envelope_id")
+        if envelope_id_raw is None:
+            msg = f"envelope_refill job {job.id} payload missing 'envelope_id'; cannot proceed"
+            raise EnvelopeRefillError(msg)
+        # Tolerate both UUID-as-string (JSON) and UUID-as-UUID (rare).
+        envelope_id = UUID(envelope_id_raw) if isinstance(envelope_id_raw, str) else envelope_id_raw
+
+        with session_maker() as session:
+            _process(session, job=job, clock=clock, envelope_id=envelope_id)
+            session.commit()
+
+    return handle
+
+
+def _process(
+    session: Session,
+    *,
+    job: ScheduledJob,
+    clock: Clock,
+    envelope_id: UUID,
+) -> None:
+    """Inner: do all the work in one session scope. Caller commits."""
+    # 1. Load envelope.
+    found = EnvelopeRepository(session, job.household_id).get(envelope_id)
+    if found is None:
+        msg = f"envelope {envelope_id} not found in household {job.household_id} — cannot refill"
+        raise EnvelopeRefillError(msg)
+    pool, env = found
+
+    if not pool.is_active:
+        # Envelope was deactivated since the job was scheduled. Don't
+        # error (which would retry); just no-op silently. Future-proof:
+        # a separate cleanup pass could cancel orphan jobs.
+        log.info(
+            "envelope_refill.skipped_inactive",
+            extra={"envelope_id": str(pool.id), "job_id": str(job.id)},
+        )
+        return
+
+    if env.refill_rule_json is None:
+        # Envelope has no rule — nothing to do. Same no-op shape.
+        log.info(
+            "envelope_refill.skipped_no_rule",
+            extra={"envelope_id": str(pool.id), "job_id": str(job.id)},
+        )
+        return
+
+    rule = RefillRule.from_dict(json.loads(env.refill_rule_json))
+
+    # 2. Lazy-create / fetch the Unallocated system pool.
+    pool_repo = AllocationPoolRepository(session, job.household_id)
+    sys_pools = pool_repo.get_or_create_system_pools(currency=pool.currency)
+    unallocated = sys_pools[PoolType.UNALLOCATED]
+
+    # 3. Current balance.
+    shadow_repo = ShadowTransactionRepository(session, job.household_id)
+    balance_dict = shadow_repo.balance_for_pool(pool.id, currency=pool.currency)
+    current_balance = Money(balance_dict.get(pool.currency, Decimal(0)), pool.currency)
+
+    # 4. Recent inflow — only relevant for PERCENTAGE_OF_INCOME.
+    recent_inflow: Money | None = None
+    if rule.strategy is RefillStrategy.PERCENTAGE_OF_INCOME:
+        since = _inflow_window_start(job, clock)
+        inflow_total = shadow_repo.inflow_since(currency=pool.currency, since=since.date())
+        recent_inflow = Money(inflow_total, pool.currency)
+
+    # 5. Evaluate.
+    refill_amount = evaluate_refill_rule(
+        rule, current_balance=current_balance, recent_inflow=recent_inflow
+    )
+    if refill_amount.amount <= 0:
+        log.info(
+            "envelope_refill.no_contribution",
+            extra={
+                "envelope_id": str(pool.id),
+                "job_id": str(job.id),
+                "reason": rule.strategy.value,
+            },
+        )
+        return
+
+    # 6. Post the shadow tx + audit row.
+    domain_tx = DomainShadowTransaction(
+        id=uuid4(),
+        household_id=job.household_id,
+        date=clock().date(),
+        description=f"Auto-refill: {pool.name}",
+        reason=DomainShadowTxReason.REFILL,
+        postings=(
+            DomainShadowPosting(
+                id=uuid4(),
+                pool_id=unallocated.id,
+                amount=Money(-refill_amount.amount, pool.currency),
+                memo=f"Auto-refill from rule (strategy={rule.strategy.value})",
+            ),
+            DomainShadowPosting(
+                id=uuid4(),
+                pool_id=pool.id,
+                amount=refill_amount,
+                memo=f"Auto-refill into {pool.name}",
+            ),
+        ),
+        status=DomainShadowTxStatus.POSTED,
+        paired_main_tx_id=None,
+        created_by_user_id=None,  # system-initiated
+    )
+    saved = shadow_repo.save_balanced(domain_tx)
+
+    AuditLogWriter(session, job.household_id).write(
+        action="create",
+        actor_kind="system",
+        actor_user_id=None,
+        entity_type="shadow_transaction",
+        entity_id=saved.id,
+        after={
+            "reason": "refill",
+            "description": domain_tx.description,
+            "amount": str(refill_amount.amount),
+            "currency": refill_amount.currency,
+            "envelope_id": str(pool.id),
+            "scheduled_job_id": str(job.id),
+            "rule_strategy": rule.strategy.value,
+        },
+        request_id=None,
+    )
+
+    log.info(
+        "envelope_refill.completed",
+        extra={
+            "envelope_id": str(pool.id),
+            "job_id": str(job.id),
+            "amount": str(refill_amount.amount),
+            "currency": refill_amount.currency,
+        },
+    )
+
+
+def _inflow_window_start(job: ScheduledJob, clock: Clock) -> datetime:
+    """Lower-bound for the recent-inflow query.
+
+    First fire (no ``last_run_at``): use a 30-day lookback. Subsequent
+    fires: use the actual ``last_run_at``.
+    """
+    now = clock()
+    if job.last_run_at is None:
+        return now - FIRST_FIRE_INFLOW_LOOKBACK
+    last = job.last_run_at
+    # SQLite DateTime(timezone=True) returns naive on read; normalize.
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=UTC)
+    return last

--- a/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
@@ -40,6 +40,9 @@ _ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
         # The runner — only legitimate writer.
         "tulip-storage/src/tulip_storage/runner/runner.py",
         "tulip-storage/src/tulip_storage/runner/__init__.py",
+        # First-party handlers — receive ScheduledJob instances from the
+        # runner; the type-only import is required for typing.
+        "tulip-storage/src/tulip_storage/runner/handlers/envelope_refill.py",
     }
 )
 

--- a/packages/tulip-storage/tests/test_envelope_refill_handler.py
+++ b/packages/tulip-storage/tests/test_envelope_refill_handler.py
@@ -1,0 +1,592 @@
+"""Integration tests for the envelope_refill runner handler (P4.3.b)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+
+from tulip_core.allocation import (
+    RefillRule,
+    RefillStrategy,
+)
+from tulip_core.allocation import (
+    ShadowPosting as DomainShadowPosting,
+)
+from tulip_core.allocation import (
+    ShadowTransaction as DomainShadowTransaction,
+)
+from tulip_core.allocation import (
+    ShadowTxReason as DomainShadowTxReason,
+)
+from tulip_core.allocation import (
+    ShadowTxStatus as DomainShadowTxStatus,
+)
+from tulip_core.money import Money
+from tulip_storage.models import (
+    AuditLog,
+    BudgetPeriod,
+    Household,
+    PoolType,
+    RolloverPolicy,
+    ShadowTransaction,
+)
+from tulip_storage.repositories import (
+    AllocationPoolRepository,
+    EnvelopeRepository,
+    ShadowTransactionRepository,
+)
+from tulip_storage.runner import Runner
+from tulip_storage.runner.handlers import make_envelope_refill_handler
+from tulip_storage.runner.handlers.envelope_refill import EnvelopeRefillError
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+# ---- Fixtures ---------------------------------------------------------
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+class FakeClock:
+    def __init__(self, *, now: datetime) -> None:
+        self._now = now
+
+    def __call__(self) -> datetime:
+        return self._now
+
+    def advance(self, delta: timedelta) -> None:
+        self._now += delta
+
+
+def _seed_envelope(
+    session: Session,
+    household_id: UUID,
+    *,
+    name: str,
+    refill_rule: RefillRule | None,
+    currency: str = "USD",
+) -> UUID:
+    repo = EnvelopeRepository(session, household_id)
+    pool, _env = repo.create(
+        name=name,
+        currency=currency,
+        budget_period=BudgetPeriod.MONTHLY,
+        rollover_policy=RolloverPolicy.RESET,
+        refill_rule=refill_rule.to_dict() if refill_rule is not None else None,
+    )
+    session.commit()
+    return pool.id
+
+
+def _seed_inflow(
+    session: Session,
+    household_id: UUID,
+    *,
+    amount: Decimal,
+    currency: str,
+    when: date,
+) -> None:
+    """Post a BUDGET_INFLOW shadow tx so PERCENTAGE_OF_INCOME has data."""
+    pool_repo = AllocationPoolRepository(session, household_id)
+    sys_pools = pool_repo.get_or_create_system_pools(currency=currency)
+    inflow_pool = sys_pools[PoolType.INFLOW]
+    unallocated_pool = sys_pools[PoolType.UNALLOCATED]
+    domain_tx = DomainShadowTransaction(
+        id=uuid4(),
+        household_id=household_id,
+        date=when,
+        description="Test inflow",
+        reason=DomainShadowTxReason.BUDGET_INFLOW,
+        postings=(
+            DomainShadowPosting(
+                id=uuid4(),
+                pool_id=inflow_pool.id,
+                amount=Money(-amount, currency),
+            ),
+            DomainShadowPosting(
+                id=uuid4(),
+                pool_id=unallocated_pool.id,
+                amount=Money(amount, currency),
+            ),
+        ),
+        status=DomainShadowTxStatus.POSTED,
+    )
+    ShadowTransactionRepository(session, household_id).save_balanced(domain_tx)
+    session.commit()
+
+
+def _make_runner_with_handler(session_maker: sessionmaker[Session], *, clock: FakeClock) -> Runner:
+    runner = Runner(session_maker, clock=clock, poll_interval_seconds=0.01)
+    runner.register_handler("envelope_refill", make_envelope_refill_handler(session_maker))
+    return runner
+
+
+def _envelope_balance(
+    session: Session, household_id: UUID, envelope_id: UUID, currency: str
+) -> Decimal:
+    return (
+        ShadowTransactionRepository(session, household_id)
+        .balance_for_pool(envelope_id, currency=currency)
+        .get(currency, Decimal(0))
+    )
+
+
+# ---- FIXED_AMOUNT happy path -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fixed_amount_refill_posts_shadow_tx(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("250"), "USD"),
+    )
+    envelope_id = _seed_envelope(session, household.id, name="Groceries", refill_rule=rule)
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        fire_at=t0,
+    )
+    fired = await runner.run_once()
+    assert fired == 1
+
+    # Envelope balance grew by 250.
+    session.expire_all()
+    balance = _envelope_balance(session, household.id, envelope_id, "USD")
+    assert balance == Decimal("250")
+
+
+# ---- FILL_TO_AMOUNT semantics ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fill_to_amount_tops_up_only_the_gap(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FILL_TO_AMOUNT,
+        amount=Money(Decimal("500"), "USD"),
+    )
+    envelope_id = _seed_envelope(session, household.id, name="Rent", refill_rule=rule)
+
+    # Pre-seed envelope with 200 via a manual refill from Unallocated.
+    pool_repo = AllocationPoolRepository(session, household.id)
+    unallocated = pool_repo.get_or_create_system_pools(currency="USD")[PoolType.UNALLOCATED]
+    seed_tx = DomainShadowTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 5, 15),
+        description="Pre-seed",
+        reason=DomainShadowTxReason.REFILL,
+        postings=(
+            DomainShadowPosting(
+                id=uuid4(),
+                pool_id=unallocated.id,
+                amount=Money(Decimal("-200"), "USD"),
+            ),
+            DomainShadowPosting(
+                id=uuid4(),
+                pool_id=envelope_id,
+                amount=Money(Decimal("200"), "USD"),
+            ),
+        ),
+        status=DomainShadowTxStatus.POSTED,
+    )
+    ShadowTransactionRepository(session, household.id).save_balanced(seed_tx)
+    session.commit()
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        fire_at=t0,
+    )
+    await runner.run_once()
+
+    session.expire_all()
+    balance = _envelope_balance(session, household.id, envelope_id, "USD")
+    assert balance == Decimal("500")  # filled to target
+
+
+@pytest.mark.asyncio
+async def test_fill_to_amount_skips_when_at_target(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FILL_TO_AMOUNT,
+        amount=Money(Decimal("500"), "USD"),
+    )
+    envelope_id = _seed_envelope(session, household.id, name="Rent", refill_rule=rule)
+    # Pre-seed envelope at exactly target.
+    pool_repo = AllocationPoolRepository(session, household.id)
+    unallocated = pool_repo.get_or_create_system_pools(currency="USD")[PoolType.UNALLOCATED]
+    ShadowTransactionRepository(session, household.id).save_balanced(
+        DomainShadowTransaction(
+            id=uuid4(),
+            household_id=household.id,
+            date=date(2026, 5, 15),
+            description="Pre-seed at target",
+            reason=DomainShadowTxReason.REFILL,
+            postings=(
+                DomainShadowPosting(
+                    id=uuid4(),
+                    pool_id=unallocated.id,
+                    amount=Money(Decimal("-500"), "USD"),
+                ),
+                DomainShadowPosting(
+                    id=uuid4(),
+                    pool_id=envelope_id,
+                    amount=Money(Decimal("500"), "USD"),
+                ),
+            ),
+            status=DomainShadowTxStatus.POSTED,
+        )
+    )
+    session.commit()
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        fire_at=t0,
+    )
+    await runner.run_once()
+
+    session.expire_all()
+    balance = _envelope_balance(session, household.id, envelope_id, "USD")
+    assert balance == Decimal("500")  # unchanged
+
+    # No new REFILL shadow tx posted (only the pre-seed exists).
+    refill_count = (
+        session.execute(
+            select(ShadowTransaction).where(
+                ShadowTransaction.household_id == household.id,
+                ShadowTransaction.description == "Auto-refill: Rent",
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert refill_count == []
+
+
+# ---- PERCENTAGE_OF_INCOME --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_percentage_of_income_uses_recent_inflow(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("0.10"),
+    )
+    envelope_id = _seed_envelope(session, household.id, name="Savings", refill_rule=rule)
+    # 3000 USD inflow within the 30-day lookback window.
+    _seed_inflow(
+        session,
+        household.id,
+        amount=Decimal("3000"),
+        currency="USD",
+        when=date(2026, 5, 28),
+    )
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        fire_at=t0,
+    )
+    await runner.run_once()
+
+    session.expire_all()
+    balance = _envelope_balance(session, household.id, envelope_id, "USD")
+    assert balance == Decimal("300.00")  # 10% of 3000
+
+
+@pytest.mark.asyncio
+async def test_percentage_of_income_zero_when_no_inflow(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.PERCENTAGE_OF_INCOME,
+        percentage=Decimal("0.10"),
+    )
+    envelope_id = _seed_envelope(session, household.id, name="Savings", refill_rule=rule)
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        fire_at=t0,
+    )
+    await runner.run_once()
+
+    session.expire_all()
+    balance = _envelope_balance(session, household.id, envelope_id, "USD")
+    assert balance == Decimal("0")
+
+
+# ---- No-op cases -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_envelope_with_no_refill_rule_is_silent_no_op(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    envelope_id = _seed_envelope(session, household.id, name="No rule", refill_rule=None)
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        fire_at=t0,
+    )
+    fired = await runner.run_once()
+    assert fired == 1
+
+    session.expire_all()
+    assert _envelope_balance(session, household.id, envelope_id, "USD") == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_inactive_envelope_is_silent_no_op(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("250"), "USD"),
+    )
+    envelope_id = _seed_envelope(session, household.id, name="Dead", refill_rule=rule)
+    AllocationPoolRepository(session, household.id).deactivate(envelope_id)
+    session.commit()
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        fire_at=t0,
+    )
+    fired = await runner.run_once()
+    assert fired == 1
+
+    session.expire_all()
+    assert _envelope_balance(session, household.id, envelope_id, "USD") == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_unknown_envelope_raises_envelope_refill_error(
+    session_maker: sessionmaker[Session],
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(uuid4())},  # nonexistent
+        fire_at=t0,
+    )
+    # The runner catches the handler exception → fails the run, schedules retry.
+    await runner.run_once()
+    # No exception bubbles out; the runner records the failure.
+
+
+@pytest.mark.asyncio
+async def test_payload_missing_envelope_id_raises(
+    session_maker: sessionmaker[Session],
+    household: Household,
+) -> None:
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    handler = make_envelope_refill_handler(session_maker)
+
+    from tulip_storage.models import ScheduledJob
+
+    bogus_job = ScheduledJob(
+        household_id=household.id,
+        id=uuid4(),
+        kind="envelope_refill",
+        payload={"wrong_key": "x"},
+        rrule=None,
+        dtstart=t0,
+        next_run_at=t0,
+        idempotency_key=None,
+        is_active=True,
+        created_by_user_id=None,
+    )
+    with pytest.raises(EnvelopeRefillError, match="envelope_id"):
+        await handler(bogus_job, clock)
+
+
+# ---- Audit log -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_row_written_with_actor_kind_system(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("250"), "USD"),
+    )
+    envelope_id = _seed_envelope(session, household.id, name="Groceries", refill_rule=rule)
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        fire_at=t0,
+    )
+    await runner.run_once()
+
+    session.expire_all()
+    audit_rows = list(
+        session.execute(
+            select(AuditLog).where(
+                AuditLog.household_id == household.id,
+                AuditLog.entity_type == "shadow_transaction",
+                AuditLog.action == "create",
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audit_rows) == 1
+    row = audit_rows[0]
+    assert row.actor_kind == "system"
+    assert row.actor_user_id is None
+    after = row.after_snapshot or {}
+    assert after.get("reason") == "refill"
+    assert after.get("envelope_id") == str(envelope_id)
+    assert after.get("amount") == "250"
+    assert after.get("rule_strategy") == "fixed_amount"
+
+
+# ---- Recurring schedule end-to-end -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recurring_refill_fires_monthly(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("100"), "USD"),
+    )
+    envelope_id = _seed_envelope(session, household.id, name="Groceries", refill_rule=rule)
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_recurring(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        rrule="FREQ=MONTHLY",
+        start_at=t0,
+    )
+
+    # Fire month 1.
+    await runner.run_once()
+    session.expire_all()
+    assert _envelope_balance(session, household.id, envelope_id, "USD") == Decimal("100")
+
+    # Advance 1 month and fire again.
+    clock.advance(timedelta(days=31))
+    await runner.run_once()
+    session.expire_all()
+    assert _envelope_balance(session, household.id, envelope_id, "USD") == Decimal("200")
+
+
+# ---- Loop drives the full pipeline -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_loop_fires_envelope_refill_end_to_end(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    """The full async loop (start/stop) materializes a refill."""
+    rule = RefillRule(
+        strategy=RefillStrategy.FIXED_AMOUNT,
+        amount=Money(Decimal("75"), "USD"),
+    )
+    envelope_id = _seed_envelope(session, household.id, name="Coffee", refill_rule=rule)
+
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _make_runner_with_handler(session_maker, clock=clock)
+    runner.schedule_one(
+        household_id=household.id,
+        kind="envelope_refill",
+        payload={"envelope_id": str(envelope_id)},
+        fire_at=t0,
+    )
+    await runner.start()
+    await asyncio.sleep(0.05)  # one poll tick
+    await runner.stop()
+
+    session.expire_all()
+    assert _envelope_balance(session, household.id, envelope_id, "USD") == Decimal("75")


### PR DESCRIPTION
Closes #69. Second slice of P4.3 — sits on top of P4.3.a's runner primitive (PR #71, just merged) and P4.1.b's API surface. Materializes envelope refills automatically when the scheduler fires.

P4.3.c (#70) ships the API + CLI surface for users to schedule / list / cancel refill jobs.

## Summary

**Pure engine** \`tulip_core.allocation.evaluate_refill_rule\`:
- Three strategies — \`FIXED_AMOUNT\`, \`FILL_TO_AMOUNT\`, \`PERCENTAGE_OF_INCOME\`. Each handled as straight arithmetic on \`Money\` values.
- Always returns non-negative \`Money\` in the envelope's currency. \`Money.zero(...)\` when the rule contributes nothing (e.g. \`FILL_TO_AMOUNT\` already at target, or \`PERCENTAGE_OF_INCOME\` with no recent inflow).
- Raises \`CurrencyMismatchError\` on cross-currency inputs. Pure function, no DB, no clock, no I/O.

**\`envelope_refill\` runner handler** in \`tulip_storage.runner.handlers.envelope_refill\`:
- Factory pattern — \`make_envelope_refill_handler(session_maker)\` returns the \`(job, clock) -> None\` callback the runner expects. Lets the handler capture its session factory in a closure without changing ADR-0002's runner surface.
- Flow: load envelope → lazy-create \`Unallocated\` system pool for the envelope's currency → compute \`current_balance\` via \`ShadowTransactionRepository.balance_for_pool\` → for \`PERCENTAGE_OF_INCOME\`, sum \`BUDGET_INFLOW\` shadow tx since \`last_run_at\` (or 30 days for first fire) → call the engine → if amount > 0, post a 2-leg \`REFILL\` shadow tx (\`Unallocated -X\` / envelope \`+X\`) → write audit row with \`actor_kind=\"system\"\`.
- **No-op cases (don't retry)**: envelope inactive, envelope has no \`refill_rule\`, engine returns zero. The schedule remains active in case the envelope reactivates.
- **Error cases (runner retries)**: envelope deleted / not found, payload missing \`envelope_id\`. Mapped to \`EnvelopeRefillError\` so retry/dead-letter from ADR-0002 §7 applies.

**New repo method** \`ShadowTransactionRepository.inflow_since(currency, since)\`:
- Sums the positive \`Unallocated\` leg of every \`BUDGET_INFLOW\` shadow tx with \`status=POSTED\` and \`date >= since\`.
- Used by the handler. Refactored out so the architecture-test boundary stays clean — handlers don't directly query \`ShadowTransaction\`/\`ShadowPosting\` from the storage layer.

**Architecture test** updated: the no-direct-shadow-writes test from P4.0 still passes (handler routes shadow access through the repo). The no-direct-scheduled-job-writes test from P4.3.a gets the handler module added to its allowlist (TYPE_CHECKING-only \`ScheduledJob\` import for the \`(job, clock)\` signature is a legitimate runner-internal site).

**Audit log** for system-initiated refills:
- \`entity_type=\"shadow_transaction\"\`, \`actor_kind=\"system\"\`, \`actor_user_id=None\`.
- \`after_snapshot\` includes \`reason\`, \`description\`, \`amount\`, \`currency\`, \`envelope_id\`, \`scheduled_job_id\`, \`rule_strategy\` — plenty of detail for forensics + future report packs.

**26 new tests** — 14 engine pure-function tests (every strategy + edge case + currency mismatch) + 12 handler integration tests (FIXED_AMOUNT happy path, FILL_TO_AMOUNT gap + at-target, PERCENTAGE_OF_INCOME with and without inflow, no-rule no-op, inactive-envelope no-op, unknown-envelope error, payload-missing-key error, audit row shape, recurring monthly schedule, full async start/stop pipeline). **Project total: 739 passing** (up from 713). Lint + mypy --strict clean.

## Subagent retrospective

Did **not** spawn Explore/Plan agents for P4.3.b. Reasoning: ADR-0002 already pinned every design decision (sign rule, evaluation engine signature, handler factory pattern, no-op vs error cases, audit shape), so the planning was already done. The P4.3.b implementation was a direct execution of that plan. Per \`feedback_subagent_usage.md\`: \"skip subagents for trivial work or anything inherently serial.\" P4.3.b was the latter — well-specified, purely linear from ADR to code. Pattern continues to validate.

## Test plan

- [x] Full pytest run: 739 passing
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy packages/\` — clean (125 source files)
- [x] Engine: every strategy + currency mismatch + edge cases (14 tests)
- [x] Handler: every strategy happy path + every no-op / error / audit path + recurring + full async loop (12 tests)
- [x] Architecture test (P4.0 no-direct-shadow-writes) still passes
- [x] Architecture test (P4.3.a no-direct-scheduled-job-writes) updated allowlist still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)