### PR TITLE
fix: reconciliation inbox excludes lines matched in prior completed recons (closes #127)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/reconciliations.py
+++ b/packages/tulip-api/src/tulip_api/routers/reconciliations.py
@@ -274,38 +274,14 @@ def get_reconciliation(
     # #127: a line whose ``reconciliation_match_id`` points at a match in a
     # prior completed reconciliation has already been accounted for elsewhere.
     # Exclude it from this reconciliation's inbox so the user isn't asked to
-    # re-match a line that's already taken.
-    from sqlalchemy import select as _select
-
-    from tulip_storage.models import (
-        Reconciliation as _Reconciliation,
-    )
-    from tulip_storage.models import (
-        ReconciliationMatch as _ReconciliationMatch,
-    )
-    from tulip_storage.models import (
-        ReconciliationStatus as _ReconciliationStatus,
-    )
-
-    prior_completed_match_ids: set[UUID] = set()
+    # re-match a line that's already taken. Storage owns the join; the
+    # architecture test bans model imports outside repositories.
     candidate_match_ids = {
         line.reconciliation_match_id for line in all_lines if line.reconciliation_match_id
     }
-    if candidate_match_ids:
-        rows = session.execute(
-            _select(_ReconciliationMatch.id)
-            .join(
-                _Reconciliation,
-                (_Reconciliation.id == _ReconciliationMatch.reconciliation_id)
-                & (_Reconciliation.household_id == _ReconciliationMatch.household_id),
-            )
-            .where(
-                _ReconciliationMatch.household_id == claims.household_id,
-                _ReconciliationMatch.id.in_(candidate_match_ids),
-                _Reconciliation.status == _ReconciliationStatus.COMPLETE,
-            )
-        ).all()
-        prior_completed_match_ids = {row[0] for row in rows}
+    prior_completed_match_ids = ReconciliationMatchRepository(
+        session, claims.household_id
+    ).filter_to_completed_recons(candidate_match_ids)
 
     unmatched_lines = [
         line

--- a/packages/tulip-api/src/tulip_api/routers/reconciliations.py
+++ b/packages/tulip-api/src/tulip_api/routers/reconciliations.py
@@ -270,8 +270,49 @@ def get_reconciliation(
         all_lines = lines_repo.list_for_batch(recon.source_import_batch_id)
     else:
         all_lines = []
+
+    # #127: a line whose ``reconciliation_match_id`` points at a match in a
+    # prior completed reconciliation has already been accounted for elsewhere.
+    # Exclude it from this reconciliation's inbox so the user isn't asked to
+    # re-match a line that's already taken.
+    from sqlalchemy import select as _select
+
+    from tulip_storage.models import (
+        Reconciliation as _Reconciliation,
+    )
+    from tulip_storage.models import (
+        ReconciliationMatch as _ReconciliationMatch,
+    )
+    from tulip_storage.models import (
+        ReconciliationStatus as _ReconciliationStatus,
+    )
+
+    prior_completed_match_ids: set[UUID] = set()
+    candidate_match_ids = {
+        line.reconciliation_match_id for line in all_lines if line.reconciliation_match_id
+    }
+    if candidate_match_ids:
+        rows = session.execute(
+            _select(_ReconciliationMatch.id)
+            .join(
+                _Reconciliation,
+                (_Reconciliation.id == _ReconciliationMatch.reconciliation_id)
+                & (_Reconciliation.household_id == _ReconciliationMatch.household_id),
+            )
+            .where(
+                _ReconciliationMatch.household_id == claims.household_id,
+                _ReconciliationMatch.id.in_(candidate_match_ids),
+                _Reconciliation.status == _ReconciliationStatus.COMPLETE,
+            )
+        ).all()
+        prior_completed_match_ids = {row[0] for row in rows}
+
     unmatched_lines = [
-        line for line in all_lines if not line.is_excluded and line.id not in matched_line_ids
+        line
+        for line in all_lines
+        if not line.is_excluded
+        and line.id not in matched_line_ids
+        and line.reconciliation_match_id not in prior_completed_match_ids
     ]
 
     tx_repo = TransactionRepository(session, claims.household_id)

--- a/packages/tulip-api/tests/test_reconciliations_endpoint.py
+++ b/packages/tulip-api/tests/test_reconciliations_endpoint.py
@@ -302,6 +302,36 @@ class TestGetReconciliationInbox:
         r = client.get(f"/v1/reconciliations/{uuid4()}", headers=auth_h)
         assert_problem(r, status=404, code="reconciliation.not_found")
 
+    def test_inbox_filters_lines_matched_in_prior_completed_recon(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        parsed_batch: str,
+        matching_ledger_txs: list[str],
+    ):
+        """#127: lines matched in a prior completed reconciliation
+        must NOT show up in a subsequent reconciliation's inbox as unmatched.
+        """
+        # Recon A: auto-match + complete -> all lines matched.
+        recon_a = _create_recon(client, auth_h, account_id=checking_account, batch_id=parsed_batch)
+        client.post(f"/v1/reconciliations/{recon_a['id']}/auto-match", headers=auth_h)
+        complete_a = client.post(f"/v1/reconciliations/{recon_a['id']}/complete", headers=auth_h)
+        assert complete_a.status_code == 200, complete_a.text
+
+        # Recon B for the same account + same batch (allowed because A is complete).
+        recon_b = _create_recon(
+            client,
+            auth_h,
+            account_id=checking_account,
+            batch_id=parsed_batch,
+            starting="1457.83",
+            ending="1457.83",  # nothing new on the bank statement
+        )
+        inbox_b = client.get(f"/v1/reconciliations/{recon_b['id']}", headers=auth_h).json()
+        # Lines from recon A's matches must not surface as "unmatched" in recon B.
+        assert inbox_b["unmatched_statement_lines"] == []
+
 
 # ---- POST /v1/reconciliations/{id}/auto-match ----------------------------
 

--- a/packages/tulip-storage/src/tulip_storage/repositories/reconciliation_match.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/reconciliation_match.py
@@ -101,6 +101,35 @@ class ReconciliationMatchRepository:
             self._session.flush()
         return match
 
+    def filter_to_completed_recons(self, match_ids: set[UUID]) -> set[UUID]:
+        """Return the subset of ``match_ids`` whose reconciliation is COMPLETE.
+
+        Used by the inbox endpoint to filter out statement lines whose
+        ``reconciliation_match_id`` points at a match in a prior completed
+        reconciliation (issue #127). The matches themselves still exist
+        (cascade-deleting on revert handles abandonment); we filter on the
+        parent reconciliation's status to know "this line is already
+        accounted for elsewhere."
+        """
+        if not match_ids:
+            return set()
+        from tulip_storage.models import Reconciliation, ReconciliationStatus
+
+        rows = self._session.execute(
+            select(ReconciliationMatch.id)
+            .join(
+                Reconciliation,
+                (Reconciliation.id == ReconciliationMatch.reconciliation_id)
+                & (Reconciliation.household_id == ReconciliationMatch.household_id),
+            )
+            .where(
+                ReconciliationMatch.household_id == self._household_id,
+                ReconciliationMatch.id.in_(match_ids),
+                Reconciliation.status == ReconciliationStatus.COMPLETE,
+            )
+        ).all()
+        return {row[0] for row in rows}
+
     def reject(self, match_id: UUID) -> None:
         """Delete a match row (rejection per ADR-0004 §Q4)."""
         match = self.get(match_id)


### PR DESCRIPTION
## Summary

`GET /v1/reconciliations/{id}` previously returned, under `unmatched_statement_lines`, any line in the source batch whose `reconciliation_match_id` was NULL **for the current reconciliation's match table** — but a line matched + completed in a prior reconciliation still carries that pointer when you open a new reconciliation against the same batch. Result: the user was misled into trying to re-match an already-accounted-for line, only to hit `409 reconciliation.line_already_matched`.

Surfaced during the P5.4.c smoke test (issue #127).

**Fix**: extend the inbox filter so a line is also excluded if its `reconciliation_match_id` points at a match belonging to a reconciliation with `status=COMPLETE`. Lines matched in the *current* in-progress recon are already filtered.

**Out of scope**: lines matched in an *abandoned* reconciliation. Per ADR-0004 §Q7, abandoned is "user explicitly walked away" — those matches should arguably also be excluded, but it's a less obvious call and there's no concrete user pain yet. Punt to a follow-up.

## Test plan

- [x] New `test_inbox_filters_lines_matched_in_prior_completed_recon` exercises: open recon A, auto-match + complete, open recon B for the same batch, assert `unmatched_statement_lines == []`.
- [x] `uv run pytest packages/tulip-api/tests/test_reconciliations_endpoint.py` → **23 passing** (22 prior + 1 new).
- [x] `just lint` → clean
- [x] `just typecheck` → clean
- [ ] CI green on this PR

No manual smoke — pure server-side behavior with full test coverage; reviewable from the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)