### PR TITLE
fix: relax import_batch idempotency index, wire ?force=true (closes #114)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -6,9 +6,9 @@ the OFX path; QIF and CSV land in P5.2.b/c. The handler:
 1. Validates content_type + size cap (defense-in-depth before slurping).
 2. Hashes the bytes; if the hash already exists for this household and
    account, returns ``import.duplicate_file`` (409). The ADR specifies a
-   ``?force=true`` override, but the underlying unique index in P5.1
-   forbids re-creating an ``import_batches`` row referencing the same
-   attachment for the same account; force-mode is tracked as a follow-up.
+   ``?force=true`` override (#114): the duplicate check is application-
+   level, the underlying index is non-unique, and the audit log records
+   the override.
 3. Persists the encrypted bytes via ``AttachmentRepository``.
 4. Creates the ``import_batches`` row.
 5. Calls the format-specific parser (``tulip_importers.ofx.parse``) and
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Final
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Depends, File, Form, Request, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, Query, Request, UploadFile, status
 
 from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.config import get_settings
@@ -165,6 +165,14 @@ async def upload_import(
             "source_format='csv'; ignored otherwise."
         ),
     ),
+    force: bool = Query(
+        default=False,
+        description=(
+            "When true, skip the same-file/same-account duplicate check and "
+            "create a second import batch referencing the existing attachment. "
+            "Per ADR-0004 §Q6. The audit log records the override."
+        ),
+    ),
     claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> ImportBatchSummary:
@@ -220,11 +228,13 @@ async def upload_import(
         attachment_root=settings.attachment_root,
     )
 
-    # Idempotency: same hash + same account = same batch.
+    # Idempotency: same hash + same account = same batch, unless ?force=true
+    # explicitly opts out (ADR-0004 §Q6). The audit log records the override
+    # so the admin trail is honest about the duplicate.
     content_hash = hashlib.sha256(raw_bytes).hexdigest()
     existing_attachment = attachment_repo.find_by_hash(content_hash)
     batch_repo = ImportBatchRepository(session, claims.household_id)
-    if existing_attachment is not None:
+    if existing_attachment is not None and not force:
         existing_batch = batch_repo.find_for_attachment(
             account_id=account_id,
             attachment_id=existing_attachment.id,
@@ -323,6 +333,7 @@ async def upload_import(
             "source_format": source_format,
             "source_filename": file.filename or default_filename,
             "line_count": len(parsed_lines),
+            "force": force,
         },
         request_id=_request_uuid(request),
     )

--- a/packages/tulip-api/tests/test_imports_endpoint.py
+++ b/packages/tulip-api/tests/test_imports_endpoint.py
@@ -170,14 +170,6 @@ class TestUploadErrorPaths:
         )
         assert r.status_code == 401
 
-    @pytest.mark.xfail(
-        reason=(
-            "force=true override conflicts with the unique idempotency index "
-            "on (household_id, account_id, source_file_attachment_id) added "
-            "in P5.1. Tracked in #114 — relax the index, wire ?force=true, "
-            "then remove this xfail."
-        )
-    )
     def test_force_override_creates_second_batch(
         self,
         client: TestClient,

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260507_2200_a4f1c8d3e9b7_relax_import_batch_idempotency_index.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260507_2200_a4f1c8d3e9b7_relax_import_batch_idempotency_index.py
@@ -1,0 +1,56 @@
+"""Relax ix_import_batches_idempotency from UNIQUE to non-unique (#114).
+
+Revision ID: a4f1c8d3e9b7
+Revises: d5c8e7a91f2b
+Create Date: 2026-05-07 22:00:00.000000
+
+P5.1 added the unique index ``ix_import_batches_idempotency`` on
+``(household_id, account_id, source_file_attachment_id)`` to enforce
+"can't re-import the same file for the same account." But ADR-0004 §Q6
+spells out a ``?force=true`` override that creates a second batch
+referencing the same attachment. The unique constraint blocks that
+override at the DB level.
+
+Fix: drop the UNIQUE flag from the index. The column ordering is still
+useful for the duplicate-lookup query (``find_for_attachment``); the
+constraint moves to application code, which raises
+``import.duplicate_file`` on idempotency conflicts and skips the lookup
+when ``?force=true`` is set.
+
+The 409 happy path stays correct because the API already calls
+``find_for_attachment`` before insert; the index just no longer blocks
+``force=true``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a4f1c8d3e9b7"
+down_revision: str | None = "d5c8e7a91f2b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Drop the unique index, recreate as non-unique."""
+    with op.batch_alter_table("import_batches", schema=None) as batch_op:
+        batch_op.drop_index("ix_import_batches_idempotency")
+        batch_op.create_index(
+            "ix_import_batches_idempotency",
+            ["household_id", "account_id", "source_file_attachment_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Restore the UNIQUE flag (caller must dedupe rows first)."""
+    with op.batch_alter_table("import_batches", schema=None) as batch_op:
+        batch_op.drop_index("ix_import_batches_idempotency")
+        batch_op.create_index(
+            "ix_import_batches_idempotency",
+            ["household_id", "account_id", "source_file_attachment_id"],
+            unique=True,
+        )


### PR DESCRIPTION
## Summary

Per ADR-0004 §Q6: `POST /v1/imports?force=true` creates a second batch referencing the same attachment when the user explicitly opts out of the same-file/same-account duplicate check. P5.1 added a UNIQUE index on `(household_id, account_id, source_file_attachment_id)` which blocked exactly that override at the DB level — the test for it has been xfailed since #94.

**Fix:**
- New migration `a4f1c8d3e9b7`: drop the UNIQUE flag, recreate the index as non-unique. Column ordering still helps the duplicate-lookup query; the constraint moves to application code (which already implements it via `find_for_attachment` before insert).
- Wire `?force=true` query param in `POST /v1/imports`: skips the duplicate lookup when set.
- Audit log records `"force": true/false` in the `after_snapshot` so the admin trail is honest about the duplicate.
- Remove `@pytest.mark.xfail` on `test_force_override_creates_second_batch` — now a regular passing test that asserts both batches share the same `source_file_attachment_id`.

The `409 import.duplicate_file` happy path stays correct: the API still calls `find_for_attachment` before insert; the index just no longer blocks `force=true` overrides.

## Test plan

- [x] `uv run pytest packages/tulip-api/tests/test_imports_endpoint.py::TestUploadErrorPaths` → all green incl. the de-xfailed `test_force_override_creates_second_batch`.
- [x] `just test` → **1132 passing**, 1 skipped (xfail removed; net +1 from main).
- [x] `just lint` → clean
- [x] `just typecheck` → clean across 172 source files
- [ ] CI green on this PR

No manual smoke — the test exercises the upload-twice-with-force flow end-to-end and asserts dual batch creation. Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)