### PR TITLE
docs: bring docs current with Phase 5 close

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Household-focused, double-entry accounting system with first-class envelope budgeting and sinking-fund support.
 
-> **Status:** Pre-alpha — Phases 0–3 complete (project bootstrap, storage + accounting engine, API surface for auth/accounts/transactions/balance, scriptable CLI client). Phase 4 (envelopes + sinking funds) not yet started. See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture, or [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
+> **Status:** Pre-alpha — Phases 0–5 complete (project bootstrap, storage + accounting engine, API surface, scriptable CLI, envelopes + sinking funds + scheduled refills, OFX/QIF/CSV importers + statement-driven reconciliation). Phase 6 (AI integration) is the next phase; pre-internal-beta hardening (#121) is in scope before then. See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture, or [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
 
 ---
 
@@ -54,9 +54,9 @@ tulip-accounting/
 ```bash
 git clone https://github.com/<your-org>/tulip-accounting
 cd tulip-accounting
-uv sync                          # installs all workspace packages + dev deps
+uv sync --all-packages --dev     # installs all workspace packages + dev deps
 uv run pre-commit install        # enable pre-commit hooks
-uv run pytest                    # confirm tests pass (460 tests, ~90s)
+just test                        # confirm tests pass (~1130 tests, ~4–5 min with xdist on 4 workers)
 ```
 
 > **Note for committers:** `main` is branch-protected and **requires every commit to be signed**. Configure SSH or GPG commit signing before your first push (`git config --global commit.gpgsign true` plus a signing key); see [CONTRIBUTING.md](CONTRIBUTING.md#branch-protection-on-main) for the details, the most common failure modes, and the diagnostic checklist if a push is rejected as unsigned.
@@ -71,14 +71,18 @@ TULIP_DATABASE_URL=sqlite:///./tulip.db \
 
 ### Common commands
 
+The [`justfile`](justfile) wraps the standard loops; see `just --list` for the full surface.
+
 ```bash
-uv run pytest                                # full test suite (all packages)
+just test                                    # full test suite, parallel (~1130 tests)
+just lint                                    # ruff check
+just typecheck                               # mypy --strict
+just coverage                                # coverage report (gate is 85% project, 90% tulip-core)
+just bench                                   # pytest-benchmark (sequential — incompatible with xdist)
+just ci                                      # everything CI runs, locally
 uv run pytest packages/tulip-core            # tests for a single package
 uv run pytest -m property                    # only property-based (hypothesis) tests
-uv run ruff check                            # lint
-uv run ruff format                           # autoformat
-uv run mypy                                  # type check (strict)
-uv run pre-commit run --all-files            # run all pre-commit hooks
+uv run pytest -m integration                 # only integration tests (CLI subprocess + live API)
 ```
 
 ### Running the API server
@@ -89,30 +93,47 @@ TULIP_JWT_SECRET="$(uv run python -c 'import secrets; print(secrets.token_urlsaf
   uv run uvicorn tulip_api.main:create_app --factory --host 127.0.0.1 --port 8000
 ```
 
-Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.0.0.1:8000/openapi.json` for the OpenAPI spec. Available endpoints:
+Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.0.0.1:8000/openapi.json` for the OpenAPI spec. Endpoint surface (Phases 0–5):
 
-- `POST /v1/auth/{register,login,login/mfa,login/recover,refresh,logout}`
-- `POST /v1/auth/mfa/{enroll,verify,recovery-codes/regenerate}` · `GET /v1/auth/mfa/recovery-codes/status`
-- `GET/POST/PATCH/DELETE /v1/accounts[/{id}]` · `GET /v1/accounts/{id}/balance`
-- `GET/POST /v1/transactions[/{id}]`
-- `GET /v1/reports/trial-balance`
+- **Auth (Phase 2 / 2.x):** `POST /v1/auth/{register,login,login/mfa,login/recover,refresh,logout}`, `POST /v1/auth/mfa/{enroll,verify,recovery-codes/regenerate}`, `GET /v1/auth/mfa/recovery-codes/status`
+- **Accounts + transactions (Phase 2):** `GET/POST/PATCH/DELETE /v1/accounts[/{id}]`, `GET /v1/accounts/{id}/balance`, `GET/POST/PATCH/DELETE /v1/transactions[/{id}]`, `POST /v1/transactions/{id}/void`, `GET /v1/reports/trial-balance`
+- **Envelopes + sinking funds + pools (Phase 4):** `GET/POST/PATCH/DELETE /v1/envelopes[/{id}]`, `GET/POST/PATCH/DELETE /v1/sinking-funds[/{id}]`, `GET /v1/pools/{id}/balance`, `POST /v1/pools/{id}/{refill,transfer,budget-inflow}`, `GET/POST/PATCH/DELETE /v1/refill-schedules[/{id}]`
+- **Importers + reconciliation (Phase 5):** `POST /v1/imports[?force=true]`, `GET /v1/imports/{id}`, `POST /v1/imports/{id}/{apply,lines/{line_id}/promote}`, `GET/POST/PATCH/DELETE /v1/imports/profiles[/{id_or_name}]` (CSV column-mapping profiles, YAML round-trip), `GET/POST/DELETE /v1/reconciliations[/{id}][?cascade=true]`, `POST /v1/reconciliations/{id}/{auto-match,complete,matches,carry-forward}`, `POST /v1/reconciliations/{id}/matches/{id}/reject`, `DELETE /v1/reconciliations/{id}/carry-forward/{tx_id}`
 
 Every non-2xx response is `application/problem+json` per RFC 9457. In production, supply `TULIP_JWT_SECRET` and `TULIP_MASTER_KEY` from a secret store rather than generating fresh on every start (existing tokens and field-encrypted columns won't validate after a restart with new secrets).
 
 ### Running the CLI
 
+A short tour through Phase 5's end-to-end loop (register → import → reconcile):
+
 ```bash
+# Set up.
 uv run tulip register --email me@example.com --display-name Me --household Mine
 uv run tulip auth login --email me@example.com
-uv run tulip accounts add --name Checking --type asset --currency USD --code assets:checking
-uv run tulip accounts add --name Food --type expense --currency USD --code expenses:food
-uv run tulip add --date 2026-04-29 --description 'Grocery store' \
-  --post expenses:food=87.42 \
-  --post assets:checking=-87.42
+uv run tulip accounts add --name Checking --type asset --currency USD --code 1110
+uv run tulip accounts add --name Food --type expense --currency USD --code 5100
+
+# A manual transaction.
+uv run tulip add --date 2026-05-12 --description 'Grocery store' \
+  --post 5100=87.42 \
+  --post 1110=-87.42
 uv run tulip balance
+
+# Importer + reconciliation flow.
+BATCH_ID=$(uv run tulip --json import ofx ./statement.ofx --account 1110 | jq -r .id)
+uv run tulip imports apply "$BATCH_ID"            # promotes lines to PENDING ledger txs
+RECON_ID=$(uv run tulip --json reconcile create \
+  --account 1110 --batch "$BATCH_ID" \
+  --period 2026-05-01..2026-05-31 \
+  --starting 0.00 --ending 1234.56 | jq -r .id)
+uv run tulip reconcile auto-match "$RECON_ID"     # bucketed-confidence matcher (P5.3)
+uv run tulip reconcile show "$RECON_ID"           # 4-section review pane
+uv run tulip reconcile complete "$RECON_ID"       # strict balance check, denormalises reconciled_at
 ```
 
 `tulip add --edit` opens `$EDITOR` with a hledger-style template instead of taking flags. `tulip accounts list` renders a Rich tree when nesting exists, a flat table otherwise (`--flat` to force the table for scripting). Tokens persist in the OS keyring; the CLI exit-code map and full RFC 9457 error rendering are documented in [docs/ARCHITECTURE.md §7.8.5](docs/ARCHITECTURE.md).
+
+Other top-level commands: `tulip envelopes`, `tulip sinking-funds`, `tulip refills`, `tulip transfer`, `tulip refill`, `tulip budget-inflow`, `tulip transactions {show,edit,void,delete}`, `tulip imports {profiles,apply}`. Each takes `--help`; the surface mirrors the API endpoints listed above.
 
 ## Development discipline
 
@@ -128,8 +149,12 @@ This project follows test-driven development. Every feature ships with tests wri
 
 - [Architecture](docs/ARCHITECTURE.md) — full system design, data model, phase roadmap, error-handling standard (§7.8)
 - [Phase Status](docs/PHASE_STATUS.md) — what's shipped, what's queued
-- [Phase 0 Checklist](docs/PHASE_0_CHECKLIST.md) — original bootstrap checklist (Phase 0 complete)
-- Additional docs (DATA_MODEL, API, CLI, DEPLOYMENT, BACKUP_RESTORE, SECURITY, AI) land as their respective phases are built. The OpenAPI spec at `/openapi.json` is the live contract for `tulip-api` until `docs/API.md` exists.
+- [Threat Model](docs/THREAT_MODEL.md) — lightweight security checkpoint (deep audit deferred to Phase 8)
+- [ADRs](docs/adrs/) — architectural decision records (envelope shadow ledger, scheduler primitive, mutation testing, reconciliation)
+- [Phase 0 Checklist](docs/PHASE_0_CHECKLIST.md) — original bootstrap checklist (historical)
+- [CONTRIBUTING.md](CONTRIBUTING.md) — TDD discipline, coverage gates, signed commits, manual smoke test format
+- [CLAUDE.md](CLAUDE.md) — operational notes for AI-assisted development on this repo
+- Additional docs (QUICKSTART, DEPLOYMENT, BACKUP_RESTORE, AI) land as their respective phases are built. The OpenAPI spec at `/openapi.json` is the live contract for `tulip-api` until `docs/API.md` exists.
 
 ## Security & privacy
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Tulip Accounting — Architectural Specification (v1)
 
-**Status:** Ready for handoff to Claude Code
-**Document version:** 1.0
-**Date:** 2026-04-29
+**Status:** Ready for handoff to Claude Code (Phases 0–5 complete; Phase 6 ADR pending)
+**Document version:** 1.1
+**Date:** 2026-04-29 (original) · 2026-05-07 (Phase 5 close + roadmap refresh)
 
 ---
 
@@ -937,17 +937,25 @@ These weren't in the original Phase 3 list but landed before Phase 4 because the
 - Account nesting end-to-end (#42) — `parent_account_id` consistency rules (type / currency / visibility / no-cycle), reparenting via PATCH, CLI `--parent` flag, tree rendering, parent-name surfacing on `show`. Multi-currency parents deliberately rejected for now (#44 is the holding pen).
 - Interactive `tulip add --edit` (#43) — opens `$EDITOR` with a hledger-subset template; reopens with a banner on parse / balance / unknown-account errors.
 
-### Phase 4 — Envelopes + sinking funds
-- Allocation pool models and CRUD
-- Refill rules implementation
-- Scheduled-tx runner (in-process)
-- Reports: envelope status, sinking-fund progress
+### Phase 4 — Envelopes + sinking funds ✅ complete
+- ✅ Allocation pool models + CRUD; pool transfers; budget-inflow command; per-currency Inflow / Unallocated / Spent system pools per [ADR-0001](adrs/0001-envelope-shadow-ledger.md)
+- ✅ Refill rules implementation (`refill_rule` JSON schema, fixed / target-balance / pct-of-inflow shapes; refill-schedule CRUD endpoints + CLI)
+- ✅ Scheduled-tx runner — in-process per [ADR-0002](adrs/0002-scheduler-primitive.md); polls `scheduled_jobs` + writes `scheduled_job_runs` audit rows; runs in the FastAPI lifespan with deliberate test-time disable via `enable_runner=False`
+- ✅ Envelope + sinking-fund CLI surface (`tulip envelopes`, `tulip sinking-funds`, `tulip refills`, `tulip refill`, `tulip transfer`, `tulip budget-inflow`)
 
-### Phase 5 — Importers + reconciliation
-- OFX, QIF, CSV importers
-- Statement-driven reconciliation matcher
-- Manual cleared/reconciled flow
-- Import batches and rollback
+### Phase 5 — Importers + reconciliation ✅ complete
+
+Per [ADR-0004](adrs/0004-reconciliation.md). Closed 2026-05-07 across nine sub-slices (P5.0 → P5.4.d) plus three follow-up cleanup PRs.
+
+- ✅ **P5.0** — Transaction void / PENDING-only edit / hard delete (#55). The un-reconcile dependency for the rest of Phase 5; ships before importers so reconciliation has a working revert path.
+- ✅ **P5.1** — Storage layer for imports + reconciliation: `attachments`, `attachment_links`, `import_batches`, `statement_lines`, `reconciliations`, `reconciliation_matches`, `csv_profiles` tables; SQLite-trigger drop-and-recreate dance for `transactions` denorms.
+- ✅ **P5.2.a/b/c** — OFX (`ofxtools`, XXE-safe), QIF (hand-rolled line parser), CSV (per-household profiles, YAML round-trip via `yaml.safe_load`) importers + `POST /v1/imports`.
+- ✅ **P5.3** — Reconciliation matcher (pure-`tulip-core`, `find_candidates` with bucketed `MatchConfidence` per ADR §Q2) + `Categorizer` Protocol DI seam for Phase 6.
+- ✅ **P5.4.a** — Apply / promote endpoints + CLI: statement lines → PENDING ledger transactions via the registered `Categorizer` (currently `NullCategorizer` → `Imbalance:Unknown`).
+- ✅ **P5.4.b** — Reconciliation envelope + auto-match: `POST/GET/DELETE /v1/reconciliations`, `/auto-match`, `/complete`, `/matches/{id}/reject`. One IN_PROGRESS reconciliation per account at a time.
+- ✅ **P5.4.c** — Manual match (`POST /matches`) + carry-forward (`/carry-forward` CRUD). `/complete` balance equation extended: `sum(matched) + sum(carry_forward) == ending - starting`.
+- ✅ **P5.4.d** — `tulip reconcile` CLI (10 subcommands wrapping the endpoints) + new `GET /v1/reconciliations` list endpoint.
+- ✅ **Cleanup**: PR #129 (#127 — inbox surfacing prior-completed-recon lines), PR #130 (#114 — relax `import_batch` idempotency index, wire `?force=true`); #118 closed wontfix.
 
 ### Phase 6 — AI integration
 - **Privacy audit** *before* AI capabilities ship — household financial data starts leaving the local boundary here, so data-flow review, redaction policy, retention, and per-tenant opt-in/opt-out shape this phase's design rather than reviewing it after. Tracked as part of the Phase 6 entry criteria.

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-07 · `main` @ **P5.4.d in flight** (`tulip reconcile` CLI — closes Phase 5)
+**Last updated:** 2026-05-07 · `main` @ **Phase 5 complete + cleanup PRs landed** (#127, #114, #118 closed)
 
 ---
 
@@ -18,7 +18,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 - **Phase 4 (envelopes + sinking funds):** ✅ **complete** — all seven slices merged 2026-05-02. P4.0 (#60), P4.1.a (#62), P4.1.b (#63), P4.2 (#66), P4.3.a (#68 — closes #7 via [ADR-0002](adrs/0002-scheduler-primitive.md)), P4.3.b (#69), P4.3.c (#70).
 - **Phase 5 (importers + reconciliation):** ✅ **complete** — P5.0 (#55), P5.1 (storage layer), P5.2.a/b/c (OFX / QIF / CSV importers), P5.3 (matcher + categorizer DI seam), P5.4.a (apply / promote endpoints + CLI), P5.4.b (reconciliation envelope + auto-match), P5.4.c (manual match + carry-forward), and P5.4.d (`tulip reconcile` CLI) all merged. Phase 5 closes per [ADR-0004](adrs/0004-reconciliation.md).
 
-**Tests:** 1113 passing · **CI:** green on `main`
+- **Phase 5 cleanup (post-merge):** three follow-ups closed — #127 (reconciliation inbox surfacing prior-completed-recon lines, fix in PR #129), #114 (relax `import_batch` idempotency index + wire `?force=true`, PR #130), #118 (CLI `--household` vs API `household_name` asymmetry — closed wontfix; rationale in `feedback_pr_body_no_backtick_escapes.md` and the issue thread).
+
+**Tests:** 1132 passing · **CI:** green on `main`
 
 ---
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -2,7 +2,7 @@
 
 **Status:** lightweight checkpoint, not a deep audit. **Deep audits** are scheduled per the [§10 audit cadence in ARCHITECTURE.md](ARCHITECTURE.md): privacy audit before Phase 6 (AI), deep security audit at Phase 8 (operations + hardening), pre-cloud re-audit at Phase 9.
 
-**Last updated:** 2026-05-01 · `main` @ `7e724a6`
+**Last updated:** 2026-05-07 · `main` @ Phase 5 complete
 
 This document captures what the system protects, what it doesn't, and the constraints Phase 4–6 work must not violate. It exists because the cheap moment to lock in trust boundaries is *before* envelopes / importers / AI add surface area, not after. Tracked as #56.
 
@@ -56,8 +56,8 @@ Single-tenant local deployment scopes the actor list down hard:
 - **Network attacker** — single-tenant local. **Phase 9.**
 - **Cross-household attacker** — single-tenant local. **Phase 9** (cloud), but the design already has composite FKs to make this safe-by-construction.
 - **Compromised AI provider / prompt injection / model exfiltration** — no AI in flight. **Phase 6.**
-- **Compromised import source** — no importers yet. **Phase 5** (importers + reconciliation) brings parser-hardening + size limits into scope as part of that phase's entry criteria — see [§5](#5-constraints-for-phase-46-work).
-- **Stolen attachment / external-document exposure** — no attachments yet (#36 holds the hook, no implementation). **Phase 5+** when imported statements become real artifacts.
+- **Compromised import source** — Phase 5 shipped 2026-05-07. Now **in scope**: see [§5.2](#52--phase-5-importers--reconciliation) for the constraints that landed (size cap, parser hardening, encrypted attachment storage).
+- **Stolen attachment / external-document exposure** — Phase 5 wired the encrypted attachment store. Now **in scope**; field-level AES-256-GCM via the master key per ARCHITECTURE.md §7.4 Layer 3.
 
 ## 4. Known-deferred mitigations
 
@@ -94,11 +94,28 @@ Rules that must hold for the work that's about to happen. Each one references wh
 - **Refill rules don't execute arbitrary expressions.** The `refill_rule` JSON field (per ARCHITECTURE.md §5.3) is a structured shape, not a code-eval surface. Audit any future "expression-y" field for the same constraint.
 - **No new uniqueness constraints on user-chosen labels** without considering "same label across households" — this bit us once already in P2.x.3 (login mismatched on email-not-unique-across-households).
 
-### 5.2 — Phase 5 (importers + reconciliation)
+### 5.2 — Phase 5 (importers + reconciliation) — ✅ shipped
 
-- **Importers handle untrusted input.** OFX / CSV / QIF parsers must be hardened against malformed input: explicit size limits (default 50MB?), explicit timeout on parse, no XML external entities, no path traversal in filename fields. This is the *first* surface in v1 that processes attacker-controlled files.
-- **Statement attachments live in the encrypted attachment store** (ARCHITECTURE.md §7.4 Layer 3). Don't shortcut to the filesystem.
-- **Transaction void / reversal** (#55) — the un-reconcile flow that lands in this phase is the prerequisite for void, not the other way around. Encode the dependency in the slice ordering.
+Phase 5 closed 2026-05-07. The constraints that were locked at Phase 5 entry, and how they landed:
+
+- **Importers handle untrusted input.** OFX / QIF / CSV parsers all run under explicit size + content-type guards in `tulip_api.routers.imports.upload_import`:
+  - **25 MB upload cap** (`MAX_OFX_BYTES` constant) checked before slurping into memory; `413 request.payload_too_large` on overflow. Real bank statements are well under 1 MB; the cap is generous and bounds worst case.
+  - **Content-type allow-list** per format (OFX accepts `application/x-ofx`, `application/octet-stream`, `text/xml`, `application/xml`; QIF / CSV similar) checked before parsing; `415 request.unsupported_media_type` otherwise.
+  - **OFX**: `ofxtools` (chosen over `ofxparse` for active maintenance + XXE safety; uses `defusedxml` under the hood). XXE rejection covered by `tulip-importers/tests/test_ofx_security.py`.
+  - **QIF**: hand-rolled line-oriented parser; no XML attack surface.
+  - **CSV**: `csv.DictReader` with a per-household `CsvProfile` (Pydantic v2, YAML round-trip via `yaml.safe_load` only — `yaml.load` is banned by an architecture test). Profile uploads cap at 100 KB.
+  - Empty-body inputs surface a typed problem (`import.ofx_parse_failed` / `qif_parse_failed` / `csv_parse_failed`) rather than crashing.
+- **Statement attachments live in the encrypted attachment store** (ARCHITECTURE.md §7.4 Layer 3). `AttachmentRepository.create` writes the encrypted blob to `Settings.attachment_root`; the master key wraps the per-attachment DEK; the file on disk is never plaintext. Content-hash dedup (`ix_attachments_hash`) ensures one Attachment row per unique bytes per household — a duplicate upload re-uses the existing attachment row.
+- **Filename safety.** `source_filename` is stored verbatim (display only); the actual on-disk path is content-hash-derived, so user-supplied filename never participates in path resolution. No path-traversal surface.
+- **Transaction void / reversal** (#55) shipped as P5.0, ahead of the reconciliation flow that depends on it. The un-reconcile path (`DELETE /v1/reconciliations/{id}?cascade=true`) routes through `ReconciliationRepository.revert()`, the architecture-test-enforced single chokepoint for `transactions.reconciliation_id` + `reconciled_at` + `carried_forward_from_reconciliation_id` writes.
+- **`?force=true` upload override** (#114, ADR §Q6, PR #130) intentionally bypasses the same-file/same-account duplicate check. The audit log records `"force": true` in the `after_snapshot` so the admin trail is honest about the duplicate. Idempotency lookup is application-level; the underlying index is a query accelerator, not a constraint.
+- **Reconciliation is single-IN_PROGRESS-per-account** by the locked P5.4.b decision (`ReconciliationAccountAlreadyInProgressError`, 409). Simplifies the matcher's "already-reconciled" detection; closes a class of double-match bugs that would otherwise be possible if two reconciliations were open simultaneously.
+
+What is **out of scope** of the Phase 5 threat model and explicitly deferred:
+
+- **Attachment download endpoint** — there's no `GET /v1/imports/{id}/attachment` yet. Statement bytes can be re-uploaded but not retrieved through the API. If/when that endpoint lands, range-request denial-of-service + content-disposition smuggling become in-scope concerns.
+- **Multi-currency reconciliation** — every Phase 5 endpoint asserts `account.currency == reconciliation.currency`; multi-currency is silently out of scope. Lifting this requires FX rate engine work first (per ARCHITECTURE.md §1.3 deferred items).
+- **Partial-of-one matches** (a $100 statement line matching $60 of a $100 ledger tx with $40 residual) — explicitly rejected for v1 per ADR-0004 §Q3. Manual match enforces `match_amount == line.amount`.
 
 ### 5.3 — Phase 6 (AI integration)
 


### PR DESCRIPTION
## Summary

Four-file refresh covering the drift between current `main` and the docs that hadn't moved since Phase 4:

- **`README.md`** — status moved from "Phases 0–3 complete" → "Phases 0–5 complete + pre-internal-beta hardening (#121) before Phase 6". Test count `460 → ~1130`, recipe references `uv run pytest → just test`, endpoint surface expanded to cover Phase 4 (envelopes / pools / refills) + full Phase 5 (imports / reconciliations). The CLI walkthrough now demonstrates the import → reconcile loop end-to-end. Documentation links surface CONTRIBUTING.md, CLAUDE.md, and the ADR directory.

- **`docs/PHASE_STATUS.md`** — header marker moved to "Phase 5 complete + cleanup PRs landed." Test count `1113 → 1132`. New bullet noting the three cleanup PRs (#129, #130) and the wontfix close on #118.

- **`docs/THREAT_MODEL.md`** — §3 "out of scope" entries for "compromised import source" and "stolen attachment" flipped to in-scope. §5.2 rewritten from "constraints for upcoming Phase 5 work" to "what shipped + how the constraints landed" — concrete numbers (25 MB cap), library choices (`ofxtools` for XXE safety, `yaml.safe_load` enforced by architecture test), and the new ADR-0004 §Q3 partial-of-one rejection. Added explicit deferred items (attachment download endpoint, multi-currency reconciliation).

- **`docs/ARCHITECTURE.md`** — doc version `1.0 → 1.1`; date stamped with Phase 5 close. §10 Phase 4 + Phase 5 entries flipped from forward-looking bullets to "complete" with sub-slice breakdowns + ADR cross-refs.

No code changes; all tests untouched. Documentation only.

## Test plan

- [x] `git diff --stat` confirms only `README.md` + `docs/*.md` changed.
- [x] Pre-commit hygiene hooks (trim whitespace, fix EOF) passed; no ruff / mypy run because no `*.py` changed.
- [ ] CI green on this PR (lint + secrets scan should be the only jobs that run on a docs-only PR per the path-conditional `changes` job in `.github/workflows/ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)