### PR TITLE
chore: add justfile mirroring CI jobs (#75)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,8 @@ uv run pre-commit install
 uv run pytest                    # confirm green
 ```
 
+A [`justfile`](./justfile) wraps the common workflows so you don't have to remember each `uv run …` invocation. `just` (no args) lists the recipes; `just ci` reproduces locally what CI runs on every PR. The recipes mirror `.github/workflows/ci.yml` and should be kept in sync with it.
+
 SQLCipher development headers are *only* required once full-DB SQLCipher encryption lands (Phase 1.x). The current Phase 1 / Phase 2 codebase uses field-level AES-256-GCM (via the pure-Python `cryptography` library) and needs no native sqlcipher install to develop or test against.
 
 ## Project conventions
@@ -101,7 +103,7 @@ If your change involves a non-trivial architectural decision — choosing betwee
 
 1. Fork the repo and create a feature branch from `main`.
 2. Make your changes following the conventions above. Commit incrementally.
-3. Ensure `uv run pytest`, `uv run ruff check`, `uv run mypy`, and `uv run pre-commit run --all-files` all pass locally.
+3. Ensure `just ci` (or the underlying `uv run pytest`, `uv run ruff check`, `uv run mypy`, and `uv run pre-commit run --all-files`) all pass locally.
 4. Push to your fork and open a PR against `main`.
 5. The PR description should:
    - Reference any related issue(s).

--- a/justfile
+++ b/justfile
@@ -1,0 +1,77 @@
+# Tulip Accounting — task runner
+#
+# Recipes mirror the jobs that CI enforces (.github/workflows/ci.yml). When CI
+# changes, update this file in the same PR — it's meant to be a single source
+# of truth for "what command do I run locally?".
+#
+# Run `just` (no args) or `just help` to see the recipe list.
+
+set shell := ["bash", "-cu"]
+
+# Default recipe: list everything available.
+default:
+    @just --list
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+# Install all workspace packages and dev dependencies.
+sync:
+    uv sync --all-packages --dev
+
+# Install pre-commit hooks into .git/hooks/.
+precommit-install:
+    uv run pre-commit install
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# Run the full test suite (matches CI's default loop).
+test:
+    uv run pytest
+
+# Fast loop — skip slow / integration markers for quick local feedback.
+test-fast:
+    uv run pytest -m "not slow and not integration"
+
+# Run tests with coverage and the 85% gate (mirrors CI exactly).
+coverage:
+    uv run pytest \
+        --cov \
+        --cov-report=term \
+        --cov-report=html \
+        --cov-fail-under=85
+
+# ---------------------------------------------------------------------------
+# Lint / format / type-check
+# ---------------------------------------------------------------------------
+
+# Lint with ruff.
+lint:
+    uv run ruff check
+
+# Apply ruff's autofixes and reformat.
+format:
+    uv run ruff check --fix
+    uv run ruff format
+
+# Verify formatting without writing (CI variant — fails if anything would change).
+format-check:
+    uv run ruff format --check
+
+# Strict static type checking.
+typecheck:
+    uv run mypy
+
+# Run all pre-commit hooks across the full tree.
+precommit:
+    uv run pre-commit run --all-files
+
+# ---------------------------------------------------------------------------
+# Aggregate
+# ---------------------------------------------------------------------------
+
+# Run every check CI runs, in roughly the same order. Use before pushing.
+ci: lint format-check typecheck coverage


### PR DESCRIPTION
Closes #75.

## Summary
- Add `justfile` at repo root with recipes that mirror what `.github/workflows/ci.yml` runs: `test`, `test-fast`, `lint`, `format`, `format-check`, `typecheck`, `coverage`, `precommit`, plus a `sync` setup helper and an aggregate `ci` recipe.
- `just` (no args) lists everything; `just ci` reproduces locally what CI enforces on every PR.
- `CONTRIBUTING.md` gets a short pointer to the new file and the PR-submission checklist now references `just ci` ahead of the underlying `uv run …` commands.

## Why
With seven workspace packages and a strict toolchain (ruff with S/D/ANN, mypy --strict, hypothesis, schemathesis, 85% coverage gate), "what command do I run?" friction adds up. A thin task runner makes the local surface discoverable without taking on a build system.

## Out of scope
- No `bench` / `mutation` recipes — those land with #78 / #79 when the underlying tooling does.

## Test plan
- [x] `just --list` shows all recipes with their docstrings.
- [x] `just lint` runs clean against the current tree.
- [x] `pre-commit run --files justfile CONTRIBUTING.md` passes.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)