### PR TITLE
P5.4.a — apply / promote endpoints + CLI

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-06 · `main` @ **P5.3 in flight** (reconciliation matcher + categorizer DI seam)
+**Last updated:** 2026-05-06 · `main` @ **P5.4.a in flight** (apply / promote endpoints + CLI)
 
 ---
 
@@ -16,9 +16,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
 - **Pre-Phase-4 docs:** threat-model checkpoint shipped (#56, [docs/THREAT_MODEL.md](THREAT_MODEL.md)). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
 - **Phase 4 (envelopes + sinking funds):** ✅ **complete** — all seven slices merged 2026-05-02. P4.0 (#60), P4.1.a (#62), P4.1.b (#63), P4.2 (#66), P4.3.a (#68 — closes #7 via [ADR-0002](adrs/0002-scheduler-primitive.md)), P4.3.b (#69), P4.3.c (#70).
-- **Phase 5 (importers + reconciliation):** in flight — P5.0 (#55), P5.1 (storage layer), P5.2.a/b/c (OFX / QIF / CSV importers), and P5.3 (matcher + categorizer DI seam) implemented per [ADR-0004](adrs/0004-reconciliation.md). Next: **P5.4** (API + CLI surface — closes Phase 5).
+- **Phase 5 (importers + reconciliation):** in flight — P5.0 (#55), P5.1 (storage layer), P5.2.a/b/c (OFX / QIF / CSV importers), P5.3 (matcher + categorizer DI seam), and P5.4.a (apply / promote endpoints + CLI) implemented per [ADR-0004](adrs/0004-reconciliation.md). The remaining P5.4 sub-slices land the reconciliation envelope (P5.4.b), manual match + carry-forward (P5.4.c), and the `tulip reconcile` CLI (P5.4.d) — closing Phase 5.
 
-**Tests:** 1028 passing · **CI:** green on `main`
+**Tests:** 1061 passing · **CI:** green on `main`
 
 ---
 
@@ -479,9 +479,28 @@ Pure-`tulip-core` slice. No API, no CLI, no storage. Adds the bucketed-confidenc
 - **Hypothesis property tests** for the bucket-classification function: `_classify_confidence(delta_days, fuzzy)` is exhaustively probed across the window, asserting boundary invariants (same-date is never LOW; date drift never returns HIGH; outside-window always emits no candidate).
 - **Tests**: 54 new (6 `MatchConfidence` + 12 `CandidateMatch` + 18 matcher integration + 5 hypothesis properties + 15 categorizer + registry; the matcher's hypothesis suite expands to multiple parametrized cases under the `--hypothesis-show-statistics` runner). Project total: **1028 passing** (up from 974).
 
-### P5.4 — API + CLI surface (closes Phase 5) — queued
+### P5.4.a — Apply / promote endpoints + CLI — ✅ *(2026-05-06)*
 
-Reconciliation CRUD endpoints, manual matching, carry-forward, `tulip reconcile` interactive flow, import apply / revert.
+First sub-slice of P5.4: closes the importer loop. Statement lines now turn into PENDING ledger transactions via the registered `Categorizer` (currently `NullCategorizer` from P5.3). The reconciliation envelope (P5.4.b), manual match + carry-forward (P5.4.c), and the `tulip reconcile` CLI (P5.4.d) follow.
+
+- **`POST /v1/imports/{batch_id}/apply`** — promote every non-excluded, non-already-promoted line in the batch to a PENDING `transaction` with two `posting`s (bank-side + categorizer-side). Flips `import_batches.status = 'applied'`. Idempotent at the batch level: re-applying returns `409 import.already_applied`.
+- **`POST /v1/imports/{batch_id}/lines/{line_id}/promote`** — single-line promotion. Returns `201` with `{statement_line_id, transaction_id}`. Idempotent at the line level (`409 import.line.already_promoted` carries the existing tx id in the response). An excluded line returns `422 import.line.excluded` — un-exclude it first.
+- **`tulip imports apply BATCH_ID`** — CLI wrapper. Renders a one-line summary in human mode; passes the JSON body through in `--json` mode.
+- **Storage prerequisites** rolled into the slice:
+  - New migration `d5c8e7a91f2b` adds `statement_lines.promoted_transaction_id` (composite FK to `transactions(household_id, id)`) for O(1) idempotency lookup. Picked over a back-query through `transactions.imported_from_id` because back-query is O(N) per line.
+  - `AccountRepository.get_by_code` for resolving the categorizer's account-code suggestion to an `account_id`.
+  - `TransactionRepository.save_balanced(..., imported_from_id=...)` propagates the FK through `_save` (the column existed in P5.1 but no path set it).
+  - Registration now seeds `Imbalance:Unknown` (EQUITY, base currency) per household — chosen over `EXPENSE` because suspense accounts conventionally sit on the balance sheet rather than shifting the P&L until categorized.
+- **`Categorizer` registry wiring** — `tulip_api.main` now calls `register_categorizer(NullCategorizer())` at module-import time. Phase 6's swap-in lands at this exact line; explicit registration makes the production wiring grep-able.
+- **Service-level orchestration** lives in `tulip_api.services.import_apply` (`promote_statement_line`, `apply_batch`, `ApplyResult`). The router awaits the service; the service flushes but never commits, so the caller can wrap a single `commit()` around the audit-log row + the promoted-tx rows for atomicity.
+- **Atomicity in `apply_batch`** is the caller's responsibility — service flushes only. Mid-batch failure (e.g., categorizer suggests an unknown account on line 3 of 5) raises `CategorizeUnknownAccountError`; the router returns `409 import.categorize.unknown_account` and FastAPI's exception path triggers `session.rollback()`. No partial state.
+- **`409 import.categorize.unknown_account`** carries the offending `account_code` as an extension field, so the client can prompt the user to create the missing account or re-train the categorizer.
+- **Audit-log entries**: `import_apply` (one row per batch, with `created_count` / `skipped_count` / `transaction_ids`) and `statement_line_promote` (one row per line, with `transaction_id` / `batch_id`).
+- **Tests**: 11 service tests + 9 router tests + 4 storage-layer tests + 2 CLI integration tests + 1 register-seed test, plus a small architecture-test enhancement (the `if TYPE_CHECKING:` walker filter so type-only model imports don't trip the chokepoint guard). Project total: **1061 passing** (up from 1028).
+
+### P5.4.b — Reconciliation envelope + auto-match — queued
+
+`POST/GET/DELETE /v1/reconciliations`, `POST /complete`, `POST /auto-match` (wires `find_candidates`), `POST /matches/{id}/reject`. Server-side only.
 
 ---
 

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -1099,6 +1099,88 @@ class ImportBatchNotFoundError(TulipProblem):
         )
 
 
+class ImportAlreadyAppliedError(TulipProblem):
+    """The import batch has already been applied to the ledger (P5.4.a)."""
+
+    def __init__(self, *, batch_id: str) -> None:
+        """Build the import.already_applied problem (409)."""
+        super().__init__(
+            code="import.already_applied",
+            title="Import already applied",
+            status=409,
+            detail=(
+                "This import batch has already been applied. To re-promote a "
+                "specific line, use POST /v1/imports/{batch_id}/lines/{line_id}/promote."
+            ),
+            extensions={"batch_id": batch_id},
+        )
+
+
+class StatementLineNotFoundError(TulipProblem):
+    """No statement line with that ID exists in this household / batch (P5.4.a)."""
+
+    def __init__(self) -> None:
+        """Build the import.line.not_found problem (404)."""
+        super().__init__(
+            code="import.line.not_found",
+            title="Statement line not found",
+            status=404,
+            detail="No statement line with that ID exists in this batch.",
+        )
+
+
+class StatementLineAlreadyPromotedError(TulipProblem):
+    """The statement line has already been promoted to a ledger tx (P5.4.a)."""
+
+    def __init__(self, *, line_id: str, transaction_id: str) -> None:
+        """Build the import.line.already_promoted problem (409)."""
+        super().__init__(
+            code="import.line.already_promoted",
+            title="Statement line already promoted",
+            status=409,
+            detail=(
+                "This statement line was already promoted to a ledger transaction. "
+                "Edit the existing transaction instead."
+            ),
+            extensions={"line_id": line_id, "transaction_id": transaction_id},
+        )
+
+
+class StatementLineExcludedError(TulipProblem):
+    """The statement line is excluded; un-exclude before promoting (P5.4.a)."""
+
+    def __init__(self, *, line_id: str) -> None:
+        """Build the import.line.excluded problem (422)."""
+        super().__init__(
+            code="import.line.excluded",
+            title="Statement line excluded",
+            status=422,
+            detail=(
+                "This statement line is excluded from import. Un-exclude it "
+                "before attempting to promote it to the ledger."
+            ),
+            extensions={"line_id": line_id},
+        )
+
+
+class ImportCategorizeUnknownAccountError(TulipProblem):
+    """The categorizer suggested an account_code with no matching Account (P5.4.a)."""
+
+    def __init__(self, *, account_code: str) -> None:
+        """Build the import.categorize.unknown_account problem (409)."""
+        super().__init__(
+            code="import.categorize.unknown_account",
+            title="Categorizer suggested an unknown account",
+            status=409,
+            detail=(
+                f"The categorizer suggested account_code={account_code!r}, but "
+                "no account with that code exists in this household. Create the "
+                "account first, then retry the apply / promote."
+            ),
+            extensions={"account_code": account_code},
+        )
+
+
 class RequestPayloadTooLargeError(TulipProblem):
     """The uploaded payload exceeds ``MAX_OFX_BYTES`` (P5.2.a).
 

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -39,7 +39,15 @@ from tulip_api.routers import (
     transactions,
     well_known_errors,
 )
+from tulip_core.reconciliation.categorizer import NullCategorizer, register_categorizer
 from tulip_storage.runner import Runner
+
+# Register the default Categorizer at module-import time so production
+# wiring is grep-able (Phase 6 will swap NullCategorizer for the real
+# AICategorizer at this exact line). Tests that need a different
+# categorizer call register_categorizer(...) themselves; the registry
+# warns on replacement, which is the right signal in production.
+register_categorizer(NullCategorizer())
 
 API_VERSION = "v1"
 API_TITLE = "Tulip Accounting API"

--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -75,9 +75,17 @@ from tulip_api.schemas.auth import (
     RegisterResponse,
     TokenResponse,
 )
-from tulip_storage.models import Household, MfaPolicy, MfaRecoveryCode, User, UserRole
+from tulip_storage.models import (
+    AccountType,
+    Household,
+    MfaPolicy,
+    MfaRecoveryCode,
+    User,
+    UserRole,
+)
 from tulip_storage.models import Session as SessionRow
 from tulip_storage.repositories import (
+    AccountRepository,
     AllocationPoolRepository,
     AuditLogWriter,
     PeriodRepository,
@@ -145,6 +153,18 @@ def register(
     # first use; see ADR-0001.
     AllocationPoolRepository(session, household.id).get_or_create_system_pools(
         currency=household.base_currency,
+    )
+
+    # Seed the Imbalance:Unknown EQUITY account so import-apply (P5.4.a)
+    # has a target the default Categorizer (NullCategorizer) can resolve
+    # without per-call account creation. Conventional accounting suspense
+    # account; user re-categorizes via the transaction-edit API.
+    AccountRepository(session, household.id).create(
+        code="Imbalance:Unknown",
+        name="Imbalance: Unknown",
+        type=AccountType.EQUITY,
+        currency=household.base_currency,
+        created_by_user_id=user.id,
     )
 
     AuditLogWriter(session, household.id).write(

--- a/packages/tulip-api/src/tulip_api/routers/csv_profiles.py
+++ b/packages/tulip-api/src/tulip_api/routers/csv_profiles.py
@@ -106,6 +106,7 @@ def list_profiles(
     response_model=CsvProfileRead,
     status_code=status.HTTP_201_CREATED,
     responses={
+        400: problem_response("request.body_invalid"),
         401: problem_response("auth.unauthorized"),
         409: problem_response("csv_profile.duplicate_name"),
         422: problem_response("validation.failed"),
@@ -168,6 +169,7 @@ def get_profile(
     "/{id_or_name}",
     response_model=CsvProfileRead,
     responses={
+        400: problem_response("request.body_invalid"),
         401: problem_response("auth.unauthorized"),
         404: problem_response("csv_profile.not_found"),
         409: problem_response("csv_profile.duplicate_name"),

--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -31,7 +31,9 @@ from tulip_api.deps import get_session
 from tulip_api.errors import (
     AccountUnknownError,
     CsvProfileNotFoundError,
+    ImportAlreadyAppliedError,
     ImportBatchNotFoundError,
+    ImportCategorizeUnknownAccountError,
     ImportCsvParseFailedError,
     ImportCsvProfileMissingError,
     ImportDuplicateFileError,
@@ -39,14 +41,28 @@ from tulip_api.errors import (
     ImportQifParseFailedError,
     ImportUnsupportedFormatError,
     RequestPayloadTooLargeError,
+    StatementLineAlreadyPromotedError,
+    StatementLineExcludedError,
+    StatementLineNotFoundError,
     UnsupportedMediaTypeError,
     problem_response,
 )
 from tulip_api.schemas.import_batch import (
+    ImportBatchApplyResponse,
     ImportBatchRead,
     ImportBatchSummary,
+    StatementLinePromoteResponse,
     StatementLineRead,
 )
+from tulip_api.services.import_apply import (
+    BatchAlreadyAppliedError,
+    CategorizeUnknownAccountError,
+    LineAlreadyPromotedError,
+    LineExcludedError,
+    apply_batch,
+    promote_statement_line,
+)
+from tulip_core.reconciliation.categorizer import get_categorizer
 from tulip_importers.csv import CsvParseError, CsvProfile
 from tulip_importers.csv import parse as csv_parse
 from tulip_importers.ofx import OfxParseError
@@ -328,6 +344,160 @@ async def upload_import(
         skipped_count=batch.skipped_count,
         error_count=batch.error_count,
         created_at=batch.created_at,
+    )
+
+
+@router.post(
+    "/{batch_id}/apply",
+    response_model=ImportBatchApplyResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("import_batch.not_found"),
+        409: problem_response(
+            "import.already_applied",
+            "import.categorize.unknown_account",
+        ),
+    },
+)
+async def apply_import(
+    batch_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> ImportBatchApplyResponse:
+    """Promote every non-excluded line in the batch to a PENDING ledger tx.
+
+    Per ADR-0004 §Q4. Idempotent at the batch level: re-applying an
+    already-applied batch returns ``import.already_applied`` (409). To
+    promote a specific line individually, see
+    ``POST /v1/imports/{batch_id}/lines/{line_id}/promote``.
+    """
+    batch_repo = ImportBatchRepository(session, claims.household_id)
+    batch = batch_repo.get(batch_id)
+    if batch is None:
+        raise ImportBatchNotFoundError()
+
+    try:
+        result = await apply_batch(
+            session=session,
+            household_id=claims.household_id,
+            batch=batch,
+            categorizer=get_categorizer(),
+            actor_user_id=claims.user_id,
+        )
+    except BatchAlreadyAppliedError as exc:
+        raise ImportAlreadyAppliedError(batch_id=str(batch_id)) from exc
+    except CategorizeUnknownAccountError as exc:
+        raise ImportCategorizeUnknownAccountError(account_code=exc.account_code) from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="import_apply",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="import_batch",
+        entity_id=batch.id,
+        after={
+            "created_count": result.created_count,
+            "skipped_count": result.skipped_count,
+            "transaction_ids": [str(t) for t in result.transaction_ids],
+        },
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "import.applied",
+        batch_id=str(batch.id),
+        created=result.created_count,
+        skipped=result.skipped_count,
+    )
+    return ImportBatchApplyResponse(
+        batch_id=batch.id,
+        status="applied",
+        created_count=result.created_count,
+        skipped_count=result.skipped_count,
+        transaction_ids=list(result.transaction_ids),
+    )
+
+
+@router.post(
+    "/{batch_id}/lines/{line_id}/promote",
+    response_model=StatementLinePromoteResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("import_batch.not_found", "import.line.not_found"),
+        409: problem_response(
+            "import.line.already_promoted",
+            "import.categorize.unknown_account",
+        ),
+        422: problem_response("import.line.excluded"),
+    },
+)
+async def promote_line(
+    batch_id: UUID,
+    line_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> StatementLinePromoteResponse:
+    """Promote one statement line to a PENDING ledger transaction.
+
+    Per ADR-0004 §Q4. Useful for line-by-line review or for re-promoting
+    a previously-excluded line after un-excluding it.
+    """
+    batch_repo = ImportBatchRepository(session, claims.household_id)
+    batch = batch_repo.get(batch_id)
+    if batch is None:
+        raise ImportBatchNotFoundError()
+
+    line_repo = StatementLineRepository(session, claims.household_id)
+    line = line_repo.get(line_id)
+    if line is None or line.import_batch_id != batch_id:
+        raise StatementLineNotFoundError()
+
+    try:
+        tx = await promote_statement_line(
+            session=session,
+            household_id=claims.household_id,
+            batch=batch,
+            line=line,
+            categorizer=get_categorizer(),
+            actor_user_id=claims.user_id,
+        )
+    except LineAlreadyPromotedError as exc:
+        # Re-fetch (line.promoted_transaction_id may have been set).
+        line2 = line_repo.get(line_id)
+        assert line2 is not None  # noqa: S101 - existence verified above
+        raise StatementLineAlreadyPromotedError(
+            line_id=str(line_id),
+            transaction_id=str(line2.promoted_transaction_id),
+        ) from exc
+    except LineExcludedError as exc:
+        raise StatementLineExcludedError(line_id=str(line_id)) from exc
+    except CategorizeUnknownAccountError as exc:
+        raise ImportCategorizeUnknownAccountError(account_code=exc.account_code) from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="statement_line_promote",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="statement_line",
+        entity_id=line.id,
+        after={"transaction_id": str(tx.id), "batch_id": str(batch.id)},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "statement_line.promoted",
+        line_id=str(line.id),
+        transaction_id=str(tx.id),
+    )
+    return StatementLinePromoteResponse(
+        statement_line_id=line.id,
+        transaction_id=tx.id,
     )
 
 

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -72,6 +72,13 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
     },
     "CsvProfileDuplicateNameError": {"name": "chase-checking"},
     "CsvProfileInvalidYamlError": {"reason": "yaml.safe_load rejected the payload"},
+    "ImportAlreadyAppliedError": {"batch_id": "<batch-uuid>"},
+    "StatementLineAlreadyPromotedError": {
+        "line_id": "<statement-line-uuid>",
+        "transaction_id": "<transaction-uuid>",
+    },
+    "StatementLineExcludedError": {"line_id": "<statement-line-uuid>"},
+    "ImportCategorizeUnknownAccountError": {"account_code": "Imbalance:Unknown"},
     "RequestPayloadTooLargeError": {"max_bytes": 26214400},
     "UnsupportedMediaTypeError": {
         "accepted": ("application/x-ofx", "application/octet-stream", "text/xml"),

--- a/packages/tulip-api/src/tulip_api/schemas/import_batch.py
+++ b/packages/tulip-api/src/tulip_api/schemas/import_batch.py
@@ -62,3 +62,29 @@ class ImportBatchRead(BaseModel):
     applied_at: datetime | None
     reverted_at: datetime | None
     lines: list[StatementLineRead]
+
+
+class ImportBatchApplyResponse(BaseModel):
+    """Response for ``POST /v1/imports/{id}/apply`` (P5.4.a)."""
+
+    batch_id: UUID
+    status: str = Field(description="The new ``status`` of the batch (always ``applied``).")
+    created_count: int = Field(
+        description="Number of PENDING ledger transactions created from the batch's lines."
+    )
+    skipped_count: int = Field(
+        description=(
+            "Number of statement lines that were not promoted because they were "
+            "already excluded or already promoted from a prior partial promote."
+        )
+    )
+    transaction_ids: list[UUID] = Field(
+        description="The IDs of the newly-created PENDING transactions, in line order."
+    )
+
+
+class StatementLinePromoteResponse(BaseModel):
+    """Response for ``POST /v1/imports/{batch_id}/lines/{line_id}/promote`` (P5.4.a)."""
+
+    statement_line_id: UUID
+    transaction_id: UUID

--- a/packages/tulip-api/src/tulip_api/services/__init__.py
+++ b/packages/tulip-api/src/tulip_api/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service-layer modules: pure-Python orchestration over repositories."""

--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -1,0 +1,230 @@
+"""Apply / promote service: turns parsed statement lines into PENDING ledger txns.
+
+Per ADR-0004 §Q4, the import flow has two terminal user-actions:
+
+- **Apply** the whole batch — every non-excluded line in the batch is
+  promoted into a PENDING ledger transaction in one atomic step. The
+  ``import_batches.status`` flips to ``APPLIED`` on success.
+- **Promote** a single line — useful for line-by-line review or for
+  re-running after fixing per-household configuration (e.g. seeding a
+  missing categorizer account).
+
+Each promotion creates exactly one PENDING transaction with two
+postings:
+
+- The bank-side posting on the import batch's account, signed as the
+  statement line's amount.
+- The other-side posting on the account resolved from the registered
+  ``Categorizer``'s suggestion. v1's ``NullCategorizer`` always returns
+  ``Imbalance:Unknown`` — the user re-categorizes during reconciliation
+  review.
+
+The service module deliberately does not commit. Callers (the API
+router) wrap it in their own commit/audit transaction so the audit
+log row + the promoted-tx rows land atomically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from tulip_core.money import Money
+from tulip_core.reconciliation.categorizer import HouseholdContext
+from tulip_core.reconciliation.statement_line import StatementLine as DomainStatementLine
+from tulip_core.transactions import (
+    Posting as DomainPosting,
+)
+from tulip_core.transactions import (
+    Transaction as DomainTransaction,
+)
+from tulip_core.transactions import (
+    TransactionStatus as DomainTxStatus,
+)
+from tulip_storage.models import ImportBatchStatus
+from tulip_storage.repositories import (
+    AccountRepository,
+    ImportBatchRepository,
+    StatementLineRepository,
+    TransactionRepository,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_core.reconciliation.categorizer import Categorizer
+    from tulip_storage.models import ImportBatch, StatementLine, Transaction
+
+
+class BatchAlreadyAppliedError(ValueError):
+    """Raised when apply_batch is called on a batch that's not PARSED."""
+
+
+class LineAlreadyPromotedError(ValueError):
+    """Raised when promote_statement_line is called on an already-promoted line."""
+
+
+class LineExcludedError(ValueError):
+    """Raised when promote_statement_line is called on an is_excluded line."""
+
+
+class CategorizeUnknownAccountError(ValueError):
+    """Raised when the categorizer returns an account_code with no matching Account."""
+
+    def __init__(self, account_code: str, household_id: UUID) -> None:
+        """Build with the bad code + household for caller-side rendering."""
+        super().__init__(
+            f"categorizer returned account_code={account_code!r} but no account "
+            f"with that code exists in household {household_id}"
+        )
+        self.account_code = account_code
+        self.household_id = household_id
+
+
+@dataclass(frozen=True, slots=True)
+class ApplyResult:
+    """Summary of a successful ``apply_batch`` call."""
+
+    batch_id: UUID
+    created_count: int
+    skipped_count: int
+    transaction_ids: tuple[UUID, ...]
+
+
+def _to_domain_line(line: StatementLine) -> DomainStatementLine:
+    """Adapt a storage StatementLine to the domain value object the categorizer expects."""
+    return DomainStatementLine(
+        id=line.id,
+        import_batch_id=line.import_batch_id,
+        line_number=line.line_number,
+        posted_date=line.posted_date,
+        amount=Money(line.amount, line.currency),
+        description=line.description,
+        raw=MappingProxyType({}),
+        counterparty=line.counterparty,
+        reference=line.reference,
+        fitid=line.fitid,
+    )
+
+
+async def promote_statement_line(
+    *,
+    session: Session,
+    household_id: UUID,
+    batch: ImportBatch,
+    line: StatementLine,
+    categorizer: Categorizer,
+    actor_user_id: UUID | None,
+) -> Transaction:
+    """Promote one statement line into a PENDING ledger Transaction.
+
+    Raises:
+        LineExcludedError: ``line.is_excluded`` is True (caller should
+            un-exclude first).
+        LineAlreadyPromotedError: ``line.promoted_transaction_id`` is set.
+        CategorizeUnknownAccountError: the categorizer returned an
+            account_code that doesn't exist in this household's chart.
+
+    """
+    if line.is_excluded:
+        raise LineExcludedError(
+            f"statement_line {line.id} is excluded; un-exclude before promoting"
+        )
+    if line.promoted_transaction_id is not None:
+        raise LineAlreadyPromotedError(
+            f"statement_line {line.id} already promoted to "
+            f"transaction {line.promoted_transaction_id}"
+        )
+
+    accounts = AccountRepository(session, household_id)
+    bank_account = accounts.get(batch.account_id)
+    if bank_account is None:  # pragma: no cover - bank account is FK-enforced
+        raise LookupError(f"batch.account_id {batch.account_id} not found")
+
+    domain_line = _to_domain_line(line)
+    suggestion = await categorizer.categorize(
+        domain_line,
+        HouseholdContext(household_id=household_id, account_whitelist=frozenset()),
+    )
+    other_account = accounts.get_by_code(suggestion.account_code)
+    if other_account is None:
+        raise CategorizeUnknownAccountError(suggestion.account_code, household_id)
+
+    bank_amount = Money(line.amount, line.currency)
+    other_amount = Money(-line.amount, line.currency)
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household_id,
+        date=line.posted_date,
+        description=line.description,
+        postings=(
+            DomainPosting(id=uuid4(), account_id=bank_account.id, amount=bank_amount),
+            DomainPosting(id=uuid4(), account_id=other_account.id, amount=other_amount),
+        ),
+        status=DomainTxStatus.PENDING,
+        created_by_user_id=actor_user_id,
+    )
+    tx = TransactionRepository(session, household_id).save_balanced(
+        domain_tx, imported_from_id=batch.id
+    )
+    StatementLineRepository(session, household_id).mark_promoted(line.id, tx.id)
+    return tx
+
+
+async def apply_batch(
+    *,
+    session: Session,
+    household_id: UUID,
+    batch: ImportBatch,
+    categorizer: Categorizer,
+    actor_user_id: UUID | None,
+) -> ApplyResult:
+    """Promote every applicable line in ``batch``, then mark batch APPLIED.
+
+    "Applicable" = not excluded and not already promoted. Excluded and
+    already-promoted lines are silently skipped (counted in
+    ``skipped_count``).
+
+    Idempotency is at the batch level: a batch in ``APPLIED`` state
+    cannot be re-applied (raises). The caller can re-promote individual
+    lines via :func:`promote_statement_line` if needed.
+
+    Atomicity is the caller's responsibility — this function only
+    flushes; the caller wraps in a single ``session.commit()`` so a
+    mid-batch failure rolls back every promotion.
+
+    Raises:
+        BatchAlreadyAppliedError: ``batch.status`` is not ``PARSED``.
+
+    """
+    if batch.status is not ImportBatchStatus.PARSED:
+        raise BatchAlreadyAppliedError(
+            f"import_batch {batch.id} is {batch.status.value}; only PARSED batches may be applied"
+        )
+
+    lines_repo = StatementLineRepository(session, household_id)
+    transaction_ids: list[UUID] = []
+    skipped = 0
+    for line in lines_repo.list_for_batch(batch.id):
+        if line.is_excluded or line.promoted_transaction_id is not None:
+            skipped += 1
+            continue
+        tx = await promote_statement_line(
+            session=session,
+            household_id=household_id,
+            batch=batch,
+            line=line,
+            categorizer=categorizer,
+            actor_user_id=actor_user_id,
+        )
+        transaction_ids.append(tx.id)
+
+    ImportBatchRepository(session, household_id).mark_applied(batch.id)
+    return ApplyResult(
+        batch_id=batch.id,
+        created_count=len(transaction_ids),
+        skipped_count=skipped,
+        transaction_ids=tuple(transaction_ids),
+    )

--- a/packages/tulip-api/tests/services/test_import_apply.py
+++ b/packages/tulip-api/tests/services/test_import_apply.py
@@ -1,0 +1,393 @@
+"""Service-level tests for import_apply (P5.4.a).
+
+The service module is the heart of the apply / promote flow:
+
+- ``promote_statement_line`` turns one parsed line into a PENDING domain
+  Transaction with two postings (bank-side + categorizer-side).
+- ``apply_batch`` walks every non-excluded, non-already-promoted line in
+  a batch and promotes it, then flips the batch to APPLIED.
+
+Tests run at the service layer (no FastAPI) so the contract is testable
+without HTTP mocking. Router-level tests in test_apply_endpoint.py /
+test_promote_endpoint.py cover wiring.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_api.services.import_apply import (
+    BatchAlreadyAppliedError,
+    CategorizeUnknownAccountError,
+    LineAlreadyPromotedError,
+    LineExcludedError,
+    apply_batch,
+    promote_statement_line,
+)
+from tulip_core.reconciliation.categorizer import (
+    CategorizationResult,
+    NullCategorizer,
+)
+from tulip_storage.models import (
+    AccountType,
+    Household,
+    ImportBatch,
+    ImportBatchStatus,
+    Posting,
+    SourceFormat,
+    StatementLine,
+    TransactionStatus,
+)
+from tulip_storage.repositories import (
+    AccountRepository,
+    PeriodRepository,
+)
+
+# ---- fixtures -------------------------------------------------------------
+
+
+@pytest.fixture
+def setup(session_maker):
+    """Seed a household + period + cash account + Imbalance:Unknown + import batch + 3 lines."""
+    with session_maker() as s:
+        h = Household(id=uuid4(), name="Smith", base_currency="USD")
+        s.add(h)
+        s.flush()
+
+        PeriodRepository(s, h.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+        cash = AccountRepository(s, h.id).create(
+            code="1110",
+            name="Checking",
+            type=AccountType.ASSET,
+            currency="USD",
+        )
+        imbalance = AccountRepository(s, h.id).create(
+            code="Imbalance:Unknown",
+            name="Imbalance: Unknown",
+            type=AccountType.EQUITY,
+            currency="USD",
+        )
+
+        # Attachment + import_batch (raw SQL: easier than wiring the full
+        # attachment-encryption pipeline for a service test).
+        from sqlalchemy import text
+
+        att_id = uuid4()
+        s.execute(
+            text(
+                "INSERT INTO attachments (household_id, id, filename, "
+                "content_type, size_bytes, content_hash, storage_uri, "
+                "uploaded_at) VALUES "
+                "(:h, :i, 'x.ofx', 'application/x-ofx', 1, :hash, 's3://x', :now)"
+            ),
+            {
+                "h": str(h.id),
+                "i": str(att_id),
+                "hash": "x" * 64,
+                "now": datetime.now(UTC).isoformat(),
+            },
+        )
+
+        batch = ImportBatch(
+            household_id=h.id,
+            id=uuid4(),
+            account_id=cash.id,
+            source_format=SourceFormat.OFX,
+            source_filename="x.ofx",
+            source_file_attachment_id=att_id,
+            status=ImportBatchStatus.PARSED,
+            imported_count=0,
+            skipped_count=0,
+            error_count=0,
+            summary_json={},
+            created_at=datetime.now(UTC),
+        )
+        s.add(batch)
+        s.flush()
+
+        lines: list[StatementLine] = []
+        for i, (amt, desc) in enumerate(
+            [
+                (Decimal("-12.50"), "Coffee"),
+                (Decimal("-100.00"), "Groceries"),
+                (Decimal("2500.00"), "Paycheck"),
+            ],
+            start=1,
+        ):
+            line = StatementLine(
+                household_id=h.id,
+                id=uuid4(),
+                import_batch_id=batch.id,
+                line_number=i,
+                posted_date=date(2026, 5, i),
+                amount=amt,
+                currency="USD",
+                description=desc,
+                raw_json="{}",
+            )
+            s.add(line)
+            lines.append(line)
+        s.commit()
+
+        yield {
+            "household_id": h.id,
+            "cash_id": cash.id,
+            "imbalance_id": imbalance.id,
+            "batch_id": batch.id,
+            "line_ids": [line.id for line in lines],
+        }
+
+
+def _reload(s: Session, model_cls, household_id: UUID, obj_id: UUID):
+    """Re-fetch a (household_id, id) row from the session."""
+    return s.get(model_cls, (household_id, obj_id))
+
+
+# ---- promote_statement_line ----------------------------------------------
+
+
+class TestPromoteStatementLine:
+    @pytest.mark.asyncio
+    async def test_creates_pending_tx_with_two_balanced_postings(self, session_maker, setup):
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=uuid4(),
+            )
+            s.commit()
+
+            assert tx.status == TransactionStatus.PENDING
+            postings = (
+                s.query(Posting).filter_by(transaction_id=tx.id).order_by(Posting.amount).all()
+            )
+            assert len(postings) == 2
+            # Postings sum to zero.
+            assert sum(p.amount for p in postings) == Decimal("0")
+            # Bank-side posting is on the batch's account, signed as the line.
+            bank = next(p for p in postings if p.account_id == setup["cash_id"])
+            assert bank.amount == Decimal("-12.50")
+            # Other-side posting is on Imbalance:Unknown, negated.
+            other = next(p for p in postings if p.account_id == setup["imbalance_id"])
+            assert other.amount == Decimal("12.50")
+            assert other.currency == "USD"
+
+    @pytest.mark.asyncio
+    async def test_sets_imported_from_id_to_batch_id(self, session_maker, setup):
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            assert tx.imported_from_id == setup["batch_id"]
+
+    @pytest.mark.asyncio
+    async def test_links_statement_line_promoted_transaction_id(self, session_maker, setup):
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            reloaded = _reload(s, StatementLine, setup["household_id"], line.id)
+            assert reloaded.promoted_transaction_id == tx.id
+
+    @pytest.mark.asyncio
+    async def test_already_promoted_raises(self, session_maker, setup):
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            line2 = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            with pytest.raises(LineAlreadyPromotedError):
+                await promote_statement_line(
+                    session=s,
+                    household_id=setup["household_id"],
+                    batch=batch,
+                    line=line2,
+                    categorizer=NullCategorizer(),
+                    actor_user_id=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_excluded_line_raises(self, session_maker, setup):
+        with session_maker() as s:
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            line.is_excluded = True
+            s.commit()
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line2 = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            with pytest.raises(LineExcludedError):
+                await promote_statement_line(
+                    session=s,
+                    household_id=setup["household_id"],
+                    batch=batch,
+                    line=line2,
+                    categorizer=NullCategorizer(),
+                    actor_user_id=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_unknown_categorizer_account_raises(self, session_maker, setup):
+        class _BadCategorizer:
+            async def categorize(self, line, household_context) -> CategorizationResult:
+                return CategorizationResult(account_code="DoesNotExist", confidence=0.5)
+
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            with pytest.raises(CategorizeUnknownAccountError):
+                await promote_statement_line(
+                    session=s,
+                    household_id=setup["household_id"],
+                    batch=batch,
+                    line=line,
+                    categorizer=_BadCategorizer(),
+                    actor_user_id=None,
+                )
+
+
+# ---- apply_batch ----------------------------------------------------------
+
+
+class TestApplyBatch:
+    @pytest.mark.asyncio
+    async def test_promotes_all_lines_and_marks_batch_applied(self, session_maker, setup):
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            result = await apply_batch(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                categorizer=NullCategorizer(),
+                actor_user_id=uuid4(),
+            )
+            s.commit()
+            assert result.created_count == 3
+            assert result.skipped_count == 0
+            assert len(result.transaction_ids) == 3
+            reloaded_batch = _reload(s, ImportBatch, setup["household_id"], batch.id)
+            assert reloaded_batch.status == ImportBatchStatus.APPLIED
+            assert reloaded_batch.applied_at is not None
+
+    @pytest.mark.asyncio
+    async def test_skips_excluded_lines(self, session_maker, setup):
+        with session_maker() as s:
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][1])
+            line.is_excluded = True
+            s.commit()
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            result = await apply_batch(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            assert result.created_count == 2
+            assert result.skipped_count == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_already_promoted_lines(self, session_maker, setup):
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            # Re-fetch (batch is unchanged, status PARSED)
+            batch2 = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            result = await apply_batch(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch2,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            assert result.created_count == 2
+            assert result.skipped_count == 1
+
+    @pytest.mark.asyncio
+    async def test_already_applied_raises(self, session_maker, setup):
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            await apply_batch(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            batch2 = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            with pytest.raises(BatchAlreadyAppliedError):
+                await apply_batch(
+                    session=s,
+                    household_id=setup["household_id"],
+                    batch=batch2,
+                    categorizer=NullCategorizer(),
+                    actor_user_id=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_all_lines_excluded_is_no_op_but_flips_status(self, session_maker, setup):
+        with session_maker() as s:
+            for line_id in setup["line_ids"]:
+                line = _reload(s, StatementLine, setup["household_id"], line_id)
+                line.is_excluded = True
+            s.commit()
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            result = await apply_batch(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            assert result.created_count == 0
+            assert result.skipped_count == 3
+            reloaded_batch = _reload(s, ImportBatch, setup["household_id"], batch.id)
+            assert reloaded_batch.status == ImportBatchStatus.APPLIED

--- a/packages/tulip-api/tests/test_accounts_endpoints.py
+++ b/packages/tulip-api/tests/test_accounts_endpoints.py
@@ -63,8 +63,10 @@ class TestAccountCrud:
         r2 = client.get("/v1/accounts", headers=auth_h)
         assert r2.status_code == 200
         rows = r2.json()
-        assert len(rows) == 1
-        assert rows[0]["name"] == "Checking"
+        # Registration seeds Imbalance:Unknown (P5.4.a) — filter to the
+        # account we just created to keep the assertion intent-focused.
+        names = {row["name"] for row in rows}
+        assert "Checking" in names
 
     def test_get_returns_not_found_for_unknown(self, client: TestClient, auth_h: dict[str, str]):
         r = client.get(
@@ -137,4 +139,8 @@ class TestTenantIsolation:
             json={"name": "A's account", "type": "asset", "currency": "USD"},
         )
         rows = client.get("/v1/accounts", headers={"Authorization": f"Bearer {b_token}"}).json()
-        assert rows == []
+        # Household B sees its own seeded Imbalance:Unknown (P5.4.a) but
+        # not the account A just created.
+        names = {row["name"] for row in rows}
+        assert "A's account" not in names
+        assert names <= {"Imbalance: Unknown"}

--- a/packages/tulip-api/tests/test_apply_promote_endpoints.py
+++ b/packages/tulip-api/tests/test_apply_promote_endpoints.py
@@ -1,0 +1,158 @@
+"""Tests for POST /v1/imports/{id}/apply + POST .../lines/{id}/promote (P5.4.a)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+_OFX_FIXTURES = (
+    Path(__file__).resolve().parents[2] / "tulip-importers" / "tests" / "fixtures" / "ofx"
+)
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r.json()["access_token"]
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+@pytest.fixture
+def checking_account(client: TestClient, auth_h: dict[str, str]) -> str:
+    r = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Checking", "type": "asset", "currency": "USD", "code": "1110"},
+    )
+    return r.json()["id"]
+
+
+@pytest.fixture
+def parsed_batch(
+    client: TestClient,
+    auth_h: dict[str, str],
+    checking_account: str,
+) -> str:
+    body = (_OFX_FIXTURES / "minimal_ofx2.ofx").read_bytes()
+    r = client.post(
+        "/v1/imports",
+        headers=auth_h,
+        files={"file": ("x.ofx", body, "application/x-ofx")},
+        data={"account_id": checking_account, "source_format": "ofx"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+# ---- /apply --------------------------------------------------------------
+
+
+class TestApplyImportHappyPath:
+    def test_promotes_all_lines_and_returns_summary(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        r = client.post(f"/v1/imports/{parsed_batch}/apply", headers=auth_h)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["batch_id"] == parsed_batch
+        assert body["status"] == "applied"
+        assert body["created_count"] == 2  # minimal_ofx2.ofx has 2 lines
+        assert body["skipped_count"] == 0
+        assert len(body["transaction_ids"]) == 2
+
+    def test_apply_flips_batch_status_to_applied(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        client.post(f"/v1/imports/{parsed_batch}/apply", headers=auth_h)
+        r = client.get(f"/v1/imports/{parsed_batch}", headers=auth_h)
+        assert r.status_code == 200
+        assert r.json()["status"] == "applied"
+        assert r.json()["applied_at"] is not None
+
+
+class TestApplyImportErrors:
+    def test_unknown_batch_returns_404(self, client: TestClient, auth_h: dict[str, str]):
+        from uuid import uuid4
+
+        r = client.post(f"/v1/imports/{uuid4()}/apply", headers=auth_h)
+        assert_problem(r, status=404, code="import_batch.not_found")
+
+    def test_already_applied_returns_409(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        client.post(f"/v1/imports/{parsed_batch}/apply", headers=auth_h)
+        r = client.post(f"/v1/imports/{parsed_batch}/apply", headers=auth_h)
+        assert_problem(r, status=409, code="import.already_applied")
+        assert r.json()["batch_id"] == parsed_batch
+
+    def test_unauthenticated_returns_401(self, client: TestClient, parsed_batch: str):
+        r = client.post(f"/v1/imports/{parsed_batch}/apply")
+        assert_problem(r, status=401, code="auth.unauthorized")
+
+
+# ---- /lines/{line_id}/promote -------------------------------------------
+
+
+def _first_line_id(client: TestClient, auth_h: dict[str, str], batch_id: str) -> str:
+    r = client.get(f"/v1/imports/{batch_id}", headers=auth_h)
+    return r.json()["lines"][0]["id"]
+
+
+class TestPromoteLineHappyPath:
+    def test_promotes_one_line_returns_201(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        line_id = _first_line_id(client, auth_h, parsed_batch)
+        r = client.post(
+            f"/v1/imports/{parsed_batch}/lines/{line_id}/promote",
+            headers=auth_h,
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["statement_line_id"] == line_id
+        assert body["transaction_id"]
+
+
+class TestPromoteLineErrors:
+    def test_already_promoted_returns_409(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        line_id = _first_line_id(client, auth_h, parsed_batch)
+        client.post(f"/v1/imports/{parsed_batch}/lines/{line_id}/promote", headers=auth_h)
+        r = client.post(f"/v1/imports/{parsed_batch}/lines/{line_id}/promote", headers=auth_h)
+        assert_problem(r, status=409, code="import.line.already_promoted")
+        assert r.json()["line_id"] == line_id
+
+    def test_unknown_batch_returns_404(self, client: TestClient, auth_h: dict[str, str]):
+        from uuid import uuid4
+
+        r = client.post(f"/v1/imports/{uuid4()}/lines/{uuid4()}/promote", headers=auth_h)
+        assert_problem(r, status=404, code="import_batch.not_found")
+
+    def test_unknown_line_returns_404(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        from uuid import uuid4
+
+        r = client.post(f"/v1/imports/{parsed_batch}/lines/{uuid4()}/promote", headers=auth_h)
+        assert_problem(r, status=404, code="import.line.not_found")

--- a/packages/tulip-api/tests/test_auth_endpoints.py
+++ b/packages/tulip-api/tests/test_auth_endpoints.py
@@ -103,7 +103,35 @@ class TestRegister:
             types = {p.pool_type for p in rows}
             assert types == {PoolType.INFLOW, PoolType.UNALLOCATED, PoolType.SPENT}
             assert all(p.currency == "USD" for p in rows)
-            assert all(p.is_active for p in rows)
+
+    def test_register_seeds_imbalance_unknown_account(self, client, session_maker):
+        """P5.4.a: a new household gets an Imbalance:Unknown EQUITY account
+        seeded so that the import-apply flow can resolve the categorizer's
+        default account-code without per-call account creation.
+        """
+        r = client.post(
+            "/v1/auth/register",
+            json={
+                "email": "imbalance@example.com",
+                "password": "correct horse battery staple",
+                "display_name": "Imbalance",
+                "household_name": "Smith",
+            },
+        )
+        assert r.status_code == 201
+        household_id = r.json()["household_id"]
+
+        from uuid import UUID
+
+        from tulip_storage.models import AccountType
+        from tulip_storage.repositories.account import AccountRepository
+
+        with session_maker() as s:
+            account = AccountRepository(s, UUID(household_id)).get_by_code("Imbalance:Unknown")
+            assert account is not None, "Imbalance:Unknown not seeded"
+            assert account.type is AccountType.EQUITY
+            assert account.currency == "USD"
+            assert account.is_active is True
 
 
 class TestLogin:

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -185,6 +185,40 @@ def import_csv(
     )
 
 
+@imports_app.command("apply")
+def apply_import(
+    ctx: typer.Context,
+    batch_id: Annotated[
+        str,
+        typer.Argument(
+            help="Import batch UUID returned by `tulip imports ofx/qif/csv`.",
+            metavar="BATCH_ID",
+        ),
+    ],
+) -> None:
+    """Apply a parsed batch: every non-excluded line becomes a PENDING ledger transaction."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post(
+                f"/v1/imports/{batch_id}/apply",
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    body = response.json()
+    typer.echo(
+        f"Applied batch {body['batch_id']}: created {body['created_count']} "
+        f"PENDING transactions, skipped {body['skipped_count']} lines."
+    )
+
+
 @imports_app.command("qif")
 def import_qif(
     ctx: typer.Context,

--- a/packages/tulip-cli/tests/test_accounts.py
+++ b/packages/tulip-cli/tests/test_accounts.py
@@ -112,11 +112,12 @@ def authed_session(live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.integration
-def test_accounts_list_when_empty(authed_session: str) -> None:
+def test_accounts_list_when_only_seeded(authed_session: str) -> None:
+    """Fresh households still get the Imbalance:Unknown seed (P5.4.a)."""
     result = _run_cli("accounts", "list", api_url=authed_session)
     assert result.returncode == 0, result.stderr
-    # Empty households still register an opening message — not just blank stdout.
-    assert "no accounts" in result.stdout.lower()
+    # The seeded Imbalance:Unknown row shows up in the rendered table.
+    assert "imbalance:unknown" in result.stdout.lower()
 
 
 @pytest.mark.integration

--- a/packages/tulip-cli/tests/test_import_command.py
+++ b/packages/tulip-cli/tests/test_import_command.py
@@ -100,6 +100,75 @@ def _seed_checking(api_url: str) -> None:
 
 
 @pytest.mark.integration
+def test_imports_apply_happy_path(authed_session: str) -> None:
+    """`tulip imports apply BATCH_ID` promotes every line into a PENDING tx."""
+    _seed_checking(authed_session)
+    fixture = _OFX_FIXTURES / "minimal_ofx2.ofx"
+    upload = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            authed_session,
+            "import",
+            "ofx",
+            str(fixture),
+            "--account",
+            "1110",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert upload.returncode == 0, upload.stderr
+    batch_id = json.loads(upload.stdout)["id"]
+
+    apply_result = _run_cli(
+        "imports",
+        "apply",
+        batch_id,
+        api_url=authed_session,
+    )
+    assert apply_result.returncode == 0, apply_result.stderr
+    assert "created 2" in apply_result.stdout
+    assert batch_id in apply_result.stdout
+
+
+@pytest.mark.integration
+def test_imports_apply_already_applied_returns_409(authed_session: str) -> None:
+    """Re-applying renders the typed Problem and exits non-zero."""
+    _seed_checking(authed_session)
+    fixture = _OFX_FIXTURES / "minimal_ofx2.ofx"
+    upload = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            authed_session,
+            "import",
+            "ofx",
+            str(fixture),
+            "--account",
+            "1110",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    batch_id = json.loads(upload.stdout)["id"]
+    _run_cli("imports", "apply", batch_id, api_url=authed_session)
+    second = _run_cli("imports", "apply", batch_id, api_url=authed_session)
+    assert second.returncode != 0
+    assert "Import already applied" in (second.stdout + second.stderr)
+
+
+@pytest.mark.integration
 def test_import_ofx_happy_path(authed_session: str) -> None:
     _seed_checking(authed_session)
     fixture = _OFX_FIXTURES / "minimal_ofx2.ofx"

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260506_1200_d5c8e7a91f2b_add_statement_line_promoted_tx.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260506_1200_d5c8e7a91f2b_add_statement_line_promoted_tx.py
@@ -1,0 +1,49 @@
+"""Add statement_lines.promoted_transaction_id (P5.4.a).
+
+Revision ID: d5c8e7a91f2b
+Revises: f4a6b9c2e7d3
+Create Date: 2026-05-06 12:00:00.000000
+
+The promote endpoint (POST /v1/imports/{batch_id}/lines/{line_id}/promote)
+turns a parsed statement line into a PENDING ledger transaction. We need
+an O(1) idempotency check: "has this line already been promoted?" rather
+than a back-scan through ``transactions.imported_from_id``. A nullable
+composite FK on ``statement_lines`` keeps the lookup at
+``WHERE id = ? AND promoted_transaction_id IS NOT NULL``.
+
+The FK target is the existing ``transactions(household_id, id)`` PK.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from tulip_storage.models.base import GUID
+
+revision: str = "d5c8e7a91f2b"
+down_revision: str | None = "f4a6b9c2e7d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``promoted_transaction_id`` + composite FK."""
+    with op.batch_alter_table("statement_lines", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("promoted_transaction_id", GUID(length=36), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_statement_lines_promoted_tx",
+            "transactions",
+            ["household_id", "promoted_transaction_id"],
+            ["household_id", "id"],
+            use_alter=True,
+        )
+
+
+def downgrade() -> None:
+    """Drop the FK + column."""
+    with op.batch_alter_table("statement_lines", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_statement_lines_promoted_tx", type_="foreignkey")
+        batch_op.drop_column("promoted_transaction_id")

--- a/packages/tulip-storage/src/tulip_storage/models/statement_line.py
+++ b/packages/tulip-storage/src/tulip_storage/models/statement_line.py
@@ -49,6 +49,7 @@ class StatementLine(Base):
     raw_json: Mapped[str] = mapped_column(Text, nullable=False)
     is_excluded: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     reconciliation_match_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    promoted_transaction_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
 
     __table_args__ = (
         PrimaryKeyConstraint("household_id", "id", name="pk_statement_lines"),

--- a/packages/tulip-storage/src/tulip_storage/repositories/account.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/account.py
@@ -60,6 +60,15 @@ class AccountRepository:
             )
         ).scalar_one_or_none()
 
+    def get_by_code(self, code: str) -> Account | None:
+        """Return the Account with the given code within this household, or None."""
+        return self._session.execute(
+            select(Account).where(
+                Account.household_id == self._household_id,
+                Account.code == code,
+            )
+        ).scalar_one_or_none()
+
     def list_active(self) -> list[Account]:
         """Return all active accounts in this household, ordered by code/name."""
         return list(

--- a/packages/tulip-storage/src/tulip_storage/repositories/statement_line.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/statement_line.py
@@ -105,3 +105,20 @@ class StatementLineRepository:
         line.is_excluded = True
         self._session.flush()
         return line
+
+    def mark_promoted(self, line_id: UUID, transaction_id: UUID) -> StatementLine:
+        """Link a statement line to the ledger Transaction it was promoted into.
+
+        Single chokepoint for setting ``promoted_transaction_id`` —
+        keeps the architecture test happy and gives one obvious place to
+        layer in audit-log writes if/when promotion needs more than the
+        router-level audit row that already covers it.
+        """
+        line = self.get(line_id)
+        if line is None:
+            raise LookupError(
+                f"statement_line {line_id} not found in household {self._household_id}"
+            )
+        line.promoted_transaction_id = transaction_id
+        self._session.flush()
+        return line

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
@@ -203,20 +203,31 @@ class TransactionRepository:
             for account_id, currency, balance in rows
         ]
 
-    def save_balanced(self, domain_tx: DomainTransaction) -> Transaction:
+    def save_balanced(
+        self,
+        domain_tx: DomainTransaction,
+        *,
+        imported_from_id: UUID | None = None,
+    ) -> Transaction:
         """Persist a balanced Domain Transaction.
 
         Inserts the header as PENDING, then all postings, then UPDATEs the
         header to the requested final status. The balance trigger validates
         on the UPDATE; if postings are unbalanced the transaction aborts.
+
+        ``imported_from_id`` links the persisted row to the
+        ``import_batches`` row that produced it (used by the apply /
+        promote flow in P5.4.a).
         """
         target_status = self._domain_to_storage(domain_tx.status)
-        return self._save(domain_tx, target_status)
+        return self._save(domain_tx, target_status, imported_from_id=imported_from_id)
 
     def _save(
         self,
         domain_tx: DomainTransaction,
         target_status: TransactionStatus,
+        *,
+        imported_from_id: UUID | None = None,
     ) -> Transaction:
         header = Transaction(
             household_id=self._household_id,
@@ -227,6 +238,7 @@ class TransactionRepository:
             status=TransactionStatus.PENDING,
             created_by_user_id=domain_tx.created_by_user_id,
             posted_at=datetime.now(tz=UTC) if target_status is TransactionStatus.POSTED else None,
+            imported_from_id=imported_from_id,
         )
         self._session.add(header)
         self._session.flush()

--- a/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
@@ -86,12 +86,48 @@ def _python_source_files() -> list[Path]:
     return out
 
 
+def _is_type_checking_block(node: ast.AST) -> bool:
+    """True iff ``node`` is ``if TYPE_CHECKING:`` (or ``if typing.TYPE_CHECKING:``)."""
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+        return True
+    if (
+        isinstance(test, ast.Attribute)
+        and test.attr == "TYPE_CHECKING"
+        and isinstance(test.value, ast.Name)
+        and test.value.id == "typing"
+    ):
+        return True
+    return False
+
+
+def _collect_type_checking_lines(tree: ast.Module) -> set[int]:
+    """Return the line numbers covered by every ``if TYPE_CHECKING:`` block in ``tree``."""
+    covered: set[int] = set()
+    for node in ast.walk(tree):
+        if _is_type_checking_block(node):
+            for child in ast.walk(node):
+                if hasattr(child, "lineno"):
+                    covered.add(child.lineno)
+    return covered
+
+
 def _illegal_storage_model_imports(path: Path) -> list[tuple[int, str]]:
-    """Return ``(lineno, name)`` pairs that import P5.1 storage-layer models."""
+    """Return ``(lineno, name)`` pairs that import P5.1 storage-layer models.
+
+    Imports inside ``if TYPE_CHECKING:`` blocks are excluded — they don't
+    create a runtime path to the model class, so they can't construct or
+    write to one. This matches mypy's standard idiom for type-only imports.
+    """
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    type_checking_lines = _collect_type_checking_lines(tree)
     hits: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module in _STORAGE_MODEL_MODULES:
+            if node.lineno in type_checking_lines:
+                continue
             for alias in node.names:
                 if alias.name in _BANNED_NAMES:
                     hits.append((node.lineno, alias.name))

--- a/packages/tulip-storage/tests/test_p51_migration.py
+++ b/packages/tulip-storage/tests/test_p51_migration.py
@@ -206,7 +206,10 @@ class TestSchemaShape:
         db_path = tmp_path / "tulip.db"
         cfg = _make_alembic_cfg(f"sqlite:///{db_path}")
         upgrade(cfg, "head")
-        downgrade(cfg, "-1")
+        # Downgrade to the revision *before* P5.1 (e7d2a4f8c1b9 = P5.0).
+        # P5.4.a (d5c8e7a91f2b) sits above P5.1, so a single "-1" no
+        # longer un-applies the P5.1 tables — reach the exact target.
+        downgrade(cfg, "e7d2a4f8c1b9")
         from sqlalchemy import create_engine
 
         eng = create_engine(f"sqlite:///{db_path}")

--- a/packages/tulip-storage/tests/test_p54_apply_promote_migration.py
+++ b/packages/tulip-storage/tests/test_p54_apply_promote_migration.py
@@ -1,0 +1,196 @@
+"""Tests for the P5.4.a apply/promote migration.
+
+Adds one nullable column on ``statement_lines``:
+``promoted_transaction_id`` — composite FK to ``transactions
+(household_id, id)``. Used by the promote endpoint to track which
+ledger transaction a parsed line was promoted into, for O(1)
+idempotency lookup. Mirrors the round-trip + orphan-FK pattern of
+``test_p51_migration.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from alembic.command import downgrade, upgrade
+from alembic.config import Config
+from sqlalchemy import create_engine, event, inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from tulip_storage.models import (
+    Account,
+    AccountType,
+    Household,
+)
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+
+
+def _make_alembic_cfg(db_url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    cfg.set_main_option(
+        "script_location",
+        str(ALEMBIC_INI.parent / "src" / "tulip_storage" / "migrations"),
+    )
+    return cfg
+
+
+@pytest.fixture
+def migrated_db(tmp_path):
+    db_path = tmp_path / "tulip.db"
+    db_url = f"sqlite:///{db_path}"
+    cfg = _make_alembic_cfg(db_url)
+    upgrade(cfg, "head")
+
+    eng = create_engine(db_url, future=True)
+
+    @event.listens_for(eng, "connect")
+    def _enable_fk(dc, _r):  # type: ignore[no-untyped-def]
+        cur = dc.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    try:
+        yield db_url, sessionmaker(eng, expire_on_commit=False)
+    finally:
+        eng.dispose()
+
+
+def _seed_household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+def _seed_account(session: Session, household_id) -> Account:
+    a = Account(
+        household_id=household_id,
+        id=uuid4(),
+        code="1110",
+        name="Checking",
+        type=AccountType.ASSET,
+        currency="USD",
+        is_active=True,
+    )
+    session.add(a)
+    session.commit()
+    return a
+
+
+class TestSchemaShape:
+    def test_promoted_transaction_id_column_exists(self, migrated_db):
+        _, sm = migrated_db
+        with sm() as s:
+            cols = {c["name"]: c for c in inspect(s.get_bind()).get_columns("statement_lines")}
+            assert "promoted_transaction_id" in cols
+            assert cols["promoted_transaction_id"]["nullable"] is True
+
+    def test_promoted_transaction_id_fk_to_transactions(self, migrated_db):
+        _, sm = migrated_db
+        with sm() as s:
+            fks = inspect(s.get_bind()).get_foreign_keys("statement_lines")
+            promote_fk = next(
+                (fk for fk in fks if "promoted_transaction_id" in fk["constrained_columns"]),
+                None,
+            )
+            assert promote_fk is not None, "FK on promoted_transaction_id missing"
+            assert promote_fk["referred_table"] == "transactions"
+            assert sorted(promote_fk["constrained_columns"]) == [
+                "household_id",
+                "promoted_transaction_id",
+            ]
+            assert sorted(promote_fk["referred_columns"]) == ["household_id", "id"]
+
+    def test_round_trip_upgrade_downgrade(self, tmp_path):
+        db_path = tmp_path / "rt.db"
+        db_url = f"sqlite:///{db_path}"
+        cfg = _make_alembic_cfg(db_url)
+        upgrade(cfg, "head")
+        # Down to P5.1, then back up.
+        downgrade(cfg, "f4a6b9c2e7d3")
+        eng = create_engine(db_url, future=True)
+        try:
+            cols = {c["name"] for c in inspect(eng).get_columns("statement_lines")}
+            assert "promoted_transaction_id" not in cols
+        finally:
+            eng.dispose()
+        upgrade(cfg, "head")
+        eng2 = create_engine(db_url, future=True)
+        try:
+            cols2 = {c["name"] for c in inspect(eng2).get_columns("statement_lines")}
+            assert "promoted_transaction_id" in cols2
+        finally:
+            eng2.dispose()
+
+
+class TestForeignKey:
+    def test_orphan_promoted_transaction_id_rejected(self, migrated_db):
+        """Inserting a statement_line with a non-existent promoted_transaction_id is rejected."""
+        _, sm = migrated_db
+        with sm() as s:
+            h = _seed_household(s)
+            a = _seed_account(s, h.id)
+            # Create import_batch + attachment minimally via raw SQL — model wiring
+            # is out of scope for the migration test. We just need an FK target.
+            attachment_id = uuid4()
+            s.execute(
+                text(
+                    "INSERT INTO attachments (household_id, id, filename, "
+                    "content_type, size_bytes, content_hash, storage_uri, "
+                    "uploaded_at) VALUES "
+                    "(:hid, :id, 'x.ofx', :ct, 1, :hash, 's3://x', :now)"
+                ),
+                {
+                    "hid": str(h.id),
+                    "id": str(attachment_id),
+                    "hash": "x" * 64,
+                    "ct": "application/x-ofx",
+                    "now": datetime.now(UTC).isoformat(),
+                },
+            )
+            batch_id = uuid4()
+            s.execute(
+                text(
+                    "INSERT INTO import_batches (household_id, id, account_id, "
+                    "source_format, source_filename, source_file_attachment_id, "
+                    "status, imported_count, skipped_count, error_count, "
+                    "summary_json, created_by_user_id, created_at) "
+                    "VALUES (:hid, :id, :aid, 'ofx', 'x.ofx', :att, 'parsed', "
+                    "0, 0, 0, '{}', :uid, :now)"
+                ),
+                {
+                    "hid": str(h.id),
+                    "id": str(batch_id),
+                    "aid": str(a.id),
+                    "att": str(attachment_id),
+                    "uid": str(uuid4()),
+                    "now": datetime.now(UTC).isoformat(),
+                },
+            )
+            s.commit()
+
+            with pytest.raises(IntegrityError):
+                s.execute(
+                    text(
+                        "INSERT INTO statement_lines (household_id, id, "
+                        "import_batch_id, line_number, posted_date, amount, "
+                        "currency, description, raw_json, is_excluded, "
+                        "promoted_transaction_id) VALUES "
+                        "(:hid, :id, :bid, 1, :d, :amt, 'USD', 'x', '{}', 0, :ptx)"
+                    ),
+                    {
+                        "hid": str(h.id),
+                        "id": str(uuid4()),
+                        "bid": str(batch_id),
+                        "d": date(2026, 5, 6).isoformat(),
+                        "amt": "-10.00",
+                        "ptx": str(uuid4()),  # nonexistent
+                    },
+                )
+                s.commit()

--- a/packages/tulip-storage/tests/test_repositories.py
+++ b/packages/tulip-storage/tests/test_repositories.py
@@ -96,6 +96,36 @@ class TestAccountRepository:
         # but get() still finds it
         assert repo.get(a.id) is not None
 
+    def test_get_by_code_returns_match(self, session: Session, household: Household):
+        repo = AccountRepository(session, household.id)
+        a = repo.create(
+            code="Imbalance:Unknown",
+            name="Imbalance: Unknown",
+            type=AccountType.EQUITY,
+            currency="USD",
+        )
+        found = repo.get_by_code("Imbalance:Unknown")
+        assert found is not None
+        assert found.id == a.id
+
+    def test_get_by_code_returns_none_when_missing(self, session: Session, household: Household):
+        repo = AccountRepository(session, household.id)
+        repo.create(code="1110", name="Checking", type=AccountType.ASSET, currency="USD")
+        assert repo.get_by_code("DoesNotExist") is None
+
+    def test_get_by_code_scoped_to_household(self, session: Session, household: Household):
+        # One household has the code; the other does not.
+        AccountRepository(session, household.id).create(
+            code="Imbalance:Unknown",
+            name="Imbalance",
+            type=AccountType.EQUITY,
+            currency="USD",
+        )
+        other = Household(id=uuid4(), name="Jones", base_currency="USD")
+        session.add(other)
+        session.commit()
+        assert AccountRepository(session, other.id).get_by_code("Imbalance:Unknown") is None
+
 
 class TestPeriodRepository:
     def test_create_and_find_for_date(self, session: Session, household: Household):
@@ -156,6 +186,35 @@ class TestTransactionRepository:
         food = repo.create(code="5100", name="Food", type=AccountType.EXPENSE, currency="USD")
         session.commit()
         return cash, food
+
+    def test_save_balanced_persists_imported_from_id(self, session: Session, household: Household):
+        """save_balanced(..., imported_from_id=...) propagates to the header."""
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+
+        batch_id = uuid4()
+        domain_tx = DomainTransaction(
+            id=uuid4(),
+            household_id=household.id,
+            date=date(2026, 6, 1),
+            description="Promoted from statement line",
+            postings=(
+                DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("8.00"), "USD")),
+                DomainPosting(
+                    id=uuid4(), account_id=cash.id, amount=Money(Decimal("-8.00"), "USD")
+                ),
+            ),
+            status=DomainTxStatus.PENDING,
+        )
+        header = TransactionRepository(session, household.id).save_balanced(
+            domain_tx, imported_from_id=batch_id
+        )
+        assert header.imported_from_id == batch_id
 
     def test_save_posted_transaction_with_postings(self, session: Session, household: Household):
         cash, food = self._seed_accounts(session, household)


### PR DESCRIPTION
## Summary

First sub-slice of P5.4: closes the importer loop. Statement lines now turn into PENDING ledger transactions via the registered `Categorizer` (currently `NullCategorizer` from P5.3). The reconciliation envelope (P5.4.b), manual match + carry-forward (P5.4.c), and the `tulip reconcile` CLI (P5.4.d) follow.

- **`POST /v1/imports/{batch_id}/apply`** — promote every non-excluded, non-already-promoted line to a PENDING `transaction` with two `posting`s (bank-side + categorizer-side). Flips `import_batches.status = 'applied'`. Idempotent at the batch level: re-applying returns `409 import.already_applied`.
- **`POST /v1/imports/{batch_id}/lines/{line_id}/promote`** — single-line promotion. Returns `201` with `{statement_line_id, transaction_id}`. Idempotent at the line level (`409 import.line.already_promoted` carries the existing tx id). An excluded line returns `422 import.line.excluded` — un-exclude it first.
- **`tulip imports apply BATCH_ID`** — CLI wrapper. Renders a one-line summary in human mode; passes the JSON body through in `--json` mode.
- **Storage prerequisites** rolled into the slice:
  - New migration `d5c8e7a91f2b` adds `statement_lines.promoted_transaction_id` (composite FK to `transactions(household_id, id)`) for O(1) idempotency lookup. Picked over a back-query through `transactions.imported_from_id` because back-query is O(N) per line.
  - `AccountRepository.get_by_code` resolves the categorizer's account-code suggestion to an `account_id`.
  - `TransactionRepository.save_balanced(..., imported_from_id=...)` propagates the FK through `_save` (the column existed in P5.1 but no path set it).
  - `StatementLineRepository.mark_promoted(line_id, tx_id)` is the single chokepoint for setting `promoted_transaction_id`; satisfies the architecture test.
  - Registration now seeds `Imbalance:Unknown` (EQUITY, base currency) per household. Chosen over EXPENSE because suspense accounts conventionally sit on the balance sheet rather than shifting the P&L until categorized.
- **`Categorizer` registry wiring** — `tulip_api.main` now calls `register_categorizer(NullCategorizer())` at module-import time. Phase 6's swap-in lands at this exact line.
- **Architecture-test enhancement** — `test_architecture_no_direct_reconciliation_writes` now skips `if TYPE_CHECKING:` blocks. Type-only imports of P5.1 storage models for function signatures don't create a runtime path to the model class and shouldn't trip the chokepoint guard.

Refs #74. P5.4.b (reconciliation envelope + auto-match) is next.

## Test plan

- [x] `uv run pytest packages/tulip-storage/tests/test_p54_apply_promote_migration.py` → 4 passing (column / FK / round-trip / orphan-FK rejected)
- [x] `uv run pytest packages/tulip-storage/tests/test_repositories.py::TestAccountRepository` → 7 passing (incl. 3 new `get_by_code` cases)
- [x] `uv run pytest packages/tulip-storage/tests/test_repositories.py::TestTransactionRepository` → 19 passing (incl. new `save_balanced(imported_from_id=...)` case)
- [x] `uv run pytest packages/tulip-api/tests/test_auth_endpoints.py::TestRegister` → 5 passing (incl. `test_register_seeds_imbalance_unknown_account`)
- [x] `uv run pytest packages/tulip-api/tests/services/test_import_apply.py` → 11 passing
- [x] `uv run pytest packages/tulip-api/tests/test_apply_promote_endpoints.py` → 9 passing
- [x] `just test` → **1061 passing**, 1 skipped, 1 xfail (up from 1028 on `main`)
- [x] `just lint` → clean
- [x] `just typecheck` → clean across 169 source files
- [ ] CI green on this PR

## Manual smoke test

```bash
set -e

# 1. Start a fresh API instance.
rm -f /tmp/tulip-smoke.db
TULIP_DATABASE_URL=sqlite:////tmp/tulip-smoke.db uv run alembic -c packages/tulip-storage/alembic.ini upgrade head
TULIP_DATABASE_URL=sqlite:////tmp/tulip-smoke.db uv run uvicorn tulip_api.main:create_app --factory --port 8000 &
API_PID=$!
sleep 2

# 2. Register + login.
TOKEN_DIR=$(mktemp -d)
export TULIP_TOKEN_STORE="$TOKEN_DIR/tokens.json"
uv run tulip register --email smoke@example.com --display-name Smoke --household Smoke --password-stdin <<< "smoke-password"
uv run tulip auth login --email smoke@example.com --password-stdin <<< "smoke-password"

# 3. Verify Imbalance:Unknown was seeded.
uv run tulip accounts list

# 4. Create a checking account and upload a statement.
uv run tulip accounts add --code 1110 --name Checking --type asset --currency USD
BATCH_ID=$(uv run tulip --json import ofx packages/tulip-importers/tests/fixtures/ofx/minimal_ofx2.ofx --account 1110 | jq -r .id)
echo "Uploaded batch: $BATCH_ID"

# 5. Apply the batch — every line becomes a PENDING tx.
uv run tulip imports apply "$BATCH_ID"
# Expected: "Applied batch <uuid>: created 2 PENDING transactions, skipped 0 lines."

# 6. Re-apply — should fail with 409 import.already_applied.
set +e
uv run tulip imports apply "$BATCH_ID"
test $? -ne 0 || { echo "FAIL: re-apply should have errored"; exit 1; }
set -e

# Cleanup.
kill "$API_PID"
wait 2>/dev/null
rm -rf "$TOKEN_DIR" /tmp/tulip-smoke.db
echo "smoke test passed"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)