### PR TITLE
P5.4.b — reconciliation envelope + auto-match

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-06 · `main` @ **P5.4.a in flight** (apply / promote endpoints + CLI)
+**Last updated:** 2026-05-06 · `main` @ **P5.4.b in flight** (reconciliation envelope + auto-match)
 
 ---
 
@@ -16,9 +16,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
 - **Pre-Phase-4 docs:** threat-model checkpoint shipped (#56, [docs/THREAT_MODEL.md](THREAT_MODEL.md)). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
 - **Phase 4 (envelopes + sinking funds):** ✅ **complete** — all seven slices merged 2026-05-02. P4.0 (#60), P4.1.a (#62), P4.1.b (#63), P4.2 (#66), P4.3.a (#68 — closes #7 via [ADR-0002](adrs/0002-scheduler-primitive.md)), P4.3.b (#69), P4.3.c (#70).
-- **Phase 5 (importers + reconciliation):** in flight — P5.0 (#55), P5.1 (storage layer), P5.2.a/b/c (OFX / QIF / CSV importers), P5.3 (matcher + categorizer DI seam), and P5.4.a (apply / promote endpoints + CLI) implemented per [ADR-0004](adrs/0004-reconciliation.md). The remaining P5.4 sub-slices land the reconciliation envelope (P5.4.b), manual match + carry-forward (P5.4.c), and the `tulip reconcile` CLI (P5.4.d) — closing Phase 5.
+- **Phase 5 (importers + reconciliation):** in flight — P5.0 (#55), P5.1 (storage layer), P5.2.a/b/c (OFX / QIF / CSV importers), P5.3 (matcher + categorizer DI seam), P5.4.a (apply / promote endpoints + CLI), and P5.4.b (reconciliation envelope + auto-match) implemented per [ADR-0004](adrs/0004-reconciliation.md). The remaining P5.4 sub-slices land manual match + carry-forward (P5.4.c) and the `tulip reconcile` CLI (P5.4.d) — closing Phase 5.
 
-**Tests:** 1061 passing · **CI:** green on `main`
+**Tests:** 1090 passing · **CI:** green on `main`
 
 ---
 
@@ -498,9 +498,26 @@ First sub-slice of P5.4: closes the importer loop. Statement lines now turn into
 - **Audit-log entries**: `import_apply` (one row per batch, with `created_count` / `skipped_count` / `transaction_ids`) and `statement_line_promote` (one row per line, with `transaction_id` / `batch_id`).
 - **Tests**: 11 service tests + 9 router tests + 4 storage-layer tests + 2 CLI integration tests + 1 register-seed test, plus a small architecture-test enhancement (the `if TYPE_CHECKING:` walker filter so type-only model imports don't trip the chokepoint guard). Project total: **1061 passing** (up from 1028).
 
-### P5.4.b — Reconciliation envelope + auto-match — queued
+### P5.4.b — Reconciliation envelope + auto-match — ✅ *(2026-05-06)*
 
-`POST/GET/DELETE /v1/reconciliations`, `POST /complete`, `POST /auto-match` (wires `find_candidates`), `POST /matches/{id}/reject`. Server-side only.
+Second sub-slice of P5.4: server-side reconciliation envelope CRUD + the auto-match endpoint that wires P5.3's matcher + persistence. Manual match (P5.4.c) and CLI (P5.4.d) follow.
+
+- **`POST /v1/reconciliations`** — open an IN_PROGRESS envelope tied to one `import_batch` for one `account`. Validates: account exists, batch exists + belongs to the account, currency match between envelope and account, no other IN_PROGRESS reconciliation for the account (one-at-a-time invariant — locked decision; simplifies the matcher's already-reconciled detection).
+- **`GET /v1/reconciliations/{id}`** — envelope **+ inline review pane**: matches, unmatched statement lines, unmatched ledger transactions in the period window. One round-trip for the entire reconciliation UI per the locked decision; the inbox is what the CLI/UI in P5.4.d will hit on every refresh.
+- **`POST /v1/reconciliations/{id}/auto-match`** — wires `tulip_core.reconciliation.matcher.find_candidates` (P5.3) over the batch's non-excluded statement lines + the period's POSTED ledger transactions, persists each emitted `CandidateMatch` as a `reconciliation_matches` row with `matcher_version="v1"`, `created_by_user_id=NULL`, and the bucketed `confidence` (HIGH/MEDIUM/LOW). Re-running on a reconciliation that already has matches returns `409 reconciliation.matches_exist` per the locked decision — user rejects individual matches or DELETEs and recreates for a fresh pass.
+- **`POST /v1/reconciliations/{id}/matches/{match_id}/reject`** — delete a match row, return the line + transaction to the unmatched pool. Mirrors `ReconciliationMatchRepository.reject`.
+- **`POST /v1/reconciliations/{id}/complete`** — strict balance check: `sum(match.match_amount) == ending_balance - starting_balance`. On pass, hands off to `ReconciliationRepository.complete()` (the **only** writer of `transactions.reconciliation_id` + `reconciled_at` per ADR §Q7 — architecture-test enforced). On fail, `409 reconciliation.unbalanced` carries `expected_net`, `matched_net`, and `residual` as extension fields so the client can show the user exactly how much is unaccounted-for.
+- **`DELETE /v1/reconciliations/{id}?cascade=true`** — un-reconcile. Requires explicit `?cascade=true` (omitting it returns `400 reconciliation.cascade_required` to gate the destructive intent). New `ReconciliationRepository.revert()` method nulls `transactions.reconciliation_id` + `reconciled_at`, clears `statement_lines.reconciliation_match_id` (no FK to cascade), then deletes the reconciliation row (cascade-deletes matches via the P5.1 FK).
+- **Service module** `tulip_api.services.reconciliation_match` with `auto_match()` and `complete()` async + sync entry points. Mirrors P5.4.a's pattern: services flush only; the router wraps a single `commit()` around the audit-log row + the persisted matches so any mid-flight failure rolls back atomically.
+- **Storage adapter** `_tx_to_domain(storage_tx, postings)` materialises a domain `Transaction` (with `Posting` tuple) from a storage row + its posting list — the matcher operates on domain types only, but `TransactionRepository.list_headers()` returns storage rows. The adapter is small and lives in the service module rather than core (no domain → storage cycle).
+- **Domain ↔ storage `MatchConfidence` translation** — both layers have a `MatchConfidence` enum with the same string values; the service module owns the explicit mapping table so the boundary is grep-able.
+- **No `transactions.reconciliation_id` write outside `ReconciliationRepository`** — verified by `test_architecture_no_direct_reconciled_at_writes`. The architecture test was extended to allowlist the new router + service files (which pass `reconciliation_id` as the FK column on `reconciliation_matches`, never to write the denorm on `transactions` — same kwarg-name collision the existing `repositories/reconciliation_match.py` carve-out already documents).
+- **Audit-log entries** — `reconciliation_create`, `reconciliation_revert`, `reconciliation_auto_match`, `reconciliation_match_reject`, `reconciliation_complete`. Each carries enough state to reconstruct the action without consulting the live row (the row may be gone post-revert).
+- **Tests**: 7 service tests + 15 router tests + 2 storage-layer tests = 24 new (1061 → 1090 passing).
+
+### P5.4.c — Manual match + carry-forward — queued
+
+`POST /v1/reconciliations/{id}/matches` (manual), carry-forward CRUD endpoints. Lets the user resolve residuals that auto-match can't pick up + carry unmatched ledger transactions to the next reconciliation.
 
 ---
 

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -1163,6 +1163,181 @@ class StatementLineExcludedError(TulipProblem):
         )
 
 
+class ReconciliationNotFoundError(TulipProblem):
+    """No reconciliation with that ID exists in this household (P5.4.b)."""
+
+    def __init__(self) -> None:
+        """Build the reconciliation.not_found problem (404)."""
+        super().__init__(
+            code="reconciliation.not_found",
+            title="Reconciliation not found",
+            status=404,
+            detail="No reconciliation with that ID exists in this household.",
+        )
+
+
+class ReconciliationMatchNotFoundError(TulipProblem):
+    """No match with that ID exists for this reconciliation (P5.4.b)."""
+
+    def __init__(self) -> None:
+        """Build the reconciliation_match.not_found problem (404)."""
+        super().__init__(
+            code="reconciliation_match.not_found",
+            title="Reconciliation match not found",
+            status=404,
+            detail="No match with that ID exists for this reconciliation.",
+        )
+
+
+class ReconciliationMatchesExistError(TulipProblem):
+    """Auto-match was called on a reconciliation that already has matches (P5.4.b).
+
+    Per the locked decision in the P5.4.b scoping discussion: re-running
+    auto-match is rejected (rather than appended-to or replaced) so the
+    contract stays simple. Caller should reject individual matches or
+    DELETE+recreate the reconciliation for a fresh pass.
+    """
+
+    def __init__(self, *, reconciliation_id: str, existing_match_count: int) -> None:
+        """Build the reconciliation.matches_exist problem (409)."""
+        super().__init__(
+            code="reconciliation.matches_exist",
+            title="Reconciliation already has matches",
+            status=409,
+            detail=(
+                "This reconciliation already has matches. Re-running auto-match "
+                "would create duplicates. Reject the existing matches one-by-one, "
+                "or DELETE the reconciliation and create a new one for a fresh pass."
+            ),
+            extensions={
+                "reconciliation_id": reconciliation_id,
+                "existing_match_count": existing_match_count,
+            },
+        )
+
+
+class ReconciliationUnbalancedError(TulipProblem):
+    """Complete was called but matched + carry-forward != ending - starting (P5.4.b).
+
+    Per the locked decision: strict balance enforcement at /complete.
+    The user must reach a fully-balanced state before marking the
+    reconciliation done — no force-complete-with-residual.
+    """
+
+    def __init__(
+        self,
+        *,
+        reconciliation_id: str,
+        expected_net: str,
+        matched_net: str,
+        residual: str,
+    ) -> None:
+        """Build the reconciliation.unbalanced problem (409)."""
+        super().__init__(
+            code="reconciliation.unbalanced",
+            title="Reconciliation does not balance",
+            status=409,
+            detail=(
+                "The matched transactions don't sum to "
+                f"(ending_balance - starting_balance) = {expected_net}. "
+                f"Matched net is {matched_net}; residual {residual} remains. "
+                "Match additional transactions, exclude lines that aren't real, "
+                "or carry-forward the residual (P5.4.c)."
+            ),
+            extensions={
+                "reconciliation_id": reconciliation_id,
+                "expected_net": expected_net,
+                "matched_net": matched_net,
+                "residual": residual,
+            },
+        )
+
+
+class ReconciliationInvalidStateError(TulipProblem):
+    """A state-transitioning action was called from a non-IN_PROGRESS state (P5.4.b)."""
+
+    def __init__(self, *, current_status: str, action: str) -> None:
+        """Build the reconciliation.invalid_state problem (409)."""
+        super().__init__(
+            code="reconciliation.invalid_state",
+            title="Reconciliation is not in a valid state for this action",
+            status=409,
+            detail=(
+                f"Cannot {action} a reconciliation in {current_status!r} status. "
+                "Only IN_PROGRESS reconciliations accept matches and completion."
+            ),
+            extensions={"current_status": current_status, "action": action},
+        )
+
+
+class ReconciliationAccountAlreadyInProgressError(TulipProblem):
+    """An IN_PROGRESS reconciliation already exists for this account (P5.4.b).
+
+    Locked decision: at most one IN_PROGRESS reconciliation per account at
+    any time. Avoids the matcher having to consult multiple in-progress
+    match tables to detect double-matches.
+    """
+
+    def __init__(self, *, account_id: str, existing_reconciliation_id: str) -> None:
+        """Build the reconciliation.account_already_in_progress problem (409)."""
+        super().__init__(
+            code="reconciliation.account_already_in_progress",
+            title="An in-progress reconciliation already exists for this account",
+            status=409,
+            detail=(
+                "Complete or delete the existing reconciliation before opening a "
+                "new one for this account."
+            ),
+            extensions={
+                "account_id": account_id,
+                "existing_reconciliation_id": existing_reconciliation_id,
+            },
+        )
+
+
+class ReconciliationCascadeRequiredError(TulipProblem):
+    """DELETE /v1/reconciliations/{id} called without ``?cascade=true`` (P5.4.b).
+
+    The destructive intent is gated behind an explicit query param so a
+    typo or browser-bookmark-replay can't silently un-reconcile a closed
+    period.
+    """
+
+    def __init__(self) -> None:
+        """Build the reconciliation.cascade_required problem (400)."""
+        super().__init__(
+            code="reconciliation.cascade_required",
+            title="Cascade flag required",
+            status=400,
+            detail=(
+                "Reverting a reconciliation deletes its matches and nulls "
+                "transactions.reconciliation_id + reconciled_at. Pass "
+                "?cascade=true to confirm the destructive intent."
+            ),
+        )
+
+
+class ReconciliationCurrencyMismatchError(TulipProblem):
+    """The import batch / account / reconciliation currencies disagree (P5.4.b)."""
+
+    def __init__(self, *, reconciliation_currency: str, source_currency: str, source: str) -> None:
+        """Build the reconciliation.currency_mismatch problem (400)."""
+        super().__init__(
+            code="reconciliation.currency_mismatch",
+            title="Currency mismatch between reconciliation and source",
+            status=400,
+            detail=(
+                f"Reconciliation currency is {reconciliation_currency!r} but "
+                f"the {source} currency is {source_currency!r}. They must match."
+            ),
+            extensions={
+                "reconciliation_currency": reconciliation_currency,
+                "source_currency": source_currency,
+                "source": source,
+            },
+        )
+
+
 class ImportCategorizeUnknownAccountError(TulipProblem):
     """The categorizer suggested an account_code with no matching Account (P5.4.a)."""
 

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -33,6 +33,7 @@ from tulip_api.routers import (
     health,
     imports,
     pools,
+    reconciliations,
     refill_schedules,
     reports,
     sinking_funds,
@@ -131,5 +132,6 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
     # absorb /v1/imports/profiles into the imports router.)
     app.include_router(csv_profiles.router)
     app.include_router(imports.router)
+    app.include_router(reconciliations.router)
 
     return app

--- a/packages/tulip-api/src/tulip_api/routers/reconciliations.py
+++ b/packages/tulip-api/src/tulip_api/routers/reconciliations.py
@@ -1,0 +1,514 @@
+"""POST/GET/DELETE /v1/reconciliations + state-transition endpoints (P5.4.b).
+
+Per ADR-0004 §Q4-Q9 + the locked P5.4.b scoping decisions:
+
+- One IN_PROGRESS reconciliation per ``account_id`` at any time.
+- ``source_import_batch_id`` is set at create time; auto-match takes no body.
+- Re-running auto-match on a reconciliation with existing matches → 409.
+- ``GET /v1/reconciliations/{id}`` returns envelope + inline inbox
+  (matches + unmatched statement lines + unmatched ledger transactions
+  in the period window) so the review pane is one round-trip.
+- ``DELETE`` requires explicit ``?cascade=true``.
+- ``/complete`` enforces strict balance: ``sum(matches) == ending - starting``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, Request, status
+
+from tulip_api.auth.deps import require_role
+from tulip_api.deps import get_session
+from tulip_api.errors import (
+    AccountNotFoundError,
+    ImportBatchNotFoundError,
+    ReconciliationAccountAlreadyInProgressError,
+    ReconciliationCurrencyMismatchError,
+    ReconciliationInvalidStateError,
+    ReconciliationMatchesExistError,
+    ReconciliationMatchNotFoundError,
+    ReconciliationNotFoundError,
+    ReconciliationUnbalancedError,
+    problem_response,
+)
+from tulip_api.schemas.reconciliation import (
+    AutoMatchResponse,
+    CompleteResponse,
+    LedgerTransactionInbox,
+    MatchRead,
+    ReconciliationCreate,
+    ReconciliationInboxResponse,
+    ReconciliationRead,
+    StatementLineInbox,
+)
+from tulip_api.services.reconciliation_match import (
+    AutoMatchAlreadyRunError,
+    AutoMatchInvalidStateError,
+    CompleteInvalidStateError,
+    CompleteUnbalancedError,
+    auto_match,
+    complete,
+)
+from tulip_storage.models import ReconciliationStatus
+from tulip_storage.repositories import (
+    AccountRepository,
+    AuditLogWriter,
+    ImportBatchRepository,
+    ReconciliationMatchRepository,
+    ReconciliationRepository,
+    StatementLineRepository,
+    TransactionRepository,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_api.auth.tokens import Claims
+
+
+router = APIRouter(prefix="/v1/reconciliations", tags=["reconciliations"])
+log = structlog.get_logger("tulip_api.reconciliations")
+
+
+def _request_uuid(request: Request) -> UUID | None:
+    rid = request.headers.get("x-request-id")
+    if rid:
+        try:
+            return UUID(rid)
+        except ValueError:
+            return None
+    return None
+
+
+def _to_read(recon: object) -> ReconciliationRead:
+    return ReconciliationRead(
+        id=recon.id,  # type: ignore[attr-defined]
+        account_id=recon.account_id,  # type: ignore[attr-defined]
+        statement_period_start=recon.statement_period_start,  # type: ignore[attr-defined]
+        statement_period_end=recon.statement_period_end,  # type: ignore[attr-defined]
+        statement_starting_balance=recon.statement_starting_balance,  # type: ignore[attr-defined]
+        statement_ending_balance=recon.statement_ending_balance,  # type: ignore[attr-defined]
+        currency=recon.currency,  # type: ignore[attr-defined]
+        status=recon.status.value,  # type: ignore[attr-defined]
+        source_import_batch_id=recon.source_import_batch_id,  # type: ignore[attr-defined]
+        created_at=recon.created_at,  # type: ignore[attr-defined]
+        completed_at=recon.completed_at,  # type: ignore[attr-defined]
+    )
+
+
+def _to_match_read(match: object) -> MatchRead:
+    return MatchRead(
+        id=match.id,  # type: ignore[attr-defined]
+        reconciliation_id=match.reconciliation_id,  # type: ignore[attr-defined]
+        statement_line_id=match.statement_line_id,  # type: ignore[attr-defined]
+        ledger_transaction_id=match.ledger_transaction_id,  # type: ignore[attr-defined]
+        match_amount=match.match_amount,  # type: ignore[attr-defined]
+        currency=match.currency,  # type: ignore[attr-defined]
+        confidence=(
+            match.confidence.value if match.confidence is not None else None  # type: ignore[attr-defined]
+        ),
+        matcher_version=match.matcher_version,  # type: ignore[attr-defined]
+        created_by_user_id=match.created_by_user_id,  # type: ignore[attr-defined]
+        created_at=match.created_at,  # type: ignore[attr-defined]
+    )
+
+
+@router.post(
+    "",
+    response_model=ReconciliationRead,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: problem_response(
+            "request.body_invalid",
+            "reconciliation.currency_mismatch",
+        ),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("account.not_found", "import_batch.not_found"),
+        409: problem_response("reconciliation.account_already_in_progress"),
+        422: problem_response("validation.failed"),
+    },
+)
+def create_reconciliation(
+    body: ReconciliationCreate,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> ReconciliationRead:
+    """Open a reconciliation envelope tied to one import batch."""
+    accounts = AccountRepository(session, claims.household_id)
+    account = accounts.get(body.account_id)
+    if account is None:
+        raise AccountNotFoundError()
+
+    batches = ImportBatchRepository(session, claims.household_id)
+    batch = batches.get(body.source_import_batch_id)
+    if batch is None or batch.account_id != body.account_id:
+        raise ImportBatchNotFoundError()
+
+    if account.currency != body.currency:
+        raise ReconciliationCurrencyMismatchError(
+            reconciliation_currency=body.currency,
+            source_currency=account.currency,
+            source="account",
+        )
+
+    repo = ReconciliationRepository(session, claims.household_id)
+    existing = [
+        r
+        for r in repo.list_for_account(body.account_id)
+        if r.status is ReconciliationStatus.IN_PROGRESS
+    ]
+    if existing:
+        raise ReconciliationAccountAlreadyInProgressError(
+            account_id=str(body.account_id),
+            existing_reconciliation_id=str(existing[0].id),
+        )
+
+    recon = repo.create(
+        account_id=body.account_id,
+        statement_period_start=body.statement_period_start,
+        statement_period_end=body.statement_period_end,
+        statement_starting_balance=body.statement_starting_balance,
+        statement_ending_balance=body.statement_ending_balance,
+        currency=body.currency,
+        source_import_batch_id=body.source_import_batch_id,
+        created_by_user_id=claims.user_id,
+    )
+    AuditLogWriter(session, claims.household_id).write(
+        action="reconciliation_create",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="reconciliation",
+        entity_id=recon.id,
+        after={
+            "account_id": str(body.account_id),
+            "source_import_batch_id": str(body.source_import_batch_id),
+            "period": (f"{body.statement_period_start}..{body.statement_period_end}"),
+        },
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info("reconciliation.created", reconciliation_id=str(recon.id))
+    return _to_read(recon)
+
+
+@router.get(
+    "/{reconciliation_id}",
+    response_model=ReconciliationInboxResponse,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        404: problem_response("reconciliation.not_found"),
+    },
+)
+def get_reconciliation(
+    reconciliation_id: UUID,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> ReconciliationInboxResponse:
+    """Fetch the reconciliation + its review pane (matches + unmatched lines + ledger txs)."""
+    repo = ReconciliationRepository(session, claims.household_id)
+    recon = repo.get(reconciliation_id)
+    if recon is None:
+        raise ReconciliationNotFoundError()
+
+    matches = ReconciliationMatchRepository(session, claims.household_id).list_for_reconciliation(
+        recon.id
+    )
+    matched_line_ids = {m.statement_line_id for m in matches}
+    matched_tx_ids = {m.ledger_transaction_id for m in matches}
+
+    lines_repo = StatementLineRepository(session, claims.household_id)
+    if recon.source_import_batch_id is not None:
+        all_lines = lines_repo.list_for_batch(recon.source_import_batch_id)
+    else:
+        all_lines = []
+    unmatched_lines = [
+        line for line in all_lines if not line.is_excluded and line.id not in matched_line_ids
+    ]
+
+    tx_repo = TransactionRepository(session, claims.household_id)
+    from tulip_storage.models import TransactionStatus
+
+    headers = tx_repo.list_headers(
+        account_id=recon.account_id,
+        from_date=recon.statement_period_start,
+        to_date=recon.statement_period_end,
+        status=TransactionStatus.POSTED,
+    )
+    unmatched_txs = [
+        h for h in headers if h.id not in matched_tx_ids and h.reconciliation_id is None
+    ]
+
+    return ReconciliationInboxResponse(
+        reconciliation=_to_read(recon),
+        matches=[_to_match_read(m) for m in matches],
+        unmatched_statement_lines=[
+            StatementLineInbox(
+                id=line.id,
+                line_number=line.line_number,
+                posted_date=line.posted_date,
+                amount=line.amount,
+                currency=line.currency,
+                description=line.description,
+                counterparty=line.counterparty,
+                reference=line.reference,
+                fitid=line.fitid,
+            )
+            for line in unmatched_lines
+        ],
+        unmatched_ledger_transactions=[
+            LedgerTransactionInbox(
+                id=h.id,
+                date=h.date,
+                description=h.description,
+                reference=h.reference,
+                status=h.status.value,
+            )
+            for h in unmatched_txs
+        ],
+    )
+
+
+@router.delete(
+    "/{reconciliation_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        400: problem_response("reconciliation.cascade_required"),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("reconciliation.not_found"),
+    },
+)
+def revert_reconciliation(
+    reconciliation_id: UUID,
+    request: Request,
+    cascade: bool = False,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> None:
+    """Un-reconcile: requires ``?cascade=true`` so the destructive intent is explicit.
+
+    Per ADR-0004 §Q7. Cascades to ``reconciliation_matches`` (FK), nulls
+    ``transactions.reconciliation_id`` + ``reconciled_at``, and clears
+    ``statement_lines.reconciliation_match_id``.
+    """
+    if not cascade:
+        from tulip_api.errors import ReconciliationCascadeRequiredError
+
+        raise ReconciliationCascadeRequiredError()
+
+    repo = ReconciliationRepository(session, claims.household_id)
+    recon = repo.get(reconciliation_id)
+    if recon is None:
+        raise ReconciliationNotFoundError()
+
+    repo.revert(reconciliation_id)
+    AuditLogWriter(session, claims.household_id).write(
+        action="reconciliation_revert",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="reconciliation",
+        entity_id=reconciliation_id,
+        before={
+            "status": recon.status.value,
+            "account_id": str(recon.account_id),
+        },
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info("reconciliation.reverted", reconciliation_id=str(reconciliation_id))
+
+
+@router.post(
+    "/{reconciliation_id}/auto-match",
+    response_model=AutoMatchResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("reconciliation.not_found"),
+        409: problem_response(
+            "reconciliation.invalid_state",
+            "reconciliation.matches_exist",
+        ),
+    },
+)
+async def auto_match_endpoint(
+    reconciliation_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> AutoMatchResponse:
+    """Run the matcher; persist candidate match rows."""
+    repo = ReconciliationRepository(session, claims.household_id)
+    recon = repo.get(reconciliation_id)
+    if recon is None:
+        raise ReconciliationNotFoundError()
+
+    try:
+        result = await auto_match(
+            session=session,
+            household_id=claims.household_id,
+            reconciliation=recon,
+            actor_user_id=claims.user_id,
+        )
+    except AutoMatchInvalidStateError as exc:
+        raise ReconciliationInvalidStateError(
+            current_status=exc.current_status, action="auto-match"
+        ) from exc
+    except AutoMatchAlreadyRunError as exc:
+        raise ReconciliationMatchesExistError(
+            reconciliation_id=str(reconciliation_id),
+            existing_match_count=exc.existing_match_count,
+        ) from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="reconciliation_auto_match",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="reconciliation",
+        entity_id=recon.id,
+        after={
+            "matches_created": result.matches_created,
+            "high": result.high_count,
+            "medium": result.medium_count,
+            "low": result.low_count,
+        },
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "reconciliation.auto_matched",
+        reconciliation_id=str(recon.id),
+        matches_created=result.matches_created,
+    )
+    return AutoMatchResponse(
+        reconciliation_id=recon.id,
+        matches_created=result.matches_created,
+        candidate_summary={
+            "high": result.high_count,
+            "medium": result.medium_count,
+            "low": result.low_count,
+        },
+    )
+
+
+@router.post(
+    "/{reconciliation_id}/matches/{match_id}/reject",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("reconciliation.not_found", "reconciliation_match.not_found"),
+    },
+)
+def reject_match(
+    reconciliation_id: UUID,
+    match_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> None:
+    """Delete a match row, returning the line + transaction to the unmatched pool."""
+    recon_repo = ReconciliationRepository(session, claims.household_id)
+    if recon_repo.get(reconciliation_id) is None:
+        raise ReconciliationNotFoundError()
+
+    match_repo = ReconciliationMatchRepository(session, claims.household_id)
+    match = match_repo.get(match_id)
+    if match is None or match.reconciliation_id != reconciliation_id:
+        raise ReconciliationMatchNotFoundError()
+
+    match_repo.reject(match_id)
+    AuditLogWriter(session, claims.household_id).write(
+        action="reconciliation_match_reject",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="reconciliation_match",
+        entity_id=match_id,
+        before={
+            "reconciliation_id": str(reconciliation_id),
+            "statement_line_id": str(match.statement_line_id),
+            "ledger_transaction_id": str(match.ledger_transaction_id),
+        },
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "reconciliation_match.rejected",
+        match_id=str(match_id),
+        reconciliation_id=str(reconciliation_id),
+    )
+
+
+@router.post(
+    "/{reconciliation_id}/complete",
+    response_model=CompleteResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("reconciliation.not_found"),
+        409: problem_response(
+            "reconciliation.invalid_state",
+            "reconciliation.unbalanced",
+        ),
+    },
+)
+def complete_endpoint(
+    reconciliation_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> CompleteResponse:
+    """Finalise the reconciliation; denormalise ``reconciled_at`` onto matched txs."""
+    repo = ReconciliationRepository(session, claims.household_id)
+    recon = repo.get(reconciliation_id)
+    if recon is None:
+        raise ReconciliationNotFoundError()
+
+    try:
+        result = complete(
+            session=session,
+            household_id=claims.household_id,
+            reconciliation=recon,
+        )
+    except CompleteInvalidStateError as exc:
+        raise ReconciliationInvalidStateError(
+            current_status=exc.current_status, action="complete"
+        ) from exc
+    except CompleteUnbalancedError as exc:
+        raise ReconciliationUnbalancedError(
+            reconciliation_id=str(reconciliation_id),
+            expected_net=str(exc.expected_net),
+            matched_net=str(exc.matched_net),
+            residual=str(exc.residual),
+        ) from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="reconciliation_complete",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="reconciliation",
+        entity_id=recon.id,
+        after={"affected_transaction_count": result.affected_transaction_count},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "reconciliation.completed",
+        reconciliation_id=str(recon.id),
+        affected=result.affected_transaction_count,
+    )
+    refreshed = repo.get(recon.id)
+    assert refreshed is not None  # noqa: S101 — just completed
+    return CompleteResponse(
+        reconciliation_id=refreshed.id,
+        status=refreshed.status.value,
+        completed_at=refreshed.completed_at,  # type: ignore[arg-type]
+        affected_transaction_count=result.affected_transaction_count,
+    )

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -79,6 +79,27 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
     },
     "StatementLineExcludedError": {"line_id": "<statement-line-uuid>"},
     "ImportCategorizeUnknownAccountError": {"account_code": "Imbalance:Unknown"},
+    "ReconciliationMatchesExistError": {
+        "reconciliation_id": "<reconciliation-uuid>",
+        "existing_match_count": 7,
+    },
+    "ReconciliationUnbalancedError": {
+        "reconciliation_id": "<reconciliation-uuid>",
+        "expected_net": "-450.00",
+        "matched_net": "-300.00",
+        "residual": "-150.00",
+    },
+    "ReconciliationInvalidStateError": {"current_status": "complete", "action": "complete"},
+    "ReconciliationAccountAlreadyInProgressError": {
+        "account_id": "<account-uuid>",
+        "existing_reconciliation_id": "<reconciliation-uuid>",
+    },
+    "ReconciliationCurrencyMismatchError": {
+        "reconciliation_currency": "USD",
+        "source_currency": "EUR",
+        "source": "import_batch",
+    },
+    # ReconciliationCascadeRequiredError takes no args.
     "RequestPayloadTooLargeError": {"max_bytes": 26214400},
     "UnsupportedMediaTypeError": {
         "accepted": ("application/x-ofx", "application/octet-stream", "text/xml"),

--- a/packages/tulip-api/src/tulip_api/schemas/reconciliation.py
+++ b/packages/tulip-api/src/tulip_api/schemas/reconciliation.py
@@ -1,0 +1,120 @@
+"""Reconciliation API schemas (P5.4.b).
+
+Pydantic models for the reconciliation envelope + auto-match endpoints.
+The reconciliation flow is: open envelope -> POST /auto-match runs the
+matcher and persists candidate match rows -> user reviews + rejects
+unwanted matches (and in P5.4.c adds manual ones) -> POST /complete
+denormalises ``reconciled_at`` onto matched transactions.
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ReconciliationCreate(BaseModel):
+    """Request body for ``POST /v1/reconciliations``."""
+
+    account_id: UUID
+    statement_period_start: date_type
+    statement_period_end: date_type
+    statement_starting_balance: Decimal
+    statement_ending_balance: Decimal
+    currency: str = Field(min_length=3, max_length=3)
+    source_import_batch_id: UUID = Field(
+        description=(
+            "The import batch whose statement lines this reconciliation will "
+            "match against. P5.4.b requires one batch per reconciliation; "
+            "multi-batch reconciliations are out of scope."
+        ),
+    )
+
+
+class ReconciliationRead(BaseModel):
+    """One reconciliation envelope."""
+
+    id: UUID
+    account_id: UUID
+    statement_period_start: date_type
+    statement_period_end: date_type
+    statement_starting_balance: Decimal
+    statement_ending_balance: Decimal
+    currency: str
+    status: str
+    source_import_batch_id: UUID | None
+    created_at: datetime
+    completed_at: datetime | None
+
+
+class MatchRead(BaseModel):
+    """One reconciliation match row."""
+
+    id: UUID
+    reconciliation_id: UUID
+    statement_line_id: UUID
+    ledger_transaction_id: UUID
+    match_amount: Decimal
+    currency: str
+    confidence: str | None = Field(
+        description="HIGH/MEDIUM/LOW for matcher-produced; null for manual matches."
+    )
+    matcher_version: str | None
+    created_by_user_id: UUID | None
+    created_at: datetime
+
+
+class StatementLineInbox(BaseModel):
+    """A statement line not yet matched in this reconciliation."""
+
+    id: UUID
+    line_number: int
+    posted_date: date_type
+    amount: Decimal
+    currency: str
+    description: str
+    counterparty: str | None
+    reference: str | None
+    fitid: str | None
+
+
+class LedgerTransactionInbox(BaseModel):
+    """A ledger transaction in the reconciliation's window not yet matched."""
+
+    id: UUID
+    date: date_type
+    description: str
+    reference: str | None
+    status: str
+
+
+class ReconciliationInboxResponse(BaseModel):
+    """Response for ``GET /v1/reconciliations/{id}`` — envelope + review pane."""
+
+    reconciliation: ReconciliationRead
+    matches: list[MatchRead]
+    unmatched_statement_lines: list[StatementLineInbox]
+    unmatched_ledger_transactions: list[LedgerTransactionInbox]
+
+
+class AutoMatchResponse(BaseModel):
+    """Response for ``POST /v1/reconciliations/{id}/auto-match``."""
+
+    reconciliation_id: UUID
+    matches_created: int
+    candidate_summary: dict[str, int] = Field(
+        description="Per-confidence counts: {'high': N, 'medium': N, 'low': N}."
+    )
+
+
+class CompleteResponse(BaseModel):
+    """Response for ``POST /v1/reconciliations/{id}/complete``."""
+
+    reconciliation_id: UUID
+    status: str
+    completed_at: datetime
+    affected_transaction_count: int

--- a/packages/tulip-api/src/tulip_api/services/reconciliation_match.py
+++ b/packages/tulip-api/src/tulip_api/services/reconciliation_match.py
@@ -1,0 +1,334 @@
+"""Auto-match + complete service for the reconciliation envelope (P5.4.b).
+
+Per ADR-0004 §Q1-Q2 and §Q7, the reconciliation flow is:
+
+1. ``POST /v1/reconciliations`` opens an envelope (status IN_PROGRESS) tied
+   to one ``import_batch`` for one ``account``.
+2. ``POST /v1/reconciliations/{id}/auto-match`` runs the P5.3 matcher over
+   the statement lines + the ledger transactions in the period, persists
+   the candidate match rows. Re-running is rejected (locked decision).
+3. User reviews + rejects unwanted matches via
+   ``POST /v1/reconciliations/{id}/matches/{match_id}/reject``.
+4. ``POST /v1/reconciliations/{id}/complete`` validates strict balance
+   and, on success, hands off to ``ReconciliationRepository.complete()``
+   which denormalises ``reconciled_at`` onto every matched transaction.
+
+The service module deliberately does not commit; the API router wraps a
+single ``commit()`` around the audit-log row + the persisted matches so
+mid-flight failures roll back atomically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+from tulip_core.money import Money
+from tulip_core.reconciliation.match_confidence import (
+    MatchConfidence as DomainMatchConfidence,
+)
+from tulip_core.reconciliation.matcher import find_candidates
+from tulip_core.reconciliation.statement_line import (
+    StatementLine as DomainStatementLine,
+)
+from tulip_core.transactions import (
+    Posting as DomainPosting,
+)
+from tulip_core.transactions import (
+    Transaction as DomainTransaction,
+)
+from tulip_core.transactions import (
+    TransactionStatus as DomainTxStatus,
+)
+from tulip_storage.models import (
+    MatchConfidence as StorageMatchConfidence,
+)
+from tulip_storage.models import (
+    ReconciliationStatus,
+    TransactionStatus,
+)
+from tulip_storage.repositories import (
+    ImportBatchRepository,
+    ReconciliationMatchRepository,
+    ReconciliationRepository,
+    StatementLineRepository,
+    TransactionRepository,
+)
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.orm import Session
+
+    from tulip_storage.models import Posting, Reconciliation, Transaction
+
+
+_MATCHER_VERSION = "v1"
+
+_DOMAIN_TO_STORAGE_STATUS: dict[DomainTxStatus, TransactionStatus] = {
+    DomainTxStatus.PENDING: TransactionStatus.PENDING,
+    DomainTxStatus.POSTED: TransactionStatus.POSTED,
+    DomainTxStatus.RECONCILED: TransactionStatus.RECONCILED,
+}
+
+_STORAGE_TO_DOMAIN_STATUS: dict[TransactionStatus, DomainTxStatus] = {
+    v: k for k, v in _DOMAIN_TO_STORAGE_STATUS.items()
+}
+
+_DOMAIN_TO_STORAGE_CONFIDENCE: dict[DomainMatchConfidence, StorageMatchConfidence] = {
+    DomainMatchConfidence.HIGH: StorageMatchConfidence.HIGH,
+    DomainMatchConfidence.MEDIUM: StorageMatchConfidence.MEDIUM,
+    DomainMatchConfidence.LOW: StorageMatchConfidence.LOW,
+}
+
+
+class AutoMatchAlreadyRunError(ValueError):
+    """Raised when auto_match is called on a reconciliation that already has matches."""
+
+    def __init__(self, existing_match_count: int) -> None:
+        """Build with the existing-match count for the typed error response."""
+        super().__init__(
+            f"reconciliation already has {existing_match_count} match(es); "
+            "re-running auto-match would create duplicates"
+        )
+        self.existing_match_count = existing_match_count
+
+
+class AutoMatchInvalidStateError(ValueError):
+    """Raised when auto_match is called on a non-IN_PROGRESS reconciliation."""
+
+    def __init__(self, current_status: ReconciliationStatus) -> None:
+        """Build with the current status for the typed error response."""
+        super().__init__(
+            f"reconciliation is {current_status.value}; "
+            "only IN_PROGRESS reconciliations accept auto-match"
+        )
+        self.current_status = current_status.value
+
+
+class CompleteUnbalancedError(ValueError):
+    """Raised when /complete is called but matched amount != ending - starting."""
+
+    def __init__(self, *, expected_net: Decimal, matched_net: Decimal, residual: Decimal) -> None:
+        """Build with the imbalance figures for the typed error response."""
+        super().__init__(
+            f"reconciliation does not balance: expected_net={expected_net}, "
+            f"matched_net={matched_net}, residual={residual}"
+        )
+        self.expected_net = expected_net
+        self.matched_net = matched_net
+        self.residual = residual
+
+
+class CompleteInvalidStateError(ValueError):
+    """Raised when /complete is called on a non-IN_PROGRESS reconciliation."""
+
+    def __init__(self, current_status: ReconciliationStatus) -> None:
+        """Build with the current status for the typed error response."""
+        super().__init__(
+            f"reconciliation is {current_status.value}; "
+            "only IN_PROGRESS reconciliations may be completed"
+        )
+        self.current_status = current_status.value
+
+
+@dataclass(frozen=True, slots=True)
+class AutoMatchResult:
+    """Summary of a successful ``auto_match`` call."""
+
+    matches_created: int
+    high_count: int
+    medium_count: int
+    low_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class CompleteResult:
+    """Summary of a successful ``complete`` call."""
+
+    affected_transaction_count: int
+
+
+def _line_to_domain(line: object) -> DomainStatementLine:
+    """Adapt a storage StatementLine to the domain value object the matcher expects."""
+    return DomainStatementLine(
+        id=line.id,  # type: ignore[attr-defined]
+        import_batch_id=line.import_batch_id,  # type: ignore[attr-defined]
+        line_number=line.line_number,  # type: ignore[attr-defined]
+        posted_date=line.posted_date,  # type: ignore[attr-defined]
+        amount=Money(line.amount, line.currency),  # type: ignore[attr-defined]
+        description=line.description,  # type: ignore[attr-defined]
+        raw=MappingProxyType({}),
+        counterparty=line.counterparty,  # type: ignore[attr-defined]
+        reference=line.reference,  # type: ignore[attr-defined]
+        fitid=line.fitid,  # type: ignore[attr-defined]
+    )
+
+
+def _tx_to_domain(tx: Transaction, postings: list[Posting]) -> DomainTransaction:
+    """Adapt a storage Transaction + its postings to a domain Transaction.
+
+    The matcher iterates ``tx.postings`` looking for the bank-side posting,
+    so postings must accompany the header. PENDING transactions are
+    upcast to a "posted-shape" only when balanced; the matcher's own
+    status filter (``POSTED``/``RECONCILED``) excludes PENDING from
+    eligibility, so we rely on that rather than re-validating here.
+    """
+    domain_postings = tuple(
+        DomainPosting(
+            id=p.id,
+            account_id=p.account_id,
+            amount=Money(p.amount, p.currency),
+            pool_id=p.pool_id,
+        )
+        for p in postings
+    )
+    return DomainTransaction(
+        id=tx.id,
+        household_id=tx.household_id,
+        date=tx.date,
+        description=tx.description,
+        reference=tx.reference,
+        postings=domain_postings,
+        status=_STORAGE_TO_DOMAIN_STATUS[tx.status],
+    )
+
+
+async def auto_match(
+    *,
+    session: Session,
+    household_id: UUID,
+    reconciliation: Reconciliation,
+    actor_user_id: UUID | None,
+) -> AutoMatchResult:
+    """Run the P5.3 matcher over the reconciliation's batch + ledger txs.
+
+    Persists every emitted ``CandidateMatch`` as a ``reconciliation_matches``
+    row with confidence + ``matcher_version="v1"``.
+
+    Raises:
+        AutoMatchInvalidStateError: ``reconciliation.status`` is not IN_PROGRESS.
+        AutoMatchAlreadyRunError: this reconciliation already has matches.
+
+    """
+    if reconciliation.status is not ReconciliationStatus.IN_PROGRESS:
+        raise AutoMatchInvalidStateError(reconciliation.status)
+
+    match_repo = ReconciliationMatchRepository(session, household_id)
+    existing = match_repo.list_for_reconciliation(reconciliation.id)
+    if existing:
+        raise AutoMatchAlreadyRunError(existing_match_count=len(existing))
+
+    # Statement lines from the source batch (non-excluded only — the matcher
+    # has no view of is_excluded; if we passed them, an excluded line could
+    # match by accident and the user would have to re-reject).
+    lines_repo = StatementLineRepository(session, household_id)
+    raw_lines = lines_repo.list_for_batch(reconciliation.source_import_batch_id)  # type: ignore[arg-type]
+    eligible_lines = [line for line in raw_lines if not line.is_excluded]
+    domain_lines = [_line_to_domain(line) for line in eligible_lines]
+
+    # Ledger transactions in the statement window for the account.
+    tx_repo = TransactionRepository(session, household_id)
+    headers = tx_repo.list_headers(
+        account_id=reconciliation.account_id,
+        from_date=reconciliation.statement_period_start,
+        to_date=reconciliation.statement_period_end,
+        status=TransactionStatus.POSTED,
+    )
+    domain_txs: list[DomainTransaction] = []
+    for header in headers:
+        postings = tx_repo.list_postings(header.id)
+        domain_txs.append(_tx_to_domain(header, postings))
+
+    # Already-reconciled set: any tx in this household with a non-NULL
+    # reconciliation_id (set only by ReconciliationRepository.complete()).
+    # The matcher's date-window pre-filter limits the set we need to check.
+    reconciled_ids = frozenset(h.id for h in headers if h.reconciliation_id is not None)
+
+    candidates = find_candidates(
+        domain_lines,
+        domain_txs,
+        account_id=reconciliation.account_id,
+        reconciled_transaction_ids=reconciled_ids,
+    )
+
+    high = medium = low = 0
+    for candidate in candidates:
+        match_repo.create(
+            reconciliation_id=reconciliation.id,
+            statement_line_id=candidate.statement_line_id,
+            ledger_transaction_id=candidate.ledger_transaction_id,
+            match_amount=candidate.match_amount.amount,
+            currency=candidate.match_amount.currency,
+            confidence=_DOMAIN_TO_STORAGE_CONFIDENCE[candidate.confidence],
+            matcher_version=_MATCHER_VERSION,
+            created_by_user_id=None,  # matcher-produced — null per ADR §Q9
+        )
+        if candidate.confidence is DomainMatchConfidence.HIGH:
+            high += 1
+        elif candidate.confidence is DomainMatchConfidence.MEDIUM:
+            medium += 1
+        else:
+            low += 1
+
+    del actor_user_id  # currently unused — auto-match rows have null user
+    return AutoMatchResult(
+        matches_created=len(candidates),
+        high_count=high,
+        medium_count=medium,
+        low_count=low,
+    )
+
+
+def complete(
+    *,
+    session: Session,
+    household_id: UUID,
+    reconciliation: Reconciliation,
+) -> CompleteResult:
+    """Validate strict balance, then hand off to the storage chokepoint.
+
+    Per the locked decision: ``sum(match.match_amount) == ending - starting``.
+    Excluded lines + carry-forward (P5.4.c) reduce the expected net but
+    are out of scope for P5.4.b — if the user has excluded any lines, the
+    balance check will likely fail and they must un-exclude.
+
+    Raises:
+        CompleteInvalidStateError: ``reconciliation.status`` is not IN_PROGRESS.
+        CompleteUnbalancedError: matched net != expected net.
+
+    """
+    if reconciliation.status is not ReconciliationStatus.IN_PROGRESS:
+        raise CompleteInvalidStateError(reconciliation.status)
+
+    match_repo = ReconciliationMatchRepository(session, household_id)
+    matches = match_repo.list_for_reconciliation(reconciliation.id)
+    matched_net = sum((m.match_amount for m in matches), Decimal("0"))
+    expected_net = (
+        reconciliation.statement_ending_balance - reconciliation.statement_starting_balance
+    )
+    residual = expected_net - matched_net
+    if residual != 0:
+        raise CompleteUnbalancedError(
+            expected_net=expected_net,
+            matched_net=matched_net,
+            residual=residual,
+        )
+
+    ReconciliationRepository(session, household_id).complete(reconciliation.id)
+    return CompleteResult(affected_transaction_count=len(matches))
+
+
+def _account_currency_for_batch(*, session: Session, household_id: UUID, batch_id: UUID) -> str:
+    """Look up the account currency on an import batch (used for create-time validation)."""
+    batch = ImportBatchRepository(session, household_id).get(batch_id)
+    if batch is None:
+        raise LookupError(f"import_batch {batch_id} not found in household {household_id}")
+    from tulip_storage.repositories import AccountRepository
+
+    account = AccountRepository(session, household_id).get(batch.account_id)
+    if account is None:  # pragma: no cover — FK-enforced
+        raise LookupError(f"account {batch.account_id} not found")
+    return account.currency

--- a/packages/tulip-api/tests/services/test_reconciliation_match.py
+++ b/packages/tulip-api/tests/services/test_reconciliation_match.py
@@ -1,0 +1,319 @@
+"""Service-level tests for the reconciliation auto-match + complete flow (P5.4.b)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from tulip_api.services.reconciliation_match import (
+    AutoMatchAlreadyRunError,
+    AutoMatchInvalidStateError,
+    CompleteInvalidStateError,
+    CompleteUnbalancedError,
+    auto_match,
+    complete,
+)
+from tulip_core.money import Money
+from tulip_core.transactions import (
+    Posting as DomainPosting,
+)
+from tulip_core.transactions import (
+    Transaction as DomainTransaction,
+)
+from tulip_core.transactions import (
+    TransactionStatus as DomainTxStatus,
+)
+from tulip_storage.models import (
+    AccountType,
+    Household,
+    ImportBatch,
+    ImportBatchStatus,
+    Reconciliation,
+    ReconciliationStatus,
+    SourceFormat,
+    StatementLine,
+)
+from tulip_storage.repositories import (
+    AccountRepository,
+    PeriodRepository,
+    ReconciliationMatchRepository,
+    ReconciliationRepository,
+    TransactionRepository,
+)
+
+# ---- fixtures -------------------------------------------------------------
+
+
+@pytest.fixture
+def setup(session_maker):
+    """Seed: household, period, checking account, import batch, 2 lines, 2 ledger txs.
+
+    Lines:
+      L1: -12.50 USD on 2026-05-12, "Coffee"
+      L2: -100.00 USD on 2026-05-15, "Groceries"
+    Ledger txs (POSTED, account = checking):
+      TX1: -12.50 USD on 2026-05-12, "Coffee Shop"
+      TX2: -100.00 USD on 2026-05-15, "Whole Foods"
+    Reconciliation envelope:
+      Period 2026-05-01..2026-05-31, ending balance -112.50
+      source_import_batch_id set
+    """
+    with session_maker() as s:
+        h = Household(id=uuid4(), name="Smith", base_currency="USD")
+        s.add(h)
+        s.flush()
+        PeriodRepository(s, h.id).create(start_date=date(2026, 1, 1), end_date=date(2026, 12, 31))
+        accounts = AccountRepository(s, h.id)
+        cash = accounts.create(code="1110", name="Checking", type=AccountType.ASSET, currency="USD")
+        food = accounts.create(code="5100", name="Food", type=AccountType.EXPENSE, currency="USD")
+
+        # Attachment + import batch (raw SQL — service test scope).
+        att_id = uuid4()
+        s.execute(
+            text(
+                "INSERT INTO attachments (household_id, id, filename, "
+                "content_type, size_bytes, content_hash, storage_uri, "
+                "uploaded_at) VALUES (:h, :i, 'x.ofx', 'application/x-ofx', "
+                "1, :hash, 's3://x', :now)"
+            ),
+            {
+                "h": str(h.id),
+                "i": str(att_id),
+                "hash": "x" * 64,
+                "now": datetime.now(UTC).isoformat(),
+            },
+        )
+        batch = ImportBatch(
+            household_id=h.id,
+            id=uuid4(),
+            account_id=cash.id,
+            source_format=SourceFormat.OFX,
+            source_filename="x.ofx",
+            source_file_attachment_id=att_id,
+            status=ImportBatchStatus.PARSED,
+            imported_count=2,
+            skipped_count=0,
+            error_count=0,
+            summary_json={},
+            created_at=datetime.now(UTC),
+        )
+        s.add(batch)
+        s.flush()
+
+        line_ids: list[UUID] = []
+        for i, (amt, desc, day) in enumerate(
+            [
+                (Decimal("-12.50"), "Coffee", 12),
+                (Decimal("-100.00"), "Groceries", 15),
+            ],
+            start=1,
+        ):
+            line = StatementLine(
+                household_id=h.id,
+                id=uuid4(),
+                import_batch_id=batch.id,
+                line_number=i,
+                posted_date=date(2026, 5, day),
+                amount=amt,
+                currency="USD",
+                description=desc,
+                raw_json="{}",
+            )
+            s.add(line)
+            line_ids.append(line.id)
+
+        # Ledger transactions: matching descriptions tilted slightly so
+        # fuzzy_score lands in MEDIUM bucket (same date + lower fuzzy =>
+        # MEDIUM per ADR §Q2).
+        tx_repo = TransactionRepository(s, h.id)
+        tx_ids: list[UUID] = []
+        for amt, desc, day in [
+            (Decimal("-12.50"), "Coffee Shop", 12),
+            (Decimal("-100.00"), "Whole Foods", 15),
+        ]:
+            tx = tx_repo.save_balanced(
+                DomainTransaction(
+                    id=uuid4(),
+                    household_id=h.id,
+                    date=date(2026, 5, day),
+                    description=desc,
+                    postings=(
+                        DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(amt, "USD")),
+                        DomainPosting(
+                            id=uuid4(),
+                            account_id=food.id,
+                            amount=Money(-amt, "USD"),
+                        ),
+                    ),
+                    status=DomainTxStatus.POSTED,
+                )
+            )
+            tx_ids.append(tx.id)
+
+        recon = ReconciliationRepository(s, h.id).create(
+            account_id=cash.id,
+            statement_period_start=date(2026, 5, 1),
+            statement_period_end=date(2026, 5, 31),
+            statement_starting_balance=Decimal("0"),
+            statement_ending_balance=Decimal("-112.50"),
+            currency="USD",
+            source_import_batch_id=batch.id,
+        )
+        s.commit()
+
+        yield {
+            "household_id": h.id,
+            "cash_id": cash.id,
+            "batch_id": batch.id,
+            "line_ids": line_ids,
+            "tx_ids": tx_ids,
+            "recon_id": recon.id,
+        }
+
+
+def _reload(s: Session, model_cls, household_id: UUID, obj_id: UUID):
+    return s.get(model_cls, (household_id, obj_id))
+
+
+# ---- auto_match -----------------------------------------------------------
+
+
+class TestAutoMatch:
+    @pytest.mark.asyncio
+    async def test_creates_match_per_candidate_with_matcher_version(self, session_maker, setup):
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            result = await auto_match(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                actor_user_id=uuid4(),
+            )
+            s.commit()
+            assert result.matches_created == 2
+            # Both same-date with non-empty fuzzy >= 0.6 — MEDIUM bucket
+            # (token_set_ratio "Coffee" vs "Coffee Shop" ≈ 1.0 -> HIGH;
+            # "Groceries" vs "Whole Foods" ≈ low -> MEDIUM under same-date).
+            # Either way, total counts == 2.
+            assert result.high_count + result.medium_count + result.low_count == 2
+
+            matches = ReconciliationMatchRepository(
+                s, setup["household_id"]
+            ).list_for_reconciliation(recon.id)
+            assert len(matches) == 2
+            assert all(m.matcher_version == "v1" for m in matches)
+            assert all(m.created_by_user_id is None for m in matches)
+            assert all(m.confidence is not None for m in matches)
+
+    @pytest.mark.asyncio
+    async def test_already_run_raises(self, session_maker, setup):
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            await auto_match(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                actor_user_id=None,
+            )
+            s.commit()
+            recon2 = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            with pytest.raises(AutoMatchAlreadyRunError) as exc:
+                await auto_match(
+                    session=s,
+                    household_id=setup["household_id"],
+                    reconciliation=recon2,
+                    actor_user_id=None,
+                )
+            assert exc.value.existing_match_count == 2
+
+    @pytest.mark.asyncio
+    async def test_completed_state_raises(self, session_maker, setup):
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            recon.status = ReconciliationStatus.COMPLETE
+            s.commit()
+            recon2 = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            with pytest.raises(AutoMatchInvalidStateError):
+                await auto_match(
+                    session=s,
+                    household_id=setup["household_id"],
+                    reconciliation=recon2,
+                    actor_user_id=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_excluded_lines_skipped(self, session_maker, setup):
+        with session_maker() as s:
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            line.is_excluded = True
+            s.commit()
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            result = await auto_match(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                actor_user_id=None,
+            )
+            s.commit()
+            # Only 1 line eligible -> at most 1 match.
+            assert result.matches_created == 1
+
+
+# ---- complete -------------------------------------------------------------
+
+
+class TestComplete:
+    @pytest.mark.asyncio
+    async def test_balanced_completes(self, session_maker, setup):
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            await auto_match(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                actor_user_id=None,
+            )
+            s.commit()
+            recon2 = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            result = complete(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon2,
+            )
+            s.commit()
+            assert result.affected_transaction_count == 2
+            reloaded = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            assert reloaded.status is ReconciliationStatus.COMPLETE
+            assert reloaded.completed_at is not None
+
+    def test_unbalanced_raises_with_residual(self, session_maker, setup):
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            # No matches yet — matched_net == 0; expected_net = -112.50.
+            with pytest.raises(CompleteUnbalancedError) as exc:
+                complete(
+                    session=s,
+                    household_id=setup["household_id"],
+                    reconciliation=recon,
+                )
+            assert exc.value.expected_net == Decimal("-112.50")
+            assert exc.value.matched_net == Decimal("0")
+            assert exc.value.residual == Decimal("-112.50")
+
+    def test_completed_state_raises(self, session_maker, setup):
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            recon.status = ReconciliationStatus.COMPLETE
+            s.commit()
+            recon2 = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            with pytest.raises(CompleteInvalidStateError):
+                complete(
+                    session=s,
+                    household_id=setup["household_id"],
+                    reconciliation=recon2,
+                )

--- a/packages/tulip-api/tests/test_reconciliations_endpoint.py
+++ b/packages/tulip-api/tests/test_reconciliations_endpoint.py
@@ -1,0 +1,529 @@
+"""Tests for /v1/reconciliations endpoints (P5.4.b)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+_OFX_FIXTURES = (
+    Path(__file__).resolve().parents[2] / "tulip-importers" / "tests" / "fixtures" / "ofx"
+)
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r.json()["access_token"]
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+@pytest.fixture
+def checking_account(client: TestClient, auth_h: dict[str, str]) -> str:
+    r = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Checking", "type": "asset", "currency": "USD", "code": "1110"},
+    )
+    return r.json()["id"]
+
+
+@pytest.fixture
+def expense_account(client: TestClient, auth_h: dict[str, str]) -> str:
+    r = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Misc Expense", "type": "expense", "currency": "USD", "code": "5100"},
+    )
+    return r.json()["id"]
+
+
+@pytest.fixture
+def parsed_batch(client: TestClient, auth_h: dict[str, str], checking_account: str) -> str:
+    """Upload an OFX batch (lines: -42.17 on 2026-05-12, +1500.00 on 2026-05-15; net 1457.83)."""
+    body = (_OFX_FIXTURES / "minimal_ofx2.ofx").read_bytes()
+    r = client.post(
+        "/v1/imports",
+        headers=auth_h,
+        files={"file": ("x.ofx", body, "application/x-ofx")},
+        data={"account_id": checking_account, "source_format": "ofx"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _post_tx(
+    client: TestClient,
+    auth_h: dict[str, str],
+    *,
+    checking_id: str,
+    other_id: str,
+    amount: str,
+    description: str,
+    posted_date: str,
+) -> dict:
+    """POST a balanced transaction; returns the response body."""
+    from decimal import Decimal
+
+    neg = str(-Decimal(amount))
+    r = client.post(
+        "/v1/transactions",
+        headers=auth_h,
+        json={
+            "date": posted_date,
+            "description": description,
+            "postings": [
+                {"account_id": checking_id, "amount": amount, "currency": "USD"},
+                {"account_id": other_id, "amount": neg, "currency": "USD"},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+@pytest.fixture
+def matching_ledger_txs(
+    client: TestClient,
+    auth_h: dict[str, str],
+    checking_account: str,
+    expense_account: str,
+) -> list[str]:
+    """Two POSTED ledger txs that match the OFX lines (-42.17 5/12, +1500.00 5/15)."""
+    a = _post_tx(
+        client,
+        auth_h,
+        checking_id=checking_account,
+        other_id=expense_account,
+        amount="-42.17",
+        description="PAYPAL",
+        posted_date="2026-05-12",
+    )
+    b = _post_tx(
+        client,
+        auth_h,
+        checking_id=checking_account,
+        other_id=expense_account,
+        amount="1500.00",
+        description="PAYROLL",
+        posted_date="2026-05-15",
+    )
+    return [a["id"], b["id"]]
+
+
+def _create_recon(
+    client: TestClient,
+    auth_h: dict[str, str],
+    *,
+    account_id: str,
+    batch_id: str,
+    starting: str = "0.00",
+    ending: str = "1457.83",
+) -> dict[str, str]:
+    """Open a reconciliation envelope."""
+    r = client.post(
+        "/v1/reconciliations",
+        headers=auth_h,
+        json={
+            "account_id": account_id,
+            "statement_period_start": "2026-05-01",
+            "statement_period_end": "2026-05-31",
+            "statement_starting_balance": starting,
+            "statement_ending_balance": ending,
+            "currency": "USD",
+            "source_import_batch_id": batch_id,
+        },
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+# ---- POST /v1/reconciliations --------------------------------------------
+
+
+class TestCreateReconciliation:
+    def test_creates_envelope_in_progress(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+    ):
+        body = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+        )
+        assert body["status"] == "in_progress"
+        assert body["account_id"] == checking_account
+        assert body["source_import_batch_id"] == parsed_batch
+
+    def test_unknown_account_returns_404(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        parsed_batch: str,
+    ):
+        r = client.post(
+            "/v1/reconciliations",
+            headers=auth_h,
+            json={
+                "account_id": str(uuid4()),
+                "statement_period_start": "2026-05-01",
+                "statement_period_end": "2026-05-31",
+                "statement_starting_balance": "0.00",
+                "statement_ending_balance": "0.00",
+                "currency": "USD",
+                "source_import_batch_id": parsed_batch,
+            },
+        )
+        assert_problem(r, status=404, code="account.not_found")
+
+    def test_unknown_batch_returns_404(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+    ):
+        r = client.post(
+            "/v1/reconciliations",
+            headers=auth_h,
+            json={
+                "account_id": checking_account,
+                "statement_period_start": "2026-05-01",
+                "statement_period_end": "2026-05-31",
+                "statement_starting_balance": "0.00",
+                "statement_ending_balance": "0.00",
+                "currency": "USD",
+                "source_import_batch_id": str(uuid4()),
+            },
+        )
+        assert_problem(r, status=404, code="import_batch.not_found")
+
+    def test_currency_mismatch_returns_400(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+    ):
+        r = client.post(
+            "/v1/reconciliations",
+            headers=auth_h,
+            json={
+                "account_id": checking_account,
+                "statement_period_start": "2026-05-01",
+                "statement_period_end": "2026-05-31",
+                "statement_starting_balance": "0.00",
+                "statement_ending_balance": "0.00",
+                "currency": "EUR",
+                "source_import_batch_id": parsed_batch,
+            },
+        )
+        assert_problem(r, status=400, code="reconciliation.currency_mismatch")
+
+    def test_second_in_progress_for_same_account_returns_409(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+    ):
+        _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+        )
+        r = client.post(
+            "/v1/reconciliations",
+            headers=auth_h,
+            json={
+                "account_id": checking_account,
+                "statement_period_start": "2026-06-01",
+                "statement_period_end": "2026-06-30",
+                "statement_starting_balance": "0.00",
+                "statement_ending_balance": "0.00",
+                "currency": "USD",
+                "source_import_batch_id": parsed_batch,
+            },
+        )
+        assert_problem(r, status=409, code="reconciliation.account_already_in_progress")
+
+
+# ---- GET /v1/reconciliations/{id} ----------------------------------------
+
+
+class TestGetReconciliationInbox:
+    def test_returns_envelope_plus_inbox(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+    ):
+        recon = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+        )
+        r = client.get(f"/v1/reconciliations/{recon['id']}", headers=auth_h)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["reconciliation"]["id"] == recon["id"]
+        assert body["matches"] == []
+        # Both lines from the batch are unmatched.
+        assert len(body["unmatched_statement_lines"]) == 2
+        assert body["unmatched_ledger_transactions"] == []  # no ledger txs yet
+
+    def test_unknown_returns_404(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.get(f"/v1/reconciliations/{uuid4()}", headers=auth_h)
+        assert_problem(r, status=404, code="reconciliation.not_found")
+
+
+# ---- POST /v1/reconciliations/{id}/auto-match ----------------------------
+
+
+class TestAutoMatchEndpoint:
+    def test_runs_matcher_and_persists(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+    ):
+        recon = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+        )
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/auto-match",
+            headers=auth_h,
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        # No ledger txs in the period yet, so matcher emits 0 candidates.
+        assert body["matches_created"] == 0
+        assert body["candidate_summary"] == {"high": 0, "medium": 0, "low": 0}
+
+    def test_re_run_returns_409(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        recon = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+        )
+        first = client.post(
+            f"/v1/reconciliations/{recon['id']}/auto-match",
+            headers=auth_h,
+        )
+        assert first.json()["matches_created"] >= 1, first.text
+        second = client.post(
+            f"/v1/reconciliations/{recon['id']}/auto-match",
+            headers=auth_h,
+        )
+        assert_problem(second, status=409, code="reconciliation.matches_exist")
+
+
+# ---- POST /v1/reconciliations/{id}/matches/{match_id}/reject -------------
+
+
+class TestRejectMatch:
+    def test_rejects_and_returns_to_unmatched(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        recon = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+        )
+        client.post(
+            f"/v1/reconciliations/{recon['id']}/auto-match",
+            headers=auth_h,
+        )
+        inbox = client.get(f"/v1/reconciliations/{recon['id']}", headers=auth_h).json()
+        assert len(inbox["matches"]) >= 1
+        match_id = inbox["matches"][0]["id"]
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/matches/{match_id}/reject",
+            headers=auth_h,
+        )
+        assert r.status_code == 204
+        # Match gone, line back in unmatched pool.
+        post_inbox = client.get(f"/v1/reconciliations/{recon['id']}", headers=auth_h).json()
+        assert all(m["id"] != match_id for m in post_inbox["matches"])
+
+    def test_unknown_match_returns_404(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+    ):
+        recon = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+        )
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/matches/{uuid4()}/reject",
+            headers=auth_h,
+        )
+        assert_problem(r, status=404, code="reconciliation_match.not_found")
+
+
+# ---- POST /v1/reconciliations/{id}/complete ------------------------------
+
+
+class TestCompleteEndpoint:
+    def test_balanced_completes(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        # minimal_ofx2.ofx net: -42.17 + 1500.00 = 1457.83
+        recon = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+            starting="0.00",
+            ending="1457.83",
+        )
+        client.post(
+            f"/v1/reconciliations/{recon['id']}/auto-match",
+            headers=auth_h,
+        )
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/complete",
+            headers=auth_h,
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "complete"
+        assert body["affected_transaction_count"] >= 1
+
+    def test_unbalanced_returns_409(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+    ):
+        recon = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+            starting="0.00",
+            ending="1457.83",
+        )
+        # No matches yet -> matched_net == 0; expected_net == 2426.58.
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/complete",
+            headers=auth_h,
+        )
+        assert_problem(r, status=409, code="reconciliation.unbalanced")
+        body = r.json()
+        from decimal import Decimal
+
+        assert Decimal(body["expected_net"]) == Decimal("1457.83")
+        assert Decimal(body["matched_net"]) == Decimal("0")
+
+
+# ---- DELETE /v1/reconciliations/{id} -------------------------------------
+
+
+class TestDeleteReconciliation:
+    def test_no_cascade_returns_400(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+    ):
+        recon = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+        )
+        r = client.delete(
+            f"/v1/reconciliations/{recon['id']}",
+            headers=auth_h,
+        )
+        assert_problem(r, status=400, code="reconciliation.cascade_required")
+
+    def test_with_cascade_reverts_completed(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        recon = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+            starting="0.00",
+            ending="1457.83",
+        )
+        client.post(
+            f"/v1/reconciliations/{recon['id']}/auto-match",
+            headers=auth_h,
+        )
+        client.post(
+            f"/v1/reconciliations/{recon['id']}/complete",
+            headers=auth_h,
+        )
+        r = client.delete(
+            f"/v1/reconciliations/{recon['id']}?cascade=true",
+            headers=auth_h,
+        )
+        assert r.status_code == 204, r.text
+        # Reconciliation gone.
+        gone = client.get(f"/v1/reconciliations/{recon['id']}", headers=auth_h)
+        assert_problem(gone, status=404, code="reconciliation.not_found")

--- a/packages/tulip-storage/src/tulip_storage/repositories/reconciliation.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/reconciliation.py
@@ -13,12 +13,13 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 
 from tulip_storage.models import (
     Reconciliation,
     ReconciliationMatch,
     ReconciliationStatus,
+    StatementLine,
     Transaction,
 )
 
@@ -149,3 +150,73 @@ class ReconciliationRepository:
         recon.status = ReconciliationStatus.ABANDONED
         self._session.flush()
         return recon
+
+    def revert(self, reconciliation_id: UUID) -> None:
+        """Un-reconcile: null tx denorms, clear line pointers, delete the row.
+
+        Per ADR-0004 §Q7, ``DELETE /v1/reconciliations/{id}?cascade=true``
+        is the user-facing un-reconcile path. This is its single
+        chokepoint:
+
+        1. Null ``transactions.reconciliation_id`` + ``reconciled_at`` for
+           every transaction this reconciliation completed (so they're
+           re-matchable).
+        2. Null ``statement_lines.reconciliation_match_id`` for every line
+           in the affected matches (the FK on ``reconciliation_matches``
+           is ON DELETE CASCADE, but the line's denormalised pointer has
+           no FK and would otherwise dangle).
+        3. Delete the reconciliation row — cascades the matches.
+
+        Raises:
+            LookupError: ``reconciliation_id`` does not exist in this household.
+
+        """
+        recon = self.get(reconciliation_id)
+        if recon is None:
+            raise LookupError(
+                f"reconciliation {reconciliation_id} not found in household {self._household_id}"
+            )
+
+        # Pull all match rows so we know which lines + txs to clean up.
+        match_rows = list(
+            self._session.execute(
+                select(ReconciliationMatch).where(
+                    ReconciliationMatch.household_id == self._household_id,
+                    ReconciliationMatch.reconciliation_id == reconciliation_id,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        line_ids = [m.statement_line_id for m in match_rows]
+
+        # Clear the statement_line denormalised pointers (no FK to cascade).
+        if line_ids:
+            self._session.execute(
+                update(StatementLine)
+                .where(
+                    StatementLine.household_id == self._household_id,
+                    StatementLine.id.in_(line_ids),
+                )
+                .values(reconciliation_match_id=None)
+            )
+
+        # Null the transaction denorms — only this method (and complete())
+        # touch these columns; architecture test enforces.
+        self._session.execute(
+            update(Transaction)
+            .where(
+                Transaction.household_id == self._household_id,
+                Transaction.reconciliation_id == reconciliation_id,
+            )
+            .values(reconciliation_id=None, reconciled_at=None)
+        )
+
+        # Delete the reconciliation row — cascades reconciliation_matches.
+        self._session.execute(
+            delete(Reconciliation).where(
+                Reconciliation.household_id == self._household_id,
+                Reconciliation.id == reconciliation_id,
+            )
+        )
+        self._session.flush()

--- a/packages/tulip-storage/tests/test_architecture_no_direct_reconciled_at_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_reconciled_at_writes.py
@@ -47,6 +47,13 @@ _ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
         "tulip-storage/src/tulip_storage/models/transaction.py",
         "tulip-storage/src/tulip_storage/migrations/versions/"
         "20260505_1000_f4a6b9c2e7d3_add_imports_reconciliations.py",
+        # The reconciliation API surface (P5.4.b) reads/passes
+        # ``reconciliation_id`` as the entity identifier (path param, FK
+        # column on reconciliation_matches, audit-log entity_id, etc.) —
+        # never as a write to ``transactions.reconciliation_id``. Same
+        # collision the AST checker can't disambiguate without context.
+        "tulip-api/src/tulip_api/routers/reconciliations.py",
+        "tulip-api/src/tulip_api/services/reconciliation_match.py",
     }
 )
 

--- a/packages/tulip-storage/tests/test_p51_repositories.py
+++ b/packages/tulip-storage/tests/test_p51_repositories.py
@@ -522,6 +522,83 @@ class TestReconciliationAndMatch:
         line = StatementLineRepository(session, household.id).get(lines[0].id)
         assert line.reconciliation_match_id is None
 
+    def test_revert_nulls_tx_denorms_and_clears_line_pointers(
+        self,
+        session: Session,
+        household: Household,
+        account: Account,
+        attachment_for_recon,
+    ):
+        """revert() un-reconciles: nulls tx denorms, clears line pointers, deletes recon."""
+        batch = ImportBatchRepository(session, household.id).create(
+            account_id=account.id,
+            source_format=SourceFormat.OFX,
+            source_filename="may.ofx",
+            source_file_attachment_id=attachment_for_recon.id,
+        )
+        session.commit()
+        lines = StatementLineRepository(session, household.id).bulk_insert(
+            batch.id,
+            [
+                {
+                    "line_number": 1,
+                    "posted_date": date(2026, 5, 12),
+                    "amount": Decimal("-12.50"),
+                    "currency": "USD",
+                    "description": "LUNCH",
+                    "raw_json": "{}",
+                }
+            ],
+        )
+        session.commit()
+        tx = _seed_posted_tx(session, household.id, account)
+        recon_repo = ReconciliationRepository(session, household.id)
+        recon = recon_repo.create(
+            account_id=account.id,
+            statement_period_start=date(2026, 5, 1),
+            statement_period_end=date(2026, 5, 31),
+            statement_starting_balance=Decimal("0"),
+            statement_ending_balance=Decimal("-12.50"),
+            currency="USD",
+        )
+        ReconciliationMatchRepository(session, household.id).create(
+            reconciliation_id=recon.id,
+            statement_line_id=lines[0].id,
+            ledger_transaction_id=tx.id,
+            match_amount=Decimal("12.50"),
+            currency="USD",
+        )
+        recon_repo.complete(recon.id)
+        session.commit()
+
+        # Sanity: tx is reconciled.
+        loaded = TransactionRepository(session, household.id).get(tx.id)
+        assert loaded.reconciliation_id == recon.id
+        assert loaded.reconciled_at is not None
+
+        # Revert.
+        recon_repo.revert(recon.id)
+        session.commit()
+
+        # Tx denorms cleared.
+        loaded = TransactionRepository(session, household.id).get(tx.id)
+        assert loaded.reconciliation_id is None
+        assert loaded.reconciled_at is None
+
+        # Line pointer cleared (cascade-deleted match left a dangling pointer
+        # otherwise — revert nulls before delete).
+        line = StatementLineRepository(session, household.id).get(lines[0].id)
+        assert line.reconciliation_match_id is None
+
+        # Reconciliation row gone.
+        assert recon_repo.get(recon.id) is None
+
+    def test_revert_missing_id_raises(self, session: Session, household: Household):
+        from uuid import uuid4
+
+        with pytest.raises(LookupError):
+            ReconciliationRepository(session, household.id).revert(uuid4())
+
 
 # ---- CsvProfile ----------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Second sub-slice of P5.4: server-side reconciliation envelope CRUD + the auto-match endpoint that wires P5.3's matcher + persistence. Manual match (P5.4.c) and CLI (P5.4.d) follow.

- **`POST /v1/reconciliations`** — open an IN_PROGRESS envelope tied to one `import_batch` + `account`. Validates: account exists, batch belongs to the account, currency match, no other IN_PROGRESS reconciliation for the account (one-at-a-time invariant — locked decision; simplifies the matcher's already-reconciled detection).
- **`GET /v1/reconciliations/{id}`** — envelope + **inline review pane** (matches + unmatched statement lines + unmatched ledger transactions in the period window). One round-trip for the entire reconciliation UI per the locked decision.
- **`POST /v1/reconciliations/{id}/auto-match`** — wires `tulip_core.reconciliation.matcher.find_candidates` (P5.3) over the batch's non-excluded lines + the period's POSTED ledger txs. Persists each `CandidateMatch` with `matcher_version="v1"`, `created_by_user_id=NULL`, bucketed confidence (HIGH/MEDIUM/LOW). Re-running on a reconciliation with existing matches returns `409 reconciliation.matches_exist` per the locked decision — user rejects individual matches or DELETEs and recreates for a fresh pass.
- **`POST /v1/reconciliations/{id}/matches/{match_id}/reject`** — delete a match row, return the line + transaction to the unmatched pool.
- **`POST /v1/reconciliations/{id}/complete`** — strict balance check (`sum(match.match_amount) == ending - starting`). On pass, hands off to `ReconciliationRepository.complete()` (the **only** writer of `transactions.reconciliation_id` + `reconciled_at` per ADR §Q7, architecture-test enforced). On fail, `409 reconciliation.unbalanced` carries `expected_net`, `matched_net`, `residual` as extension fields.
- **`DELETE /v1/reconciliations/{id}?cascade=true`** — un-reconcile. Requires explicit `?cascade=true` (omitting returns `400 reconciliation.cascade_required`). New `ReconciliationRepository.revert()` method nulls `transactions.reconciliation_id` + `reconciled_at`, clears `statement_lines.reconciliation_match_id` (no FK to cascade), then deletes the reconciliation row (cascade-deletes matches via P5.1 FK).
- **Service module** `tulip_api.services.reconciliation_match` with `auto_match()` (async) + `complete()` (sync). Mirrors P5.4.a: services flush only; router wraps a single `commit()` around the audit-log row + the persisted matches so any mid-flight failure rolls back atomically.
- **Storage adapter** `_tx_to_domain` materialises a domain `Transaction` from a storage row + its posting list — the matcher operates on domain types only, but `TransactionRepository.list_headers()` returns storage rows.
- **Architecture test** `test_architecture_no_direct_reconciled_at_writes` extended to allowlist the new router + service files (same kwarg-name collision the existing `repositories/reconciliation_match.py` carve-out already documents — `reconciliation_id` is the FK column on `reconciliation_matches`, never a write to `transactions.reconciliation_id`).
- **Audit-log entries**: `reconciliation_create`, `reconciliation_revert`, `reconciliation_auto_match`, `reconciliation_match_reject`, `reconciliation_complete`.

Refs #74. P5.4.c (manual match + carry-forward) is next.

## Test plan

- [x] `uv run pytest packages/tulip-storage/tests/test_p51_repositories.py::TestReconciliationAndMatch` → 6 passing (incl. 2 new revert tests)
- [x] `uv run pytest packages/tulip-api/tests/services/test_reconciliation_match.py` → 7 passing
- [x] `uv run pytest packages/tulip-api/tests/test_reconciliations_endpoint.py` → 15 passing
- [x] `just test` → **1090 passing**, 1 skipped, 1 xfail (up from 1061 on `main`)
- [x] `just lint` → clean
- [x] `just typecheck` → clean across 170 source files
- [ ] CI green on this PR

## Manual smoke test

```bash
set -e

rm -f /tmp/tulip-smoke.db
TULIP_DATABASE_URL=sqlite:////tmp/tulip-smoke.db uv run alembic -c packages/tulip-storage/alembic.ini upgrade head
TULIP_DATABASE_URL=sqlite:////tmp/tulip-smoke.db uv run uvicorn tulip_api.main:create_app --factory --port 8000 &
API_PID=$!
sleep 2

TOKEN_DIR=$(mktemp -d)
export TULIP_TOKEN_STORE="$TOKEN_DIR/tokens.json"
uv run tulip register --email smoke@example.com --display-name Smoke --household Smoke --password-stdin <<< "smoke-password"
uv run tulip auth login --email smoke@example.com --password-stdin <<< "smoke-password"

# Seed: checking + expense, upload OFX, post 2 matching ledger txs.
uv run tulip accounts add --code 1110 --name Checking --type asset --currency USD
uv run tulip accounts add --code 5100 --name Misc --type expense --currency USD
BATCH_ID=$(uv run tulip --json import ofx packages/tulip-importers/tests/fixtures/ofx/minimal_ofx2.ofx --account 1110 | jq -r .id)
echo "Uploaded batch: $BATCH_ID"

CHECKING_ID=$(uv run tulip --json accounts list | jq -r '.[] | select(.code=="1110") | .id')
EXPENSE_ID=$(uv run tulip --json accounts list | jq -r '.[] | select(.code=="5100") | .id')
TOKEN=$(jq -r '.["http://127.0.0.1:8000"].access_token' "$TOKEN_DIR/tokens.json")

# Two POSTED ledger txs that will match.
curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  http://127.0.0.1:8000/v1/transactions \
  -d "{\"date\":\"2026-05-12\",\"description\":\"PAYPAL\",\"postings\":[{\"account_id\":\"$CHECKING_ID\",\"amount\":\"-42.17\",\"currency\":\"USD\"},{\"account_id\":\"$EXPENSE_ID\",\"amount\":\"42.17\",\"currency\":\"USD\"}]}" | jq .id
curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  http://127.0.0.1:8000/v1/transactions \
  -d "{\"date\":\"2026-05-15\",\"description\":\"PAYROLL\",\"postings\":[{\"account_id\":\"$CHECKING_ID\",\"amount\":\"1500.00\",\"currency\":\"USD\"},{\"account_id\":\"$EXPENSE_ID\",\"amount\":\"-1500.00\",\"currency\":\"USD\"}]}" | jq .id

# Open the reconciliation.
RECON_ID=$(curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  http://127.0.0.1:8000/v1/reconciliations \
  -d "{\"account_id\":\"$CHECKING_ID\",\"statement_period_start\":\"2026-05-01\",\"statement_period_end\":\"2026-05-31\",\"statement_starting_balance\":\"0.00\",\"statement_ending_balance\":\"1457.83\",\"currency\":\"USD\",\"source_import_batch_id\":\"$BATCH_ID\"}" | jq -r .id)
echo "Reconciliation: $RECON_ID"

# Auto-match.
curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
  "http://127.0.0.1:8000/v1/reconciliations/$RECON_ID/auto-match" | jq .

# Inspect the inbox.
curl -sS -H "Authorization: Bearer $TOKEN" \
  "http://127.0.0.1:8000/v1/reconciliations/$RECON_ID" | jq '{matches: (.matches|length), unmatched_lines: (.unmatched_statement_lines|length)}'

# Complete (should be balanced).
curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
  "http://127.0.0.1:8000/v1/reconciliations/$RECON_ID/complete" | jq .

# Re-running auto-match must 409.
set +e
curl -sS -o /dev/null -w "auto-match-rerun: %{http_code}\n" -X POST -H "Authorization: Bearer $TOKEN" \
  "http://127.0.0.1:8000/v1/reconciliations/$RECON_ID/auto-match"
# DELETE without ?cascade=true must 400.
curl -sS -o /dev/null -w "delete-no-cascade: %{http_code}\n" -X DELETE -H "Authorization: Bearer $TOKEN" \
  "http://127.0.0.1:8000/v1/reconciliations/$RECON_ID"
set -e

# Cleanup.
curl -sS -X DELETE -H "Authorization: Bearer $TOKEN" \
  "http://127.0.0.1:8000/v1/reconciliations/$RECON_ID?cascade=true"
kill "$API_PID"
wait 2>/dev/null
rm -rf "$TOKEN_DIR" /tmp/tulip-smoke.db
echo "smoke test passed"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)