### PR TITLE
chore: VS Code workspace baseline (extensions, settings, launch configs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,14 @@ junit.xml
 *.sqlite3
 
 # IDE / editor
-.vscode/
+# Team-shared VS Code config (extensions, workspace settings, debug
+# launch configs) is committed; everything else under .vscode/ is
+# user-local. Add new shared files to the whitelist.
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/launch.json
+!.vscode/tasks.json
 .idea/
 *.swp
 *.swo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,23 @@
+{
+  "// ": "Extensions VS Code recommends when this workspace opens. Each one matches a tool already in the project's CI / pre-commit / justfile, so accepting them gives the same lint/format/type-check loop as `just ci` directly in the editor.",
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff",
+    "ms-python.mypy-type-checker",
+    "tamasfe.even-better-toml",
+    "redhat.vscode-yaml",
+    "editorconfig.editorconfig",
+    "github.vscode-github-actions",
+    "nefrob.vscode-just-syntax",
+    "yzhang.markdown-all-in-one"
+  ],
+  "// unwantedRecommendations": "Tools that overlap with or contradict the project's toolchain. Ruff replaces all of these, so suggesting them would be misleading.",
+  "unwantedRecommendations": [
+    "ms-python.black-formatter",
+    "ms-python.isort",
+    "ms-python.flake8",
+    "ms-python.pylint",
+    "ms-python.autopep8"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,60 @@
+{
+  // Debug entry points. Each one matches a workflow developers actually
+  // run; if you find yourself debugging the same scenario three times
+  // through Run Without Debugging, add a config here.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Pytest: current file",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "${file}",
+        "-vv",
+        "-x"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "Pytest: full default loop",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "-vv",
+        "-m",
+        "not benchmark"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "Tulip API (uvicorn, dev)",
+      // Test-only secrets — never use these against a real database.
+      // Same values the CLI integration tests use for live_api.
+      "type": "debugpy",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": [
+        "tulip_api.main:create_app",
+        "--factory",
+        "--reload",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8000",
+        "--log-level",
+        "debug"
+      ],
+      "env": {
+        "TULIP_DATABASE_URL": "sqlite:///${workspaceFolder}/tulip-dev.db",
+        "TULIP_JWT_SECRET": "dev-secret-32bytes-dev-secret!!!",
+        "TULIP_MASTER_KEY": "q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s="
+      },
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,78 @@
+{
+  // Team-shared VS Code settings for the tulip-accounting workspace.
+  //
+  // Goal: opening this repo and accepting the recommended extensions
+  // (.vscode/extensions.json) gives the same lint / format / type-check
+  // loop that `just ci` runs, without per-contributor setup. Anything
+  // user-specific belongs in your local settings, not here.
+
+  // ---- Python interpreter --------------------------------------------------
+  // Point at the uv-managed venv so pytest/mypy/ruff resolve from there.
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.terminal.activateEnvInCurrentTerminal": true,
+
+  // ---- Pytest -------------------------------------------------------------
+  // Match the markers configured in pyproject.toml. The `not benchmark`
+  // selector mirrors the default loop — benchmarks are run via `just bench`.
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestArgs": [
+    "-m",
+    "not benchmark"
+  ],
+
+  // ---- Type checking: mypy --strict, not Pylance --------------------------
+  // Pylance handles completion / navigation / symbol search. Type checking
+  // is delegated to the mypy extension so the editor matches CI's mypy --strict.
+  "python.analysis.typeCheckingMode": "off",
+  "mypy-type-checker.preferDaemon": true,
+
+  // ---- Ruff: format on save + organize imports ----------------------------
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    },
+    "editor.rulers": [100]
+  },
+
+  // ---- Other file types ---------------------------------------------------
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  },
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  },
+
+  // GitHub Actions schema for workflow yaml — gives autocomplete and
+  // catches typos in `if:` / `needs:` / `on:` keys.
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.yml"
+  },
+
+  // ---- Search / file tree noise -------------------------------------------
+  // Hide tooling artefacts from the file explorer and search. These are
+  // rebuilt on demand and you don't want to grep through them.
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/.pytest_cache": true,
+    "**/.mypy_cache": true,
+    "**/.ruff_cache": true,
+    "**/.hypothesis": true,
+    "**/htmlcov": true,
+    "**/*.egg-info": true,
+    "**/mutants": true
+  },
+  "search.exclude": {
+    "**/.venv": true,
+    "**/uv.lock": true,
+    "**/htmlcov": true,
+    "**/mutants": true,
+    "**/.benchmarks": true
+  }
+}


### PR DESCRIPTION
## Summary
Team-shared \`.vscode/\` config so opening the repo and accepting the recommended extensions gives the same lint / format / type-check loop that \`just ci\` runs — no per-contributor setup needed.

### \`.vscode/extensions.json\`
Recommends only the extensions that match tools already in the project's CI / pre-commit / justfile:

| Extension | Why |
|---|---|
| \`ms-python.python\` | Python language support |
| \`ms-python.vscode-pylance\` | Completion, navigation, symbol search |
| \`charliermarsh.ruff\` | Matches \`ruff\` in pre-commit + CI; format on save |
| \`ms-python.mypy-type-checker\` | Matches \`mypy --strict\` in CI |
| \`tamasfe.even-better-toml\` | \`pyproject.toml\` editing |
| \`redhat.vscode-yaml\` | Workflow yamls + JSON schema validation |
| \`editorconfig.editorconfig\` | Honors \`.editorconfig\` |
| \`github.vscode-github-actions\` | CI workflow editing |
| \`nefrob.vscode-just-syntax\` | \`justfile\` syntax |
| \`yzhang.markdown-all-in-one\` | ADRs / phase docs |

\`unwantedRecommendations\` discourages \`black-formatter\` / \`isort\` / \`flake8\` / \`pylint\` / \`autopep8\` — ruff replaces all of them.

### \`.vscode/settings.json\`
- Interpreter pinned to \`.venv/bin/python\`.
- Format-on-save with ruff + \`source.organizeImports.ruff\`.
- \`python.analysis.typeCheckingMode: off\` so Pylance handles completion/navigation but mypy (via the dedicated extension) does the type checking — keeping editor and CI in sync.
- Pytest discovery passes \`-m "not benchmark"\` so the test explorer mirrors the default loop.
- Tooling caches (\`__pycache__\`, \`.mypy_cache\`, \`.ruff_cache\`, \`.pytest_cache\`, \`.hypothesis\`, \`mutants/\`, \`htmlcov\`, \`*.egg-info\`) hidden from the file tree and excluded from search.
- GitHub Actions JSON schema attached to \`.github/workflows/*.yml\` for autocomplete / typo-catching.

### \`.vscode/launch.json\`
Three debug configs:
- **Pytest: current file** — debug the open test file.
- **Pytest: full default loop** — debug the whole suite minus benchmarks.
- **Tulip API (uvicorn, dev)** — debug the FastAPI app against a workspace-local \`tulip-dev.db\` (already gitignored). Uses the same test-only secrets the CLI integration tests use, with a comment that they're never to be used against a real database.

### \`.gitignore\`
Was \`.vscode/\` (everything ignored). Now whitelists the four team-shared files while keeping user-local stuff under \`.vscode/\` ignored.

## Test plan
- [x] \`git check-ignore .vscode/extensions.json .vscode/settings.json .vscode/launch.json\` returns empty (files not ignored).
- [x] All three JSON files parse — \`pre-commit run --files\` clean.
- [x] No code paths or tests touched, so CI on this PR exercises the path-conditional filters: should run \`lint\`, \`secrets-scan\`, and skip \`test\`/\`benchmarks\`/\`type-check\`/\`audit\`.

## Manual smoke
On a fresh checkout:
1. Open the repo in VS Code.
2. Accept the recommended-extensions prompt.
3. Open any \`.py\` file in \`packages/\` — interpreter shows as \`.venv\`, ruff formats on save, mypy underlines real type errors, pytest discovery shows the test tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)