### PR TITLE
chore: SECURITY.md, PR + issue templates, labeler, .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Default to LF line endings for all text files. Git's default `autocrlf`
+# setting can cause spurious diffs on Windows; pinning here defends against
+# it without requiring per-contributor git config.
+* text=auto eol=lf
+
+# Lock files: generated, large diffs are noise rather than signal.
+# `linguist-generated` hides them from PR diffs by default and keeps them
+# out of language statistics on the repo page.
+uv.lock              linguist-generated=true
+package-lock.json    linguist-generated=true
+
+# Treat as binary so Git doesn't attempt line-ending or diff manipulation.
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.pdf    binary
+*.db     binary
+*.sqlite binary
+*.sqlite3 binary
+*.zip    binary
+*.tar.gz binary

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Something isn't working as documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Small details ("worked yesterday", a stack trace, the exact command) often unblock the fix in one round of back-and-forth.
+
+  - type: textarea
+    id: what-you-did
+    attributes:
+      label: What you did
+      description: Minimal commands or steps to reproduce.
+      placeholder: |
+        ```
+        uv run tulip add 'rent' ...
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      description: Error message, unexpected output, anything you observed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        OS, Python (`python --version`), uv (`uv --version`), Tulip commit (`git rev-parse --short HEAD`).
+      placeholder: |
+        macOS 15.4, Python 3.12.3, uv 0.5.0, commit abc1234
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Tulip emits structured JSON logs. Redact any sensitive data before pasting.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest something new or an enhancement to an existing feature.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests should describe the **use case**, not just the proposed solution. "I want to track shared expenses with a roommate without merging households" is more useful than "add expense splitting" — it lets us think about the right shape of the solution.
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What are you trying to accomplish? What's the workflow?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach (optional)
+      description: If you have a concrete suggestion, describe it. Otherwise leave blank — discussion may surface a better one.
+
+  - type: textarea
+    id: scope-thoughts
+    attributes:
+      label: Scope considerations
+      description: |
+        How does this fit (or not) with the v1 scope in [`docs/ARCHITECTURE.md` §1.2](../blob/main/docs/ARCHITECTURE.md)? Aware of which phase it might belong to per [`docs/PHASE_STATUS.md`](../blob/main/docs/PHASE_STATUS.md)?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+Thanks for opening a PR. Fill out the sections that apply; delete the rest.
+For larger changes, also add `## Why` and `## Out of scope` sections. See
+recent merged PRs (or CLAUDE.md) for examples.
+-->
+
+Closes #
+
+## Summary
+
+<!-- 3-5 bullets covering what changed and why. -->
+
+-
+
+## Test plan
+
+<!--
+Commands you ran locally and what they showed. Use `[x]` for completed items
+and `[ ]` for items that finish during CI. If the PR adds a manual smoke test,
+include the runnable steps inline (env vars, requests with bodies, expected
+outcomes, cleanup) per CONTRIBUTING.md.
+-->
+
+- [ ] CI green on this PR.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,63 @@
+# actions/labeler@v5 config — auto-applies area labels to PRs based on
+# changed paths. The label values must exist on the repo (created via
+# `gh label create`) before the action will apply them; missing labels
+# are silently skipped.
+#
+# Keep this file in sync with #92's path-conditional CI filters
+# (`.github/workflows/ci.yml` `changes` job) — same path → same area.
+
+"area:core":
+  - changed-files:
+      - any-glob-to-any-file: 'packages/tulip-core/**'
+
+"area:storage":
+  - changed-files:
+      - any-glob-to-any-file: 'packages/tulip-storage/**'
+
+"area:api":
+  - changed-files:
+      - any-glob-to-any-file: 'packages/tulip-api/**'
+
+"area:cli":
+  - changed-files:
+      - any-glob-to-any-file: 'packages/tulip-cli/**'
+
+"area:ai":
+  - changed-files:
+      - any-glob-to-any-file: 'packages/tulip-ai/**'
+
+"area:importers":
+  - changed-files:
+      - any-glob-to-any-file: 'packages/tulip-importers/**'
+
+"area:reports":
+  - changed-files:
+      - any-glob-to-any-file: 'packages/tulip-reports/**'
+
+"area:ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/labeler.yml'
+
+"area:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '*.md'
+          - 'CLAUDE.md'
+
+"area:tooling":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'justfile'
+          - 'pyproject.toml'
+          - 'uv.lock'
+          - '.vscode/**'
+          - '.mcp.json'
+          - '.gitignore'
+          - '.gitattributes'
+          - '.editorconfig'
+          - '.pre-commit-config.yaml'
+          - '.github/PULL_REQUEST_TEMPLATE.md'
+          - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,32 @@
+# Auto-apply `area:*` labels to PRs based on changed paths.
+#
+# Uses `pull_request_target` so the action has write access to apply
+# labels (the standard `pull_request` trigger doesn't on PRs from forks).
+# This is safe because the action only reads paths from the diff and
+# applies labels — it doesn't execute PR code, doesn't run `run:` blocks
+# with PR-controlled input, and doesn't check out the PR's source.
+#
+# Labels and path mapping live in `.github/labeler.yml`. The labels
+# themselves must exist on the repo (created once via `gh label create`)
+# or the action silently skips missing ones.
+
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply area labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security policy
+
+Tulip Accounting handles personal financial data. Security is taken seriously, even though the project is solo and hobby-paced.
+
+## Reporting a vulnerability
+
+**Preferred:** open a private security advisory at <https://github.com/rmwarriner/tulip-accounting/security/advisories/new>. This lets us discuss the issue privately until a fix lands.
+
+**Fallback** (if GitHub is unavailable): email <rmwarriner@icloud.com> with a description and reproduction steps.
+
+Please do **not** open a regular issue or pull request for security-relevant findings.
+
+## Response timeline
+
+This is a hobby project, not a product with an SLA. Reasonable best-effort:
+
+- Initial response within 7 days.
+- A status update at most every 14 days while the issue is open.
+- Critical findings (e.g. credential exposure, remote code execution, data leakage across households) get prioritized over feature work.
+
+## Supported versions
+
+The project is pre-1.0 (`pyproject.toml` ships `0.0.0`). All security work targets `main`. There are no supported release branches yet — this section will be revisited when 1.0 ships.
+
+## Scope
+
+**In scope:**
+
+- Vulnerabilities in any of the seven `tulip-*` workspace packages.
+- Vulnerabilities in default deployment configurations (FastAPI app, CLI client, encrypted backups).
+- Issues in test fixtures or scaffolding that could ship with a release artifact.
+
+**Out of scope:**
+
+- Vulnerabilities in third-party dependencies — file those upstream. Our `dependency-audit` CI job (#76) catches known CVEs in the lockfile.
+- Issues that require physical access to the user's machine or root-level OS access.
+- Theoretical attacks against the documented threat model — those belong in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) discussion, not the security advisory channel.
+
+## Recognition
+
+If you'd like to be credited in the eventual fix's release notes, mention this in the advisory. Otherwise reports are kept anonymous by default.


### PR DESCRIPTION
## Summary
A bundle of small admin/support files that codify what the project already does informally. None change behaviour; they make existing conventions discoverable.

| File | Purpose |
|---|---|
| \`SECURITY.md\` | Public vulnerability disclosure policy (private-advisory + email fallback). Surfaces on GitHub's Security tab. |
| \`.github/PULL_REQUEST_TEMPLATE.md\` | Formalises the \`Closes #N\` / Summary / Test plan structure used by every recent PR. |
| \`.github/ISSUE_TEMPLATE/bug.yml\` | Structured bug form: what-you-did / expected / actual / environment / logs. Pre-applies the \`bug\` label. |
| \`.github/ISSUE_TEMPLATE/feature.yml\` | Structured feature form emphasising use case over proposed solution per \`CONTRIBUTING.md\`. Pre-applies \`enhancement\`. |
| \`.github/labeler.yml\` + \`.github/workflows/labeler.yml\` | Auto-applies \`area:<package>\` / \`area:{ci,docs,tooling}\` labels to PRs. Same path mapping as the \`changes\` job from #92, so filters and labels stay in sync. |
| \`.gitattributes\` | LF line endings for text, \`uv.lock\` marked \`linguist-generated\` (hidden from PR diffs), explicit binary types. |

## Why this together
None of these files have non-trivial dependencies on each other; bundling keeps the slice ratio sane. The labeler is the only one with a follow-up — see below.

## Labeler follow-up (post-merge)
\`actions/labeler\` silently skips non-existent labels. After this PR merges, one-shot label creation:

\`\`\`
gh label create "area:core"      --color "0075ca" --description "tulip-core changes"
gh label create "area:storage"   --color "0075ca" --description "tulip-storage changes"
gh label create "area:api"       --color "0075ca" --description "tulip-api changes"
gh label create "area:cli"       --color "0075ca" --description "tulip-cli changes"
gh label create "area:ai"        --color "0075ca" --description "tulip-ai changes"
gh label create "area:importers" --color "0075ca" --description "tulip-importers changes"
gh label create "area:reports"   --color "0075ca" --description "tulip-reports changes"
gh label create "area:ci"        --color "5319e7" --description "CI workflows / labeler config"
gh label create "area:docs"      --color "1d76db" --description "Markdown documentation"
gh label create "area:tooling"   --color "ededed" --description "justfile, pyproject, IDE/git config"
\`\`\`

The first PR after that runs against the new workflow.

## Why \`pull_request_target\` for the labeler
\`actions/labeler\` needs \`pull-requests: write\` to apply labels — \`pull_request\` doesn't grant that on PRs from forks. \`pull_request_target\` does. Safe in this case because the action only reads the diff and applies labels; no \`run:\` blocks with PR-controlled input, no \`actions/checkout\` of the PR's source.

## Test plan
- [x] \`yaml.safe_load\` succeeds on all four new yaml files.
- [x] \`pre-commit run --files <changed>\` clean.
- [x] PR template renders correctly when previewed.
- [ ] CI green on this PR. Path filters from #92 will route this as \`ci=true\` (new workflow file) → \`test\`/\`benchmarks\`/\`audit\` run; \`type-check\` skips (no Python).
- [ ] (Post-merge) \`gh label create\` block runs cleanly.
- [ ] (Post-merge) Next PR has area labels applied automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)