### PR TITLE
chore: cap pytest-xdist worker count to 4 (local + CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,13 @@ jobs:
       - name: Run tests with coverage
         # --cov-fail-under enforces the project floor declared in README.md.
         # Bump this number as coverage improves; never lower it without an ADR.
-        # `-n auto` parallelises test execution across CPU cores via
-        # pytest-xdist; pytest-cov handles coverage aggregation across workers.
+        # `-n auto --maxprocesses=4` parallelises test execution across CPU
+        # cores via pytest-xdist while capping at 4 workers so local
+        # invocations don't saturate developer machines (CI runners are
+        # 4-vCPU so the cap is a no-op here; it matters locally). The cap
+        # mirrors XDIST_WORKERS in the justfile.
         run: |
-          uv run pytest -n auto \
+          uv run pytest -n auto --maxprocesses 4 \
             --cov \
             --cov-report=term \
             --cov-report=xml \

--- a/justfile
+++ b/justfile
@@ -28,17 +28,24 @@ precommit-install:
 # Tests
 # ---------------------------------------------------------------------------
 
+# Worker cap for pytest-xdist. `auto` resolves to os.cpu_count(), which on
+# typical dev machines (8-12 cores) saturates the box and makes the rest
+# of the system unusable mid-run. Cap to 4 — leaves headroom for browser /
+# editor / Slack and matches CI's 4-vCPU runner so local + CI stay aligned.
+# Override per-invocation via `XDIST_WORKERS=8 just test`.
+export XDIST_WORKERS := env_var_or_default("XDIST_WORKERS", "4")
+
 # Run the full test suite, parallelised via pytest-xdist (matches CI).
 test:
-    uv run pytest -n auto
+    uv run pytest -n auto --maxprocesses {{XDIST_WORKERS}}
 
 # Fast loop — skip slow / integration markers for quick local feedback.
 test-fast:
-    uv run pytest -n auto -m "not slow and not integration"
+    uv run pytest -n auto --maxprocesses {{XDIST_WORKERS}} -m "not slow and not integration"
 
 # Run tests with coverage and the 85% gate (mirrors CI exactly).
 coverage:
-    uv run pytest -n auto \
+    uv run pytest -n auto --maxprocesses {{XDIST_WORKERS}} \
         --cov \
         --cov-report=term \
         --cov-report=html \


### PR DESCRIPTION
## Summary

`-n auto` resolves to `os.cpu_count()`, which on typical dev machines (8–12 cores) saturates the system mid-test and prevents anything else from running. Cap to 4 — leaves headroom for browser / editor / chat without meaningful runtime regression.

**Justfile changes:**
- New `XDIST_WORKERS` env var (default `4`) controls the cap. Override per-invocation: `XDIST_WORKERS=8 just test`.
- `test`, `test-fast`, `coverage` recipes pass `--maxprocesses {{XDIST_WORKERS}}` alongside `-n auto`.

**CI workflow:**
- The `Test (pytest + coverage)` job now passes `--maxprocesses 4`.
- GitHub Actions runners are 4-vCPU, so the cap is a no-op for CI runtime. The change keeps local + CI invocations aligned per the project's "recipes mirror CI" principle.

**Tradeoff:** full local suite goes from ~3:15 to ~5:20 wall-clock on a high-core machine. The dev-experience win (machine remains usable) is worth the runtime cost.

## Test plan

- [x] `just test` runs to 917 passed locally with the new cap.
- [x] `pytest -n auto --maxprocesses 4 --collect-only` confirms the flag is accepted on the installed pytest-xdist.
- [ ] CI on this PR exercises the workflow change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)