### PR TITLE
fix: TULIP_KEY_FILE master-key store with permission gate (closes #132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,12 @@ Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.
 - **Envelopes + sinking funds + pools (Phase 4):** `GET/POST/PATCH/DELETE /v1/envelopes[/{id}]`, `GET/POST/PATCH/DELETE /v1/sinking-funds[/{id}]`, `GET /v1/pools/{id}/balance`, `POST /v1/pools/{id}/{refill,transfer,budget-inflow}`, `GET/POST/PATCH/DELETE /v1/refill-schedules[/{id}]`
 - **Importers + reconciliation (Phase 5):** `POST /v1/imports[?force=true]`, `GET /v1/imports/{id}`, `POST /v1/imports/{id}/{apply,lines/{line_id}/promote}`, `GET/POST/PATCH/DELETE /v1/imports/profiles[/{id_or_name}]` (CSV column-mapping profiles, YAML round-trip), `GET/POST/DELETE /v1/reconciliations[/{id}][?cascade=true]`, `POST /v1/reconciliations/{id}/{auto-match,complete,matches,carry-forward}`, `POST /v1/reconciliations/{id}/matches/{id}/reject`, `DELETE /v1/reconciliations/{id}/carry-forward/{tx_id}`
 
-Every non-2xx response is `application/problem+json` per RFC 9457. In production, supply `TULIP_JWT_SECRET` and `TULIP_MASTER_KEY` from a secret store rather than generating fresh on every start (existing tokens and field-encrypted columns won't validate after a restart with new secrets).
+Every non-2xx response is `application/problem+json` per RFC 9457. In production, supply `TULIP_JWT_SECRET` and the master key from a secret store rather than generating fresh on every start (existing tokens and field-encrypted columns won't validate after a restart with new secrets). The master key can come from one of two sources, in this order of precedence:
+
+1. **`TULIP_MASTER_KEY`** — base64-encoded 32 bytes, inline in the environment. Convenient for `docker run -e ...` and CI.
+2. **`TULIP_KEY_FILE`** — path to a file containing the base64-encoded 32 bytes. The file **must** be `chmod 0600` (owner-only RW); any group or other access bit refuses boot with a typed error. This is the recommended path for self-hosted internal-beta deploys via Docker secrets (#132).
+
+If neither is set, an ephemeral key is generated and a warning is logged — fine for tests and dev, fatal for production.
 
 ### Running the CLI
 

--- a/packages/tulip-api/src/tulip_api/config.py
+++ b/packages/tulip-api/src/tulip_api/config.py
@@ -36,28 +36,67 @@ def _default_attachment_root() -> Path:
     return Path.home() / ".local" / "share" / "tulip" / "attachments"
 
 
-def _default_master_key() -> bytes:
-    """Resolve the field-encryption master key.
+def _decode_key_bytes(raw: str, *, source: str) -> bytes:
+    """Decode a base64 string into a 32-byte key, with typed errors.
 
-    Reads ``TULIP_MASTER_KEY`` (base64-encoded 32 bytes). If unset, falls
-    back to a freshly generated ephemeral key and logs a warning — fine
-    for tests and dev, fatal for prod (existing TOTP secrets become
-    undecryptable on every restart).
+    ``source`` is a human-readable origin used in the error message
+    (e.g. ``TULIP_MASTER_KEY`` or ``$TULIP_KEY_FILE``).
     """
-    raw = os.environ.get("TULIP_MASTER_KEY")
-    if raw is None:
-        log.warning(
-            "TULIP_MASTER_KEY not set; using an ephemeral master key. "
-            "Field-encrypted data (e.g. TOTP secrets) will not survive a process restart."
-        )
-        return secrets.token_bytes(32)
     try:
         decoded = base64.b64decode(raw, validate=True)
     except (binascii.Error, ValueError) as exc:
-        raise ValueError("TULIP_MASTER_KEY must be valid base64 (32 raw bytes encoded).") from exc
+        raise ValueError(f"{source} must be valid base64 (32 raw bytes encoded).") from exc
     if len(decoded) != 32:
-        raise ValueError(f"TULIP_MASTER_KEY must decode to exactly 32 bytes (got {len(decoded)}).")
+        raise ValueError(f"{source} must decode to exactly 32 bytes (got {len(decoded)}).")
     return decoded
+
+
+def _load_master_key_from_file(path: Path) -> bytes:
+    """Load the master key from a file, refusing world/group-readable modes.
+
+    Per ADR / #132 hardening: the file mode must be 0600 (owner-only RW).
+    Any group/other read or write bit refuses boot — internal-beta deploys
+    must keep the key off shared filesystems.
+    """
+    if not path.exists():
+        raise ValueError(f"$TULIP_KEY_FILE points at {path}, but that file was not found.")
+    mode = path.stat().st_mode & 0o777
+    if mode & 0o077:
+        raise ValueError(
+            f"$TULIP_KEY_FILE {path} has mode {mode:#o}; group/other access "
+            "is forbidden. Run `chmod 0600 {path}` and retry."
+        )
+    contents = path.read_text(encoding="ascii").strip()
+    return _decode_key_bytes(contents, source=f"$TULIP_KEY_FILE ({path})")
+
+
+def _default_master_key() -> bytes:
+    """Resolve the field-encryption master key.
+
+    Resolution order:
+
+    1. ``TULIP_MASTER_KEY`` (base64-encoded 32 bytes) wins if set.
+    2. ``TULIP_KEY_FILE`` (path to a 0600 file containing base64-encoded
+       32 bytes) is the second choice. Per #132 hardening: the file mode
+       gate refuses boot on a world/group-readable file.
+    3. Fall back to a freshly generated ephemeral key with a warning.
+       Fine for tests and dev; fatal for prod (existing TOTP secrets
+       become undecryptable on every restart).
+    """
+    raw = os.environ.get("TULIP_MASTER_KEY")
+    if raw is not None:
+        return _decode_key_bytes(raw, source="TULIP_MASTER_KEY")
+
+    file_path = os.environ.get("TULIP_KEY_FILE")
+    if file_path:
+        return _load_master_key_from_file(Path(file_path).expanduser())
+
+    log.warning(
+        "Neither TULIP_MASTER_KEY nor TULIP_KEY_FILE is set; using an ephemeral "
+        "master key. Field-encrypted data (e.g. TOTP secrets) will not survive "
+        "a process restart."
+    )
+    return secrets.token_bytes(32)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/tulip-api/tests/test_config.py
+++ b/packages/tulip-api/tests/test_config.py
@@ -48,3 +48,85 @@ class TestMasterKey:
         a = Settings()
         b = Settings()
         assert a.master_key != b.master_key
+
+
+class TestMasterKeyFile:
+    """``$TULIP_KEY_FILE`` file-based key store (#132 / #121 hardening).
+
+    Locked design decisions:
+    - Env var TULIP_KEY_FILE points at a file containing base64-encoded 32 bytes.
+    - File mode must be 0600 (or stricter); any group/other read bit refuses boot.
+    - TULIP_MASTER_KEY (if set) takes precedence — file is the fallback for
+      the env var, ephemeral is the fallback for both.
+    """
+
+    def _write_key(self, tmp_path, raw: bytes, *, mode: int = 0o600):
+        from pathlib import Path
+
+        key_file = Path(tmp_path) / "master.key"
+        key_file.write_text(base64.b64encode(raw).decode("ascii"))
+        key_file.chmod(mode)
+        return key_file
+
+    def test_loads_from_file_with_strict_mode(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        raw = b"\x02" * 32
+        key_file = self._write_key(tmp_path, raw, mode=0o600)
+        monkeypatch.setenv("TULIP_KEY_FILE", str(key_file))
+        s = Settings()
+        assert s.master_key == raw
+
+    def test_refuses_world_readable_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        key_file = self._write_key(tmp_path, b"\x03" * 32, mode=0o644)
+        monkeypatch.setenv("TULIP_KEY_FILE", str(key_file))
+        with pytest.raises(ValueError, match="0600"):
+            Settings()
+
+    def test_refuses_group_readable_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        key_file = self._write_key(tmp_path, b"\x04" * 32, mode=0o640)
+        monkeypatch.setenv("TULIP_KEY_FILE", str(key_file))
+        with pytest.raises(ValueError, match="0600"):
+            Settings()
+
+    def test_refuses_bad_base64(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        from pathlib import Path
+
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        key_file = Path(tmp_path) / "master.key"
+        key_file.write_text("not-base64!!!")
+        key_file.chmod(0o600)
+        monkeypatch.setenv("TULIP_KEY_FILE", str(key_file))
+        with pytest.raises(ValueError, match="base64"):
+            Settings()
+
+    def test_refuses_wrong_length(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        key_file = self._write_key(tmp_path, b"\x05" * 16, mode=0o600)
+        monkeypatch.setenv("TULIP_KEY_FILE", str(key_file))
+        with pytest.raises(ValueError, match="32 bytes"):
+            Settings()
+
+    def test_refuses_missing_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        monkeypatch.setenv("TULIP_KEY_FILE", str(tmp_path / "does-not-exist.key"))
+        with pytest.raises(ValueError, match=r"not found|does not exist"):
+            Settings()
+
+    def test_env_var_wins_when_both_set(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        env_key = b"\x06" * 32
+        file_key = b"\x07" * 32
+        monkeypatch.setenv("TULIP_MASTER_KEY", base64.b64encode(env_key).decode("ascii"))
+        key_file = self._write_key(tmp_path, file_key, mode=0o600)
+        monkeypatch.setenv("TULIP_KEY_FILE", str(key_file))
+        s = Settings()
+        assert s.master_key == env_key  # env wins
+
+    def test_neither_set_falls_back_to_ephemeral(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        monkeypatch.delenv("TULIP_KEY_FILE", raising=False)
+        with patch("tulip_api.config.log") as mock_log:
+            s = Settings()
+        assert len(s.master_key) == 32
+        mock_log.warning.assert_called_once()


### PR DESCRIPTION
## Summary

Per [#121](https://github.com/rmwarriner/tulip-accounting/issues/121) hardening Tier 1: internal-beta deploys need a real key-management story so a misconfigured environment refuses to boot rather than silently using ephemeral key material.

**Resolution order** (highest precedence first):

1. `TULIP_MASTER_KEY` env var (existing).
2. **`TULIP_KEY_FILE`** *(new)* — path to a file containing base64-encoded 32 bytes. Per locked design decision **B** in #121: env-var-pointed (not XDG; XDG clashes with Docker secrets, see #134). The file mode must be `0600`; any group/other access bit refuses boot with a typed error pointing at `chmod 0600`. Internal-beta users following #134's `compose.yml` will inject the key via Docker secret which mounts at `0400` owner-only, passing the gate.
3. Ephemeral fallback with warning (existing).

Key rotation deferred per locked design decision **C** — internal-beta users get a cookbook entry in QUICKSTART (#138), not a CLI command.

README updated to document the new env var alongside `TULIP_MASTER_KEY`.

## Test plan

- [x] `uv run pytest packages/tulip-api/tests/test_config.py` → **13 passing** (5 prior + 8 new).
- [x] `just test` → **1140 passing**, 1 skipped (up from 1132 on `main`).
- [x] `just lint` → clean
- [x] `just typecheck` → clean across 172 source files
- [ ] CI green on this PR

Test matrix covers:

- File present + `0600` + valid base64 → loaded.
- File mode `0644` → refused with typed error.
- File mode `0640` → refused (group-readable).
- File contents are not valid base64 → refused.
- File contents decode to wrong byte length → refused.
- File path doesn't exist → refused.
- Both `TULIP_MASTER_KEY` and `TULIP_KEY_FILE` set → env var wins (precedence preserved).
- Neither set → ephemeral fallback with warning (existing path unchanged).

Closes #132. Refs #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)