### PR TITLE
chore: project-level sqlite MCP config (.mcp.json)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "sqlite": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "mcp-server-sqlite",
+        "--db-path",
+        "./tulip.db"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds \`.mcp.json\` at the repo root that points the \`sqlite\` MCP server at this project's \`./tulip.db\` instead of whatever stale path a contributor's user-level \`~/.claude.json\` happens to have.

## Why
Claude Code resolves MCP servers by name across three scopes:
1. \`~/.claude.json\` — user-level, one entry per machine.
2. \`.mcp.json\` at the project root — project-level, takes precedence in this repo.
3. \`.claude/settings.local.json\` — user-local override for this project (gitignored).

Without a project-level \`.mcp.json\`, the maintainer's user-level config was sending all sqlite queries from this repo's sessions to envelopeledger's database — the predecessor project. With this PR, opening Claude Code from this repo's directory automatically routes the \`sqlite\` MCP at \`./tulip.db\`.

The DB itself stays gitignored (\`*.db\`); contributors who haven't populated a local DB just get an empty server until they do.

## Out of scope
The maintainer's stale user-level \`mcpServers.sqlite\` entry pointing at envelopeledger has been removed locally (separate from this PR — \`~/.claude.json\` isn't a repo file). The cleanup is one-time and doesn't affect anyone else.

## Test plan
- [x] \`.mcp.json\` is valid JSON (no committed without parsing).
- [x] Pre-commit clean.
- [ ] CI green on this PR (no Python/deps/CI changes — \`test\`, \`type-check\`, \`benchmarks\`, \`audit\` should all skip via #93's path filter; only \`lint\` + \`secrets-scan\` run).
- [ ] In a new Claude Code session from this repo, sqlite MCP queries hit \`./tulip.db\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)