### PR TITLE
P5.4.c — manual match + carry-forward

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-06 · `main` @ **P5.4.b in flight** (reconciliation envelope + auto-match)
+**Last updated:** 2026-05-07 · `main` @ **P5.4.c in flight** (manual match + carry-forward)
 
 ---
 
@@ -16,9 +16,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Post-Phase-3 enhancements:** balance + trial-balance endpoints (#31), account nesting end-to-end (#42), interactive `tulip add --edit` (#43)
 - **Pre-Phase-4 docs:** threat-model checkpoint shipped (#56, [docs/THREAT_MODEL.md](THREAT_MODEL.md)). Transaction void / PENDING-only edit (#55) deliberately deferred to Phase 5 alongside reconciliation. Deep security/privacy audits deliberately deferred — see [ARCHITECTURE.md §10 audit cadence](ARCHITECTURE.md) (privacy: pre-Phase 6; deep security: Phase 8; pre-cloud re-audit: Phase 9).
 - **Phase 4 (envelopes + sinking funds):** ✅ **complete** — all seven slices merged 2026-05-02. P4.0 (#60), P4.1.a (#62), P4.1.b (#63), P4.2 (#66), P4.3.a (#68 — closes #7 via [ADR-0002](adrs/0002-scheduler-primitive.md)), P4.3.b (#69), P4.3.c (#70).
-- **Phase 5 (importers + reconciliation):** in flight — P5.0 (#55), P5.1 (storage layer), P5.2.a/b/c (OFX / QIF / CSV importers), P5.3 (matcher + categorizer DI seam), P5.4.a (apply / promote endpoints + CLI), and P5.4.b (reconciliation envelope + auto-match) implemented per [ADR-0004](adrs/0004-reconciliation.md). The remaining P5.4 sub-slices land manual match + carry-forward (P5.4.c) and the `tulip reconcile` CLI (P5.4.d) — closing Phase 5.
+- **Phase 5 (importers + reconciliation):** in flight — P5.0 (#55), P5.1 (storage layer), P5.2.a/b/c (OFX / QIF / CSV importers), P5.3 (matcher + categorizer DI seam), P5.4.a (apply / promote endpoints + CLI), P5.4.b (reconciliation envelope + auto-match), and P5.4.c (manual match + carry-forward) implemented per [ADR-0004](adrs/0004-reconciliation.md). The remaining P5.4 sub-slice is **P5.4.d** (the `tulip reconcile` CLI) — closing Phase 5.
 
-**Tests:** 1090 passing · **CI:** green on `main`
+**Tests:** 1113 passing · **CI:** green on `main`
 
 ---
 
@@ -515,9 +515,26 @@ Second sub-slice of P5.4: server-side reconciliation envelope CRUD + the auto-ma
 - **Audit-log entries** — `reconciliation_create`, `reconciliation_revert`, `reconciliation_auto_match`, `reconciliation_match_reject`, `reconciliation_complete`. Each carries enough state to reconstruct the action without consulting the live row (the row may be gone post-revert).
 - **Tests**: 7 service tests + 15 router tests + 2 storage-layer tests = 24 new (1061 → 1090 passing).
 
-### P5.4.c — Manual match + carry-forward — queued
+### P5.4.c — Manual match + carry-forward — ✅ *(2026-05-07)*
 
-`POST /v1/reconciliations/{id}/matches` (manual), carry-forward CRUD endpoints. Lets the user resolve residuals that auto-match can't pick up + carry unmatched ledger transactions to the next reconciliation.
+Third sub-slice of P5.4. Lets the user resolve residuals auto-match can't pick up (manual match) and exclude in-flight ledger transactions from the current period's balance check (carry-forward — e.g., a check the bank hasn't cashed yet). The `tulip reconcile` CLI (P5.4.d) closes Phase 5.
+
+- **`POST /v1/reconciliations/{id}/matches`** — body `{statement_line_id, ledger_transaction_id, match_amount, currency}`. Persists a manual match: `created_by_user_id` set, `matcher_version=NULL`, `confidence=NULL` per ADR §Q9. Validates four invariants before insert (locked decision: cheap insurance against typo'd UUIDs):
+  - Statement line exists and belongs to the reconciliation's source batch (`400 reconciliation.line_not_in_batch` otherwise).
+  - Statement line not already matched (`409 reconciliation.line_already_matched` — locked decision: user must explicitly reject the prior match first).
+  - `match_amount == line.amount` exactly (`400 reconciliation.line_amount_mismatch` — partial-of-one matching deferred past v1 per ADR §Q3).
+  - Ledger transaction exists and has at least one posting on the reconciliation's account (`400 reconciliation.tx_account_mismatch`).
+- **`POST /v1/reconciliations/{id}/carry-forward`** — body `{transaction_ids: [UUID]}`. Marks ledger transactions as carry-forward via `transactions.carried_forward_from_reconciliation_id`. Validates each tx exists and falls within `[period_start, period_end]` — locked decision: out-of-period rejected (`400 reconciliation.tx_not_in_period`) so the user can't paper over real reconciliation problems.
+- **`DELETE /v1/reconciliations/{id}/carry-forward/{transaction_id}`** — un-mark.
+- **`/complete` balance equation updated** to `sum(matched) + sum(carry_forward) == ending - starting`. Carry-forward txs deduct from the expected net for *this* reconciliation: the bank counts them in `ending_balance`, but the user has explicitly said "this isn't mine yet" — so their bank-side posting amounts are subtracted. Carry-forward sums use a session-scoped query (no new repo method); the math is per-reconciliation and doesn't merit caching.
+- **`ReconciliationRepository.set_carry_forward(tx_id, recon_id)`** + **`clear_carry_forward(tx_id)`** — the single chokepoint for `carried_forward_from_reconciliation_id` writes (architecture-test-enforced — same module that owns `complete()` and `revert()`).
+- **`revert()` extension**: now also nulls carry-forward links pointing at the deleted reconciliation. Carry-forward is "this tx was counted in reconciliation X"; when X is reverted, that audit-trail link breaks and gets cleared. Mirrors how `transactions.reconciliation_id` is nulled in the same method.
+- **Audit-log entries**: `reconciliation_match_create_manual`, `reconciliation_carry_forward_add`, `reconciliation_carry_forward_remove`. The `_manual` suffix on the match-create action distinguishes user-driven matches from `reconciliation_auto_match` (which writes one row covering the whole batch).
+- **Tests**: 8 service tests + 7 router tests + 4 storage-layer tests + 1 inbox-shape test = ~20 new (1090 → **1113 passing**).
+
+### P5.4.d — `tulip reconcile` CLI — queued
+
+Closes Phase 5. Imperative CLI subcommands per the locked decision (no Textual TUI for v1): `tulip reconcile create`, `tulip reconcile show`, `tulip reconcile auto-match`, `tulip reconcile match`, `tulip reconcile reject`, `tulip reconcile carry-forward`, `tulip reconcile complete`, `tulip reconcile delete`. Wraps the existing endpoints; no new server-side work.
 
 ---
 

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -1295,6 +1295,142 @@ class ReconciliationAccountAlreadyInProgressError(TulipProblem):
         )
 
 
+class ReconciliationLineAlreadyMatchedError(TulipProblem):
+    """A manual match was attempted on a statement line that already has a match (P5.4.c).
+
+    Per the locked decision: manual match doesn't auto-reject prior matches.
+    The user must explicitly reject the existing match before creating a
+    new one.
+    """
+
+    def __init__(self, *, statement_line_id: str, existing_match_id: str) -> None:
+        """Build the reconciliation.line_already_matched problem (409)."""
+        super().__init__(
+            code="reconciliation.line_already_matched",
+            title="Statement line already matched",
+            status=409,
+            detail=(
+                "This statement line already has a match. Reject the existing "
+                "match first, then re-create with the corrected pairing."
+            ),
+            extensions={
+                "statement_line_id": statement_line_id,
+                "existing_match_id": existing_match_id,
+            },
+        )
+
+
+class ReconciliationLineNotInBatchError(TulipProblem):
+    """A manual match referenced a line outside the reconciliation's source batch (P5.4.c)."""
+
+    def __init__(self, *, statement_line_id: str, expected_batch_id: str) -> None:
+        """Build the reconciliation.line_not_in_batch problem (400)."""
+        super().__init__(
+            code="reconciliation.line_not_in_batch",
+            title="Statement line not in reconciliation's batch",
+            status=400,
+            detail=(
+                "The statement line belongs to a different import batch than this "
+                "reconciliation's source batch. Pick a line from the correct batch."
+            ),
+            extensions={
+                "statement_line_id": statement_line_id,
+                "expected_batch_id": expected_batch_id,
+            },
+        )
+
+
+class ReconciliationLineAmountMismatchError(TulipProblem):
+    """A manual match's match_amount disagrees with the line's amount (P5.4.c).
+
+    P5.4.c rejects partial-of-one matches per ADR §Q3 — the match_amount
+    must equal the line's amount exactly. Partial matching is deferred
+    past v1.
+    """
+
+    def __init__(self, *, statement_line_id: str, line_amount: str, match_amount: str) -> None:
+        """Build the reconciliation.line_amount_mismatch problem (400)."""
+        super().__init__(
+            code="reconciliation.line_amount_mismatch",
+            title="Match amount doesn't match the statement line's amount",
+            status=400,
+            detail=(
+                f"Statement line amount is {line_amount}, but the match was "
+                f"submitted with {match_amount}. Partial-of-one matching isn't "
+                "supported in v1; the amounts must agree exactly."
+            ),
+            extensions={
+                "statement_line_id": statement_line_id,
+                "line_amount": line_amount,
+                "match_amount": match_amount,
+            },
+        )
+
+
+class ReconciliationTxAccountMismatchError(TulipProblem):
+    """A manual match referenced a tx with no posting on the reconciliation's account (P5.4.c)."""
+
+    def __init__(self, *, ledger_transaction_id: str, expected_account_id: str) -> None:
+        """Build the reconciliation.tx_account_mismatch problem (400)."""
+        super().__init__(
+            code="reconciliation.tx_account_mismatch",
+            title="Ledger transaction has no posting on the reconciliation's account",
+            status=400,
+            detail=(
+                "Manual match requires the ledger transaction to have at least "
+                "one posting on the reconciliation's bank account. Pick a "
+                "different transaction."
+            ),
+            extensions={
+                "ledger_transaction_id": ledger_transaction_id,
+                "expected_account_id": expected_account_id,
+            },
+        )
+
+
+class ReconciliationTxNotInPeriodError(TulipProblem):
+    """A carry-forward request referenced a tx outside the reconciliation's period (P5.4.c)."""
+
+    def __init__(
+        self,
+        *,
+        ledger_transaction_id: str,
+        tx_date: str,
+        period_start: str,
+        period_end: str,
+    ) -> None:
+        """Build the reconciliation.tx_not_in_period problem (400)."""
+        super().__init__(
+            code="reconciliation.tx_not_in_period",
+            title="Transaction is outside the reconciliation's period",
+            status=400,
+            detail=(
+                f"Transaction date {tx_date} is outside the reconciliation's "
+                f"window {period_start}..{period_end}. Carry-forward is only "
+                "valid for in-period ledger transactions."
+            ),
+            extensions={
+                "ledger_transaction_id": ledger_transaction_id,
+                "tx_date": tx_date,
+                "period_start": period_start,
+                "period_end": period_end,
+            },
+        )
+
+
+class ReconciliationTxNotFoundError(TulipProblem):
+    """A carry-forward / match request referenced a missing ledger transaction (P5.4.c)."""
+
+    def __init__(self) -> None:
+        """Build the reconciliation.transaction_not_found problem (404)."""
+        super().__init__(
+            code="reconciliation.transaction_not_found",
+            title="Ledger transaction not found",
+            status=404,
+            detail="No ledger transaction with that ID exists in this household.",
+        )
+
+
 class ReconciliationCascadeRequiredError(TulipProblem):
     """DELETE /v1/reconciliations/{id} called without ``?cascade=true`` (P5.4.b).
 

--- a/packages/tulip-api/src/tulip_api/routers/reconciliations.py
+++ b/packages/tulip-api/src/tulip_api/routers/reconciliations.py
@@ -28,16 +28,26 @@ from tulip_api.errors import (
     ReconciliationAccountAlreadyInProgressError,
     ReconciliationCurrencyMismatchError,
     ReconciliationInvalidStateError,
+    ReconciliationLineAlreadyMatchedError,
+    ReconciliationLineAmountMismatchError,
+    ReconciliationLineNotInBatchError,
     ReconciliationMatchesExistError,
     ReconciliationMatchNotFoundError,
     ReconciliationNotFoundError,
+    ReconciliationTxAccountMismatchError,
+    ReconciliationTxNotFoundError,
+    ReconciliationTxNotInPeriodError,
     ReconciliationUnbalancedError,
+    StatementLineNotFoundError,
     problem_response,
 )
 from tulip_api.schemas.reconciliation import (
     AutoMatchResponse,
+    CarryForwardCreate,
+    CarryForwardResponse,
     CompleteResponse,
     LedgerTransactionInbox,
+    ManualMatchCreate,
     MatchRead,
     ReconciliationCreate,
     ReconciliationInboxResponse,
@@ -47,10 +57,21 @@ from tulip_api.schemas.reconciliation import (
 from tulip_api.services.reconciliation_match import (
     AutoMatchAlreadyRunError,
     AutoMatchInvalidStateError,
+    CarryForwardTxNotFoundError,
+    CarryForwardTxNotInPeriodError,
     CompleteInvalidStateError,
     CompleteUnbalancedError,
+    ManualMatchAmountMismatchError,
+    ManualMatchLineAlreadyMatchedError,
+    ManualMatchLineNotFoundError,
+    ManualMatchLineNotInBatchError,
+    ManualMatchTxAccountMismatchError,
+    ManualMatchTxNotFoundError,
+    add_carry_forward,
     auto_match,
     complete,
+    manual_match,
+    remove_carry_forward,
 )
 from tulip_storage.models import ReconciliationStatus
 from tulip_storage.repositories import (
@@ -511,4 +532,237 @@ def complete_endpoint(
         status=refreshed.status.value,
         completed_at=refreshed.completed_at,  # type: ignore[arg-type]
         affected_transaction_count=result.affected_transaction_count,
+    )
+
+
+@router.post(
+    "/{reconciliation_id}/matches",
+    response_model=MatchRead,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: problem_response(
+            "request.body_invalid",
+            "reconciliation.line_not_in_batch",
+            "reconciliation.line_amount_mismatch",
+            "reconciliation.tx_account_mismatch",
+        ),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response(
+            "reconciliation.not_found",
+            "import.line.not_found",
+            "reconciliation.transaction_not_found",
+        ),
+        409: problem_response(
+            "reconciliation.invalid_state",
+            "reconciliation.line_already_matched",
+        ),
+        422: problem_response("validation.failed"),
+    },
+)
+async def create_manual_match(
+    reconciliation_id: UUID,
+    body: ManualMatchCreate,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> MatchRead:
+    """Create a manual match — used when auto-match missed a pairing.
+
+    Per ADR §Q9: manual matches set ``created_by_user_id``, leave
+    ``confidence`` and ``matcher_version`` NULL.
+    """
+    repo = ReconciliationRepository(session, claims.household_id)
+    recon = repo.get(reconciliation_id)
+    if recon is None:
+        raise ReconciliationNotFoundError()
+
+    try:
+        match = await manual_match(
+            session=session,
+            household_id=claims.household_id,
+            reconciliation=recon,
+            statement_line_id=body.statement_line_id,
+            ledger_transaction_id=body.ledger_transaction_id,
+            match_amount=body.match_amount,
+            currency=body.currency,
+            actor_user_id=claims.user_id,
+        )
+    except CompleteInvalidStateError as exc:
+        raise ReconciliationInvalidStateError(
+            current_status=exc.current_status, action="create-manual-match"
+        ) from exc
+    except ManualMatchLineNotFoundError as exc:
+        raise StatementLineNotFoundError() from exc
+    except ManualMatchLineNotInBatchError as exc:
+        raise ReconciliationLineNotInBatchError(
+            statement_line_id=str(exc.statement_line_id),
+            expected_batch_id=str(exc.expected_batch_id),
+        ) from exc
+    except ManualMatchLineAlreadyMatchedError as exc:
+        raise ReconciliationLineAlreadyMatchedError(
+            statement_line_id=str(exc.statement_line_id),
+            existing_match_id=str(exc.existing_match_id),
+        ) from exc
+    except ManualMatchAmountMismatchError as exc:
+        raise ReconciliationLineAmountMismatchError(
+            statement_line_id=str(exc.statement_line_id),
+            line_amount=str(exc.line_amount),
+            match_amount=str(exc.match_amount),
+        ) from exc
+    except ManualMatchTxNotFoundError as exc:
+        raise ReconciliationTxNotFoundError() from exc
+    except ManualMatchTxAccountMismatchError as exc:
+        raise ReconciliationTxAccountMismatchError(
+            ledger_transaction_id=str(exc.ledger_transaction_id),
+            expected_account_id=str(exc.expected_account_id),
+        ) from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="reconciliation_match_create_manual",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="reconciliation_match",
+        entity_id=match.id,
+        after={
+            "reconciliation_id": str(reconciliation_id),
+            "statement_line_id": str(body.statement_line_id),
+            "ledger_transaction_id": str(body.ledger_transaction_id),
+        },
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "reconciliation_match.manual_created",
+        match_id=str(match.id),
+        reconciliation_id=str(reconciliation_id),
+    )
+    return _to_match_read(match)
+
+
+@router.post(
+    "/{reconciliation_id}/carry-forward",
+    response_model=CarryForwardResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: problem_response(
+            "request.body_invalid",
+            "reconciliation.tx_not_in_period",
+        ),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response(
+            "reconciliation.not_found",
+            "reconciliation.transaction_not_found",
+        ),
+        409: problem_response("reconciliation.invalid_state"),
+        422: problem_response("validation.failed"),
+    },
+)
+def add_carry_forward_endpoint(
+    reconciliation_id: UUID,
+    body: CarryForwardCreate,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> CarryForwardResponse:
+    """Mark in-period ledger transactions as carry-forward to the next reconciliation."""
+    repo = ReconciliationRepository(session, claims.household_id)
+    recon = repo.get(reconciliation_id)
+    if recon is None:
+        raise ReconciliationNotFoundError()
+
+    try:
+        added = add_carry_forward(
+            session=session,
+            household_id=claims.household_id,
+            reconciliation=recon,
+            transaction_ids=body.transaction_ids,
+        )
+    except CompleteInvalidStateError as exc:
+        raise ReconciliationInvalidStateError(
+            current_status=exc.current_status, action="add-carry-forward"
+        ) from exc
+    except CarryForwardTxNotFoundError as exc:
+        raise ReconciliationTxNotFoundError() from exc
+    except CarryForwardTxNotInPeriodError as exc:
+        raise ReconciliationTxNotInPeriodError(
+            ledger_transaction_id=str(exc.ledger_transaction_id),
+            tx_date=exc.tx_date,
+            period_start=exc.period_start,
+            period_end=exc.period_end,
+        ) from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="reconciliation_carry_forward_add",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="reconciliation",
+        entity_id=reconciliation_id,
+        after={"transaction_ids": [str(t) for t in added]},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "reconciliation.carry_forward_added",
+        reconciliation_id=str(reconciliation_id),
+        count=len(added),
+    )
+    return CarryForwardResponse(reconciliation_id=reconciliation_id, transaction_ids=added)
+
+
+@router.delete(
+    "/{reconciliation_id}/carry-forward/{transaction_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response(
+            "reconciliation.not_found",
+            "reconciliation.transaction_not_found",
+        ),
+        409: problem_response("reconciliation.invalid_state"),
+    },
+)
+def remove_carry_forward_endpoint(
+    reconciliation_id: UUID,
+    transaction_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> None:
+    """Un-mark a transaction's carry-forward link."""
+    repo = ReconciliationRepository(session, claims.household_id)
+    recon = repo.get(reconciliation_id)
+    if recon is None:
+        raise ReconciliationNotFoundError()
+
+    try:
+        remove_carry_forward(
+            session=session,
+            household_id=claims.household_id,
+            reconciliation=recon,
+            transaction_id=transaction_id,
+        )
+    except CompleteInvalidStateError as exc:
+        raise ReconciliationInvalidStateError(
+            current_status=exc.current_status, action="remove-carry-forward"
+        ) from exc
+    except CarryForwardTxNotFoundError as exc:
+        raise ReconciliationTxNotFoundError() from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="reconciliation_carry_forward_remove",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="reconciliation",
+        entity_id=reconciliation_id,
+        before={"transaction_id": str(transaction_id)},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "reconciliation.carry_forward_removed",
+        reconciliation_id=str(reconciliation_id),
+        transaction_id=str(transaction_id),
     )

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -100,6 +100,30 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
         "source": "import_batch",
     },
     # ReconciliationCascadeRequiredError takes no args.
+    "ReconciliationLineAlreadyMatchedError": {
+        "statement_line_id": "<statement-line-uuid>",
+        "existing_match_id": "<match-uuid>",
+    },
+    "ReconciliationLineNotInBatchError": {
+        "statement_line_id": "<statement-line-uuid>",
+        "expected_batch_id": "<batch-uuid>",
+    },
+    "ReconciliationLineAmountMismatchError": {
+        "statement_line_id": "<statement-line-uuid>",
+        "line_amount": "-42.17",
+        "match_amount": "-40.00",
+    },
+    "ReconciliationTxAccountMismatchError": {
+        "ledger_transaction_id": "<transaction-uuid>",
+        "expected_account_id": "<account-uuid>",
+    },
+    "ReconciliationTxNotInPeriodError": {
+        "ledger_transaction_id": "<transaction-uuid>",
+        "tx_date": "2026-04-15",
+        "period_start": "2026-05-01",
+        "period_end": "2026-05-31",
+    },
+    # ReconciliationTxNotFoundError takes no args.
     "RequestPayloadTooLargeError": {"max_bytes": 26214400},
     "UnsupportedMediaTypeError": {
         "accepted": ("application/x-ofx", "application/octet-stream", "text/xml"),

--- a/packages/tulip-api/src/tulip_api/schemas/reconciliation.py
+++ b/packages/tulip-api/src/tulip_api/schemas/reconciliation.py
@@ -118,3 +118,25 @@ class CompleteResponse(BaseModel):
     status: str
     completed_at: datetime
     affected_transaction_count: int
+
+
+class ManualMatchCreate(BaseModel):
+    """Request body for ``POST /v1/reconciliations/{id}/matches`` (manual match)."""
+
+    statement_line_id: UUID
+    ledger_transaction_id: UUID
+    match_amount: Decimal
+    currency: str = Field(min_length=3, max_length=3)
+
+
+class CarryForwardCreate(BaseModel):
+    """Request body for ``POST /v1/reconciliations/{id}/carry-forward``."""
+
+    transaction_ids: list[UUID] = Field(min_length=1)
+
+
+class CarryForwardResponse(BaseModel):
+    """Response for ``POST /v1/reconciliations/{id}/carry-forward``."""
+
+    reconciliation_id: UUID
+    transaction_ids: list[UUID]

--- a/packages/tulip-api/src/tulip_api/services/reconciliation_match.py
+++ b/packages/tulip-api/src/tulip_api/services/reconciliation_match.py
@@ -62,7 +62,12 @@ if TYPE_CHECKING:
 
     from sqlalchemy.orm import Session
 
-    from tulip_storage.models import Posting, Reconciliation, Transaction
+    from tulip_storage.models import (
+        Posting,
+        Reconciliation,
+        ReconciliationMatch,
+        Transaction,
+    )
 
 
 _MATCHER_VERSION = "v1"
@@ -109,17 +114,111 @@ class AutoMatchInvalidStateError(ValueError):
 
 
 class CompleteUnbalancedError(ValueError):
-    """Raised when /complete is called but matched amount != ending - starting."""
+    """Raised when /complete is called but matched + carry_forward != ending - starting."""
 
-    def __init__(self, *, expected_net: Decimal, matched_net: Decimal, residual: Decimal) -> None:
+    def __init__(
+        self,
+        *,
+        expected_net: Decimal,
+        matched_net: Decimal,
+        carry_forward_net: Decimal,
+        residual: Decimal,
+    ) -> None:
         """Build with the imbalance figures for the typed error response."""
         super().__init__(
             f"reconciliation does not balance: expected_net={expected_net}, "
-            f"matched_net={matched_net}, residual={residual}"
+            f"matched_net={matched_net}, carry_forward_net={carry_forward_net}, "
+            f"residual={residual}"
         )
         self.expected_net = expected_net
         self.matched_net = matched_net
+        self.carry_forward_net = carry_forward_net
         self.residual = residual
+
+
+class ManualMatchLineNotFoundError(LookupError):
+    """Raised when the statement_line_id doesn't exist in this household."""
+
+
+class ManualMatchTxNotFoundError(LookupError):
+    """Raised when the ledger_transaction_id doesn't exist in this household."""
+
+
+class ManualMatchLineNotInBatchError(ValueError):
+    """Raised when the statement line is from a different batch than the recon's source."""
+
+    def __init__(self, statement_line_id: UUID, expected_batch_id: UUID) -> None:
+        """Build with line + expected batch."""
+        super().__init__(
+            f"statement_line {statement_line_id} not in expected batch {expected_batch_id}"
+        )
+        self.statement_line_id = statement_line_id
+        self.expected_batch_id = expected_batch_id
+
+
+class ManualMatchLineAlreadyMatchedError(ValueError):
+    """Raised when the statement line already has a match."""
+
+    def __init__(self, statement_line_id: UUID, existing_match_id: UUID) -> None:
+        """Build with line + existing match."""
+        super().__init__(
+            f"statement_line {statement_line_id} already matched to {existing_match_id}"
+        )
+        self.statement_line_id = statement_line_id
+        self.existing_match_id = existing_match_id
+
+
+class ManualMatchAmountMismatchError(ValueError):
+    """Raised when match_amount != line.amount (P5.4.c rejects partial-of-one)."""
+
+    def __init__(
+        self,
+        statement_line_id: UUID,
+        line_amount: Decimal,
+        match_amount: Decimal,
+    ) -> None:
+        """Build with the figures."""
+        super().__init__(f"line.amount={line_amount} != match_amount={match_amount}")
+        self.statement_line_id = statement_line_id
+        self.line_amount = line_amount
+        self.match_amount = match_amount
+
+
+class ManualMatchTxAccountMismatchError(ValueError):
+    """Raised when the ledger tx has no posting on the reconciliation's account."""
+
+    def __init__(self, ledger_transaction_id: UUID, expected_account_id: UUID) -> None:
+        """Build with the tx + account."""
+        super().__init__(
+            f"transaction {ledger_transaction_id} has no posting on account {expected_account_id}"
+        )
+        self.ledger_transaction_id = ledger_transaction_id
+        self.expected_account_id = expected_account_id
+
+
+class CarryForwardTxNotFoundError(LookupError):
+    """Raised when the ledger_transaction_id doesn't exist in this household."""
+
+
+class CarryForwardTxNotInPeriodError(ValueError):
+    """Raised when a carry-forward tx falls outside the reconciliation's period."""
+
+    def __init__(
+        self,
+        ledger_transaction_id: UUID,
+        tx_date: str,
+        period_start: str,
+        period_end: str,
+    ) -> None:
+        """Build with the tx + period bounds."""
+        super().__init__(
+            f"transaction {ledger_transaction_id} dated {tx_date} is outside "
+            f"period {period_start}..{period_end}"
+        )
+        self.ledger_transaction_id = ledger_transaction_id
+        self.tx_date = tx_date
+        self.period_start = period_start
+        self.period_end = period_end
 
 
 class CompleteInvalidStateError(ValueError):
@@ -306,19 +405,190 @@ def complete(
     match_repo = ReconciliationMatchRepository(session, household_id)
     matches = match_repo.list_for_reconciliation(reconciliation.id)
     matched_net = sum((m.match_amount for m in matches), Decimal("0"))
+
+    # Carry-forward txs (ledger txs in the period the user has deferred to
+    # the next reconciliation) reduce the expected net for THIS reconciliation:
+    # the bank counts them in ending_balance, but the user has explicitly
+    # said "this isn't mine yet". Sum their bank-side posting amounts.
+    carry_forward_net = _carry_forward_net(
+        session=session,
+        household_id=household_id,
+        reconciliation=reconciliation,
+    )
+
     expected_net = (
         reconciliation.statement_ending_balance - reconciliation.statement_starting_balance
     )
-    residual = expected_net - matched_net
+    residual = expected_net - (matched_net + carry_forward_net)
     if residual != 0:
         raise CompleteUnbalancedError(
             expected_net=expected_net,
             matched_net=matched_net,
+            carry_forward_net=carry_forward_net,
             residual=residual,
         )
 
     ReconciliationRepository(session, household_id).complete(reconciliation.id)
     return CompleteResult(affected_transaction_count=len(matches))
+
+
+def _carry_forward_net(
+    *, session: Session, household_id: UUID, reconciliation: Reconciliation
+) -> Decimal:
+    """Sum of the bank-side posting amounts of carry-forward txs for this recon."""
+    from sqlalchemy import select
+
+    from tulip_storage.models import Posting, Transaction
+
+    rows = session.execute(
+        select(Posting.amount)
+        .join(
+            Transaction,
+            (Transaction.id == Posting.transaction_id)
+            & (Transaction.household_id == Posting.household_id),
+        )
+        .where(
+            Transaction.household_id == household_id,
+            Transaction.carried_forward_from_reconciliation_id == reconciliation.id,
+            Posting.account_id == reconciliation.account_id,
+        )
+    ).all()
+    return sum((Decimal(r[0]) for r in rows), Decimal("0"))
+
+
+async def manual_match(
+    *,
+    session: Session,
+    household_id: UUID,
+    reconciliation: Reconciliation,
+    statement_line_id: UUID,
+    ledger_transaction_id: UUID,
+    match_amount: Decimal,
+    currency: str,
+    actor_user_id: UUID,
+) -> ReconciliationMatch:
+    """Persist a manual match (user-resolved pairing).
+
+    Validates four invariants before persisting:
+
+    - The statement line exists.
+    - The line belongs to the reconciliation's source batch.
+    - The line is not already matched.
+    - The line's amount equals ``match_amount`` (no partial-of-one in v1).
+    - The ledger transaction exists.
+    - The transaction has at least one posting on the reconciliation's account.
+
+    Raises:
+        CompleteInvalidStateError: ``reconciliation.status`` is not IN_PROGRESS.
+        ManualMatchLineNotFoundError / ManualMatchTxNotFoundError:
+            referenced row doesn't exist.
+        ManualMatchLineNotInBatchError: line is from a different batch.
+        ManualMatchLineAlreadyMatchedError: line already has a match.
+        ManualMatchAmountMismatchError: match_amount != line.amount.
+        ManualMatchTxAccountMismatchError: tx has no posting on recon's account.
+
+    """
+    if reconciliation.status is not ReconciliationStatus.IN_PROGRESS:
+        raise CompleteInvalidStateError(reconciliation.status)
+
+    lines_repo = StatementLineRepository(session, household_id)
+    line = lines_repo.get(statement_line_id)
+    if line is None:
+        raise ManualMatchLineNotFoundError(f"statement_line {statement_line_id} not found")
+    if line.import_batch_id != reconciliation.source_import_batch_id:
+        raise ManualMatchLineNotInBatchError(
+            statement_line_id,
+            reconciliation.source_import_batch_id,  # type: ignore[arg-type]
+        )
+    if line.reconciliation_match_id is not None:
+        raise ManualMatchLineAlreadyMatchedError(statement_line_id, line.reconciliation_match_id)
+    if line.amount != match_amount:
+        raise ManualMatchAmountMismatchError(statement_line_id, line.amount, match_amount)
+
+    tx_repo = TransactionRepository(session, household_id)
+    tx = tx_repo.get(ledger_transaction_id)
+    if tx is None:
+        raise ManualMatchTxNotFoundError(f"transaction {ledger_transaction_id} not found")
+    postings = tx_repo.list_postings(ledger_transaction_id)
+    if not any(p.account_id == reconciliation.account_id for p in postings):
+        raise ManualMatchTxAccountMismatchError(ledger_transaction_id, reconciliation.account_id)
+
+    match_repo = ReconciliationMatchRepository(session, household_id)
+    match = match_repo.create(
+        reconciliation_id=reconciliation.id,
+        statement_line_id=statement_line_id,
+        ledger_transaction_id=ledger_transaction_id,
+        match_amount=match_amount,
+        currency=currency,
+        confidence=None,  # manual — null per ADR §Q9
+        matcher_version=None,  # manual — null per ADR §Q9
+        created_by_user_id=actor_user_id,
+    )
+    return match
+
+
+def add_carry_forward(
+    *,
+    session: Session,
+    household_id: UUID,
+    reconciliation: Reconciliation,
+    transaction_ids: list[UUID],
+) -> list[UUID]:
+    """Mark each ledger transaction as carry-forward from this reconciliation.
+
+    Validates each transaction exists and falls within the reconciliation's
+    period. Per the locked decision: out-of-period carry-forward is
+    rejected — would let the user paper over real reconciliation problems.
+
+    Raises:
+        CompleteInvalidStateError: ``reconciliation.status`` is not IN_PROGRESS.
+        CarryForwardTxNotFoundError: a transaction_id is missing.
+        CarryForwardTxNotInPeriodError: a transaction's date is out-of-period.
+
+    """
+    if reconciliation.status is not ReconciliationStatus.IN_PROGRESS:
+        raise CompleteInvalidStateError(reconciliation.status)
+
+    tx_repo = TransactionRepository(session, household_id)
+    recon_repo = ReconciliationRepository(session, household_id)
+    period_start = reconciliation.statement_period_start
+    period_end = reconciliation.statement_period_end
+    for tx_id in transaction_ids:
+        tx = tx_repo.get(tx_id)
+        if tx is None:
+            raise CarryForwardTxNotFoundError(f"transaction {tx_id} not found")
+        if not (period_start <= tx.date <= period_end):
+            raise CarryForwardTxNotInPeriodError(
+                tx_id,
+                tx.date.isoformat(),
+                period_start.isoformat(),
+                period_end.isoformat(),
+            )
+        recon_repo.set_carry_forward(tx_id, reconciliation.id)
+    return list(transaction_ids)
+
+
+def remove_carry_forward(
+    *,
+    session: Session,
+    household_id: UUID,
+    reconciliation: Reconciliation,
+    transaction_id: UUID,
+) -> None:
+    """Un-mark a single transaction's carry-forward link.
+
+    Raises:
+        CompleteInvalidStateError: ``reconciliation.status`` is not IN_PROGRESS.
+        CarryForwardTxNotFoundError: transaction_id is missing.
+
+    """
+    if reconciliation.status is not ReconciliationStatus.IN_PROGRESS:
+        raise CompleteInvalidStateError(reconciliation.status)
+
+    tx = TransactionRepository(session, household_id).get(transaction_id)
+    if tx is None:
+        raise CarryForwardTxNotFoundError(f"transaction {transaction_id} not found")
+    ReconciliationRepository(session, household_id).clear_carry_forward(transaction_id)
 
 
 def _account_currency_for_batch(*, session: Session, household_id: UUID, batch_id: UUID) -> str:

--- a/packages/tulip-api/tests/services/test_reconciliation_match.py
+++ b/packages/tulip-api/tests/services/test_reconciliation_match.py
@@ -317,3 +317,249 @@ class TestComplete:
                     household_id=setup["household_id"],
                     reconciliation=recon2,
                 )
+
+
+# ---- manual_match ---------------------------------------------------------
+
+
+class TestManualMatch:
+    @pytest.mark.asyncio
+    async def test_creates_match_with_user_id_no_matcher_version(self, session_maker, setup):
+        from tulip_api.services.reconciliation_match import manual_match
+
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            user_id = uuid4()
+            match = await manual_match(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                statement_line_id=setup["line_ids"][0],
+                ledger_transaction_id=setup["tx_ids"][0],
+                match_amount=Decimal("-12.50"),
+                currency="USD",
+                actor_user_id=user_id,
+            )
+            s.commit()
+            assert match.created_by_user_id == user_id
+            assert match.matcher_version is None
+            assert match.confidence is None
+
+    @pytest.mark.asyncio
+    async def test_amount_mismatch_raises(self, session_maker, setup):
+        from tulip_api.services.reconciliation_match import (
+            ManualMatchAmountMismatchError,
+            manual_match,
+        )
+
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            with pytest.raises(ManualMatchAmountMismatchError):
+                await manual_match(
+                    session=s,
+                    household_id=setup["household_id"],
+                    reconciliation=recon,
+                    statement_line_id=setup["line_ids"][0],
+                    ledger_transaction_id=setup["tx_ids"][0],
+                    match_amount=Decimal("-10.00"),
+                    currency="USD",
+                    actor_user_id=uuid4(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_already_matched_raises(self, session_maker, setup):
+        from tulip_api.services.reconciliation_match import (
+            ManualMatchLineAlreadyMatchedError,
+            manual_match,
+        )
+
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            await manual_match(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                statement_line_id=setup["line_ids"][0],
+                ledger_transaction_id=setup["tx_ids"][0],
+                match_amount=Decimal("-12.50"),
+                currency="USD",
+                actor_user_id=uuid4(),
+            )
+            s.commit()
+            recon2 = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            with pytest.raises(ManualMatchLineAlreadyMatchedError):
+                await manual_match(
+                    session=s,
+                    household_id=setup["household_id"],
+                    reconciliation=recon2,
+                    statement_line_id=setup["line_ids"][0],
+                    ledger_transaction_id=setup["tx_ids"][1],
+                    match_amount=Decimal("-12.50"),
+                    currency="USD",
+                    actor_user_id=uuid4(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_tx_account_mismatch_raises(self, session_maker, setup):
+        from tulip_api.services.reconciliation_match import (
+            ManualMatchTxAccountMismatchError,
+            manual_match,
+        )
+        from tulip_storage.models import AccountType
+        from tulip_storage.repositories import (
+            AccountRepository,
+            TransactionRepository,
+        )
+
+        with session_maker() as s:
+            other = AccountRepository(s, setup["household_id"]).create(
+                code="2000",
+                name="Other",
+                type=AccountType.LIABILITY,
+                currency="USD",
+            )
+            food = AccountRepository(s, setup["household_id"]).get_by_code("5100")
+            assert food is not None
+            tx = TransactionRepository(s, setup["household_id"]).save_balanced(
+                DomainTransaction(
+                    id=uuid4(),
+                    household_id=setup["household_id"],
+                    date=date(2026, 5, 15),
+                    description="Unrelated",
+                    postings=(
+                        DomainPosting(
+                            id=uuid4(), account_id=other.id, amount=Money(Decimal("-5"), "USD")
+                        ),
+                        DomainPosting(
+                            id=uuid4(), account_id=food.id, amount=Money(Decimal("5"), "USD")
+                        ),
+                    ),
+                    status=DomainTxStatus.POSTED,
+                )
+            )
+            s.commit()
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            with pytest.raises(ManualMatchTxAccountMismatchError):
+                await manual_match(
+                    session=s,
+                    household_id=setup["household_id"],
+                    reconciliation=recon,
+                    statement_line_id=setup["line_ids"][0],
+                    ledger_transaction_id=tx.id,
+                    match_amount=Decimal("-12.50"),
+                    currency="USD",
+                    actor_user_id=uuid4(),
+                )
+
+
+# ---- carry-forward --------------------------------------------------------
+
+
+class TestCarryForward:
+    def test_add_marks_in_period_tx(self, session_maker, setup):
+        from tulip_api.services.reconciliation_match import add_carry_forward
+        from tulip_storage.repositories import TransactionRepository
+
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            add_carry_forward(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                transaction_ids=[setup["tx_ids"][0]],
+            )
+            s.commit()
+            tx = TransactionRepository(s, setup["household_id"]).get(setup["tx_ids"][0])
+            assert tx.carried_forward_from_reconciliation_id == recon.id
+
+    def test_add_out_of_period_raises(self, session_maker, setup):
+        from tulip_api.services.reconciliation_match import (
+            CarryForwardTxNotInPeriodError,
+            add_carry_forward,
+        )
+        from tulip_storage.repositories import (
+            AccountRepository,
+            TransactionRepository,
+        )
+
+        with session_maker() as s:
+            cash = AccountRepository(s, setup["household_id"]).get_by_code("1110")
+            food = AccountRepository(s, setup["household_id"]).get_by_code("5100")
+            assert cash is not None and food is not None
+            out_tx = TransactionRepository(s, setup["household_id"]).save_balanced(
+                DomainTransaction(
+                    id=uuid4(),
+                    household_id=setup["household_id"],
+                    date=date(2026, 6, 5),
+                    description="Out of period",
+                    postings=(
+                        DomainPosting(
+                            id=uuid4(), account_id=cash.id, amount=Money(Decimal("-7"), "USD")
+                        ),
+                        DomainPosting(
+                            id=uuid4(), account_id=food.id, amount=Money(Decimal("7"), "USD")
+                        ),
+                    ),
+                    status=DomainTxStatus.POSTED,
+                )
+            )
+            s.commit()
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            with pytest.raises(CarryForwardTxNotInPeriodError):
+                add_carry_forward(
+                    session=s,
+                    household_id=setup["household_id"],
+                    reconciliation=recon,
+                    transaction_ids=[out_tx.id],
+                )
+
+    def test_remove_clears_link(self, session_maker, setup):
+        from tulip_api.services.reconciliation_match import (
+            add_carry_forward,
+            remove_carry_forward,
+        )
+        from tulip_storage.repositories import TransactionRepository
+
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            add_carry_forward(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                transaction_ids=[setup["tx_ids"][0]],
+            )
+            s.commit()
+            remove_carry_forward(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                transaction_id=setup["tx_ids"][0],
+            )
+            s.commit()
+            tx = TransactionRepository(s, setup["household_id"]).get(setup["tx_ids"][0])
+            assert tx.carried_forward_from_reconciliation_id is None
+
+    def test_complete_with_carry_forward_balances(self, session_maker, setup):
+        """Carry-forward deducts from expected_net so /complete balances."""
+        from tulip_api.services.reconciliation_match import (
+            add_carry_forward,
+            complete,
+        )
+
+        with session_maker() as s:
+            recon = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            add_carry_forward(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon,
+                transaction_ids=setup["tx_ids"],
+            )
+            s.commit()
+            recon2 = _reload(s, Reconciliation, setup["household_id"], setup["recon_id"])
+            result = complete(
+                session=s,
+                household_id=setup["household_id"],
+                reconciliation=recon2,
+            )
+            s.commit()
+            assert result.affected_transaction_count == 0

--- a/packages/tulip-api/tests/test_reconciliations_endpoint.py
+++ b/packages/tulip-api/tests/test_reconciliations_endpoint.py
@@ -527,3 +527,189 @@ class TestDeleteReconciliation:
         # Reconciliation gone.
         gone = client.get(f"/v1/reconciliations/{recon['id']}", headers=auth_h)
         assert_problem(gone, status=404, code="reconciliation.not_found")
+
+
+# ---- POST /v1/reconciliations/{id}/matches (manual) ----------------------
+
+
+class TestManualMatch:
+    def test_creates_manual_match(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        recon = _create_recon(client, auth_h, account_id=checking_account, batch_id=parsed_batch)
+        # Find a line + a matching tx by date.
+        from decimal import Decimal as _D
+
+        inbox = client.get(f"/v1/reconciliations/{recon['id']}", headers=auth_h).json()
+        line = next(
+            line
+            for line in inbox["unmatched_statement_lines"]
+            if _D(line["amount"]) == _D("-42.17")
+        )
+        tx = next(tx for tx in inbox["unmatched_ledger_transactions"] if tx["date"] == "2026-05-12")
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/matches",
+            headers=auth_h,
+            json={
+                "statement_line_id": line["id"],
+                "ledger_transaction_id": tx["id"],
+                "match_amount": "-42.17",
+                "currency": "USD",
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["confidence"] is None
+        assert body["matcher_version"] is None
+        assert body["created_by_user_id"] is not None
+
+    def test_amount_mismatch_returns_400(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        recon = _create_recon(client, auth_h, account_id=checking_account, batch_id=parsed_batch)
+        inbox = client.get(f"/v1/reconciliations/{recon['id']}", headers=auth_h).json()
+        line = inbox["unmatched_statement_lines"][0]
+        tx = inbox["unmatched_ledger_transactions"][0]
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/matches",
+            headers=auth_h,
+            json={
+                "statement_line_id": line["id"],
+                "ledger_transaction_id": tx["id"],
+                "match_amount": "0.01",  # wrong
+                "currency": "USD",
+            },
+        )
+        assert_problem(r, status=400, code="reconciliation.line_amount_mismatch")
+
+    def test_already_matched_returns_409(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        recon = _create_recon(client, auth_h, account_id=checking_account, batch_id=parsed_batch)
+        # Auto-match populates matches; manual match on the same line must 409.
+        client.post(f"/v1/reconciliations/{recon['id']}/auto-match", headers=auth_h)
+        # Pick a matched line by querying the batch's lines via /imports.
+        batch = client.get(f"/v1/imports/{parsed_batch}", headers=auth_h).json()
+        line_id = batch["lines"][0]["id"]
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/matches",
+            headers=auth_h,
+            json={
+                "statement_line_id": line_id,
+                "ledger_transaction_id": matching_ledger_txs[0],
+                "match_amount": "-42.17",
+                "currency": "USD",
+            },
+        )
+        assert_problem(r, status=409, code="reconciliation.line_already_matched")
+
+
+# ---- POST/DELETE /v1/reconciliations/{id}/carry-forward[/{tx_id}] --------
+
+
+class TestCarryForwardEndpoints:
+    def test_add_marks_in_period_tx(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        recon = _create_recon(client, auth_h, account_id=checking_account, batch_id=parsed_batch)
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/carry-forward",
+            headers=auth_h,
+            json={"transaction_ids": [matching_ledger_txs[0]]},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["transaction_ids"] == [matching_ledger_txs[0]]
+
+    def test_add_out_of_period_returns_400(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+    ):
+        # Create a tx outside the May period.
+        # Need a second account (expense) for the balanced posting.
+        ex = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Misc", "type": "expense", "currency": "USD", "code": "5500"},
+        ).json()
+        out_tx = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": "2026-06-15",
+                "description": "Out of period",
+                "postings": [
+                    {"account_id": checking_account, "amount": "-5.00", "currency": "USD"},
+                    {"account_id": ex["id"], "amount": "5.00", "currency": "USD"},
+                ],
+            },
+        ).json()
+        recon = _create_recon(client, auth_h, account_id=checking_account, batch_id=parsed_batch)
+        r = client.post(
+            f"/v1/reconciliations/{recon['id']}/carry-forward",
+            headers=auth_h,
+            json={"transaction_ids": [out_tx["id"]]},
+        )
+        assert_problem(r, status=400, code="reconciliation.tx_not_in_period")
+
+    def test_remove_clears_link(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        recon = _create_recon(client, auth_h, account_id=checking_account, batch_id=parsed_batch)
+        client.post(
+            f"/v1/reconciliations/{recon['id']}/carry-forward",
+            headers=auth_h,
+            json={"transaction_ids": [matching_ledger_txs[0]]},
+        )
+        r = client.delete(
+            f"/v1/reconciliations/{recon['id']}/carry-forward/{matching_ledger_txs[0]}",
+            headers=auth_h,
+        )
+        assert r.status_code == 204, r.text
+
+    def test_complete_with_carry_forward_balances(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        """Carry-forward both txs (sum 1457.83); /complete should balance with 0 matches."""
+        recon = _create_recon(client, auth_h, account_id=checking_account, batch_id=parsed_batch)
+        client.post(
+            f"/v1/reconciliations/{recon['id']}/carry-forward",
+            headers=auth_h,
+            json={"transaction_ids": matching_ledger_txs},
+        )
+        r = client.post(f"/v1/reconciliations/{recon['id']}/complete", headers=auth_h)
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "complete"

--- a/packages/tulip-storage/src/tulip_storage/repositories/reconciliation.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/reconciliation.py
@@ -212,11 +212,79 @@ class ReconciliationRepository:
             .values(reconciliation_id=None, reconciled_at=None)
         )
 
+        # Also null any carry-forward links pointing at this reconciliation —
+        # carry-forward is "this tx was counted in reconciliation X"; when X
+        # is reverted, the audit trail breaks (P5.4.c).
+        self._session.execute(
+            update(Transaction)
+            .where(
+                Transaction.household_id == self._household_id,
+                Transaction.carried_forward_from_reconciliation_id == reconciliation_id,
+            )
+            .values(carried_forward_from_reconciliation_id=None)
+        )
+
         # Delete the reconciliation row — cascades reconciliation_matches.
         self._session.execute(
             delete(Reconciliation).where(
                 Reconciliation.household_id == self._household_id,
                 Reconciliation.id == reconciliation_id,
             )
+        )
+        self._session.flush()
+
+    def set_carry_forward(self, transaction_id: UUID, reconciliation_id: UUID) -> None:
+        """Mark a transaction as carry-forward from this reconciliation.
+
+        Single chokepoint for ``transactions.carried_forward_from_reconciliation_id``
+        writes (architecture-test enforced). Per ADR-0004 §Q3: a ledger
+        transaction in the period that the user wants to defer to the
+        next reconciliation gets pinned here so the current reconciliation's
+        balance check ignores it but the audit trail records "this tx was
+        counted in reconciliation X."
+
+        Raises:
+            LookupError: ``transaction_id`` does not exist in this household.
+
+        """
+        tx = self._session.get(Transaction, (self._household_id, transaction_id))
+        if tx is None:
+            raise LookupError(
+                f"transaction {transaction_id} not found in household {self._household_id}"
+            )
+        self._session.execute(
+            update(Transaction)
+            .where(
+                Transaction.household_id == self._household_id,
+                Transaction.id == transaction_id,
+            )
+            .values(carried_forward_from_reconciliation_id=reconciliation_id)
+        )
+        self._session.flush()
+
+    def clear_carry_forward(self, transaction_id: UUID) -> None:
+        """Un-mark a transaction's carry-forward link.
+
+        Single chokepoint for nulling
+        ``transactions.carried_forward_from_reconciliation_id``. Caller is
+        responsible for verifying the user intent — this method does not
+        check whether the transaction was actually carried forward.
+
+        Raises:
+            LookupError: ``transaction_id`` does not exist in this household.
+
+        """
+        tx = self._session.get(Transaction, (self._household_id, transaction_id))
+        if tx is None:
+            raise LookupError(
+                f"transaction {transaction_id} not found in household {self._household_id}"
+            )
+        self._session.execute(
+            update(Transaction)
+            .where(
+                Transaction.household_id == self._household_id,
+                Transaction.id == transaction_id,
+            )
+            .values(carried_forward_from_reconciliation_id=None)
         )
         self._session.flush()

--- a/packages/tulip-storage/tests/test_p51_repositories.py
+++ b/packages/tulip-storage/tests/test_p51_repositories.py
@@ -599,6 +599,92 @@ class TestReconciliationAndMatch:
         with pytest.raises(LookupError):
             ReconciliationRepository(session, household.id).revert(uuid4())
 
+    def test_set_carry_forward_links_tx_to_recon(
+        self,
+        session: Session,
+        household: Household,
+        account: Account,
+    ):
+        """set_carry_forward(tx_id, recon_id) sets carried_forward_from_reconciliation_id."""
+        tx = _seed_posted_tx(session, household.id, account)
+        recon = ReconciliationRepository(session, household.id).create(
+            account_id=account.id,
+            statement_period_start=date(2026, 5, 1),
+            statement_period_end=date(2026, 5, 31),
+            statement_starting_balance=Decimal("0"),
+            statement_ending_balance=Decimal("-12.50"),
+            currency="USD",
+        )
+        session.commit()
+        repo = ReconciliationRepository(session, household.id)
+        repo.set_carry_forward(tx.id, recon.id)
+        session.commit()
+        loaded = TransactionRepository(session, household.id).get(tx.id)
+        assert loaded.carried_forward_from_reconciliation_id == recon.id
+
+    def test_clear_carry_forward_nulls_link(
+        self,
+        session: Session,
+        household: Household,
+        account: Account,
+    ):
+        tx = _seed_posted_tx(session, household.id, account)
+        recon = ReconciliationRepository(session, household.id).create(
+            account_id=account.id,
+            statement_period_start=date(2026, 5, 1),
+            statement_period_end=date(2026, 5, 31),
+            statement_starting_balance=Decimal("0"),
+            statement_ending_balance=Decimal("-12.50"),
+            currency="USD",
+        )
+        repo = ReconciliationRepository(session, household.id)
+        repo.set_carry_forward(tx.id, recon.id)
+        session.commit()
+        repo.clear_carry_forward(tx.id)
+        session.commit()
+        loaded = TransactionRepository(session, household.id).get(tx.id)
+        assert loaded.carried_forward_from_reconciliation_id is None
+
+    def test_set_carry_forward_missing_tx_raises(
+        self, session: Session, household: Household, account: Account
+    ):
+        from uuid import uuid4
+
+        recon = ReconciliationRepository(session, household.id).create(
+            account_id=account.id,
+            statement_period_start=date(2026, 5, 1),
+            statement_period_end=date(2026, 5, 31),
+            statement_starting_balance=Decimal("0"),
+            statement_ending_balance=Decimal("0"),
+            currency="USD",
+        )
+        with pytest.raises(LookupError):
+            ReconciliationRepository(session, household.id).set_carry_forward(uuid4(), recon.id)
+
+    def test_revert_nulls_carry_forward_links(
+        self,
+        session: Session,
+        household: Household,
+        account: Account,
+    ):
+        """revert() also nulls carried_forward_from_reconciliation_id pointers."""
+        tx = _seed_posted_tx(session, household.id, account)
+        repo = ReconciliationRepository(session, household.id)
+        recon = repo.create(
+            account_id=account.id,
+            statement_period_start=date(2026, 5, 1),
+            statement_period_end=date(2026, 5, 31),
+            statement_starting_balance=Decimal("0"),
+            statement_ending_balance=Decimal("-12.50"),
+            currency="USD",
+        )
+        repo.set_carry_forward(tx.id, recon.id)
+        session.commit()
+        repo.revert(recon.id)
+        session.commit()
+        loaded = TransactionRepository(session, household.id).get(tx.id)
+        assert loaded.carried_forward_from_reconciliation_id is None
+
 
 # ---- CsvProfile ----------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Third sub-slice of P5.4. Manual match resolves residuals auto-match can't pick up; carry-forward defers in-flight ledger txs (e.g., a check the bank hasn't cashed yet) to the next reconciliation. The `tulip reconcile` CLI (P5.4.d) closes Phase 5.

- **`POST /v1/reconciliations/{id}/matches`** — manual match. Body `{statement_line_id, ledger_transaction_id, match_amount, currency}`. Persisted with `created_by_user_id` set, `matcher_version=NULL`, `confidence=NULL` per ADR §Q9. Validates four invariants (locked decision: cheap insurance against typo'd UUIDs):
  - line belongs to the reconciliation's source batch (`400 reconciliation.line_not_in_batch`)
  - line not already matched (`409 reconciliation.line_already_matched` — user must explicitly reject the prior match first per locked decision)
  - `match_amount == line.amount` exactly (`400 reconciliation.line_amount_mismatch` — partial-of-one matching deferred past v1 per ADR §Q3)
  - tx has at least one posting on the reconciliation's account (`400 reconciliation.tx_account_mismatch`)
- **`POST /v1/reconciliations/{id}/carry-forward`** — body `{transaction_ids: [UUID]}`. Marks ledger txs via `transactions.carried_forward_from_reconciliation_id`. Out-of-period txs rejected (`400 reconciliation.tx_not_in_period`) per locked decision so users can't paper over real reconciliation problems.
- **`DELETE /v1/reconciliations/{id}/carry-forward/{transaction_id}`** — un-mark a single tx.
- **`/complete` balance equation updated** to `sum(matched) + sum(carry_forward) == ending - starting`. Carry-forward txs deduct from the expected net for *this* reconciliation: the bank counts them in `ending_balance`, but the user has explicitly said "this isn't mine yet".
- **`ReconciliationRepository.set_carry_forward()`** + **`clear_carry_forward()`** — the single chokepoint for `carried_forward_from_reconciliation_id` writes (architecture-test-enforced; same module owns `complete()` + `revert()`).
- **`revert()` extension** — now also nulls carry-forward links pointing at the deleted reconciliation. Mirrors how `transactions.reconciliation_id` is nulled in the same method.
- **Audit-log entries**: `reconciliation_match_create_manual`, `reconciliation_carry_forward_add`, `reconciliation_carry_forward_remove`.

Refs #74. **P5.4.d** (CLI) closes Phase 5.

## Test plan

- [x] `uv run pytest packages/tulip-storage/tests/test_p51_repositories.py::TestReconciliationAndMatch` → 10 passing (incl. 4 new carry-forward + revert tests)
- [x] `uv run pytest packages/tulip-api/tests/services/test_reconciliation_match.py` → 15 passing (incl. 8 new manual-match + carry-forward tests)
- [x] `uv run pytest packages/tulip-api/tests/test_reconciliations_endpoint.py` → 22 passing (incl. 7 new endpoint tests)
- [x] `just test` → **1113 passing**, 1 skipped, 1 xfail (up from 1090 on `main`)
- [x] `just lint` → clean
- [x] `just typecheck` → clean across 170 source files
- [ ] CI green on this PR

## Manual smoke test

Save as `/tmp/smoke-p54c.sh` and run with `bash /tmp/smoke-p54c.sh`:

```bash
#!/usr/bin/env bash
set -eu
API=http://127.0.0.1:8000
DB=/tmp/tulip-smoke.db

rm -f "$DB"
TULIP_DATABASE_URL="sqlite:///$DB" uv run alembic -c packages/tulip-storage/alembic.ini upgrade head
TULIP_DATABASE_URL="sqlite:///$DB" uv run uvicorn tulip_api.main:create_app --factory --port 8000 &
API_PID=$!
trap "kill $API_PID 2>/dev/null; wait 2>/dev/null; rm -f $DB" EXIT
for i in 1 2 3 4 5 6 7 8 9 10; do curl -sS "$API/health" >/dev/null 2>&1 && break; sleep 1; done

curl -fsS -X POST "$API/v1/auth/register" -H "Content-Type: application/json" \
  -d '{"email":"smoke@example.com","password":"smoke-password","display_name":"Smoke","household_name":"Smoke"}' >/dev/null
TOKEN=$(curl -fsS -X POST "$API/v1/auth/login" -H "Content-Type: application/json" \
  -d '{"email":"smoke@example.com","password":"smoke-password"}' | jq -r .access_token)
auth=(-H "Authorization: Bearer $TOKEN")

CHECKING_ID=$(curl -fsS -X POST "$API/v1/accounts" "${auth[@]}" -H "Content-Type: application/json" \
  -d '{"name":"Checking","type":"asset","currency":"USD","code":"1110"}' | jq -r .id)
EXPENSE_ID=$(curl -fsS -X POST "$API/v1/accounts" "${auth[@]}" -H "Content-Type: application/json" \
  -d '{"name":"Misc","type":"expense","currency":"USD","code":"5100"}' | jq -r .id)

BATCH_ID=$(curl -fsS -X POST "$API/v1/imports" "${auth[@]}" \
  -F "file=@packages/tulip-importers/tests/fixtures/ofx/minimal_ofx2.ofx;type=application/x-ofx" \
  -F "account_id=$CHECKING_ID" -F "source_format=ofx" | jq -r .id)

# ONE matching ledger tx (so auto-match catches one line; we'll manual-match the other).
TX_ID_1=$(curl -fsS -X POST "$API/v1/transactions" "${auth[@]}" -H "Content-Type: application/json" \
  -d "{\"date\":\"2026-05-12\",\"description\":\"PAYPAL\",\"postings\":[{\"account_id\":\"$CHECKING_ID\",\"amount\":\"-42.17\",\"currency\":\"USD\"},{\"account_id\":\"$EXPENSE_ID\",\"amount\":\"42.17\",\"currency\":\"USD\"}]}" | jq -r .id)
TX_ID_2=$(curl -fsS -X POST "$API/v1/transactions" "${auth[@]}" -H "Content-Type: application/json" \
  -d "{\"date\":\"2026-05-15\",\"description\":\"PAYROLL\",\"postings\":[{\"account_id\":\"$CHECKING_ID\",\"amount\":\"1500.00\",\"currency\":\"USD\"},{\"account_id\":\"$EXPENSE_ID\",\"amount\":\"-1500.00\",\"currency\":\"USD\"}]}" | jq -r .id)

RECON_ID=$(curl -fsS -X POST "$API/v1/reconciliations" "${auth[@]}" -H "Content-Type: application/json" \
  -d "{\"account_id\":\"$CHECKING_ID\",\"statement_period_start\":\"2026-05-01\",\"statement_period_end\":\"2026-05-31\",\"statement_starting_balance\":\"0.00\",\"statement_ending_balance\":\"1457.83\",\"currency\":\"USD\",\"source_import_batch_id\":\"$BATCH_ID\"}" | jq -r .id)

# Auto-match catches some matches.
echo "--- auto-match"
curl -fsS -X POST "$API/v1/reconciliations/$RECON_ID/auto-match" "${auth[@]}" | jq .

# Reject one match to free up a line for manual matching.
MATCH_ID=$(curl -fsS "$API/v1/reconciliations/$RECON_ID" "${auth[@]}" | jq -r .matches[0].id)
echo "--- reject $MATCH_ID"
curl -fsS -o /dev/null -w "reject status: %{http_code}\n" -X POST "$API/v1/reconciliations/$RECON_ID/matches/$MATCH_ID/reject" "${auth[@]}"

# Find the now-unmatched line + the now-unmatched ledger tx + create a manual match.
INBOX=$(curl -fsS "$API/v1/reconciliations/$RECON_ID" "${auth[@]}")
LINE_ID=$(echo "$INBOX" | jq -r '.unmatched_statement_lines[0].id')
LINE_AMT=$(echo "$INBOX" | jq -r '.unmatched_statement_lines[0].amount')
TX_ID=$(echo "$INBOX" | jq -r '.unmatched_ledger_transactions[0].id')

echo "--- manual match line=$LINE_ID tx=$TX_ID amt=$LINE_AMT"
curl -fsS -X POST "$API/v1/reconciliations/$RECON_ID/matches" "${auth[@]}" -H "Content-Type: application/json" \
  -d "{\"statement_line_id\":\"$LINE_ID\",\"ledger_transaction_id\":\"$TX_ID\",\"match_amount\":\"$LINE_AMT\",\"currency\":\"USD\"}" | jq '{confidence,matcher_version,created_by_user_id}'

# Now /complete should balance.
echo "--- complete"
curl -fsS -X POST "$API/v1/reconciliations/$RECON_ID/complete" "${auth[@]}" | jq .

# --- Negative checks ---

# Open a fresh reconciliation for negative-test scenarios.
DB2=/tmp/tulip-smoke-2.db
rm -f "$DB2"
TULIP_DATABASE_URL="sqlite:///$DB2" uv run alembic -c packages/tulip-storage/alembic.ini upgrade head >/dev/null
# (Reuse same API process — tests below run on the SAME DB; just open another recon.)

echo "--- carry-forward out-of-period must 400"
# Create an out-of-period tx (June).
OUT_TX=$(curl -fsS -X POST "$API/v1/transactions" "${auth[@]}" -H "Content-Type: application/json" \
  -d "{\"date\":\"2026-06-01\",\"description\":\"NEXT MONTH\",\"postings\":[{\"account_id\":\"$CHECKING_ID\",\"amount\":\"-5.00\",\"currency\":\"USD\"},{\"account_id\":\"$EXPENSE_ID\",\"amount\":\"5.00\",\"currency\":\"USD\"}]}" | jq -r .id)
# Open another reconciliation (after the first was completed).
RECON2_ID=$(curl -fsS -X POST "$API/v1/reconciliations" "${auth[@]}" -H "Content-Type: application/json" \
  -d "{\"account_id\":\"$CHECKING_ID\",\"statement_period_start\":\"2026-05-01\",\"statement_period_end\":\"2026-05-31\",\"statement_starting_balance\":\"1457.83\",\"statement_ending_balance\":\"1457.83\",\"currency\":\"USD\",\"source_import_batch_id\":\"$BATCH_ID\"}" | jq -r .id)
status=$(curl -sS -o /dev/null -w "%{http_code}" -X POST "$API/v1/reconciliations/$RECON2_ID/carry-forward" "${auth[@]}" -H "Content-Type: application/json" \
  -d "{\"transaction_ids\":[\"$OUT_TX\"]}")
[ "$status" = "400" ] || { echo "FAIL: expected 400, got $status"; exit 1; }
echo "ok ($status)"

echo "--- manual match with wrong amount must 400"
LINE2_ID=$(curl -fsS "$API/v1/reconciliations/$RECON2_ID" "${auth[@]}" | jq -r '.unmatched_statement_lines[0].id // empty')
if [ -n "$LINE2_ID" ]; then
  status=$(curl -sS -o /dev/null -w "%{http_code}" -X POST "$API/v1/reconciliations/$RECON2_ID/matches" "${auth[@]}" -H "Content-Type: application/json" \
    -d "{\"statement_line_id\":\"$LINE2_ID\",\"ledger_transaction_id\":\"$TX_ID_1\",\"match_amount\":\"99.99\",\"currency\":\"USD\"}")
  [ "$status" = "400" ] || { echo "FAIL: expected 400, got $status"; exit 1; }
  echo "ok ($status)"
else
  echo "skip — no unmatched line in second recon (expected: prior recon already consumed both)"
fi

echo "smoke test passed"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)