### PR TITLE
P5.0 — transaction void + PENDING-only edit / delete (#55)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-04 · `main` @ **Phase 5 kickoff** ([ADR-0004](adrs/0004-reconciliation.md) proposed; no Phase 5 code yet)
+**Last updated:** 2026-05-04 · `main` @ **P5.0 in flight** ([ADR-0004](adrs/0004-reconciliation.md) merged; first implementation slice on transaction void + PENDING-only edit)
 
 ---
 
@@ -16,9 +16,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
 - **Pre-Phase-4 docs:** threat-model checkpoint shipped (#56, [docs/THREAT_MODEL.md](THREAT_MODEL.md)). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
 - **Phase 4 (envelopes + sinking funds):** ✅ **complete** — all seven slices merged 2026-05-02. P4.0 (#60), P4.1.a (#62), P4.1.b (#63), P4.2 (#66), P4.3.a (#68 — closes #7 via [ADR-0002](adrs/0002-scheduler-primitive.md)), P4.3.b (#69), P4.3.c (#70).
-- **Phase 5 (importers + reconciliation):** in flight — design only. [ADR-0004](adrs/0004-reconciliation.md) (Proposed, 2026-05-04) settles the nine open questions from #101; closes the design phase before any code lands. P5.0 = #55 (transaction void + PENDING-only edit) is the first implementation slice.
+- **Phase 5 (importers + reconciliation):** in flight — P5.0 (transaction void + PENDING-only edit, #55) implemented per [ADR-0004](adrs/0004-reconciliation.md). 829 tests passing locally. Next: P5.1 (schema + storage layer for `attachments` / `import_batches` / `reconciliations`).
 
-**Tests:** 772 passing · **CI:** green on `main`
+**Tests:** 829 passing · **CI:** green on `main`
 
 ---
 
@@ -397,13 +397,27 @@ Umbrella issue: #74. Per [ADR-0004](adrs/0004-reconciliation.md). Phase 5 adds s
 
 Closes #101. Pre-code design doc — no implementation lands until reviewed. Settles the nine open questions: match candidates (account + exact amount + ±3 day window + not-already-reconciled); confidence buckets (`high` / `medium` / `low`, rule-based, `rapidfuzz`); partial / split matches via M:N `reconciliation_matches`; manual override on the same row with NULL confidence; unmatched inbox with three actions per side; idempotency on raw-file SHA-256; hybrid state model (separate `reconciliations` table is truth, denorm columns on `transactions`); `StatementLine` common-denominator dataclass in `tulip-core`; three-layer audit (audit_log + match provenance + encrypted file attachment).
 
-### P5.0 — Transaction void / PENDING-only edit — queued (#55)
+### P5.0 — Transaction void / PENDING-only edit — ✅ *(2026-05-04)*
 
-First implementation slice. Adds `transactions.voided_by_transaction_id`, `voided_at`. API: `POST /v1/transactions/{id}/void`, `PATCH /v1/transactions/{id}` (PENDING-only), `DELETE /v1/transactions/{id}` (PENDING-only). CLI: `tulip transactions {edit,void,delete}`. Prerequisite for every later slice's revert / un-reconcile / cleanup paths.
+Closes #55. First Phase 5 implementation slice; prerequisite for every later slice's revert / un-reconcile / cleanup paths.
 
-### P5.1 — P5.4 — queued
+- **Migration** (`e7d2a4f8c1b9`): adds `transactions.voided_by_transaction_id` (composite self-FK with `use_alter=True`) + `voided_at` timestamp. Reuses the trigger drop-and-recreate dance from P4.0's `a3f4d8e91b22` because the main-ledger balance triggers reference `transactions` by name.
+- **Domain layer**: `Transaction` value object learns optional `voided_by_transaction_id`; `__post_init__` rejects the impossible `PENDING + voided_by` state. New `tulip_core.accounting.build_reversal()` helper produces a sign-flipped PENDING reversal sibling; the API handler runs `post_transaction(reversal, periods)` to gate against open periods on the **reversal date**, not the source's date (the void's *own* date is what's checked, per ADR-0004).
+- **Storage repos**: `TransactionRepository` learns `persist_reversal`, `update_pending`, `delete_pending` with typed exceptions (`TransactionAlreadyVoidedError`, `TransactionNotVoidableError`, `TransactionNotEditableError`, `TransactionNotDeletableError`). `ShadowTransactionRepository` learns a `void` chokepoint that flips status `posted → voided` (idempotent on already-voided; rejects PENDING).
+- **API**: three new verbs on `/v1/transactions/{id}`. `POST /void` builds the reversal, persists it, and atomically auto-voids the paired shadow tx if any (option (c) — main-side reversal sibling, shadow-side status flip; balance auto-corrects since `balance_for_pool` already excludes voided shadow txs). `PATCH` and `DELETE` are PENDING-only; POSTED / RECONCILED return 409.
+- **New error codes**: `transaction.not_editable` (409), `transaction.not_deletable` (409), `transaction.already_voided` (409, with `voided_by_transaction_id` extension), `transaction.not_voidable` (409, with `status` extension).
+- **CLI**: new `tulip transactions {void, delete, edit}`. `void` takes `--reason` + optional `--date` + `--yes`; renders "Voided X; reversal posted as Y" and a one-liner when a paired shadow tx was auto-voided. `edit` reuses the `--edit` editor flow from #43, rendering the existing tx into hledger format and PATCH'ing on save.
+- **Audit log**: one row per user action (`transaction_void`, `transaction_update`, `transaction_delete`); `paired_shadow_tx_id_voided` extends the void row's `after_snapshot` when applicable, mirroring P4.1.a's pattern.
+- **Architecture test**: `test_architecture_no_direct_void_link_writes.py` AST scan rejects writes to `transactions.voided_by_transaction_id` outside `TransactionRepository.persist_reversal`, mirroring P4.0's shadow-write guard.
+- **Tests**: 57 new (4 core, 16 storage, 15 API, 8 CLI E2E + arch tests). Project total: **829 passing** (up from 772).
 
-Per ADR-0004 § slice ordering. P5.1 ships schema + storage layer + architecture-test guards; P5.2.{a,b,c} ship the three importers in parallel; P5.3 ships the matcher + categorizer DI seam; P5.4 closes Phase 5 with the API + CLI surface.
+### P5.1 — Schema + storage layer for imports + reconciliations — queued
+
+Per ADR-0004 § slice ordering. Adds `attachments`, `attachment_links`, `import_batches`, `statement_lines`, `reconciliations`, `reconciliation_matches`, `csv_profiles` tables + the §4.1-sketched columns on `transactions` (`cleared_at`, `reconciled_at`, `reconciliation_id`, `imported_from_id`, `carried_forward_from_reconciliation_id`). Architecture-test guards mirror the void-link guard added in P5.0.
+
+### P5.2 — P5.4 — queued
+
+P5.2.{a,b,c} ship the three importers in parallel; P5.3 ships the matcher + categorizer DI seam; P5.4 closes Phase 5 with the API + CLI surface.
 
 ---
 

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -511,6 +511,86 @@ class TransactionNotFoundError(TulipProblem):
         )
 
 
+class TransactionNotEditableError(TulipProblem):
+    """PATCH was attempted on a non-PENDING transaction (P5.0)."""
+
+    def __init__(self) -> None:
+        """Build the transaction.not_editable problem."""
+        super().__init__(
+            code="transaction.not_editable",
+            title="Transaction is not editable",
+            status=409,
+            detail=(
+                "Only PENDING transactions can be edited. To change a posted "
+                "transaction, void it (POST /v1/transactions/{id}/void) and "
+                "create a corrected entry."
+            ),
+        )
+
+
+class TransactionNotDeletableError(TulipProblem):
+    """DELETE was attempted on a non-PENDING transaction (P5.0)."""
+
+    def __init__(self) -> None:
+        """Build the transaction.not_deletable problem."""
+        super().__init__(
+            code="transaction.not_deletable",
+            title="Transaction is not deletable",
+            status=409,
+            detail=(
+                "Only PENDING transactions can be hard-deleted. Posted "
+                "transactions must be voided (POST /v1/transactions/{id}/void) "
+                "to preserve the audit trail."
+            ),
+        )
+
+
+class TransactionAlreadyVoidedError(TulipProblem):
+    """A void was attempted on a transaction that is already voided (P5.0)."""
+
+    def __init__(self, voided_by_transaction_id: str) -> None:
+        """Build the transaction.already_voided problem.
+
+        ``voided_by_transaction_id`` is surfaced as a Problem extension so
+        clients can fetch the existing reversal without a second query.
+        """
+        super().__init__(
+            code="transaction.already_voided",
+            title="Transaction already voided",
+            status=409,
+            detail=(
+                "This transaction has already been voided. The reversal "
+                "transaction is referenced via the voided_by_transaction_id "
+                "extension."
+            ),
+            extensions={"voided_by_transaction_id": voided_by_transaction_id},
+        )
+
+
+class TransactionNotVoidableError(TulipProblem):
+    """A void was attempted on a transaction that isn't POSTED / RECONCILED (P5.0)."""
+
+    def __init__(self, status: str) -> None:
+        """Build the transaction.not_voidable problem.
+
+        Surfaces the offending transaction's status as a Problem extension
+        so the client can route to the correct corrective action (DELETE
+        for PENDING, un-reconcile-then-void for RECONCILED in P5.1+).
+        """
+        super().__init__(
+            code="transaction.not_voidable",
+            title="Transaction is not in a voidable state",
+            status=409,
+            detail=(
+                "Only POSTED transactions can be voided in this slice. "
+                "PENDING transactions should be hard-deleted with DELETE; "
+                "RECONCILED transactions need to be un-reconciled first "
+                "(coming in P5.1+)."
+            ),
+            extensions={"status": status},
+        )
+
+
 class PoolNotFoundError(TulipProblem):
     """A posting carries a pool_id that doesn't exist in this household."""
 

--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from datetime import date as date_type
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
@@ -19,8 +20,12 @@ from tulip_api.errors import (
     PoolInvalidAccountTypePairingError,
     PoolNotFoundError,
     ShadowLedgerInternalError,
+    TransactionAlreadyVoidedError,
     TransactionInvalidError,
+    TransactionNotDeletableError,
+    TransactionNotEditableError,
     TransactionNotFoundError,
+    TransactionNotVoidableError,
     TransactionUnbalancedError,
     problem_response,
 )
@@ -28,11 +33,15 @@ from tulip_api.schemas.transaction import (
     PostingRead,
     TransactionCreate,
     TransactionRead,
+    TransactionUpdate,
+    TransactionVoidRequest,
+    TransactionVoidResponse,
 )
 from tulip_core.account import AccountType as DomainAccountType
 from tulip_core.accounting import (
     ClosedPeriodError,
     UnbalancedTransactionError,
+    build_reversal,
     post_transaction,
 )
 from tulip_core.allocation import (
@@ -62,6 +71,12 @@ from tulip_storage.repositories import (
     PeriodRepository,
     ShadowTransactionRepository,
     TransactionRepository,
+)
+from tulip_storage.repositories.transaction import (
+    TransactionNotDeletableError as RepoNotDeletableError,
+)
+from tulip_storage.repositories.transaction import (
+    TransactionNotEditableError as RepoNotEditableError,
 )
 
 if TYPE_CHECKING:
@@ -256,6 +271,137 @@ def create_transaction(
     )
 
 
+@router.post(
+    "/{tx_id}/void",
+    response_model=TransactionVoidResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: problem_response("period.closed", "transaction.unbalanced"),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("transaction.not_found"),
+        409: problem_response("transaction.already_voided", "transaction.not_voidable"),
+        422: problem_response("validation.failed"),
+    },
+)
+def void_transaction(
+    tx_id: UUID,
+    body: TransactionVoidRequest,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> TransactionVoidResponse:
+    """Post a sibling reversal that voids ``tx_id``.
+
+    The reversal is a normal POSTED transaction with sign-flipped postings.
+    Its ``date`` (defaulting to today) is checked against open periods —
+    the source's period being closed is fine because the reversal lives in
+    a different (open) period (per ADR-0004 §"What P5.0 ships").
+
+    When the source carries a paired shadow tx (ADR-0001), the shadow tx
+    is auto-voided (status flip to ``voided``) in the same atomic commit.
+    Pool balances auto-correct because the shadow-balance query excludes
+    voided shadow txs.
+    """
+    tx_repo = TransactionRepository(session, claims.household_id)
+    source_storage = tx_repo.get(tx_id)
+    if source_storage is None:
+        raise TransactionNotFoundError()
+    if source_storage.voided_by_transaction_id is not None:
+        raise TransactionAlreadyVoidedError(
+            voided_by_transaction_id=str(source_storage.voided_by_transaction_id)
+        )
+    if source_storage.status not in (
+        StorageTxStatus.POSTED,
+        StorageTxStatus.RECONCILED,
+    ):
+        raise TransactionNotVoidableError(status=source_storage.status.value)
+
+    # Reconstitute source as a domain Transaction so build_reversal can
+    # sign-flip its postings cleanly.
+    source_postings = tx_repo.list_postings(tx_id)
+    source_domain = DomainTransaction(
+        id=source_storage.id,
+        household_id=source_storage.household_id,
+        date=source_storage.date,
+        description=source_storage.description,
+        reference=source_storage.reference,
+        postings=tuple(
+            DomainPosting(
+                id=p.id,
+                account_id=p.account_id,
+                amount=Money(p.amount, p.currency),
+                memo=p.memo,
+                pool_id=p.pool_id,
+            )
+            for p in source_postings
+        ),
+        status=DomainTxStatus(source_storage.status.value),
+        created_by_user_id=source_storage.created_by_user_id,
+    )
+
+    reversal_date = body.reversal_date or date_type.today()
+    reversal_pending = build_reversal(
+        source_domain,
+        reversal_id=uuid4(),
+        reversal_date=reversal_date,
+        description=f"Reversal of {source_domain.description}: {body.reason}",
+        actor_user_id=claims.user_id,
+    )
+
+    period_repo = PeriodRepository(session, claims.household_id)
+    candidate_periods = _domain_periods(period_repo)
+    try:
+        reversal_posted = post_transaction(reversal_pending, periods=candidate_periods)
+    except ClosedPeriodError as exc:
+        raise PeriodClosedError(reason=str(exc)) from exc
+    except UnbalancedTransactionError as exc:  # defense in depth
+        raise TransactionUnbalancedError(
+            reason=f"Reversal failed to balance (Tulip bug): {exc}"
+        ) from exc
+
+    voided_at = datetime.now(tz=UTC)
+    tx_repo.persist_reversal(tx_id, reversal_posted, voided_at=voided_at)
+
+    # Option (c): if the source had a paired shadow tx, auto-void it in
+    # the same commit. Status flip → balance_for_pool auto-corrects.
+    shadow_repo = ShadowTransactionRepository(session, claims.household_id)
+    paired_shadow_tx_id = shadow_repo.get_paired_id_for_main_tx(tx_id)
+    if paired_shadow_tx_id is not None:
+        shadow_repo.void(paired_shadow_tx_id, voided_at=voided_at)
+
+    audit_after: dict[str, str] = {
+        "reversal_id": str(reversal_posted.id),
+        "reason": body.reason,
+        "reversal_date": reversal_date.isoformat(),
+    }
+    if paired_shadow_tx_id is not None:
+        audit_after["paired_shadow_tx_id_voided"] = str(paired_shadow_tx_id)
+    AuditLogWriter(session, claims.household_id).write(
+        action="void",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="transaction",
+        entity_id=tx_id,
+        before={"voided_by_transaction_id": None},
+        after=audit_after,
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "transaction.voided",
+        source_id=str(tx_id),
+        reversal_id=str(reversal_posted.id),
+        paired_shadow_tx_id_voided=(str(paired_shadow_tx_id) if paired_shadow_tx_id else None),
+    )
+    return TransactionVoidResponse(
+        source_id=tx_id,
+        reversal_id=reversal_posted.id,
+        voided_at=voided_at,
+        paired_shadow_tx_id_voided=paired_shadow_tx_id,
+    )
+
+
 @router.get(
     "/{tx_id}",
     response_model=TransactionRead,
@@ -274,6 +420,147 @@ def get_transaction(
     if repo.get(tx_id) is None:
         raise TransactionNotFoundError()
     return _read_response(tx_id, claims.household_id, session)
+
+
+@router.patch(
+    "/{tx_id}",
+    response_model=TransactionRead,
+    responses={
+        400: problem_response("account.unknown"),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("transaction.not_found"),
+        409: problem_response("transaction.not_editable"),
+        422: problem_response("validation.failed"),
+    },
+)
+def patch_transaction(
+    tx_id: UUID,
+    body: TransactionUpdate,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> TransactionRead:
+    """Edit a PENDING transaction. POSTED / RECONCILED return 409."""
+    tx_repo = TransactionRepository(session, claims.household_id)
+    existing = tx_repo.get(tx_id)
+    if existing is None:
+        raise TransactionNotFoundError()
+
+    # Merge body into existing values; PATCH semantics — fields omitted from
+    # the body keep their current value.
+    new_date = body.date if body.date is not None else existing.date
+    new_desc = body.description if body.description is not None else existing.description
+    new_ref = body.reference if body.reference is not None else existing.reference
+
+    if body.postings is not None:
+        # Validate account refs before delegating to the repo.
+        accounts_repo = AccountRepository(session, claims.household_id)
+        for p in body.postings:
+            if accounts_repo.get(p.account_id) is None:
+                raise AccountUnknownError(account_id=str(p.account_id))
+        new_postings: tuple[DomainPosting, ...] = tuple(
+            DomainPosting(
+                id=uuid4(),
+                account_id=p.account_id,
+                amount=Money(p.amount, p.currency),
+                memo=p.memo,
+                pool_id=p.pool_id,
+            )
+            for p in body.postings
+        )
+    else:
+        existing_postings = tx_repo.list_postings(tx_id)
+        new_postings = tuple(
+            DomainPosting(
+                id=p.id,
+                account_id=p.account_id,
+                amount=Money(p.amount, p.currency),
+                memo=p.memo,
+                pool_id=p.pool_id,
+            )
+            for p in existing_postings
+        )
+
+    before_snapshot = {
+        "date": existing.date.isoformat(),
+        "description": existing.description,
+        "reference": existing.reference,
+    }
+    try:
+        tx_repo.update_pending(
+            tx_id,
+            date=new_date,
+            description=new_desc,
+            reference=new_ref,
+            postings=new_postings,
+        )
+    except RepoNotEditableError as exc:
+        raise TransactionNotEditableError() from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="update",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="transaction",
+        entity_id=tx_id,
+        before=before_snapshot,
+        after={
+            "date": new_date.isoformat(),
+            "description": new_desc,
+            "reference": new_ref,
+        },
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info("transaction.updated", tx_id=str(tx_id))
+    return _read_response(tx_id, claims.household_id, session)
+
+
+@router.delete(
+    "/{tx_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("transaction.not_found"),
+        409: problem_response("transaction.not_deletable"),
+    },
+)
+def delete_transaction(
+    tx_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> None:
+    """Hard-delete a PENDING transaction. POSTED / RECONCILED return 409."""
+    tx_repo = TransactionRepository(session, claims.household_id)
+    existing = tx_repo.get(tx_id)
+    if existing is None:
+        raise TransactionNotFoundError()
+
+    before_snapshot = {
+        "date": existing.date.isoformat(),
+        "description": existing.description,
+        "reference": existing.reference,
+        "status": existing.status.value,
+    }
+    try:
+        tx_repo.delete_pending(tx_id)
+    except RepoNotDeletableError as exc:
+        raise TransactionNotDeletableError() from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="delete",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="transaction",
+        entity_id=tx_id,
+        before=before_snapshot,
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info("transaction.deleted", tx_id=str(tx_id))
 
 
 @router.get(
@@ -386,6 +673,8 @@ def _read_response(
             for p in postings
         ],
         paired_shadow_tx_id=paired_shadow_tx_id,
+        voided_by_transaction_id=header.voided_by_transaction_id,
+        voided_at=header.voided_at,
     )
 
 

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -57,6 +57,8 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
     "PoolTransferSystemPoolForbiddenError": {"role": "source"},
     "PoolInflowCurrencyUnknownError": {"currency": "ZZZ"},
     "RefillScheduleInvalidRRuleError": {"reason": "<dateutil parser error>"},
+    "TransactionAlreadyVoidedError": {"voided_by_transaction_id": "<reversal-transaction-uuid>"},
+    "TransactionNotVoidableError": {"status": "pending"},
     "ValidationFailedError": {
         "errors": [
             {

--- a/packages/tulip-api/src/tulip_api/schemas/transaction.py
+++ b/packages/tulip-api/src/tulip_api/schemas/transaction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date as date_type
+from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
@@ -55,3 +56,42 @@ class TransactionRead(BaseModel):
     status: str
     postings: list[PostingRead]
     paired_shadow_tx_id: UUID | None = None
+    voided_by_transaction_id: UUID | None = None
+    voided_at: datetime | None = None
+
+
+class TransactionVoidRequest(BaseModel):
+    """Body for POST /v1/transactions/{id}/void (P5.0)."""
+
+    reason: str = Field(min_length=1, max_length=500)
+    reversal_date: date_type | None = Field(
+        default=None,
+        description=(
+            "Date for the reversal sibling. Defaults to today. The reversal "
+            "date — not the source's date — is checked against open periods."
+        ),
+    )
+
+
+class TransactionVoidResponse(BaseModel):
+    """Response for POST /v1/transactions/{id}/void (P5.0)."""
+
+    source_id: UUID
+    reversal_id: UUID
+    voided_at: datetime
+    paired_shadow_tx_id_voided: UUID | None = Field(
+        default=None,
+        description=(
+            "If the source had a paired shadow tx (per ADR-0001), it has "
+            "been auto-voided in the same atomic commit. Null otherwise."
+        ),
+    )
+
+
+class TransactionUpdate(BaseModel):
+    """PATCH /v1/transactions/{id} body — PENDING-only, all fields optional."""
+
+    date: date_type | None = None
+    description: str | None = Field(default=None, min_length=1, max_length=500)
+    reference: str | None = Field(default=None, max_length=200)
+    postings: list[PostingCreate] | None = Field(default=None, min_length=2)

--- a/packages/tulip-api/tests/test_transactions_patch_delete_endpoint.py
+++ b/packages/tulip-api/tests/test_transactions_patch_delete_endpoint.py
@@ -1,0 +1,247 @@
+"""Tests for PATCH + DELETE /v1/transactions/{id} (P5.0, PENDING-only)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r.json()["access_token"]
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+@pytest.fixture
+def cash_and_food(client: TestClient, auth_h: dict[str, str]) -> tuple[str, str]:
+    cash = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Cash", "type": "asset", "currency": "USD", "code": "1110"},
+    ).json()
+    food = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Food", "type": "expense", "currency": "USD", "code": "5100"},
+    ).json()
+    return cash["id"], food["id"]
+
+
+def _post_lunch(
+    client: TestClient,
+    auth_h: dict[str, str],
+    cash: str,
+    food: str,
+) -> dict:
+    body = {
+        "date": date.today().isoformat(),
+        "description": "Lunch",
+        "postings": [
+            {"account_id": food, "amount": "12.50", "currency": "USD"},
+            {"account_id": cash, "amount": "-12.50", "currency": "USD"},
+        ],
+    }
+    r = client.post("/v1/transactions", headers=auth_h, json=body)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _create_pending(
+    client: TestClient,
+    auth_h: dict[str, str],
+    cash: str,
+    food: str,
+) -> dict:
+    """Force a PENDING transaction by posting one and then... we can't via API.
+
+    Trick: PENDING txs are created by the importer pipeline (Phase 5+). For
+    now, we go directly through the storage layer to seed a PENDING row.
+    """
+    # The API only creates POSTED transactions today. Use the storage layer
+    # directly via the dependency-injected session.
+    raise NotImplementedError("seeded by helper below")
+
+
+@pytest.fixture
+def pending_tx(app, session_maker, auth_h: dict[str, str], cash_and_food: tuple[str, str]):
+    """Insert a PENDING transaction via the storage layer.
+
+    The HTTP API only emits POSTED transactions until importers ship in
+    P5.2. We bypass via session_maker to exercise the PENDING-only edit
+    and delete contracts.
+    """
+    from decimal import Decimal
+    from uuid import UUID, uuid4
+
+    from tulip_core.money import Money
+    from tulip_core.transactions import Posting as DomainPosting
+    from tulip_core.transactions import Transaction as DomainTransaction
+    from tulip_core.transactions import TransactionStatus as DomainTxStatus
+    from tulip_storage.repositories import TransactionRepository
+
+    cash, food = cash_and_food
+    # Decode the JWT to get household_id (test convenience).
+    import base64
+    import json
+
+    token = auth_h["Authorization"].removeprefix("Bearer ")
+    payload = token.split(".")[1] + "=="
+    claims = json.loads(base64.urlsafe_b64decode(payload))
+    household_id = UUID(claims["household_id"])
+
+    pending_id = uuid4()
+    with session_maker() as session:
+        domain_tx = DomainTransaction(
+            id=pending_id,
+            household_id=household_id,
+            date=date.today(),
+            description="Pending lunch (from import)",
+            postings=(
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=UUID(food),
+                    amount=Money(Decimal("12.50"), "USD"),
+                ),
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=UUID(cash),
+                    amount=Money(Decimal("-12.50"), "USD"),
+                ),
+            ),
+            status=DomainTxStatus.PENDING,
+        )
+        TransactionRepository(session, household_id).save_balanced(domain_tx)
+        session.commit()
+    return str(pending_id)
+
+
+class TestPatch:
+    def test_patches_pending_description(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        pending_tx: str,
+    ):
+        r = client.patch(
+            f"/v1/transactions/{pending_tx}",
+            headers=auth_h,
+            json={"description": "Lunch (corrected)"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["description"] == "Lunch (corrected)"
+
+    def test_patches_postings_replaces_all(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        pending_tx: str,
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        r = client.patch(
+            f"/v1/transactions/{pending_tx}",
+            headers=auth_h,
+            json={
+                "postings": [
+                    {"account_id": food, "amount": "20.00", "currency": "USD"},
+                    {"account_id": cash, "amount": "-20.00", "currency": "USD"},
+                ],
+            },
+        )
+        assert r.status_code == 200, r.text
+        amounts = sorted(float(p["amount"]) for p in r.json()["postings"])
+        assert amounts == [-20.0, 20.0]
+
+    def test_patch_posted_returns_409(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        posted = _post_lunch(client, auth_h, cash, food)
+        r = client.patch(
+            f"/v1/transactions/{posted['id']}",
+            headers=auth_h,
+            json={"description": "too late"},
+        )
+        assert_problem(r, code="transaction.not_editable", status=409)
+
+    def test_patch_unknown_returns_404(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        bogus = "11111111-1111-1111-1111-111111111111"
+        r = client.patch(
+            f"/v1/transactions/{bogus}",
+            headers=auth_h,
+            json={"description": "ghost"},
+        )
+        assert_problem(r, code="transaction.not_found", status=404)
+
+    def test_patch_unauthenticated_returns_401(
+        self,
+        client: TestClient,
+        pending_tx: str,
+    ):
+        r = client.patch(
+            f"/v1/transactions/{pending_tx}",
+            json={"description": "anon"},
+        )
+        assert r.status_code == 401
+
+
+class TestDelete:
+    def test_deletes_pending(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        pending_tx: str,
+    ):
+        r = client.delete(f"/v1/transactions/{pending_tx}", headers=auth_h)
+        assert r.status_code == 204, r.text
+        # Subsequent GET returns 404.
+        r2 = client.get(f"/v1/transactions/{pending_tx}", headers=auth_h)
+        assert_problem(r2, code="transaction.not_found", status=404)
+
+    def test_delete_posted_returns_409(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        posted = _post_lunch(client, auth_h, cash, food)
+        r = client.delete(f"/v1/transactions/{posted['id']}", headers=auth_h)
+        assert_problem(r, code="transaction.not_deletable", status=409)
+
+    def test_delete_unknown_returns_404(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        bogus = "11111111-1111-1111-1111-111111111111"
+        r = client.delete(f"/v1/transactions/{bogus}", headers=auth_h)
+        assert_problem(r, code="transaction.not_found", status=404)

--- a/packages/tulip-api/tests/test_transactions_void_endpoint.py
+++ b/packages/tulip-api/tests/test_transactions_void_endpoint.py
@@ -1,0 +1,293 @@
+"""Tests for POST /v1/transactions/{id}/void (P5.0)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r.json()["access_token"]
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+@pytest.fixture
+def cash_and_food(client: TestClient, auth_h: dict[str, str]) -> tuple[str, str]:
+    cash = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Cash", "type": "asset", "currency": "USD", "code": "1110"},
+    ).json()
+    food = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Food", "type": "expense", "currency": "USD", "code": "5100"},
+    ).json()
+    return cash["id"], food["id"]
+
+
+def _post_lunch(
+    client: TestClient,
+    auth_h: dict[str, str],
+    cash: str,
+    food: str,
+    *,
+    when: date | None = None,
+) -> dict:
+    body = {
+        "date": (when or date.today()).isoformat(),
+        "description": "Lunch",
+        "postings": [
+            {"account_id": food, "amount": "12.50", "currency": "USD"},
+            {"account_id": cash, "amount": "-12.50", "currency": "USD"},
+        ],
+    }
+    r = client.post("/v1/transactions", headers=auth_h, json=body)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestVoidHappyPath:
+    def test_void_creates_reversal_and_links_source(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        source = _post_lunch(client, auth_h, cash, food)
+
+        r = client.post(
+            f"/v1/transactions/{source['id']}/void",
+            headers=auth_h,
+            json={"reason": "duplicate charge"},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["source_id"] == source["id"]
+        assert body["reversal_id"] != source["id"]
+        assert body["voided_at"] is not None
+
+        # Source now reports voided_by_transaction_id.
+        s = client.get(f"/v1/transactions/{source['id']}", headers=auth_h).json()
+        assert s["voided_by_transaction_id"] == body["reversal_id"]
+        assert s["voided_at"] is not None
+
+        # Reversal is a real POSTED transaction with sign-flipped amounts.
+        rev = client.get(f"/v1/transactions/{body['reversal_id']}", headers=auth_h).json()
+        assert rev["status"] == "posted"
+        assert rev["voided_by_transaction_id"] is None
+        amounts = sorted(float(p["amount"]) for p in rev["postings"])
+        assert amounts == [-12.5, 12.5]
+        # Reversal description carries the reason.
+        assert "duplicate charge" in rev["description"].lower()
+
+    def test_void_default_date_is_today(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        source = _post_lunch(client, auth_h, cash, food)
+
+        r = client.post(
+            f"/v1/transactions/{source['id']}/void",
+            headers=auth_h,
+            json={"reason": "test"},
+        )
+        assert r.status_code == 201, r.text
+        rev = client.get(f"/v1/transactions/{r.json()['reversal_id']}", headers=auth_h).json()
+        assert rev["date"] == date.today().isoformat()
+
+    def test_void_with_explicit_reversal_date(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        # Source dated 5 days ago.
+        source = _post_lunch(client, auth_h, cash, food, when=date.today() - timedelta(days=5))
+
+        # Reversal explicitly dated 2 days ago.
+        explicit = (date.today() - timedelta(days=2)).isoformat()
+        r = client.post(
+            f"/v1/transactions/{source['id']}/void",
+            headers=auth_h,
+            json={"reason": "x", "reversal_date": explicit},
+        )
+        assert r.status_code == 201, r.text
+        rev = client.get(f"/v1/transactions/{r.json()['reversal_id']}", headers=auth_h).json()
+        assert rev["date"] == explicit
+
+
+class TestVoidErrorPaths:
+    def test_unknown_source_returns_404(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        bogus = "11111111-1111-1111-1111-111111111111"
+        r = client.post(
+            f"/v1/transactions/{bogus}/void",
+            headers=auth_h,
+            json={"reason": "x"},
+        )
+        assert_problem(r, code="transaction.not_found", status=404)
+
+    def test_already_voided_returns_409(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        source = _post_lunch(client, auth_h, cash, food)
+        first = client.post(
+            f"/v1/transactions/{source['id']}/void",
+            headers=auth_h,
+            json={"reason": "x"},
+        )
+        assert first.status_code == 201, first.text
+        second = client.post(
+            f"/v1/transactions/{source['id']}/void",
+            headers=auth_h,
+            json={"reason": "y"},
+        )
+        body = assert_problem(second, code="transaction.already_voided", status=409)
+        assert body["voided_by_transaction_id"] == first.json()["reversal_id"]
+
+    def test_unauthenticated_returns_401(
+        self,
+        client: TestClient,
+        cash_and_food: tuple[str, str],
+        auth_h: dict[str, str],
+    ):
+        cash, food = cash_and_food
+        source = _post_lunch(client, auth_h, cash, food)
+        r = client.post(
+            f"/v1/transactions/{source['id']}/void",
+            json={"reason": "x"},
+        )
+        assert r.status_code == 401
+
+
+class TestVoidWithShadowPair:
+    """Voiding a pool-tagged main tx must auto-void the paired shadow tx (option c)."""
+
+    @pytest.fixture
+    def envelope(self, client: TestClient, auth_h: dict[str, str]) -> str:
+        # Seed Unallocated, create an envelope, refill it to 25.00 so a
+        # subsequent $25 spend lands the balance at zero.
+        seed = client.post(
+            "/v1/pools/budget-inflow",
+            headers=auth_h,
+            json={
+                "amount": "100.00",
+                "currency": "USD",
+                "date": date.today().isoformat(),
+                "description": "Seed",
+            },
+        )
+        assert seed.status_code in (200, 201), seed.text
+        r = client.post(
+            "/v1/envelopes",
+            headers=auth_h,
+            json={
+                "name": "Groceries",
+                "currency": "USD",
+                "budget_period": "monthly",
+                "rollover_policy": "accumulate",
+                "refill_rule": {
+                    "strategy": "fixed_amount",
+                    "amount": "25.00",
+                    "currency": "USD",
+                },
+            },
+        )
+        assert r.status_code == 201, r.text
+        env_id = r.json()["id"]
+        ref = client.post(
+            f"/v1/envelopes/{env_id}/refill",
+            headers=auth_h,
+            json={
+                "amount": "25.00",
+                "date": date.today().isoformat(),
+                "description": "Initial refill",
+            },
+        )
+        assert ref.status_code in (200, 201), ref.text
+        return env_id
+
+    def test_voiding_pool_tagged_tx_auto_voids_paired_shadow_tx(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        envelope: str,
+    ):
+        cash, food = cash_and_food
+        # Spend $25 from the envelope.
+        spend = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Groceries run",
+                "postings": [
+                    {
+                        "account_id": food,
+                        "amount": "25.00",
+                        "currency": "USD",
+                        "pool_id": envelope,
+                    },
+                    {"account_id": cash, "amount": "-25.00", "currency": "USD"},
+                ],
+            },
+        )
+        assert spend.status_code == 201, spend.text
+        spend_body = spend.json()
+        assert spend_body["paired_shadow_tx_id"] is not None
+
+        # Envelope balance reflects the spend (25 refilled, 25 spent → 0).
+        bal_before = client.get(f"/v1/envelopes/{envelope}/balance", headers=auth_h).json()
+        assert float(bal_before["balance"]) == 0.0
+
+        # Void the spend.
+        r = client.post(
+            f"/v1/transactions/{spend_body['id']}/void",
+            headers=auth_h,
+            json={"reason": "wrong card"},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        # Response surfaces the shadow void.
+        assert body["paired_shadow_tx_id_voided"] == spend_body["paired_shadow_tx_id"]
+
+        # Envelope balance reverts to the refilled amount (the voided shadow
+        # tx is excluded from balance_for_pool).
+        bal_after = client.get(f"/v1/envelopes/{envelope}/balance", headers=auth_h).json()
+        assert float(bal_after["balance"]) == 25.0

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -548,3 +548,236 @@ def show_transaction(
         sys.stdout.write(response.text + "\n")
         return
     _render_tx_detail(response.json())
+
+
+@transactions_app.command("void")
+def void_transaction(
+    ctx: typer.Context,
+    tx_id: Annotated[
+        str,
+        typer.Argument(help="Transaction UUID to void.", metavar="TXID"),
+    ],
+    reason: Annotated[
+        str,
+        typer.Option(
+            "--reason",
+            "-r",
+            help="Reason for the void; surfaced in the reversal's description.",
+        ),
+    ],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip confirmation prompt.",
+        ),
+    ] = False,
+    reversal_date: Annotated[
+        str | None,
+        typer.Option(
+            "--date",
+            help=(
+                "Reversal date (YYYY-MM-DD). Defaults to today. The reversal "
+                "date is checked against open periods, not the source's date."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Void a POSTED transaction by posting a sign-flipped sibling reversal."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    try:
+        UUID(tx_id)
+    except ValueError as exc:
+        raise typer.BadParameter("TXID must be a UUID") from exc
+
+    if reversal_date is not None:
+        _validate_iso_date(reversal_date, flag="--date")
+
+    if not yes:
+        confirmed = typer.confirm(
+            f"Void transaction {tx_id}? This posts a reversal sibling.",
+            default=False,
+        )
+        if not confirmed:
+            typer.echo("Aborted; no changes made.")
+            return
+
+    body: dict[str, Any] = {"reason": reason}
+    if reversal_date is not None:
+        body["reversal_date"] = reversal_date
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post(
+                f"/v1/transactions/{tx_id}/void",
+                json=body,
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    out = response.json()
+    typer.echo(f"Voided {out['source_id']}; reversal posted as {out['reversal_id']}.")
+    if out.get("paired_shadow_tx_id_voided"):
+        typer.echo(f"  Paired shadow transaction {out['paired_shadow_tx_id_voided']} auto-voided.")
+
+
+@transactions_app.command("delete")
+def delete_transaction(
+    ctx: typer.Context,
+    tx_id: Annotated[
+        str,
+        typer.Argument(help="Transaction UUID to delete.", metavar="TXID"),
+    ],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip confirmation prompt.",
+        ),
+    ] = False,
+) -> None:
+    """Hard-delete a PENDING transaction. Use ``void`` for POSTED transactions."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    try:
+        UUID(tx_id)
+    except ValueError as exc:
+        raise typer.BadParameter("TXID must be a UUID") from exc
+
+    if not yes:
+        confirmed = typer.confirm(
+            f"Hard-delete transaction {tx_id}? Only PENDING transactions can be deleted.",
+            default=False,
+        )
+        if not confirmed:
+            typer.echo("Aborted; no changes made.")
+            return
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            client.delete(f"/v1/transactions/{tx_id}", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write('{"deleted": "' + tx_id + '"}\n')
+        return
+    typer.echo(f"Deleted transaction {tx_id}.")
+
+
+@transactions_app.command("edit")
+def edit_transaction(
+    ctx: typer.Context,
+    tx_id: Annotated[
+        str,
+        typer.Argument(help="Transaction UUID to edit.", metavar="TXID"),
+    ],
+) -> None:
+    """Edit a PENDING transaction in ``$EDITOR`` (hledger format).
+
+    POSTED / RECONCILED transactions cannot be edited; use ``void``
+    + create a corrected entry instead.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    try:
+        UUID(tx_id)
+    except ValueError as exc:
+        raise typer.BadParameter("TXID must be a UUID") from exc
+
+    # Pre-flight: load the existing transaction so we can render it into the
+    # editor buffer and reject early when it's not PENDING.
+    try:
+        with _client(config, as_json=as_json) as client:
+            current = client.get(f"/v1/transactions/{tx_id}", authenticated=True).json()
+            if current.get("status") != "pending":
+                from tulip_cli.errors import CliError as _CliError
+
+                raise _CliError(
+                    problem={
+                        "code": "transaction.not_editable",
+                        "title": "Transaction is not editable",
+                        "status": 409,
+                        "detail": (
+                            "Only PENDING transactions can be edited. Use "
+                            "`tulip transactions void` for posted transactions."
+                        ),
+                    },
+                    as_json=as_json,
+                )
+
+            postings = client.get("/v1/accounts", authenticated=True).json()
+            accounts_by_id = {a["id"]: a for a in postings}
+
+            buffer = _render_tx_for_edit(current, accounts_by_id)
+            while True:
+                edited = edit_buffer(buffer)
+                if _looks_empty(edited):
+                    typer.echo("No changes saved (empty buffer).")
+                    return
+                try:
+                    parsed = parse_ledger_text(edited)
+                except LedgerParseError as exc:
+                    buffer = _with_banner(edited, str(exc))
+                    continue
+                try:
+                    resolved = _resolve_postings(
+                        client,
+                        [ParsedPosting(p.account, p.amount, p.currency) for p in parsed.postings],
+                    )
+                    body = {
+                        "date": parsed.date.isoformat(),
+                        "description": parsed.description,
+                        "postings": resolved,
+                    }
+                    response = client.patch(
+                        f"/v1/transactions/{tx_id}",
+                        json=body,
+                        authenticated=True,
+                    )
+                except CliError as err:
+                    code = str(err.problem.get("code", ""))
+                    if code in _RECOVERABLE_CODES:
+                        detail = str(err.problem.get("detail") or err.problem.get("title"))
+                        buffer = _with_banner(edited, detail)
+                        continue
+                    raise
+
+                if as_json:
+                    sys.stdout.write(response.text + "\n")
+                    return
+                _render_transaction(response.json())
+                return
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+
+def _render_tx_for_edit(tx: dict[str, Any], accounts_by_id: dict[str, dict[str, Any]]) -> str:
+    """Render an existing transaction back into the hledger-subset format.
+
+    Uses account ``code`` when available; falls back to UUID. Inverse of
+    :func:`tulip_cli.commands._ledger.parse_ledger_text`.
+    """
+    lines: list[str] = [_EDITOR_TEMPLATE_HEADER, ""]
+    lines.append(f"{tx.get('date', '')} {tx.get('description', '')}")
+    for p in tx.get("postings", []):
+        account_ref = accounts_by_id.get(p.get("account_id", ""), {}).get("code") or p.get(
+            "account_id", ""
+        )
+        amount = p.get("amount", "")
+        currency = p.get("currency", "")
+        lines.append(f"  {account_ref}  {amount} {currency}")
+    return "\n".join(lines) + "\n"

--- a/packages/tulip-cli/tests/test_transactions_void_delete_edit_cli.py
+++ b/packages/tulip-cli/tests/test_transactions_void_delete_edit_cli.py
@@ -1,0 +1,339 @@
+"""E2E tests for ``tulip transactions {void, delete, edit}`` (P5.0)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+_FAKE_EDITOR_SOURCE = '''\
+"""Fake editor: writes canned content to argv[1] (per-invocation queue)."""
+import os, pathlib, sys
+target = pathlib.Path(sys.argv[1])
+counter_path = pathlib.Path(os.environ["TULIP_FAKE_EDITOR_COUNTER"])
+try:
+    n = int(counter_path.read_text())
+except FileNotFoundError:
+    n = 0
+outputs = os.environ["TULIP_FAKE_EDITOR_OUTPUTS"].split("\\x1e")
+chosen = outputs[min(n, len(outputs) - 1)]
+target.write_text(chosen)
+counter_path.write_text(str(n + 1))
+'''
+
+
+def _fake_editor(tmp_path: Path) -> Path:
+    p = tmp_path / "fake_editor.py"
+    p.write_text(_FAKE_EDITOR_SOURCE)
+    return p
+
+
+def _run_cli(
+    *args: str,
+    api_url: str,
+    extra_env: dict[str, str] | None = None,
+    stdin_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=env,
+        input=stdin_text,
+    )
+
+
+@pytest.fixture
+def authed_session(live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    login = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--api-url",
+            live_api,
+            "auth",
+            "login",
+            "--email",
+            "alice@example.com",
+            "--password-stdin",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=f"{_PASSWORD}\n",
+        timeout=10,
+    )
+    assert login.returncode == 0, login.stderr
+    return live_api
+
+
+def _seed_accounts(api_url: str) -> None:
+    for name, code, type_ in (
+        ("Cash", "assets:cash", "asset"),
+        ("Food", "expenses:food", "expense"),
+    ):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tulip_cli",
+                "--api-url",
+                api_url,
+                "accounts",
+                "add",
+                "--name",
+                name,
+                "--type",
+                type_,
+                "--currency",
+                "USD",
+                "--code",
+                code,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+def _post_via_cli(api_url: str) -> str:
+    """Post a USD lunch transaction; return the new transaction's id."""
+    today = date.today().isoformat()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            api_url,
+            "add",
+            "--date",
+            today,
+            "-m",
+            "Lunch",
+            "--post",
+            "expenses:food=12.50@USD",
+            "--post",
+            "assets:cash=-12.50@USD",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)["id"]
+
+
+# PENDING-only happy-path tests for `transactions edit` and `transactions
+# delete` are deferred to the API integration tests (see
+# packages/tulip-api/tests/test_transactions_patch_delete_endpoint.py).
+# The CLI cannot create PENDING rows until P5.2 (importers) ships, so the
+# CLI E2E here only covers POSTED-source rejection paths plus the void
+# happy path. Cross-layer coverage is otherwise complete.
+
+
+# ---- void ------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_void_with_yes_creates_reversal(authed_session: str) -> None:
+    _seed_accounts(authed_session)
+    tx_id = _post_via_cli(authed_session)
+    result = _run_cli(
+        "transactions",
+        "void",
+        tx_id,
+        "--reason",
+        "duplicate",
+        "--yes",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Voided" in result.stdout
+    assert tx_id in result.stdout
+
+
+@pytest.mark.integration
+def test_void_aborts_on_no_confirmation(authed_session: str) -> None:
+    _seed_accounts(authed_session)
+    tx_id = _post_via_cli(authed_session)
+    result = _run_cli(
+        "transactions",
+        "void",
+        tx_id,
+        "--reason",
+        "duplicate",
+        api_url=authed_session,
+        stdin_text="n\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Aborted" in result.stdout
+
+
+@pytest.mark.integration
+def test_void_json_emits_response_body(authed_session: str) -> None:
+    _seed_accounts(authed_session)
+    tx_id = _post_via_cli(authed_session)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            authed_session,
+            "transactions",
+            "void",
+            tx_id,
+            "--reason",
+            "x",
+            "--yes",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    body = json.loads(result.stdout)
+    assert body["source_id"] == tx_id
+    assert body["reversal_id"] != tx_id
+
+
+@pytest.mark.integration
+def test_void_already_voided_surfaces_problem(authed_session: str) -> None:
+    _seed_accounts(authed_session)
+    tx_id = _post_via_cli(authed_session)
+    first = _run_cli(
+        "transactions",
+        "void",
+        tx_id,
+        "--reason",
+        "x",
+        "--yes",
+        api_url=authed_session,
+    )
+    assert first.returncode == 0, first.stderr
+    second = _run_cli(
+        "transactions",
+        "void",
+        tx_id,
+        "--reason",
+        "y",
+        "--yes",
+        api_url=authed_session,
+    )
+    assert second.returncode != 0
+    assert "already voided" in (second.stdout + second.stderr).lower()
+
+
+# ---- delete ----------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_delete_posted_returns_problem(authed_session: str) -> None:
+    _seed_accounts(authed_session)
+    tx_id = _post_via_cli(authed_session)
+    result = _run_cli(
+        "transactions",
+        "delete",
+        tx_id,
+        "--yes",
+        api_url=authed_session,
+    )
+    assert result.returncode != 0
+    assert "not deletable" in (result.stdout + result.stderr).lower()
+
+
+@pytest.mark.integration
+def test_delete_aborts_on_no(authed_session: str) -> None:
+    _seed_accounts(authed_session)
+    tx_id = _post_via_cli(authed_session)
+    result = _run_cli(
+        "transactions",
+        "delete",
+        tx_id,
+        api_url=authed_session,
+        stdin_text="n\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Aborted" in result.stdout
+
+
+# ---- edit ------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_edit_posted_returns_not_editable(authed_session: str) -> None:
+    _seed_accounts(authed_session)
+    tx_id = _post_via_cli(authed_session)
+    result = _run_cli(
+        "transactions",
+        "edit",
+        tx_id,
+        api_url=authed_session,
+    )
+    assert result.returncode != 0
+    assert "not editable" in (result.stdout + result.stderr).lower()
+
+
+# ---- unauthenticated rejections -------------------------------------------
+
+
+@pytest.mark.integration
+def test_void_unauthenticated_exits_2(live_api: str, tmp_path: Path) -> None:
+    bogus = "11111111-1111-1111-1111-111111111111"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--api-url",
+            live_api,
+            "transactions",
+            "void",
+            bogus,
+            "--reason",
+            "x",
+            "--yes",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={
+            **os.environ,
+            "TULIP_TOKEN_STORE": str(tmp_path / "no-tokens.json"),
+        },
+    )
+    assert result.returncode == 2, result.stderr

--- a/packages/tulip-core/src/tulip_core/accounting/__init__.py
+++ b/packages/tulip-core/src/tulip_core/accounting/__init__.py
@@ -9,6 +9,7 @@ from tulip_core.accounting.engine import (
     ClosedPeriodError,
     UnbalancedTransactionError,
     balance_with_fx_postings,
+    build_reversal,
     post_transaction,
 )
 
@@ -16,5 +17,6 @@ __all__ = [
     "ClosedPeriodError",
     "UnbalancedTransactionError",
     "balance_with_fx_postings",
+    "build_reversal",
     "post_transaction",
 ]

--- a/packages/tulip-core/src/tulip_core/accounting/engine.py
+++ b/packages/tulip-core/src/tulip_core/accounting/engine.py
@@ -26,6 +26,7 @@ from tulip_core.transactions import Posting, Transaction, TransactionStatus
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from datetime import date
     from uuid import UUID
 
     from tulip_core.periods import Period
@@ -42,6 +43,67 @@ class ClosedPeriodError(ValueError):
     - No period covers the transaction date.
     - A period covers the date but is soft-closed and override is not set.
     """
+
+
+def build_reversal(
+    source: Transaction,
+    *,
+    reversal_id: UUID,
+    reversal_date: date,
+    description: str,
+    actor_user_id: UUID | None = None,
+) -> Transaction:
+    """Construct a sign-flipped PENDING reversal sibling for a posted source.
+
+    Postings carry the same ``account_id``, ``pool_id``, and ``memo`` as
+    the source; amounts are negated within the same currency. The returned
+    transaction is balanced by construction (each currency's net is zero).
+    Each posting receives a fresh UUID so the reversal can be persisted as
+    a distinct row.
+
+    The caller is expected to run :func:`post_transaction` on the result,
+    which enforces the period gate against ``reversal_date`` (per ADR-0004
+    §"What P5.0 ships": the void's *own* date must be in an open period).
+
+    Args:
+        source: The POSTED or RECONCILED transaction being voided.
+        reversal_id: The UUID for the new reversal transaction.
+        reversal_date: Date for the reversal — typically today.
+        description: Description for the reversal row.
+        actor_user_id: Optional creator id propagated to the reversal row.
+
+    Returns:
+        A balanced PENDING ``Transaction`` ready for :func:`post_transaction`.
+
+    Raises:
+        ValueError: ``source`` is not POSTED or RECONCILED.
+
+    """
+    if source.status not in (TransactionStatus.POSTED, TransactionStatus.RECONCILED):
+        raise ValueError(
+            f"only POSTED or RECONCILED transactions may be voided; got {source.status.value}"
+        )
+
+    flipped: list[Posting] = []
+    for p in source.postings:
+        flipped.append(
+            Posting(
+                id=uuid4(),
+                account_id=p.account_id,
+                amount=Money(-p.amount.amount, p.amount.currency),
+                pool_id=p.pool_id,
+                memo=p.memo,
+            )
+        )
+    return Transaction(
+        id=reversal_id,
+        household_id=source.household_id,
+        date=reversal_date,
+        description=description,
+        postings=tuple(flipped),
+        status=TransactionStatus.PENDING,
+        created_by_user_id=actor_user_id,
+    )
 
 
 def post_transaction(

--- a/packages/tulip-core/src/tulip_core/transactions/transaction.py
+++ b/packages/tulip-core/src/tulip_core/transactions/transaction.py
@@ -46,9 +46,10 @@ class Transaction:
     status: TransactionStatus
     reference: str | None = field(default=None)
     created_by_user_id: UUID | None = field(default=None)
+    voided_by_transaction_id: UUID | None = field(default=None)
 
     def __post_init__(self) -> None:
-        """Validate posting count and balance (when status requires it)."""
+        """Validate posting count, balance, and void-link / status coherence."""
         if len(self.postings) < 2:
             raise ValueError(
                 f"transaction must have at least two postings, got {len(self.postings)}"
@@ -58,6 +59,8 @@ class Transaction:
             unbalanced = {ccy: bal for ccy, bal in balances.items() if bal != 0}
             if unbalanced:
                 raise ValueError(f"transaction does not balance per currency: {unbalanced}")
+        if self.status is TransactionStatus.PENDING and self.voided_by_transaction_id is not None:
+            raise ValueError("PENDING transactions cannot be voided; use hard delete")
 
     def balance_per_currency(self) -> dict[str, Decimal]:
         """Return a {currency: net amount} dict over all postings."""

--- a/packages/tulip-core/tests/test_accounting_engine.py
+++ b/packages/tulip-core/tests/test_accounting_engine.py
@@ -12,6 +12,7 @@ from tulip_core.accounting import (
     ClosedPeriodError,
     UnbalancedTransactionError,
     balance_with_fx_postings,
+    build_reversal,
     post_transaction,
 )
 from tulip_core.money import Money
@@ -183,3 +184,108 @@ class TestBalanceWithFxPostings:
         assert len(fx_postings) == 2
         # Original postings preserved at the head.
         assert balanced.postings[: len(unbal.postings)] == unbal.postings
+
+
+class TestBuildReversal:
+    def _posted_source(self, when: date = date(2026, 6, 1)) -> Transaction:
+        return Transaction(
+            id=uuid4(),
+            household_id=HOUSEHOLD,
+            date=when,
+            description="Lunch",
+            reference="cc-1234",
+            postings=(
+                Posting(
+                    id=uuid4(),
+                    account_id=uuid4(),
+                    amount=Money(Decimal("12.50"), "USD"),
+                    memo="Sandwich",
+                    pool_id=uuid4(),
+                ),
+                Posting(
+                    id=uuid4(),
+                    account_id=uuid4(),
+                    amount=Money(Decimal("-12.50"), "USD"),
+                ),
+            ),
+            status=TransactionStatus.POSTED,
+        )
+
+    def test_returns_balanced_pending_with_signs_flipped(self):
+        source = self._posted_source()
+        reversal = build_reversal(
+            source,
+            reversal_id=uuid4(),
+            reversal_date=date(2026, 7, 1),
+            description="Reversal of Lunch: duplicate charge",
+        )
+        assert reversal.status is TransactionStatus.PENDING
+        assert reversal.is_balanced() is True
+        assert len(reversal.postings) == len(source.postings)
+        # Each leg's amount is the source's negated amount, same currency.
+        source_amounts = {
+            (p.account_id, p.amount.currency): p.amount.amount for p in source.postings
+        }
+        for r in reversal.postings:
+            key = (r.account_id, r.amount.currency)
+            assert r.amount.amount == -source_amounts[key]
+
+    def test_metadata_carried_or_overridden(self):
+        source = self._posted_source()
+        new_id = uuid4()
+        reversal = build_reversal(
+            source,
+            reversal_id=new_id,
+            reversal_date=date(2026, 7, 1),
+            description="Reversal of Lunch: typo",
+            actor_user_id=uuid4(),
+        )
+        assert reversal.id == new_id
+        assert reversal.household_id == source.household_id
+        assert reversal.date == date(2026, 7, 1)
+        assert reversal.description == "Reversal of Lunch: typo"
+        # Reference defaults to None (the reversal is its own row in the
+        # ledger; the source's reference is not the reversal's reference).
+        assert reversal.reference is None
+        # voided_by_transaction_id is null on the reversal itself.
+        assert reversal.voided_by_transaction_id is None
+
+    def test_postings_get_fresh_uuids(self):
+        source = self._posted_source()
+        reversal = build_reversal(
+            source,
+            reversal_id=uuid4(),
+            reversal_date=date(2026, 7, 1),
+            description="Reversal",
+        )
+        source_ids = {p.id for p in source.postings}
+        reversal_ids = {p.id for p in reversal.postings}
+        assert source_ids.isdisjoint(reversal_ids)
+
+    def test_pool_id_and_memo_preserved(self):
+        # Pool tags survive the sign-flip; the paired-shadow-tx-void chokepoint
+        # in the API handler relies on the reversal carrying the same pool_id.
+        source = self._posted_source()
+        reversal = build_reversal(
+            source,
+            reversal_id=uuid4(),
+            reversal_date=date(2026, 7, 1),
+            description="Reversal",
+        )
+        # Match by account_id, since posting ids differ.
+        source_by_acct = {p.account_id: p for p in source.postings}
+        for r in reversal.postings:
+            s = source_by_acct[r.account_id]
+            assert r.pool_id == s.pool_id
+            assert r.memo == s.memo
+
+    def test_pending_source_rejected(self):
+        # Only POSTED / RECONCILED can be voided.
+        pending = _balanced_pending_tx(date(2026, 6, 1))
+        with pytest.raises(ValueError, match="POSTED"):
+            build_reversal(
+                pending,
+                reversal_id=uuid4(),
+                reversal_date=date(2026, 7, 1),
+                description="Reversal",
+            )

--- a/packages/tulip-core/tests/test_transaction.py
+++ b/packages/tulip-core/tests/test_transaction.py
@@ -105,6 +105,58 @@ class TestTransactionConstruction:
             )
 
 
+class TestVoidedByLink:
+    def test_posted_with_voided_by_id_is_valid(self):
+        tx = Transaction(
+            id=uuid4(),
+            household_id=uuid4(),
+            date=date(2026, 1, 15),
+            description="Voided coffee",
+            postings=_balanced_postings(),
+            status=TransactionStatus.POSTED,
+            voided_by_transaction_id=uuid4(),
+        )
+        assert tx.voided_by_transaction_id is not None
+
+    def test_posted_default_voided_by_id_is_none(self):
+        tx = Transaction(
+            id=uuid4(),
+            household_id=uuid4(),
+            date=date(2026, 1, 15),
+            description="Live coffee",
+            postings=_balanced_postings(),
+            status=TransactionStatus.POSTED,
+        )
+        assert tx.voided_by_transaction_id is None
+
+    def test_reconciled_with_voided_by_id_is_valid(self):
+        tx = Transaction(
+            id=uuid4(),
+            household_id=uuid4(),
+            date=date(2026, 1, 15),
+            description="Reconciled then voided",
+            postings=_balanced_postings(),
+            status=TransactionStatus.RECONCILED,
+            voided_by_transaction_id=uuid4(),
+        )
+        assert tx.status is TransactionStatus.RECONCILED
+        assert tx.voided_by_transaction_id is not None
+
+    def test_pending_with_voided_by_id_raises(self):
+        # PENDING transactions should be hard-deleted, never voided. The
+        # voided_by link only makes sense on POSTED / RECONCILED.
+        with pytest.raises(ValueError, match="voided"):
+            Transaction(
+                id=uuid4(),
+                household_id=uuid4(),
+                date=date(2026, 1, 15),
+                description="Impossible state",
+                postings=_balanced_postings(),
+                status=TransactionStatus.PENDING,
+                voided_by_transaction_id=uuid4(),
+            )
+
+
 class TestBalancePerCurrency:
     def test_single_currency_balance(self):
         tx = Transaction(

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260504_2000_e7d2a4f8c1b9_add_transaction_void_links.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260504_2000_e7d2a4f8c1b9_add_transaction_void_links.py
@@ -1,0 +1,75 @@
+"""Add transactions.voided_by_transaction_id + voided_at (P5.0).
+
+Per ADR-0004 §"What P5.0 ships". The void mechanic for POSTED transactions
+records the reversal sibling via a self-FK on the source row. ``voided_at``
+is the timestamp when the link was established. Both columns are nullable
+since most transactions are never voided.
+
+The composite self-FK requires a SQLite table rebuild via batch_alter_table,
+which conflicts with the main-ledger balance triggers (they reference
+``transactions`` and ``postings`` by name). Drop the triggers around the
+rebuild and recreate them — same dance as P4.0's
+``20260502_1200_a3f4d8e91b22_add_allocation_shadow_ledger.py``.
+
+Revision ID: e7d2a4f8c1b9
+Revises: b8a91c2f3d44
+Create Date: 2026-05-04 20:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from tulip_storage.migrations._triggers import (
+    INITIAL_TRIGGER_NAMES,
+    INITIAL_TRIGGERS,
+)
+from tulip_storage.models.base import GUID
+
+revision: str = "e7d2a4f8c1b9"
+down_revision: str | None = "b8a91c2f3d44"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the two void-link columns + composite self-FK on transactions."""
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        for trigger_name in reversed(INITIAL_TRIGGER_NAMES):
+            op.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+
+    with op.batch_alter_table("transactions", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("voided_by_transaction_id", GUID(length=36), nullable=True))
+        batch_op.add_column(sa.Column("voided_at", sa.DateTime(timezone=True), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_transactions_voided_by",
+            "transactions",
+            ["household_id", "voided_by_transaction_id"],
+            ["household_id", "id"],
+            use_alter=True,
+        )
+
+    if bind.dialect.name == "sqlite":
+        for ddl in INITIAL_TRIGGERS:
+            op.execute(ddl)
+
+
+def downgrade() -> None:
+    """Drop the void-link columns + the self-FK."""
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        for trigger_name in reversed(INITIAL_TRIGGER_NAMES):
+            op.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+
+    with op.batch_alter_table("transactions", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_transactions_voided_by", type_="foreignkey")
+        batch_op.drop_column("voided_at")
+        batch_op.drop_column("voided_by_transaction_id")
+
+    if bind.dialect.name == "sqlite":
+        for ddl in INITIAL_TRIGGERS:
+            op.execute(ddl)

--- a/packages/tulip-storage/src/tulip_storage/models/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/models/transaction.py
@@ -41,6 +41,8 @@ class Transaction(Base):
     )
     notes_encrypted: Mapped[bytes | None] = mapped_column(nullable=True)
     created_by_user_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    voided_by_transaction_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    voided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
@@ -42,6 +42,10 @@ _DOMAIN_TO_STORAGE_STATUS: dict[str, ShadowTxStatus] = {
 _BALANCE_STATUSES = (ShadowTxStatus.POSTED,)
 
 
+class ShadowTxNotVoidableError(ValueError):
+    """Raised when a shadow tx is not in a voidable state (i.e. PENDING)."""
+
+
 class ShadowTransactionRepository:
     """Persists shadow transactions and queries pool balances, scoped to a household."""
 
@@ -164,6 +168,52 @@ class ShadowTransactionRepository:
             query = query.where(ShadowTransaction.date <= as_of)
         rows = self._session.execute(query).all()
         return {ccy: Decimal(str(bal)) for ccy, bal in rows}
+
+    def void(self, shadow_tx_id: UUID, *, voided_at: datetime) -> ShadowTransaction:
+        """Flip a POSTED shadow transaction's status to VOIDED.
+
+        Voided shadow transactions are excluded from ``balance_for_pool`` and
+        ``inflow_since`` so pool balances auto-correct. Idempotent on
+        already-voided rows. Used by the main-tx void chokepoint (ADR-0004
+        §P5.0) to keep the shadow ledger consistent when a pool-tagged main
+        tx is voided.
+
+        The shadow ledger has no period concept and balances are derived,
+        so a status flip is sufficient — no sibling reversal needed. The
+        ``voided_by_shadow_tx_id`` column stays NULL for this path; it's
+        reserved for a future shadow-internal void-via-sibling pattern that
+        we don't need today.
+
+        Raises:
+            LookupError: shadow tx not found in this household.
+            ShadowTxNotVoidableError: shadow tx is PENDING (work-in-progress).
+
+        """
+        existing = self.get(shadow_tx_id)
+        if existing is None:
+            raise LookupError(
+                f"shadow_transaction {shadow_tx_id} not found in household {self._household_id}"
+            )
+        if existing.status is ShadowTxStatus.VOIDED:
+            return existing  # idempotent no-op
+        if existing.status is not ShadowTxStatus.POSTED:
+            raise ShadowTxNotVoidableError(
+                f"shadow_transaction {shadow_tx_id} is {existing.status.value}; "
+                "only POSTED shadow transactions may be voided"
+            )
+        self._session.execute(
+            update(ShadowTransaction)
+            .where(
+                ShadowTransaction.household_id == self._household_id,
+                ShadowTransaction.id == shadow_tx_id,
+            )
+            .values(status=ShadowTxStatus.VOIDED.value, voided_at=voided_at)
+        )
+        # Refresh in-session.
+        self._session.expire(existing)
+        loaded = self.get(shadow_tx_id)
+        assert loaded is not None  # noqa: S101 - just updated above
+        return loaded
 
     def save_balanced(self, domain_tx: DomainShadowTx) -> ShadowTransaction:
         """Persist a balanced domain ShadowTransaction.

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
@@ -17,15 +17,34 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import func, select, update
+from sqlalchemy import delete, func, select, update
 
 from tulip_storage.models import Posting, Transaction, TransactionStatus
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from sqlalchemy.orm import Session
 
+    from tulip_core.transactions import Posting as DomainPosting
     from tulip_core.transactions import Transaction as DomainTransaction
     from tulip_core.transactions import TransactionStatus as DomainTxStatus
+
+
+class TransactionAlreadyVoidedError(ValueError):
+    """Raised when a void is attempted on a transaction that already has a reversal."""
+
+
+class TransactionNotVoidableError(ValueError):
+    """Raised when void is attempted on a transaction that isn't POSTED / RECONCILED."""
+
+
+class TransactionNotEditableError(ValueError):
+    """Raised when PATCH is attempted on a non-PENDING transaction."""
+
+
+class TransactionNotDeletableError(ValueError):
+    """Raised when hard-delete is attempted on a non-PENDING transaction."""
 
 
 _DOMAIN_TO_STORAGE_STATUS: dict[str, TransactionStatus] = {
@@ -243,6 +262,149 @@ class TransactionRepository:
             header.status = target_status
 
         return header
+
+    def persist_reversal(
+        self,
+        source_id: UUID,
+        reversal: DomainTransaction,
+        *,
+        voided_at: datetime,
+    ) -> Transaction:
+        """Persist a reversal sibling and link the source's voided_by_transaction_id.
+
+        The caller is expected to have already constructed ``reversal`` via
+        :func:`tulip_core.accounting.build_reversal` and validated the
+        period gate via :func:`tulip_core.accounting.post_transaction`.
+
+        Raises:
+            LookupError: ``source_id`` does not exist in this household.
+            TransactionAlreadyVoidedError: source is already voided.
+            TransactionNotVoidableError: source is PENDING (not in the ledger).
+
+        """
+        source = self.get(source_id)
+        if source is None:
+            raise LookupError(
+                f"transaction {source_id} not found in household {self._household_id}"
+            )
+        if source.voided_by_transaction_id is not None:
+            raise TransactionAlreadyVoidedError(
+                f"transaction {source_id} already voided by {source.voided_by_transaction_id}"
+            )
+        if source.status not in _LEDGER_STATUSES:
+            raise TransactionNotVoidableError(
+                f"transaction {source_id} is {source.status.value}; "
+                "only POSTED / RECONCILED transactions may be voided"
+            )
+
+        # Persist the reversal sibling. _save handles the PENDING-then-UPDATE
+        # dance the balance trigger requires.
+        target = self._domain_to_storage(reversal.status)
+        self._save(reversal, target)
+
+        # Link the source row.
+        self._session.execute(
+            update(Transaction)
+            .where(
+                Transaction.household_id == self._household_id,
+                Transaction.id == source_id,
+            )
+            .values(
+                voided_by_transaction_id=reversal.id,
+                voided_at=voided_at,
+            )
+        )
+        return self._session.get(Transaction, (self._household_id, reversal.id))  # type: ignore[return-value]
+
+    def delete_pending(self, tx_id: UUID) -> None:
+        """Hard-delete a PENDING transaction and its postings.
+
+        Raises:
+            LookupError: ``tx_id`` does not exist in this household.
+            TransactionNotDeletableError: transaction is not PENDING.
+
+        """
+        existing = self.get(tx_id)
+        if existing is None:
+            raise LookupError(f"transaction {tx_id} not found in household {self._household_id}")
+        if existing.status is not TransactionStatus.PENDING:
+            raise TransactionNotDeletableError(
+                f"transaction {tx_id} is {existing.status.value}; "
+                "only PENDING transactions may be hard-deleted (use void otherwise)"
+            )
+        self._session.execute(
+            delete(Posting).where(
+                Posting.household_id == self._household_id,
+                Posting.transaction_id == tx_id,
+            )
+        )
+        self._session.execute(
+            delete(Transaction).where(
+                Transaction.household_id == self._household_id,
+                Transaction.id == tx_id,
+            )
+        )
+
+    def update_pending(
+        self,
+        tx_id: UUID,
+        *,
+        date: date_type,
+        description: str,
+        reference: str | None,
+        postings: tuple[DomainPosting, ...],
+    ) -> Transaction:
+        """Update fields and replace postings on a PENDING transaction.
+
+        Raises:
+            LookupError: ``tx_id`` does not exist in this household.
+            TransactionNotEditableError: transaction is not PENDING.
+
+        """
+        existing = self.get(tx_id)
+        if existing is None:
+            raise LookupError(f"transaction {tx_id} not found in household {self._household_id}")
+        if existing.status is not TransactionStatus.PENDING:
+            raise TransactionNotEditableError(
+                f"transaction {tx_id} is {existing.status.value}; "
+                "only PENDING transactions may be edited (use void otherwise)"
+            )
+        self._session.execute(
+            update(Transaction)
+            .where(
+                Transaction.household_id == self._household_id,
+                Transaction.id == tx_id,
+            )
+            .values(date=date, description=description, reference=reference)
+        )
+        # Replace postings wholesale: simpler than diff-merge and the trigger
+        # is a no-op on PENDING transactions.
+        self._session.execute(
+            delete(Posting).where(
+                Posting.household_id == self._household_id,
+                Posting.transaction_id == tx_id,
+            )
+        )
+        for p in postings:
+            self._session.add(
+                Posting(
+                    id=p.id,
+                    household_id=self._household_id,
+                    transaction_id=tx_id,
+                    account_id=p.account_id,
+                    pool_id=p.pool_id,
+                    amount=p.amount.amount,
+                    currency=p.amount.currency,
+                    fx_rate=p.fx_rate,
+                    fx_amount=p.fx_amount.amount if p.fx_amount is not None else None,
+                    fx_currency=(p.fx_amount.currency if p.fx_amount is not None else None),
+                    memo=p.memo,
+                )
+            )
+        self._session.flush()
+        refreshed = self._session.get(Transaction, (self._household_id, tx_id))
+        assert refreshed is not None  # noqa: S101 - existence verified above
+        return refreshed
 
     def _force_post_unbalanced_for_test(self, domain_tx: DomainTransaction) -> Transaction:
         """Force-post a (potentially unbalanced) Domain Transaction.

--- a/packages/tulip-storage/tests/test_architecture_no_direct_void_link_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_void_link_writes.py
@@ -1,0 +1,103 @@
+"""Architecture test: void-link writes go through TransactionRepository (P5.0).
+
+Per ADR-0004, ``transactions.voided_by_transaction_id`` is the truth of
+"this transaction has been reversed." It must only ever be set by
+:class:`tulip_storage.repositories.TransactionRepository.persist_reversal`,
+which atomically writes the reversal sibling and links the source row.
+
+The check rejects any source file under ``packages/*/src/`` (tests
+excluded; tests legitimately seed rows for setup) that uses
+``voided_by_transaction_id`` as a keyword argument or attribute assignment.
+Reading the column is permitted everywhere — the API handler reads it for
+the already-voided pre-flight check.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
+_PACKAGES: Final[Path] = _REPO_ROOT / "packages"
+
+_GUARDED: Final[str] = "voided_by_transaction_id"
+
+#: Files allowed to mention ``voided_by_transaction_id`` as a kwarg or
+#: attribute assignment. The repository is the only place that *writes* to
+#: the underlying DB column; the API router and the API schemas legitimately
+#: pass it as a kwarg to read-side objects (``TransactionRead`` Pydantic
+#: model, ``TransactionAlreadyVoidedError`` Problem Details extension).
+#: Paths are relative to ``packages/``.
+_ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
+    {
+        # The repository chokepoint — the only legitimate DB writer.
+        "tulip-storage/src/tulip_storage/repositories/transaction.py",
+        # The ORM model declares the column.
+        "tulip-storage/src/tulip_storage/models/transaction.py",
+        # The migration adds the column.
+        "tulip-storage/src/tulip_storage/migrations/versions/"
+        "20260504_2000_e7d2a4f8c1b9_add_transaction_void_links.py",
+        # API surface: read-side responses + Problem extensions. No DB writes.
+        "tulip-api/src/tulip_api/schemas/transaction.py",
+        "tulip-api/src/tulip_api/errors.py",
+        "tulip-api/src/tulip_api/routers/transactions.py",
+    }
+)
+
+
+def _python_source_files() -> list[Path]:
+    out: list[Path] = []
+    for pkg in sorted(_PACKAGES.iterdir()):
+        src = pkg / "src"
+        if not src.is_dir():
+            continue
+        out.extend(sorted(src.rglob("*.py")))
+    return out
+
+
+def _writes_to_void_link(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, kind)`` pairs where the file writes the void link.
+
+    Two write shapes are considered:
+    - ``foo.voided_by_transaction_id = ...`` (attribute assignment).
+    - ``...(voided_by_transaction_id=...)`` (keyword-arg in a call).
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        # Attribute assignment.
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Attribute) and target.attr == _GUARDED:
+                    hits.append((node.lineno, "assign"))
+        if isinstance(node, ast.AugAssign) and (
+            isinstance(node.target, ast.Attribute) and node.target.attr == _GUARDED
+        ):
+            hits.append((node.lineno, "augassign"))
+        # Keyword arg in a call (covers both .values(voided_...=) and
+        # MyModel(voided_...=) construction).
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == _GUARDED:
+                    hits.append((node.lineno, "kwarg"))
+    return hits
+
+
+def test_no_direct_void_link_writes_outside_allowlist() -> None:
+    offenders: dict[str, list[tuple[int, str]]] = {}
+    for path in _python_source_files():
+        rel = str(path.relative_to(_PACKAGES))
+        if rel in _ALLOWED_RELATIVE:
+            continue
+        hits = _writes_to_void_link(path)
+        if hits:
+            offenders[rel] = hits
+
+    assert not offenders, (
+        "Direct writes to transactions.voided_by_transaction_id outside the "
+        "TransactionRepository.persist_reversal chokepoint — route through "
+        "the repo so the void link and the reversal-sibling write stay "
+        "atomic (per ADR-0004 §P5.0):\n"
+        + "\n".join(f"  {file}: {hits}" for file, hits in offenders.items())
+    )

--- a/packages/tulip-storage/tests/test_p50_migration.py
+++ b/packages/tulip-storage/tests/test_p50_migration.py
@@ -1,0 +1,196 @@
+"""Tests for the P5.0 transaction-void migration.
+
+Adds two columns to ``transactions``:
+- ``voided_by_transaction_id``: nullable self-FK to the reversal sibling.
+- ``voided_at``: nullable timestamp.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from alembic.command import downgrade, upgrade
+from alembic.config import Config
+from sqlalchemy import event, inspect
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from tulip_storage.models import (
+    Account,
+    AccountType,
+    Household,
+    Posting,
+    Transaction,
+    TransactionStatus,
+)
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+
+
+def _make_alembic_cfg(db_url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    cfg.set_main_option(
+        "script_location",
+        str(ALEMBIC_INI.parent / "src" / "tulip_storage" / "migrations"),
+    )
+    return cfg
+
+
+@pytest.fixture
+def migrated_db(tmp_path):
+    db_path = tmp_path / "tulip.db"
+    db_url = f"sqlite:///{db_path}"
+    cfg = _make_alembic_cfg(db_url)
+    upgrade(cfg, "head")
+
+    from sqlalchemy import create_engine
+
+    eng = create_engine(db_url, future=True)
+
+    @event.listens_for(eng, "connect")
+    def _enable_fk(dc, _r):  # type: ignore[no-untyped-def]
+        cur = dc.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    yield db_url, sessionmaker(eng, expire_on_commit=False)
+    eng.dispose()
+
+
+def _seed_household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+def _seed_balanced_tx(session: Session, household_id) -> Transaction:
+    cash = Account(
+        household_id=household_id,
+        id=uuid4(),
+        code="1110",
+        name="Checking",
+        type=AccountType.ASSET,
+        currency="USD",
+        visibility="shared",
+    )
+    food = Account(
+        household_id=household_id,
+        id=uuid4(),
+        code="5100",
+        name="Food",
+        type=AccountType.EXPENSE,
+        currency="USD",
+        visibility="shared",
+    )
+    session.add_all([cash, food])
+    session.commit()
+    tx = Transaction(
+        household_id=household_id,
+        id=uuid4(),
+        date=date(2026, 6, 1),
+        description="Lunch",
+        status=TransactionStatus.PENDING,
+    )
+    session.add(tx)
+    session.flush()
+    session.add_all(
+        [
+            Posting(
+                id=uuid4(),
+                household_id=household_id,
+                transaction_id=tx.id,
+                account_id=food.id,
+                amount=Decimal("12.50"),
+                currency="USD",
+            ),
+            Posting(
+                id=uuid4(),
+                household_id=household_id,
+                transaction_id=tx.id,
+                account_id=cash.id,
+                amount=Decimal("-12.50"),
+                currency="USD",
+            ),
+        ]
+    )
+    session.flush()
+    tx.status = TransactionStatus.POSTED
+    session.commit()
+    return tx
+
+
+class TestSchemaShape:
+    def test_voided_columns_exist(self, migrated_db):
+        db_url, _ = migrated_db
+        from sqlalchemy import create_engine
+
+        eng = create_engine(db_url)
+        cols = {c["name"]: c for c in inspect(eng).get_columns("transactions")}
+        assert "voided_by_transaction_id" in cols
+        assert cols["voided_by_transaction_id"]["nullable"] is True
+        assert "voided_at" in cols
+        assert cols["voided_at"]["nullable"] is True
+        eng.dispose()
+
+    def test_voided_by_self_fk_exists(self, migrated_db):
+        db_url, _ = migrated_db
+        from sqlalchemy import create_engine
+
+        eng = create_engine(db_url)
+        fks = inspect(eng).get_foreign_keys("transactions")
+        self_fks = [
+            fk
+            for fk in fks
+            if "voided_by_transaction_id" in fk["constrained_columns"]
+            and fk["referred_table"] == "transactions"
+        ]
+        assert self_fks, f"expected self-FK on voided_by_transaction_id, got {fks}"
+        eng.dispose()
+
+    def test_round_trip_upgrade_downgrade(self, tmp_path):
+        db_path = tmp_path / "tulip.db"
+        cfg = _make_alembic_cfg(f"sqlite:///{db_path}")
+        upgrade(cfg, "head")
+        downgrade(cfg, "-1")
+        from sqlalchemy import create_engine
+
+        eng = create_engine(f"sqlite:///{db_path}")
+        cols = {c["name"] for c in inspect(eng).get_columns("transactions")}
+        assert "voided_by_transaction_id" not in cols
+        assert "voided_at" not in cols
+        eng.dispose()
+
+
+class TestVoidLinkPersistence:
+    def test_set_voided_by_persists_round_trip(self, migrated_db):
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            h = _seed_household(s)
+            tx = _seed_balanced_tx(s, h.id)
+            reversal = _seed_balanced_tx(s, h.id)
+            tx.voided_by_transaction_id = reversal.id
+            from datetime import datetime
+
+            tx.voided_at = datetime.now(UTC)
+            s.commit()
+
+            with Smaker() as s2:
+                fresh = s2.get(Transaction, (h.id, tx.id))
+                assert fresh is not None
+                assert fresh.voided_by_transaction_id == reversal.id
+                assert fresh.voided_at is not None
+
+    def test_orphan_voided_by_id_rejected(self, migrated_db):
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            h = _seed_household(s)
+            tx = _seed_balanced_tx(s, h.id)
+            tx.voided_by_transaction_id = uuid4()  # no matching tx
+            with pytest.raises(IntegrityError):
+                s.commit()

--- a/packages/tulip-storage/tests/test_shadow_transaction_repository_void.py
+++ b/packages/tulip-storage/tests/test_shadow_transaction_repository_void.py
@@ -1,0 +1,176 @@
+"""Tests for the ShadowTransactionRepository.void chokepoint (P5.0)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_core.allocation import (
+    ShadowPosting as DomainShadowPosting,
+)
+from tulip_core.allocation import (
+    ShadowTransaction as DomainShadowTx,
+)
+from tulip_core.allocation import (
+    ShadowTxReason,
+    ShadowTxStatus,
+)
+from tulip_core.money import Money
+from tulip_storage.models import (
+    AllocationPool,
+    Household,
+    PoolType,
+)
+from tulip_storage.models import (
+    ShadowTxStatus as StorageShadowStatus,
+)
+from tulip_storage.repositories import ShadowTransactionRepository
+from tulip_storage.repositories.shadow_transaction import ShadowTxNotVoidableError
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+def _seed_pools(session: Session, household: Household) -> tuple[AllocationPool, AllocationPool]:
+    """Create one user envelope + one Spent system pool, both USD."""
+    env = AllocationPool(
+        household_id=household.id,
+        id=uuid4(),
+        pool_type=PoolType.ENVELOPE,
+        name="Groceries",
+        currency="USD",
+        is_active=True,
+        is_system=False,
+    )
+    spent = AllocationPool(
+        household_id=household.id,
+        id=uuid4(),
+        pool_type=PoolType.SPENT,
+        name="Spent USD",
+        currency="USD",
+        is_active=True,
+        is_system=True,
+    )
+    session.add_all([env, spent])
+    session.commit()
+    return env, spent
+
+
+def _post_shadow_tx(
+    session: Session,
+    household: Household,
+    *,
+    env: AllocationPool,
+    spent: AllocationPool,
+) -> DomainShadowTx:
+    """Insert a POSTED shadow tx via save_balanced."""
+    domain_tx = DomainShadowTx(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 6, 1),
+        description="Groceries spend pairing",
+        reason=ShadowTxReason.SPEND,
+        status=ShadowTxStatus.POSTED,
+        postings=(
+            DomainShadowPosting(
+                id=uuid4(),
+                pool_id=env.id,
+                amount=Money(Decimal("-25.00"), "USD"),
+            ),
+            DomainShadowPosting(
+                id=uuid4(),
+                pool_id=spent.id,
+                amount=Money(Decimal("25.00"), "USD"),
+            ),
+        ),
+    )
+    ShadowTransactionRepository(session, household.id).save_balanced(domain_tx)
+    session.commit()
+    return domain_tx
+
+
+class TestVoid:
+    def test_posted_shadow_tx_status_flips_to_voided(self, session: Session, household: Household):
+        env, spent = _seed_pools(session, household)
+        stx = _post_shadow_tx(session, household, env=env, spent=spent)
+
+        repo = ShadowTransactionRepository(session, household.id)
+        voided_at = datetime.now(tz=UTC)
+        repo.void(stx.id, voided_at=voided_at)
+        session.commit()
+
+        loaded = repo.get(stx.id)
+        assert loaded is not None
+        assert loaded.status is StorageShadowStatus.VOIDED
+        assert loaded.voided_at is not None
+
+    def test_balance_for_pool_excludes_voided_shadow_tx(
+        self, session: Session, household: Household
+    ):
+        # Before void: pool balance reflects the spend.
+        # After void: pool balance is zero (status=voided is excluded).
+        env, spent = _seed_pools(session, household)
+        stx = _post_shadow_tx(session, household, env=env, spent=spent)
+
+        repo = ShadowTransactionRepository(session, household.id)
+        before = repo.balance_for_pool(env.id, currency="USD")
+        assert before["USD"] == Decimal("-25.00")
+
+        repo.void(stx.id, voided_at=datetime.now(tz=UTC))
+        session.commit()
+
+        after = repo.balance_for_pool(env.id, currency="USD")
+        assert after.get("USD", Decimal("0")) == Decimal("0")
+
+    def test_already_voided_is_idempotent_noop(self, session: Session, household: Household):
+        env, spent = _seed_pools(session, household)
+        stx = _post_shadow_tx(session, household, env=env, spent=spent)
+
+        repo = ShadowTransactionRepository(session, household.id)
+        first_at = datetime.now(tz=UTC)
+        repo.void(stx.id, voided_at=first_at)
+        session.commit()
+        first_loaded_at = repo.get(stx.id).voided_at  # type: ignore[union-attr]
+
+        # Second void should be a no-op — voided_at unchanged.
+        later = datetime.now(tz=UTC)
+        repo.void(stx.id, voided_at=later)
+        session.commit()
+        second_loaded_at = repo.get(stx.id).voided_at  # type: ignore[union-attr]
+        assert first_loaded_at == second_loaded_at
+
+    def test_pending_shadow_tx_rejected(self, session: Session, household: Household):
+        _seed_pools(session, household)
+        # Insert a PENDING shadow tx directly via the model layer (no commit-
+        # then-flip). PENDING isn't valid input for void.
+        from tulip_storage.models import ShadowTransaction as StorageShadowTx
+        from tulip_storage.models import ShadowTxReason as StorageShadowReason
+
+        pending = StorageShadowTx(
+            household_id=household.id,
+            id=uuid4(),
+            date=date(2026, 6, 1),
+            description="WIP",
+            reason=StorageShadowReason.MANUAL,
+            status=StorageShadowStatus.PENDING,
+        )
+        session.add(pending)
+        session.commit()
+
+        repo = ShadowTransactionRepository(session, household.id)
+        with pytest.raises(ShadowTxNotVoidableError):
+            repo.void(pending.id, voided_at=datetime.now(tz=UTC))
+
+    def test_unknown_shadow_tx_raises_lookup_error(self, session: Session, household: Household):
+        repo = ShadowTransactionRepository(session, household.id)
+        with pytest.raises(LookupError):
+            repo.void(uuid4(), voided_at=datetime.now(tz=UTC))

--- a/packages/tulip-storage/tests/test_transaction_repository_void.py
+++ b/packages/tulip-storage/tests/test_transaction_repository_void.py
@@ -1,0 +1,352 @@
+"""Tests for P5.0 TransactionRepository void / edit / delete additions."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_core.accounting import build_reversal
+from tulip_core.money import Money
+from tulip_core.transactions import Posting as DomainPosting
+from tulip_core.transactions import Transaction as DomainTransaction
+from tulip_core.transactions import TransactionStatus as DomainTxStatus
+from tulip_storage.models import (
+    Account as AccountModel,
+)
+from tulip_storage.models import (
+    AccountType,
+    Household,
+)
+from tulip_storage.models import (
+    Posting as PostingModel,
+)
+from tulip_storage.models import (
+    Transaction as TxModel,
+)
+from tulip_storage.repositories import (
+    AccountRepository,
+    TransactionRepository,
+)
+from tulip_storage.repositories.transaction import (
+    TransactionAlreadyVoidedError,
+    TransactionNotDeletableError,
+    TransactionNotEditableError,
+    TransactionNotVoidableError,
+)
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+def _seed_accounts(session: Session, household: Household) -> tuple[AccountModel, AccountModel]:
+    repo = AccountRepository(session, household.id)
+    cash = repo.create(code="1110", name="Cash", type=AccountType.ASSET, currency="USD")
+    food = repo.create(code="5100", name="Food", type=AccountType.EXPENSE, currency="USD")
+    session.commit()
+    return cash, food
+
+
+def _post_lunch(
+    session: Session, household: Household, food: AccountModel, cash: AccountModel
+) -> DomainTransaction:
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 6, 1),
+        description="Lunch",
+        postings=(
+            DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("12.50"), "USD")),
+            DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(Decimal("-12.50"), "USD")),
+        ),
+        status=DomainTxStatus.POSTED,
+    )
+    TransactionRepository(session, household.id).save_balanced(domain_tx)
+    session.commit()
+    return domain_tx
+
+
+def _post_pending_lunch(
+    session: Session, household: Household, food: AccountModel, cash: AccountModel
+) -> DomainTransaction:
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 6, 1),
+        description="Lunch (pending)",
+        postings=(
+            DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("12.50"), "USD")),
+            DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(Decimal("-12.50"), "USD")),
+        ),
+        status=DomainTxStatus.PENDING,
+    )
+    TransactionRepository(session, household.id).save_balanced(domain_tx)
+    session.commit()
+    return domain_tx
+
+
+class TestPersistReversal:
+    def test_links_source_and_persists_sibling(self, session: Session, household: Household):
+        cash, food = _seed_accounts(session, household)
+        source = _post_lunch(session, household, food, cash)
+
+        reversal = build_reversal(
+            source,
+            reversal_id=uuid4(),
+            reversal_date=date(2026, 7, 1),
+            description="Reversal: duplicate charge",
+        )
+        # Engine would normally validate period; for repo test, we set the
+        # status directly to POSTED since period validation is the API
+        # layer's concern.
+        from dataclasses import replace
+
+        reversal_posted = replace(reversal, status=DomainTxStatus.POSTED)
+
+        repo = TransactionRepository(session, household.id)
+        voided_at = datetime.now(tz=UTC)
+        result = repo.persist_reversal(source.id, reversal_posted, voided_at=voided_at)
+        session.commit()
+
+        # Reversal row exists with POSTED status.
+        loaded_reversal = session.query(TxModel).filter_by(id=reversal_posted.id).one()
+        assert loaded_reversal.status.value == "posted"
+        assert result.id == reversal_posted.id
+
+        # Reversal postings are sign-flipped.
+        rev_postings = (
+            session.query(PostingModel).filter_by(transaction_id=reversal_posted.id).all()
+        )
+        rev_by_acct = {p.account_id: p.amount for p in rev_postings}
+        assert rev_by_acct[food.id] == Decimal("-12.50")
+        assert rev_by_acct[cash.id] == Decimal("12.50")
+
+        # Source's voided_by_transaction_id is set.
+        loaded_source = session.query(TxModel).filter_by(id=source.id).one()
+        assert loaded_source.voided_by_transaction_id == reversal_posted.id
+        assert loaded_source.voided_at is not None
+
+    def test_already_voided_source_raises(self, session: Session, household: Household):
+        cash, food = _seed_accounts(session, household)
+        source = _post_lunch(session, household, food, cash)
+
+        from dataclasses import replace
+
+        first = replace(
+            build_reversal(
+                source,
+                reversal_id=uuid4(),
+                reversal_date=date(2026, 7, 1),
+                description="First reversal",
+            ),
+            status=DomainTxStatus.POSTED,
+        )
+        repo = TransactionRepository(session, household.id)
+        repo.persist_reversal(source.id, first, voided_at=datetime.now(tz=UTC))
+        session.commit()
+
+        # Second attempt: source is already voided.
+        second = replace(
+            build_reversal(
+                source,
+                reversal_id=uuid4(),
+                reversal_date=date(2026, 7, 2),
+                description="Second reversal (should fail)",
+            ),
+            status=DomainTxStatus.POSTED,
+        )
+        with pytest.raises(TransactionAlreadyVoidedError):
+            repo.persist_reversal(source.id, second, voided_at=datetime.now(tz=UTC))
+
+    def test_pending_source_raises_not_voidable(self, session: Session, household: Household):
+        cash, food = _seed_accounts(session, household)
+        source = _post_pending_lunch(session, household, food, cash)
+
+        from dataclasses import replace
+
+        # Build a stand-in reversal — the repo should reject before persistence.
+        bogus_reversal = DomainTransaction(
+            id=uuid4(),
+            household_id=household.id,
+            date=date(2026, 7, 1),
+            description="Bogus",
+            postings=(
+                DomainPosting(
+                    id=uuid4(), account_id=food.id, amount=Money(Decimal("-12.50"), "USD")
+                ),
+                DomainPosting(
+                    id=uuid4(), account_id=cash.id, amount=Money(Decimal("12.50"), "USD")
+                ),
+            ),
+            status=DomainTxStatus.POSTED,
+        )
+        del replace  # unused in this branch
+        repo = TransactionRepository(session, household.id)
+        with pytest.raises(TransactionNotVoidableError):
+            repo.persist_reversal(source.id, bogus_reversal, voided_at=datetime.now(tz=UTC))
+
+    def test_unknown_source_raises_lookup_error(self, session: Session, household: Household):
+        cash, food = _seed_accounts(session, household)
+        bogus = DomainTransaction(
+            id=uuid4(),
+            household_id=household.id,
+            date=date(2026, 7, 1),
+            description="Bogus",
+            postings=(
+                DomainPosting(
+                    id=uuid4(), account_id=food.id, amount=Money(Decimal("-12.50"), "USD")
+                ),
+                DomainPosting(
+                    id=uuid4(), account_id=cash.id, amount=Money(Decimal("12.50"), "USD")
+                ),
+            ),
+            status=DomainTxStatus.POSTED,
+        )
+        repo = TransactionRepository(session, household.id)
+        with pytest.raises(LookupError):
+            repo.persist_reversal(uuid4(), bogus, voided_at=datetime.now(tz=UTC))
+
+
+class TestDeletePending:
+    def test_pending_tx_deleted_with_postings(self, session: Session, household: Household):
+        cash, food = _seed_accounts(session, household)
+        source = _post_pending_lunch(session, household, food, cash)
+        repo = TransactionRepository(session, household.id)
+        repo.delete_pending(source.id)
+        session.commit()
+
+        assert session.query(TxModel).filter_by(id=source.id).one_or_none() is None
+        assert session.query(PostingModel).filter_by(transaction_id=source.id).all() == []
+
+    def test_posted_tx_raises(self, session: Session, household: Household):
+        cash, food = _seed_accounts(session, household)
+        source = _post_lunch(session, household, food, cash)
+        repo = TransactionRepository(session, household.id)
+        with pytest.raises(TransactionNotDeletableError):
+            repo.delete_pending(source.id)
+
+    def test_unknown_tx_raises_lookup_error(self, session: Session, household: Household):
+        repo = TransactionRepository(session, household.id)
+        with pytest.raises(LookupError):
+            repo.delete_pending(uuid4())
+
+
+class TestUpdatePending:
+    def test_updates_header_fields_and_replaces_postings(
+        self, session: Session, household: Household
+    ):
+        cash, food = _seed_accounts(session, household)
+        source = _post_pending_lunch(session, household, food, cash)
+        repo = TransactionRepository(session, household.id)
+
+        repo.update_pending(
+            source.id,
+            date=date(2026, 6, 2),
+            description="Lunch (corrected)",
+            reference="cc-9999",
+            postings=(
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=food.id,
+                    amount=Money(Decimal("15.00"), "USD"),
+                ),
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=cash.id,
+                    amount=Money(Decimal("-15.00"), "USD"),
+                ),
+            ),
+        )
+        session.commit()
+
+        loaded = session.query(TxModel).filter_by(id=source.id).one()
+        assert loaded.description == "Lunch (corrected)"
+        assert loaded.reference == "cc-9999"
+        assert loaded.date == date(2026, 6, 2)
+
+        postings = session.query(PostingModel).filter_by(transaction_id=source.id).all()
+        assert len(postings) == 2
+        amounts = sorted(p.amount for p in postings)
+        assert amounts == [Decimal("-15.00"), Decimal("15.00")]
+
+    def test_pending_unbalanced_postings_allowed(self, session: Session, household: Household):
+        # PENDING transactions may be unbalanced; the trigger only fires on
+        # transitions into POSTED.
+        cash, food = _seed_accounts(session, household)
+        source = _post_pending_lunch(session, household, food, cash)
+        repo = TransactionRepository(session, household.id)
+
+        repo.update_pending(
+            source.id,
+            date=date(2026, 6, 2),
+            description="WIP",
+            reference=None,
+            postings=(
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=food.id,
+                    amount=Money(Decimal("15.00"), "USD"),
+                ),
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=cash.id,
+                    amount=Money(Decimal("-10.00"), "USD"),
+                ),
+            ),
+        )
+        session.commit()
+
+    def test_posted_tx_raises(self, session: Session, household: Household):
+        cash, food = _seed_accounts(session, household)
+        source = _post_lunch(session, household, food, cash)
+        repo = TransactionRepository(session, household.id)
+        with pytest.raises(TransactionNotEditableError):
+            repo.update_pending(
+                source.id,
+                date=date(2026, 6, 2),
+                description="too late",
+                reference=None,
+                postings=(
+                    DomainPosting(
+                        id=uuid4(),
+                        account_id=food.id,
+                        amount=Money(Decimal("12.50"), "USD"),
+                    ),
+                    DomainPosting(
+                        id=uuid4(),
+                        account_id=cash.id,
+                        amount=Money(Decimal("-12.50"), "USD"),
+                    ),
+                ),
+            )
+
+    def test_unknown_tx_raises_lookup_error(self, session: Session, household: Household):
+        cash, food = _seed_accounts(session, household)
+        repo = TransactionRepository(session, household.id)
+        with pytest.raises(LookupError):
+            repo.update_pending(
+                uuid4(),
+                date=date(2026, 6, 2),
+                description="ghost",
+                reference=None,
+                postings=(
+                    DomainPosting(
+                        id=uuid4(),
+                        account_id=food.id,
+                        amount=Money(Decimal("12.50"), "USD"),
+                    ),
+                    DomainPosting(
+                        id=uuid4(),
+                        account_id=cash.id,
+                        amount=Money(Decimal("-12.50"), "USD"),
+                    ),
+                ),
+            )


### PR DESCRIPTION
## Summary

First Phase 5 implementation slice; closes #55. Implements ADR-0004 §"What P5.0 ships" plus the **option (c)** decision to atomically auto-void the paired shadow transaction when a pool-tagged main tx is voided. Prerequisite for every later slice's revert / un-reconcile / cleanup paths.

- **Migration `e7d2a4f8c1b9`**: adds `transactions.voided_by_transaction_id` (composite self-FK with `use_alter=True`) + `voided_at`. Reuses the trigger drop-and-recreate dance from P4.0's `a3f4d8e91b22` because the main-ledger balance triggers reference `transactions` by name.
- **Domain (tulip-core)**: `Transaction` value object learns optional `voided_by_transaction_id`; `__post_init__` rejects `PENDING + voided_by` (you can only void what's been posted). New `build_reversal()` helper produces a sign-flipped PENDING reversal sibling. The API handler runs `post_transaction(reversal, periods)` so the period gate checks the **reversal's date**, not the source's, per ADR-0004's "void's own date must be in an open period" rule.
- **Storage repos**: `TransactionRepository` learns `persist_reversal` / `update_pending` / `delete_pending` with typed exceptions (`TransactionAlreadyVoidedError`, `TransactionNotVoidableError`, `TransactionNotEditableError`, `TransactionNotDeletableError`). `ShadowTransactionRepository` learns a `void` chokepoint that flips status `posted → voided` — idempotent on already-voided, rejects PENDING. Status flip is sufficient because `balance_for_pool` already excludes voided shadow txs.
- **API**: three new verbs on `/v1/transactions/{id}`. `POST /void` builds + period-validates the reversal, persists it, and auto-voids the paired shadow tx if any (option (c)). One audit row per user action; `paired_shadow_tx_id_voided` extends the void row's `after_snapshot` when applicable (mirrors P4.1.a). `PATCH` and `DELETE` are PENDING-only; POSTED / RECONCILED return 409.
- **New error codes** (all 409): `transaction.not_editable`, `transaction.not_deletable`, `transaction.already_voided` (extension `voided_by_transaction_id`), `transaction.not_voidable` (extension `status`).
- **CLI**: `tulip transactions {void, delete, edit}`. `void` takes `--reason` / `--yes` / `--date`; `edit` reuses the `--edit` editor flow from #43, rendering the existing tx into hledger format and PATCH'ing on save. All three support `--json`.
- **Architecture test**: `test_architecture_no_direct_void_link_writes.py` AST-scans for writes to `transactions.voided_by_transaction_id` outside `TransactionRepository`, mirroring P4.0's shadow-write guard.

**Tests**: 57 new (4 core, 16 storage, 15 API, 8 CLI E2E + architecture). Project total: **829 passing** (up from 772). \`just lint\`, \`just typecheck\`, full test suite all green locally.

Doc: \`docs/PHASE_STATUS.md\` updated to flip P5.0 to ✅ and reframe the queued P5.1+ slices.

## Test plan

- [x] \`uv run pytest\` — 829 passing locally.
- [x] \`just lint\` — ruff + format clean (pre-commit ran format on commit).
- [x] \`just typecheck\` — mypy --strict clean across 130 source files.
- [x] Migration round-trip (upgrade → downgrade -1 → upgrade) verified by \`test_p50_migration.py::test_round_trip_upgrade_downgrade\`.
- [x] Architecture guards: void-link writes outside the repo are rejected; existing shadow + scheduled-job + HTTPException guards still pass.
- [x] Option (c) auto-void: \`test_voiding_pool_tagged_tx_auto_voids_paired_shadow_tx\` round-trips a $25 envelope spend → void → balance reverts to the refilled amount.
- [ ] CI green on this PR (expect ~6-7 min for code paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)