### PR TITLE
docs: codify operational decisions from recent CI / test-fixture work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,10 @@ this file points at them and adds the few things that aren't covered there.
 ## Toolchain
 
 - `uv` is the package manager. Use `uv sync --all-packages --dev` to install, `uv run <cmd>` to invoke. Never `pip`, never `python -m venv` — `uv` manages the workspace.
-- The [`justfile`](justfile) wraps the common loops: `just test`, `just lint`, `just typecheck`, `just coverage`, `just audit`, `just ci` (run-all). `just --list` shows everything.
+- The [`justfile`](justfile) wraps the common loops: `just test`, `just lint`, `just typecheck`, `just coverage`, `just audit`, `just bench`, `just mutate`, `just ci` (run-all). `just --list` shows everything.
 - Recipes mirror `.github/workflows/ci.yml`. If you change CI, update recipes in the same PR (and vice versa).
+- Editor: [`.vscode/`](.vscode/) is committed (extensions, settings, debug launch configs). Open the repo in VS Code, accept the recommended-extensions prompt, and the editor's lint/format/type-check loop matches `just ci`.
+- MCP: [`.mcp.json`](.mcp.json) configures a project-scoped `sqlite` MCP at `./tulip.db`. Restart your Claude Code session if you've just changed `.mcp.json` — MCP servers are launched at session start.
 
 ## Workflow
 
@@ -46,11 +48,35 @@ Manual smoke tests **must** include the full runnable steps inline (env vars, re
 
 ### After opening a PR
 
-Watch CI. When all required checks are green, squash-merge with `gh pr merge <N> --squash --delete-branch`, sync `main` locally, then surface the next slice. Don't enable repo-level auto-merge or use `gh pr merge --auto` — past experience is that it fires before required checks gate the merge.
+Watch CI with the **`Monitor`** tool, not `Bash run_in_background` — Monitor emits one event per check transition; bash watch goes silent until the very end. The poll script in [`feedback_auto_pr_workflow.md` user memory](../../.claude/projects/-Users-robert-Projects-tulip-accounting/memory/feedback_auto_pr_workflow.md) is the canonical shape.
+
+When the Monitor reports `ALL_GREEN`, squash-merge with `gh pr merge <N> --squash --delete-branch`, sync `main` locally (`git checkout main && git pull --ff-only && git branch -D <branch>`), then surface the next slice.
+
+**Do not** enable repo-level auto-merge or pass `--auto` to `gh pr merge`. Past experience is that auto-merge fired before required checks gated the merge — a manual squash-merge from this side after `ALL_GREEN` is the safer pattern.
+
+## CI surface
+
+Three workflows live under `.github/workflows/`:
+
+- **`ci.yml`** runs on every PR and every push to `main`. Jobs are path-conditional via a top-level `changes` job (#92):
+  - `lint` and `secrets-scan` always run.
+  - `type-check` runs when Python source or `pyproject.toml` changed.
+  - `test` and `benchmarks` run when Python source / `pyproject.toml` / `uv.lock` / `.github/workflows/**` changed.
+  - `dependency-audit` runs when `pyproject.toml` / `uv.lock` / `.github/workflows/**` changed.
+  - `push` to `main` (post-merge) always runs all jobs as a final gate, regardless of paths.
+  - The aggregate `All checks passed` job accepts `success` *or* `skipped`.
+  - Net effect: docs/tooling-only PRs run in ~1-2 min; code PRs run in ~6-7 min.
+
+- **`mutation.yml`** runs `mutmut` against `tulip-core` weekly (Sunday 06:00 UTC) and on `workflow_dispatch`. Surviving mutants are reported to a tracking issue, not a PR gate. Don't add per-PR mutation testing — a full run is 1-2h on a 4-vCPU runner. ADR-0003 covers the reasoning.
+
+- **`labeler.yml`** auto-applies `area:<package>` and `area:{ci,docs,tooling}` labels to PRs based on changed paths. Path mapping in `.github/labeler.yml` mirrors the `changes` job's filters.
+
+When editing any `.github/workflows/*.yml`, the security pre-commit hook fires informationally. Don't reference untrusted PR-controlled context (`github.event.issue.title`, `github.event.pull_request.body`, etc.) inside `run:` blocks; bind them through `env:` variables when needed.
 
 ## What goes where
 
-- **Bugs and ideas**: GitHub Issues on `rmwarriner/tulip-accounting`. Don't invent parallel TODO files in the repo.
+- **Bugs and ideas**: GitHub Issues on `rmwarriner/tulip-accounting`. Don't invent parallel TODO files in the repo. The repo has issue templates (`.github/ISSUE_TEMPLATE/{bug,feature}.yml`) for human use; when filing programmatically, follow the same body shape (Why / Scope / Out of scope / Acceptance) recent issues use.
+- **Vulnerability reports**: private security advisory per [`SECURITY.md`](SECURITY.md), not a regular issue. The engineering threat model lives separately in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md).
 - **Architectural decisions** (new dependency, deviation from established pattern, design tradeoff): an ADR in [`docs/adrs/`](docs/adrs). Look at existing ones for the format.
 - **Phase tracking**: update [`docs/PHASE_STATUS.md`](docs/PHASE_STATUS.md) at the end of a slice — it's the source of truth for project state.
 
@@ -64,6 +90,15 @@ These are the easiest things for an AI assistant to inadvertently break. The ful
 - **Coverage gate at 85%** (90% inside `tulip-core`). Don't argue with the gate — write more tests.
 - **`ruff` + `mypy --strict`** with the `S`/`D`/`ANN` selects on. Pre-commit runs them; CI checks them. `# type: ignore` requires a comment.
 - **Signed commits to `main`.** Branch protection rejects unsigned pushes — `CONTRIBUTING.md → Branch protection on main` covers the diagnosis when this surprises you.
+
+## Test fixture and marker patterns
+
+These are conventions that aren't enforced by the type system or pre-commit but matter under parallel test execution.
+
+- **Engine fixtures must dispose.** When adding a fixture that creates a SQLAlchemy `Engine`, return `Iterator[T]` and dispose on teardown (`try / yield / finally: eng.dispose()`). Without this, the connection pool retains FDs until process exit; under xdist parallelism on macOS this exhausts the default 256-fd limit. See #90.
+- **Module-level engines use `NullPool`.** The OpenAPI contract test is the only example today (`packages/tulip-api/tests/test_openapi_contract.py`). Module-level engines can't yield + dispose without a refactor; `poolclass=NullPool` closes connections on check-in instead of pooling, eliminating FD residency.
+- **`benchmark` marker is excluded from the default loop.** `pyproject.toml [tool.pytest.ini_options].addopts` includes `-m "not benchmark"`. Run benchmarks via `just bench` (sequential — pytest-benchmark is incompatible with xdist).
+- **Marker registry.** Existing markers in `pyproject.toml`: `property` (hypothesis), `integration` (DB / network / spawned process), `slow` (excluded from the default fast loop), `benchmark` (perf baselines, excluded from the default loop). Register any new marker — `--strict-markers` is on, so unknown markers fail collection.
 
 ## When in doubt
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ Good bug reports are gold. A good one includes:
 
 Feature requests should include the use case, not just the proposed solution. "I want to track shared expenses with a roommate without merging households" is more useful than "add expense splitting" because it lets us think about the right shape of the solution.
 
+GitHub form templates are wired up for both kinds of report — the [issue picker](../../issues/new/choose) presents structured forms covering the fields above so you don't have to remember them.
+
+**Security-relevant findings do not go through the normal issue tracker.** See [`SECURITY.md`](SECURITY.md) for the private-advisory channel.
+
 ## Setting up a development environment
 
 See [README.md](README.md) for the standard setup. The short version:
@@ -35,6 +39,14 @@ uv run pytest                    # confirm green
 ```
 
 A [`justfile`](./justfile) wraps the common workflows so you don't have to remember each `uv run …` invocation. `just` (no args) lists the recipes; `just ci` reproduces locally what CI runs on every PR. The recipes mirror `.github/workflows/ci.yml` and should be kept in sync with it.
+
+Recipes worth knowing beyond `just ci`:
+
+- `just bench` — pytest-benchmark performance baselines on hot ledger paths (sequential; xdist-incompatible). Excluded from the default loop.
+- `just audit` — `pip-audit --skip-editable` against the resolved env; flags any installed third-party package with a known PyPA advisory.
+- `just mutate` — `mutmut` against `tulip-core` (slow, ~1-2h locally; CI runs it weekly via `.github/workflows/mutation.yml`). See [ADR-0003](docs/adrs/0003-mutation-testing.md) for the cadence rationale.
+
+The repo's [`.vscode/`](.vscode/) directory is committed: opening the workspace and accepting the recommended-extensions prompt gives you ruff-on-save, mypy-in-editor, pytest discovery, and three debug launch configs without any per-machine setup.
 
 SQLCipher development headers are *only* required once full-DB SQLCipher encryption lands (Phase 1.x). The current Phase 1 / Phase 2 codebase uses field-level AES-256-GCM (via the pure-Python `cryptography` library) and needs no native sqlcipher install to develop or test against.
 
@@ -72,6 +84,25 @@ Always `decimal.Decimal`. Always paired with a currency in the `Money` value obj
 
 When dividing money (e.g., splitting a bill three ways), be explicit about the rounding mode and the residual. Tulip uses banker's rounding (`ROUND_HALF_EVEN`) and assigns any residual cent to a designated party (typically the first posting). Look at `tulip_core.money.split` for the canonical pattern.
 
+### Test fixture hygiene
+
+Fixtures that create a SQLAlchemy `Engine` must dispose it on teardown. Use the yielding pattern:
+
+```python
+@pytest.fixture
+def session_maker(db_url: str) -> Iterator[sessionmaker[Session]]:
+    eng = create_engine(db_url, future=True)
+    # ... event listeners, etc. ...
+    try:
+        yield sessionmaker(eng, expire_on_commit=False)
+    finally:
+        eng.dispose()
+```
+
+For module-level engines that can't easily yield (the OpenAPI contract test is the only example today), pass `poolclass=NullPool` so connections close on check-in instead of pooling.
+
+Without this, the connection pool retains FDs until process exit. Under xdist parallelism on macOS this exhausts the default 256-fd limit mid-suite and produces `OSError: [Errno 24] Too many open files` — see [#90](../../issues/90) for the postmortem.
+
 ### Code style
 
 - Linting and formatting: **ruff** (no debate, no manual formatting). Pre-commit runs it; CI checks it.
@@ -105,8 +136,8 @@ If your change involves a non-trivial architectural decision — choosing betwee
 2. Make your changes following the conventions above. Commit incrementally.
 3. Ensure `just ci` (or the underlying `uv run pytest`, `uv run ruff check`, `uv run mypy`, and `uv run pre-commit run --all-files`) all pass locally.
 4. Push to your fork and open a PR against `main`.
-5. The PR description should:
-   - Reference any related issue(s).
+5. The PR description should follow [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md), which is pre-populated when you open a PR through the GitHub UI:
+   - Reference any related issue(s) (`Closes #N` or `Follow-up: #N`).
    - Briefly explain the change and the rationale.
    - Note any user-visible impact.
    - Confirm that tests were written first (the TDD rule).


### PR DESCRIPTION
## Summary
Updates \`CLAUDE.md\` and \`CONTRIBUTING.md\` to capture the operational practice established across today's tooling slices, so it's discoverable for future sessions and contributors instead of living only in commit messages and user-level memory.

### \`CLAUDE.md\` (105 lines, was 70)
- **Toolchain:** names the new \`bench\` / \`audit\` / \`mutate\` recipes, points at the committed \`.vscode/\` baseline, notes \`.mcp.json\` is project-scoped to \`./tulip.db\`.
- **After opening a PR:** expanded to explicitly use the \`Monitor\` tool, manually squash-merge via \`gh pr merge --squash --delete-branch\` on \`ALL_GREEN\`, with the rationale for *not* using \`--auto\` or repo-level auto-merge.
- **New \`CI surface\` section:** enumerates the three workflows (\`ci.yml\` with path-conditional jobs from #92, \`mutation.yml\` weekly per ADR-0003, \`labeler.yml\` for \`area:*\` labels) and the security-hook caveat for editing workflow yamls.
- **What goes where:** pointers to the issue templates, \`SECURITY.md\`, and the engineering threat model.
- **New \`Test fixture and marker patterns\` section:** codifies yield+dispose / NullPool patterns from #90, the \`not benchmark\` default in \`addopts\`, and the registered marker set.

### \`CONTRIBUTING.md\` (281 lines, was 250)
- **Filing issues:** mentions GitHub form templates, redirects security-relevant reports to \`SECURITY.md\`.
- **Dev environment:** lists \`just bench\` / \`just audit\` / \`just mutate\`; notes \`.vscode/\` baseline.
- **New \`Test fixture hygiene\` subsection in Project conventions:** canonical engine-disposal snippet with a cross-link to #90.
- **Submitting a PR:** delegates the body structure to \`.github/PULL_REQUEST_TEMPLATE.md\` instead of enumerating it inline.

The user-memory \`MEMORY.md\` index pointer for the auto-PR workflow is also refreshed (separate from this PR — \`~/.claude/projects/...\` isn't repo-tracked).

## Why
Today's slices established several conventions (Monitor for CI, manual squash-merge, path-conditional CI awareness, engine-disposal pattern, marker registry) that aren't obvious from the diffs alone. Without codifying them, the next session — or anyone else opening the repo — won't know that \`gh pr merge --auto\` is deliberately avoided, or that engine fixtures must yield+dispose.

## Out of scope
- No changes to \`docs/ARCHITECTURE.md\` or \`docs/PHASE_STATUS.md\`. Architecture is the v1 spec and unchanged; PHASE_STATUS still says "Phase 4 complete, Phase 5 not started" which is accurate.
- No new ADR. ADRs are reserved for v1 architectural decisions; tooling/CI conventions live in \`CLAUDE.md\` + \`CONTRIBUTING.md\` + workflow comments.

## Test plan
- [x] \`wc -l CLAUDE.md\` → 105 (under the 150-line cap from #77).
- [x] \`pre-commit run --files CLAUDE.md CONTRIBUTING.md\` clean.
- [x] All inline links resolve to existing files.
- [ ] CI green on this PR. Path filter from #92 routes this as docs-only (no Python / deps / CI yaml changed) — \`test\`, \`benchmarks\`, \`type-check\`, \`audit\` should all skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)