### PR TITLE
chore: bump file-descriptor soft limit in just test recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,6 +8,15 @@
 
 set shell := ["bash", "-cu"]
 
+# Raise the file-descriptor soft limit before running pytest. Default macOS
+# soft limit is 256, which is too low for parallel xdist + per-test
+# SQLAlchemy engine pools across 700+ tests; symptom is `OSError: [Errno
+# 24] Too many open files` mid-run. CI Linux runners default to 1024+ and
+# don't need this. The redirect silences the error if the platform's hard
+# limit caps below our request — tests still run with whatever soft limit
+# was in place. See #90 for the underlying engine-disposal cleanup.
+fd_bump := "ulimit -n 8192 2>/dev/null || true"
+
 # Default recipe: list everything available.
 default:
     @just --list
@@ -30,15 +39,15 @@ precommit-install:
 
 # Run the full test suite, parallelised via pytest-xdist (matches CI).
 test:
-    uv run pytest -n auto
+    {{fd_bump}}; uv run pytest -n auto
 
 # Fast loop — skip slow / integration markers for quick local feedback.
 test-fast:
-    uv run pytest -n auto -m "not slow and not integration"
+    {{fd_bump}}; uv run pytest -n auto -m "not slow and not integration"
 
 # Run tests with coverage and the 85% gate (mirrors CI exactly).
 coverage:
-    uv run pytest -n auto \
+    {{fd_bump}}; uv run pytest -n auto \
         --cov \
         --cov-report=term \
         --cov-report=html \
@@ -76,7 +85,7 @@ audit:
 # Run pytest-benchmark performance baselines (excluded from default test loop).
 # Sequential — pytest-benchmark is incompatible with xdist parallelism.
 bench:
-    uv run pytest -m benchmark --benchmark-only
+    {{fd_bump}}; uv run pytest -m benchmark --benchmark-only
 
 # Run mutation testing on tulip-core. SLOW — expect roughly an hour of
 # wall-clock on a default machine. Don't run this in the inner dev loop;


### PR DESCRIPTION
## Summary
- Each pytest-running \`just\` recipe (\`test\`, \`test-fast\`, \`coverage\`, \`bench\`) now prepends \`ulimit -n 8192\` before invoking pytest. macOS default is 256, which isn't enough for parallel xdist + per-test SQLAlchemy engine pools across 700+ tests.
- New \`fd_bump\` variable in the justfile keeps the snippet defined once with a comment explaining the why and pointing at the follow-up issue.
- File a follow-up issue (#90) to fix the underlying engine-leak in the conftest fixtures rather than relying on this band-aid forever.

## Why band-aid + follow-up
\`OSError: [Errno 24] Too many open files\` is a *symptom* of the test fixtures not disposing SQLAlchemy engines on teardown. The proper fix (yield + dispose, or \`NullPool\`) is a real refactor across the api / cli / contract-test conftests — covered in #90. This PR unblocks the inner dev loop today; #90 removes the workaround later.

## Numbers
On the user's macOS (default \`ulimit -n 256\`):
- before: 31 failed + 18 errored mid-suite (per their \`just-ci.txt\`)
- after: **772 passed in 108s**

## Test plan
- [x] \`just --list\` parses cleanly; recipe expansion shows the \`fd_bump\` interpolation.
- [x] \`just test\` runs the full suite green (772 passed, 108s).
- [x] \`pre-commit run --files justfile\` clean.
- [ ] CI green on this PR (CI is unaffected — Linux runners already have higher fd limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)