### PR TITLE
test: dispose SQLAlchemy engines on fixture teardown (#90)

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,15 +8,6 @@
 
 set shell := ["bash", "-cu"]
 
-# Raise the file-descriptor soft limit before running pytest. Default macOS
-# soft limit is 256, which is too low for parallel xdist + per-test
-# SQLAlchemy engine pools across 700+ tests; symptom is `OSError: [Errno
-# 24] Too many open files` mid-run. CI Linux runners default to 1024+ and
-# don't need this. The redirect silences the error if the platform's hard
-# limit caps below our request — tests still run with whatever soft limit
-# was in place. See #90 for the underlying engine-disposal cleanup.
-fd_bump := "ulimit -n 8192 2>/dev/null || true"
-
 # Default recipe: list everything available.
 default:
     @just --list
@@ -39,15 +30,15 @@ precommit-install:
 
 # Run the full test suite, parallelised via pytest-xdist (matches CI).
 test:
-    {{fd_bump}}; uv run pytest -n auto
+    uv run pytest -n auto
 
 # Fast loop — skip slow / integration markers for quick local feedback.
 test-fast:
-    {{fd_bump}}; uv run pytest -n auto -m "not slow and not integration"
+    uv run pytest -n auto -m "not slow and not integration"
 
 # Run tests with coverage and the 85% gate (mirrors CI exactly).
 coverage:
-    {{fd_bump}}; uv run pytest -n auto \
+    uv run pytest -n auto \
         --cov \
         --cov-report=term \
         --cov-report=html \
@@ -85,7 +76,7 @@ audit:
 # Run pytest-benchmark performance baselines (excluded from default test loop).
 # Sequential — pytest-benchmark is incompatible with xdist parallelism.
 bench:
-    {{fd_bump}}; uv run pytest -m benchmark --benchmark-only
+    uv run pytest -m benchmark --benchmark-only
 
 # Run mutation testing on tulip-core. SLOW — expect roughly an hour of
 # wall-clock on a default machine. Don't run this in the inner dev loop;

--- a/packages/tulip-api/tests/conftest.py
+++ b/packages/tulip-api/tests/conftest.py
@@ -48,7 +48,11 @@ def db_url(tmp_path: Path) -> str:
 
 
 @pytest.fixture
-def session_maker(db_url: str) -> sessionmaker[Session]:
+def session_maker(db_url: str) -> Iterator[sessionmaker[Session]]:
+    # Yield + dispose so every test's engine has its connection pool
+    # explicitly closed at teardown. Without this, ~200 API tests each
+    # leave a 5-connection pool open until process exit, exhausting the
+    # macOS 256-fd default soft limit under xdist parallelism. See #90.
     eng = create_engine(db_url, future=True)
 
     @event.listens_for(eng, "connect")
@@ -57,7 +61,10 @@ def session_maker(db_url: str) -> sessionmaker[Session]:
         c.execute("PRAGMA foreign_keys=ON")
         c.close()
 
-    return sessionmaker(eng, expire_on_commit=False)
+    try:
+        yield sessionmaker(eng, expire_on_commit=False)
+    finally:
+        eng.dispose()
 
 
 @pytest.fixture

--- a/packages/tulip-api/tests/test_openapi_contract.py
+++ b/packages/tulip-api/tests/test_openapi_contract.py
@@ -70,6 +70,7 @@ def _build_app():
     from alembic.config import Config
     from sqlalchemy import create_engine, event
     from sqlalchemy.orm import Session, sessionmaker
+    from sqlalchemy.pool import NullPool
 
     db_path = Path(tempfile.gettempdir()) / f"tulip-schemathesis-{os.getpid()}.db"
     db_path.unlink(missing_ok=True)
@@ -84,7 +85,11 @@ def _build_app():
     )
     upgrade(cfg, "head")
 
-    engine = create_engine(db_url, future=True)
+    # NullPool: this engine lives at module scope (until process exit),
+    # so a normal QueuePool would retain up to 5 connections per xdist
+    # worker for the full test run. NullPool closes each connection
+    # when it's checked back in, eliminating the FD residency. See #90.
+    engine = create_engine(db_url, future=True, poolclass=NullPool)
 
     @event.listens_for(engine, "connect")
     def _enable_fk(dc, _r):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Closes #90.

## Summary
Two fixes that close the test-suite FD leak that #91 papered over with a \`ulimit\` bump.

1. **\`packages/tulip-api/tests/conftest.py\` — \`session_maker\` is now an \`Iterator\` fixture.** It yields the sessionmaker and explicitly calls \`engine.dispose()\` on teardown. Previously each of ~200 API tests left a 5-connection pool open until process exit, producing thousands of accumulated FDs across the run.

2. **\`packages/tulip-api/tests/test_openapi_contract.py\` — module-level engine now uses \`poolclass=NullPool\`.** This engine lives at module scope (until process exit), so a yielding fixture isn't an option without a much larger refactor. \`NullPool\` closes each connection when checked back in instead, eliminating FD residency without changing the engine's lifetime.

The \`tulip-cli\` \`live_api\` fixture's uvicorn subprocesses already terminate at fixture teardown, so subprocess engine pools are naturally cleaned up. No change needed there.

The \`fd_bump\` band-aid in \`justfile\` from #91 is removed.

## Verification

| Test | Before this PR | After this PR |
|---|---|---|
| \`bash -c 'ulimit -n 256 && uv run pytest -n auto'\` | 31 failed + 18 errored mid-suite (\`OSError: [Errno 24] Too many open files\`) | **772 passed, 103s** |
| \`grep -c "unclosed database" <output>\` | hundreds | **0** |

This satisfies #90's full acceptance:
- [x] Remove the \`fd_bump\` workaround from \`justfile\`.
- [x] \`just test\` passes on a fresh macOS shell with default \`ulimit -n 256\`.
- [x] No unclosed-connection \`ResourceWarning\`s in the test output.

## Test plan
- [x] \`bash -c 'ulimit -n 256 && just test'\` — passes 772/772.
- [x] \`pytest -n auto 2>&1 | grep -c "unclosed database"\` — 0.
- [x] \`pre-commit run --files <changed>\` — clean.
- [ ] CI green on this PR (Linux runners already have plenty of FDs; this PR shouldn't change CI behaviour, just makes local-mac match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)