### PR TITLE
feat: tulip backup / restore CLI (closes #133)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/backup.py
+++ b/packages/tulip-cli/src/tulip_cli/backup.py
@@ -1,0 +1,382 @@
+"""Backup + restore primitives for ``tulip backup`` / ``tulip restore`` (#133).
+
+Internal-beta hardening (#121 Tier 1b). The backup format is a tar.gz
+containing:
+
+- ``manifest.json`` (top-level): format version, alembic head, Tulip
+  version, hostname, ISO-8601 UTC timestamp, master-key envelope.
+- ``db/tulip.db``: SQLite snapshot taken via the stdlib ``sqlite3``
+  ``.backup`` API (concurrent-safe; the API process can stay running
+  during backup).
+- ``attachments/<...>``: full ``$TULIP_ATTACHMENT_ROOT`` tree, files
+  preserved as-is (already field-encrypted via the master key).
+
+The master-key envelope is HMAC-SHA256 of a fixed constant under the
+master key. Restore recomputes the HMAC with the currently-loaded master
+key; mismatch refuses extraction. The key itself is never written into
+the backup — losing the backup file alone doesn't leak the key.
+
+Per the locked design decision in #121: the tarball itself is *not*
+re-encrypted. The high-confidentiality fields (TOTP secrets, attachment
+bytes) are already field/file-encrypted; doubling up adds ergonomic
+friction (need the key just to inspect a backup) for marginal gain.
+Pre-external-beta we revisit.
+
+The CLI imports stdlib (``sqlite3``, ``tarfile``, ``hmac``, ``hashlib``)
+only — the architecture test forbids ``tulip_storage`` / ``sqlalchemy``
+/ ``alembic`` in this package.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import io
+import json
+import os
+import platform
+import socket
+import sqlite3
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import IO
+
+#: Bumped when the on-disk shape changes incompatibly. Restore refuses
+#: a backup whose ``manifest.format_version`` is newer than this.
+FORMAT_VERSION = 1
+
+#: Fixed constant fed to HMAC-SHA256 under the master key. Verifies
+#: "this backup was made with the same master key as the current install"
+#: without storing the key in the backup.
+ENVELOPE_INPUT = b"tulip-backup-key-verify-v1"
+
+#: Top-level path inside the tarball.
+_MANIFEST_NAME = "manifest.json"
+_DB_PATH_PREFIX = "db/"
+_ATTACHMENTS_PATH_PREFIX = "attachments/"
+
+
+class BackupError(Exception):
+    """Raised when backup creation fails for a recoverable reason."""
+
+
+class RestoreError(Exception):
+    """Raised when restore fails for a recoverable reason (envelope mismatch, etc)."""
+
+
+@dataclass(frozen=True, slots=True)
+class Manifest:
+    """Backup manifest, serialised as the ``manifest.json`` entry."""
+
+    format_version: int
+    tulip_version: str
+    alembic_head: str | None
+    hostname: str
+    timestamp: str
+    key_envelope: str  # base64-encoded HMAC-SHA256
+
+    def to_json(self) -> bytes:
+        """Serialise to the canonical ``manifest.json`` byte form."""
+        return json.dumps(
+            {
+                "format_version": self.format_version,
+                "tulip_version": self.tulip_version,
+                "alembic_head": self.alembic_head,
+                "hostname": self.hostname,
+                "timestamp": self.timestamp,
+                "key_envelope": self.key_envelope,
+            },
+            indent=2,
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @classmethod
+    def from_json(cls, data: bytes) -> Manifest:
+        """Parse a ``manifest.json`` byte payload back into a ``Manifest`` dataclass."""
+        try:
+            obj = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise RestoreError("manifest.json is not valid JSON") from exc
+        try:
+            return cls(
+                format_version=int(obj["format_version"]),
+                tulip_version=str(obj["tulip_version"]),
+                alembic_head=(str(obj["alembic_head"]) if obj.get("alembic_head") else None),
+                hostname=str(obj["hostname"]),
+                timestamp=str(obj["timestamp"]),
+                key_envelope=str(obj["key_envelope"]),
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise RestoreError(f"manifest.json missing required field: {exc}") from exc
+
+
+def _seal_key_envelope(master_key: bytes) -> str:
+    """Compute the HMAC-SHA256 of ENVELOPE_INPUT under ``master_key``, base64-encoded."""
+    digest = hmac.new(master_key, ENVELOPE_INPUT, hashlib.sha256).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def _verify_key_envelope(envelope: str, master_key: bytes) -> bool:
+    """Constant-time check that ``envelope`` was sealed with ``master_key``."""
+    expected = _seal_key_envelope(master_key)
+    return hmac.compare_digest(expected, envelope)
+
+
+def build_manifest(*, alembic_head: str | None, master_key: bytes, tulip_version: str) -> Manifest:
+    """Construct a Manifest for the current process / install."""
+    return Manifest(
+        format_version=FORMAT_VERSION,
+        tulip_version=tulip_version,
+        alembic_head=alembic_head,
+        hostname=socket.gethostname() or platform.node() or "unknown",
+        timestamp=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        key_envelope=_seal_key_envelope(master_key),
+    )
+
+
+def snapshot_sqlite_db(source_path: Path, dest_path: Path) -> None:
+    """Hot-copy a SQLite database via the stdlib ``.backup`` API.
+
+    Concurrent-safe: the source DB can be in use by another process. The
+    snapshot is a complete, consistent copy at the moment of the call.
+
+    Raises:
+        BackupError: source file does not exist or is not a SQLite database.
+
+    """
+    if not source_path.exists():
+        raise BackupError(f"database file not found: {source_path}")
+    try:
+        src = sqlite3.connect(f"file:{source_path}?mode=ro", uri=True)
+    except sqlite3.OperationalError as exc:
+        raise BackupError(f"could not open database {source_path}: {exc}") from exc
+    try:
+        dest = sqlite3.connect(str(dest_path))
+        try:
+            src.backup(dest)
+        finally:
+            dest.close()
+    finally:
+        src.close()
+
+
+def alembic_head_from_db(db_path: Path) -> str | None:
+    """Read the current alembic revision from a SQLite database, or None if absent."""
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.OperationalError:
+        return None
+    try:
+        cur = conn.execute("SELECT version_num FROM alembic_version LIMIT 1")
+        row = cur.fetchone()
+        return str(row[0]) if row else None
+    except sqlite3.OperationalError:
+        return None
+    finally:
+        conn.close()
+
+
+def write_backup(
+    *,
+    db_path: Path,
+    attachment_root: Path,
+    master_key: bytes,
+    tulip_version: str,
+    out: IO[bytes],
+) -> Manifest:
+    """Stream a tar.gz backup to ``out`` (file or stdout buffer).
+
+    Returns the manifest for caller-side reporting.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        snapshot_path = td_path / "tulip.db"
+        snapshot_sqlite_db(db_path, snapshot_path)
+
+        manifest = build_manifest(
+            alembic_head=alembic_head_from_db(snapshot_path),
+            master_key=master_key,
+            tulip_version=tulip_version,
+        )
+
+        with tarfile.open(fileobj=out, mode="w:gz") as tar:
+            # manifest.json first so streaming readers can verify the
+            # envelope before extracting any data.
+            manifest_bytes = manifest.to_json()
+            info = tarfile.TarInfo(name=_MANIFEST_NAME)
+            info.size = len(manifest_bytes)
+            info.mode = 0o600
+            info.mtime = int(datetime.now(UTC).timestamp())
+            tar.addfile(info, io.BytesIO(manifest_bytes))
+
+            # db/tulip.db
+            tar.add(
+                snapshot_path,
+                arcname=_DB_PATH_PREFIX + snapshot_path.name,
+                recursive=False,
+            )
+
+            # attachments/...
+            if attachment_root.exists():
+                tar.add(attachment_root, arcname=_ATTACHMENTS_PATH_PREFIX.rstrip("/"))
+
+    return manifest
+
+
+def read_backup_manifest(in_path: Path) -> Manifest:
+    """Read just the manifest from an on-disk backup, without extracting."""
+    with tarfile.open(in_path, mode="r:gz") as tar:
+        try:
+            member = tar.getmember(_MANIFEST_NAME)
+        except KeyError as exc:
+            raise RestoreError(f"backup is missing the required {_MANIFEST_NAME} entry") from exc
+        f = tar.extractfile(member)
+        if f is None:
+            raise RestoreError(f"could not read {_MANIFEST_NAME} from backup")
+        return Manifest.from_json(f.read())
+
+
+def restore_backup(
+    *,
+    in_path: Path,
+    db_path: Path,
+    attachment_root: Path,
+    master_key: bytes,
+    current_alembic_head: str | None,
+    force: bool,
+) -> Manifest:
+    """Restore a backup tarball onto ``db_path`` + ``attachment_root``.
+
+    Refuses with :class:`RestoreError` if:
+
+    - The manifest's key envelope doesn't match the current master key.
+    - The format_version is newer than this build supports.
+    - ``db_path`` exists or ``attachment_root`` is non-empty, unless
+      ``force=True``.
+    - The manifest's alembic_head differs from ``current_alembic_head``
+      (the user must run ``alembic upgrade head`` against the restored
+      DB before re-pointing the API at it).
+
+    Returns the restored manifest for caller-side reporting.
+    """
+    manifest = read_backup_manifest(in_path)
+
+    if manifest.format_version > FORMAT_VERSION:
+        raise RestoreError(
+            f"backup format_version is {manifest.format_version}; this build "
+            f"only understands up to v{FORMAT_VERSION}. Upgrade Tulip and retry."
+        )
+
+    if not _verify_key_envelope(manifest.key_envelope, master_key):
+        raise RestoreError(
+            "key envelope mismatch — the backup was made with a different "
+            "master key than the current install. Set TULIP_MASTER_KEY / "
+            "TULIP_KEY_FILE to the key that was active when the backup was "
+            "taken, then retry."
+        )
+
+    if (
+        current_alembic_head is not None
+        and manifest.alembic_head is not None
+        and manifest.alembic_head != current_alembic_head
+    ):
+        raise RestoreError(
+            f"backup was taken at alembic head {manifest.alembic_head!r}, but "
+            f"the current install is at {current_alembic_head!r}. Restore the "
+            "backup to a scratch path, run `alembic upgrade head` against it, "
+            "then move it into place. (Auto-migrate during restore is "
+            "intentionally not done — the operator should see the schema "
+            "transition.)"
+        )
+
+    if not force:
+        if db_path.exists():
+            raise RestoreError(
+                f"refusing to overwrite existing database at {db_path}. "
+                "Pass --force to overwrite, or restore to an empty path."
+            )
+        if attachment_root.exists() and any(attachment_root.iterdir()):
+            raise RestoreError(
+                f"refusing to overwrite non-empty attachment root at "
+                f"{attachment_root}. Pass --force to overwrite."
+            )
+
+    with tarfile.open(in_path, mode="r:gz") as tar:
+        for member in tar.getmembers():
+            name = member.name
+            if name == _MANIFEST_NAME:
+                continue
+            if name.startswith(_DB_PATH_PREFIX):
+                member.name = db_path.name
+                tar.extract(member, path=db_path.parent, filter="data")
+            elif name.startswith(_ATTACHMENTS_PATH_PREFIX):
+                # Re-root attachments under attachment_root.
+                stripped = name[len(_ATTACHMENTS_PATH_PREFIX) :]
+                if not stripped:
+                    continue  # the directory entry itself
+                attachment_root.mkdir(parents=True, exist_ok=True)
+                target = attachment_root / stripped
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                else:
+                    f = tar.extractfile(member)
+                    if f is not None:
+                        target.write_bytes(f.read())
+            else:
+                # Unknown top-level entry — skip rather than error so a
+                # forward-compatible v2 backup can still be read by v1
+                # for the parts it understands.
+                continue
+
+    return manifest
+
+
+def resolve_db_path_from_url(database_url: str) -> Path:
+    """Extract the SQLite file path from a sqlite:/// URL."""
+    if not database_url.startswith("sqlite:///"):
+        raise BackupError(
+            f"backup only supports sqlite:/// URLs (got {database_url!r}). "
+            "Postgres backup is a Phase 9 concern."
+        )
+    return Path(database_url[len("sqlite:///") :]).expanduser().resolve()
+
+
+def load_master_key_from_env() -> bytes:
+    """Resolve the master key the same way the API does (#132)."""
+    raw = os.environ.get("TULIP_MASTER_KEY")
+    if raw is not None:
+        decoded = base64.b64decode(raw, validate=True)
+        if len(decoded) != 32:
+            raise BackupError(f"TULIP_MASTER_KEY must decode to 32 bytes (got {len(decoded)})")
+        return decoded
+
+    file_path = os.environ.get("TULIP_KEY_FILE")
+    if file_path:
+        path = Path(file_path).expanduser()
+        if not path.exists():
+            raise BackupError(f"$TULIP_KEY_FILE points at {path}, but file not found")
+        mode = path.stat().st_mode & 0o777
+        if mode & 0o077:
+            raise BackupError(
+                f"$TULIP_KEY_FILE {path} has mode {mode:#o}; group/other access is forbidden"
+            )
+        contents = path.read_text(encoding="ascii").strip()
+        decoded = base64.b64decode(contents, validate=True)
+        if len(decoded) != 32:
+            raise BackupError(
+                f"$TULIP_KEY_FILE {path} must decode to 32 bytes (got {len(decoded)})"
+            )
+        return decoded
+
+    raise BackupError(
+        "Master key not configured. Set TULIP_MASTER_KEY or TULIP_KEY_FILE "
+        "before running backup/restore. Backup-time key envelope verification "
+        "would be meaningless under an ephemeral key."
+    )

--- a/packages/tulip-cli/src/tulip_cli/commands/backup_restore.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/backup_restore.py
@@ -1,0 +1,239 @@
+"""``tulip backup`` + ``tulip restore`` commands (#133, #121 hardening Tier 1b)."""
+
+from __future__ import annotations
+
+import json as _json
+import os
+import sys
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from tulip_cli.backup import (
+    BackupError,
+    RestoreError,
+    alembic_head_from_db,
+    read_backup_manifest,
+    resolve_db_path_from_url,
+    restore_backup,
+    write_backup,
+)
+from tulip_cli.backup import (
+    load_master_key_from_env as _load_master_key,
+)
+
+
+def _tulip_version() -> str:
+    try:
+        return _pkg_version("tulip-cli")
+    except Exception:  # pragma: no cover - missing package metadata
+        return "0.0.0"
+
+
+def _attachment_root() -> Path:
+    raw = os.environ.get("TULIP_ATTACHMENT_ROOT")
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return Path.home() / ".local" / "share" / "tulip" / "attachments"
+
+
+def _database_url() -> str:
+    return os.environ.get("TULIP_DATABASE_URL", "sqlite:///./tulip.db")
+
+
+def backup_command(
+    ctx: typer.Context,
+    out: Annotated[
+        str,
+        typer.Option(
+            "--out",
+            help=(
+                "Destination path for the tar.gz backup. Use '-' to stream to "
+                "stdout (pipeable into gpg/age/curl)."
+            ),
+        ),
+    ],
+) -> None:
+    """Produce a portable backup of the database + attachments + manifest.
+
+    The tarball contains: the SQLite snapshot (taken via the stdlib
+    ``.backup`` API; concurrent-safe — the API process can stay running),
+    the full encrypted attachment tree, and a manifest with a key envelope
+    so restore can verify the right master key is in scope. The tarball
+    itself is *not* re-encrypted (the high-confidentiality fields are
+    already field-encrypted).
+    """
+    as_json: bool = ctx.obj["json"]
+    try:
+        master_key = _load_master_key()
+        db_path = resolve_db_path_from_url(_database_url())
+    except BackupError as exc:
+        typer.echo(f"backup: {exc}", err=True)
+        raise typer.Exit(2) from None
+
+    if out == "-":
+        manifest = write_backup(
+            db_path=db_path,
+            attachment_root=_attachment_root(),
+            master_key=master_key,
+            tulip_version=_tulip_version(),
+            out=sys.stdout.buffer,
+        )
+        if not as_json:
+            # Stderr so stdout is the tar bytes only.
+            typer.echo(f"backup: streamed to stdout (timestamp {manifest.timestamp})", err=True)
+        return
+
+    out_path = Path(out).expanduser().resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with out_path.open("wb") as f:
+            manifest = write_backup(
+                db_path=db_path,
+                attachment_root=_attachment_root(),
+                master_key=master_key,
+                tulip_version=_tulip_version(),
+                out=f,
+            )
+    except BackupError as exc:
+        typer.echo(f"backup: {exc}", err=True)
+        if out_path.exists():
+            out_path.unlink()
+        raise typer.Exit(2) from None
+
+    if as_json:
+        sys.stdout.write(
+            _json.dumps(
+                {
+                    "out": str(out_path),
+                    "format_version": manifest.format_version,
+                    "tulip_version": manifest.tulip_version,
+                    "alembic_head": manifest.alembic_head,
+                    "timestamp": manifest.timestamp,
+                    "size_bytes": out_path.stat().st_size,
+                }
+            )
+            + "\n"
+        )
+        return
+    typer.echo(
+        f"backup: wrote {out_path} ({out_path.stat().st_size} bytes, "
+        f"alembic head {manifest.alembic_head or 'unknown'}, "
+        f"timestamp {manifest.timestamp})."
+    )
+
+
+def restore_command(
+    ctx: typer.Context,
+    in_path: Annotated[
+        Path,
+        typer.Argument(
+            help="Path to the tar.gz backup to restore.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            metavar="BACKUP_PATH",
+        ),
+    ],
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help=(
+                "Overwrite the database file + attachment root if they're "
+                "already populated. Without this flag, restore refuses rather "
+                "than silently destroying existing data."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Restore a backup onto the configured database + attachment root.
+
+    Refuses if the master-key envelope doesn't match (wrong key in
+    scope), if the schema differs from the current install (operator must
+    migrate the restored DB explicitly), or if existing data would be
+    overwritten without ``--force``.
+    """
+    as_json: bool = ctx.obj["json"]
+    try:
+        master_key = _load_master_key()
+        db_path = resolve_db_path_from_url(_database_url())
+    except BackupError as exc:
+        typer.echo(f"restore: {exc}", err=True)
+        raise typer.Exit(2) from None
+
+    current_head = alembic_head_from_db(db_path) if db_path.exists() else None
+
+    try:
+        manifest = restore_backup(
+            in_path=in_path,
+            db_path=db_path,
+            attachment_root=_attachment_root(),
+            master_key=master_key,
+            current_alembic_head=current_head,
+            force=force,
+        )
+    except RestoreError as exc:
+        typer.echo(f"restore: {exc}", err=True)
+        raise typer.Exit(2) from None
+
+    if as_json:
+        sys.stdout.write(
+            _json.dumps(
+                {
+                    "restored_to_db": str(db_path),
+                    "restored_to_attachments": str(_attachment_root()),
+                    "manifest": {
+                        "format_version": manifest.format_version,
+                        "tulip_version": manifest.tulip_version,
+                        "alembic_head": manifest.alembic_head,
+                        "hostname": manifest.hostname,
+                        "timestamp": manifest.timestamp,
+                    },
+                }
+            )
+            + "\n"
+        )
+        return
+    typer.echo(
+        f"restore: restored {in_path} to {db_path} + {_attachment_root()} "
+        f"(backup taken on {manifest.hostname} at {manifest.timestamp})."
+    )
+
+
+def manifest_command(
+    ctx: typer.Context,
+    in_path: Annotated[
+        Path,
+        typer.Argument(
+            help="Path to a tar.gz backup to inspect.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            metavar="BACKUP_PATH",
+        ),
+    ],
+) -> None:
+    """Print the manifest of a backup without extracting anything."""
+    as_json: bool = ctx.obj["json"]
+    try:
+        manifest = read_backup_manifest(in_path)
+    except RestoreError as exc:
+        typer.echo(f"backup-inspect: {exc}", err=True)
+        raise typer.Exit(2) from None
+
+    if as_json:
+        sys.stdout.write(manifest.to_json().decode("utf-8") + "\n")
+        return
+    typer.echo(
+        f"backup {in_path}:\n"
+        f"  format_version: {manifest.format_version}\n"
+        f"  tulip_version:  {manifest.tulip_version}\n"
+        f"  alembic_head:   {manifest.alembic_head or '<unknown>'}\n"
+        f"  hostname:       {manifest.hostname}\n"
+        f"  timestamp:      {manifest.timestamp}"
+    )

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -16,6 +16,11 @@ import typer
 from tulip_cli import __version__
 from tulip_cli.commands.accounts import accounts_app
 from tulip_cli.commands.auth import auth_app
+from tulip_cli.commands.backup_restore import (
+    backup_command,
+    manifest_command,
+    restore_command,
+)
 from tulip_cli.commands.balance import balance as balance_command
 from tulip_cli.commands.envelopes import envelopes_app
 from tulip_cli.commands.imports import imports_app
@@ -118,6 +123,9 @@ app.add_typer(refills_app, name="refills")
 app.add_typer(imports_app, name="imports")
 app.add_typer(imports_app, name="import")
 app.add_typer(reconcile_app, name="reconcile")
+app.command("backup")(backup_command)
+app.command("restore")(restore_command)
+app.command("backup-inspect")(manifest_command)
 
 
 if __name__ == "__main__":

--- a/packages/tulip-cli/tests/test_backup_restore.py
+++ b/packages/tulip-cli/tests/test_backup_restore.py
@@ -1,0 +1,453 @@
+"""Tests for ``tulip backup`` / ``tulip restore`` (#133)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from tulip_cli.backup import (
+    FORMAT_VERSION,
+    BackupError,
+    Manifest,
+    RestoreError,
+    _seal_key_envelope,
+    _verify_key_envelope,
+    alembic_head_from_db,
+    build_manifest,
+    read_backup_manifest,
+    resolve_db_path_from_url,
+    restore_backup,
+    snapshot_sqlite_db,
+    write_backup,
+)
+
+# ---- Manifest + envelope --------------------------------------------------
+
+
+class TestKeyEnvelope:
+    def test_seal_then_verify_round_trips(self):
+        key = b"\x01" * 32
+        env = _seal_key_envelope(key)
+        assert _verify_key_envelope(env, key) is True
+
+    def test_verify_rejects_wrong_key(self):
+        env = _seal_key_envelope(b"\x01" * 32)
+        assert _verify_key_envelope(env, b"\x02" * 32) is False
+
+    def test_envelope_is_base64(self):
+        env = _seal_key_envelope(b"\x03" * 32)
+        # Round-trip through base64 must succeed.
+        base64.b64decode(env, validate=True)
+
+
+class TestManifestSerialisation:
+    def test_to_json_then_from_json_round_trips(self):
+        m = build_manifest(
+            alembic_head="deadbeef",
+            master_key=b"\x04" * 32,
+            tulip_version="1.2.3",
+        )
+        roundtripped = Manifest.from_json(m.to_json())
+        assert roundtripped == m
+
+    def test_from_json_rejects_garbage(self):
+        with pytest.raises(RestoreError, match="not valid JSON"):
+            Manifest.from_json(b"not-json")
+
+    def test_from_json_rejects_missing_field(self):
+        with pytest.raises(RestoreError, match="missing required field"):
+            Manifest.from_json(b'{"format_version": 1}')
+
+
+# ---- Snapshot + alembic_head_from_db --------------------------------------
+
+
+@pytest.fixture
+def seeded_db(tmp_path: Path) -> Path:
+    """Tiny SQLite DB with an alembic_version row."""
+    db = tmp_path / "src.db"
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute("CREATE TABLE alembic_version (version_num TEXT NOT NULL)")
+        conn.execute("INSERT INTO alembic_version VALUES ('aaaa1111')")
+        conn.execute("CREATE TABLE rows (id INTEGER PRIMARY KEY, label TEXT)")
+        conn.execute("INSERT INTO rows VALUES (1, 'one'), (2, 'two')")
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+class TestSnapshot:
+    def test_snapshot_copies_data(self, tmp_path: Path, seeded_db: Path):
+        dest = tmp_path / "snap.db"
+        snapshot_sqlite_db(seeded_db, dest)
+        assert dest.exists()
+        conn = sqlite3.connect(str(dest))
+        try:
+            rows = conn.execute("SELECT label FROM rows ORDER BY id").fetchall()
+        finally:
+            conn.close()
+        assert [r[0] for r in rows] == ["one", "two"]
+
+    def test_snapshot_missing_source_raises(self, tmp_path: Path):
+        with pytest.raises(BackupError, match="not found"):
+            snapshot_sqlite_db(tmp_path / "nope.db", tmp_path / "snap.db")
+
+    def test_alembic_head_from_db(self, seeded_db: Path):
+        assert alembic_head_from_db(seeded_db) == "aaaa1111"
+
+    def test_alembic_head_returns_none_for_missing(self, tmp_path: Path):
+        assert alembic_head_from_db(tmp_path / "nope.db") is None
+
+    def test_alembic_head_returns_none_for_no_table(self, tmp_path: Path):
+        db = tmp_path / "empty.db"
+        sqlite3.connect(str(db)).close()
+        assert alembic_head_from_db(db) is None
+
+
+# ---- write_backup / restore_backup round-trip -----------------------------
+
+
+@pytest.fixture
+def attachment_root(tmp_path: Path) -> Path:
+    """Attachment tree with two files, mirroring the real layout."""
+    root = tmp_path / "attachments"
+    (root / "ab" / "cd").mkdir(parents=True)
+    (root / "ab" / "cd" / "doc.bin").write_bytes(b"opaque encrypted bytes 1")
+    (root / "ef").mkdir(parents=True)
+    (root / "ef" / "more.bin").write_bytes(b"opaque encrypted bytes 2")
+    return root
+
+
+class TestRoundTrip:
+    def test_backup_then_restore_recovers_db_and_attachments(
+        self, tmp_path: Path, seeded_db: Path, attachment_root: Path
+    ):
+        master_key = b"\x05" * 32
+        backup_path = tmp_path / "snap.tar.gz"
+        with backup_path.open("wb") as f:
+            write_backup(
+                db_path=seeded_db,
+                attachment_root=attachment_root,
+                master_key=master_key,
+                tulip_version="0.1.0",
+                out=f,
+            )
+        assert backup_path.stat().st_size > 0
+
+        # Restore to fresh paths.
+        new_db = tmp_path / "restored.db"
+        new_root = tmp_path / "restored-attachments"
+        manifest = restore_backup(
+            in_path=backup_path,
+            db_path=new_db,
+            attachment_root=new_root,
+            master_key=master_key,
+            current_alembic_head="aaaa1111",  # matches seeded DB
+            force=False,
+        )
+        assert manifest.format_version == FORMAT_VERSION
+        assert new_db.exists()
+        # DB content survives.
+        conn = sqlite3.connect(str(new_db))
+        try:
+            rows = conn.execute("SELECT label FROM rows ORDER BY id").fetchall()
+        finally:
+            conn.close()
+        assert [r[0] for r in rows] == ["one", "two"]
+        # Attachments survive.
+        assert (new_root / "ab" / "cd" / "doc.bin").read_bytes() == b"opaque encrypted bytes 1"
+        assert (new_root / "ef" / "more.bin").read_bytes() == b"opaque encrypted bytes 2"
+
+    def test_restore_refuses_wrong_master_key(
+        self, tmp_path: Path, seeded_db: Path, attachment_root: Path
+    ):
+        backup_path = tmp_path / "snap.tar.gz"
+        with backup_path.open("wb") as f:
+            write_backup(
+                db_path=seeded_db,
+                attachment_root=attachment_root,
+                master_key=b"\x06" * 32,
+                tulip_version="0.1.0",
+                out=f,
+            )
+        with pytest.raises(RestoreError, match="key envelope mismatch"):
+            restore_backup(
+                in_path=backup_path,
+                db_path=tmp_path / "restored.db",
+                attachment_root=tmp_path / "restored-attachments",
+                master_key=b"\x07" * 32,  # wrong key
+                current_alembic_head="aaaa1111",
+                force=False,
+            )
+
+    def test_restore_refuses_schema_mismatch(
+        self, tmp_path: Path, seeded_db: Path, attachment_root: Path
+    ):
+        backup_path = tmp_path / "snap.tar.gz"
+        with backup_path.open("wb") as f:
+            write_backup(
+                db_path=seeded_db,
+                attachment_root=attachment_root,
+                master_key=b"\x08" * 32,
+                tulip_version="0.1.0",
+                out=f,
+            )
+        with pytest.raises(RestoreError, match="alembic upgrade head"):
+            restore_backup(
+                in_path=backup_path,
+                db_path=tmp_path / "restored.db",
+                attachment_root=tmp_path / "restored-attachments",
+                master_key=b"\x08" * 32,
+                current_alembic_head="zzzz9999",  # different head
+                force=False,
+            )
+
+    def test_restore_refuses_existing_db_without_force(
+        self, tmp_path: Path, seeded_db: Path, attachment_root: Path
+    ):
+        backup_path = tmp_path / "snap.tar.gz"
+        with backup_path.open("wb") as f:
+            write_backup(
+                db_path=seeded_db,
+                attachment_root=attachment_root,
+                master_key=b"\x09" * 32,
+                tulip_version="0.1.0",
+                out=f,
+            )
+        existing_db = tmp_path / "existing.db"
+        existing_db.write_text("not a db, just exists")
+        with pytest.raises(RestoreError, match="refusing to overwrite"):
+            restore_backup(
+                in_path=backup_path,
+                db_path=existing_db,
+                attachment_root=tmp_path / "restored-attachments",
+                master_key=b"\x09" * 32,
+                current_alembic_head="aaaa1111",
+                force=False,
+            )
+
+    def test_restore_overwrites_with_force(
+        self, tmp_path: Path, seeded_db: Path, attachment_root: Path
+    ):
+        backup_path = tmp_path / "snap.tar.gz"
+        with backup_path.open("wb") as f:
+            write_backup(
+                db_path=seeded_db,
+                attachment_root=attachment_root,
+                master_key=b"\x0a" * 32,
+                tulip_version="0.1.0",
+                out=f,
+            )
+        existing_db = tmp_path / "existing.db"
+        existing_db.write_text("not a db, just exists")
+        # Should not raise.
+        restore_backup(
+            in_path=backup_path,
+            db_path=existing_db,
+            attachment_root=tmp_path / "restored-attachments",
+            master_key=b"\x0a" * 32,
+            current_alembic_head="aaaa1111",
+            force=True,
+        )
+
+    def test_read_manifest_without_extracting(
+        self, tmp_path: Path, seeded_db: Path, attachment_root: Path
+    ):
+        backup_path = tmp_path / "snap.tar.gz"
+        with backup_path.open("wb") as f:
+            write_backup(
+                db_path=seeded_db,
+                attachment_root=attachment_root,
+                master_key=b"\x0b" * 32,
+                tulip_version="0.1.0",
+                out=f,
+            )
+        manifest = read_backup_manifest(backup_path)
+        assert manifest.format_version == FORMAT_VERSION
+        assert manifest.alembic_head == "aaaa1111"
+        assert manifest.tulip_version == "0.1.0"
+
+    def test_format_version_too_new_refused(self, tmp_path: Path):
+        # Build a tarball with a manifest whose format_version is FORMAT_VERSION+1.
+        backup_path = tmp_path / "future.tar.gz"
+        future_manifest = {
+            "format_version": FORMAT_VERSION + 1,
+            "tulip_version": "9.9.9",
+            "alembic_head": "ffff",
+            "hostname": "future",
+            "timestamp": "2099-12-31T23:59:59Z",
+            "key_envelope": _seal_key_envelope(b"\x0c" * 32),
+        }
+        with tarfile.open(backup_path, mode="w:gz") as tar:
+            data = json.dumps(future_manifest).encode("utf-8")
+            info = tarfile.TarInfo(name="manifest.json")
+            info.size = len(data)
+            import io as _io
+
+            tar.addfile(info, _io.BytesIO(data))
+        with pytest.raises(RestoreError, match="format_version"):
+            restore_backup(
+                in_path=backup_path,
+                db_path=tmp_path / "restored.db",
+                attachment_root=tmp_path / "restored-attachments",
+                master_key=b"\x0c" * 32,
+                current_alembic_head="ffff",
+                force=False,
+            )
+
+    def test_missing_manifest_raises(self, tmp_path: Path):
+        backup_path = tmp_path / "no-manifest.tar.gz"
+        with tarfile.open(backup_path, mode="w:gz") as tar:
+            data = b"some payload"
+            info = tarfile.TarInfo(name="other.txt")
+            info.size = len(data)
+            import io as _io
+
+            tar.addfile(info, _io.BytesIO(data))
+        with pytest.raises(RestoreError, match="missing the required manifest"):
+            read_backup_manifest(backup_path)
+
+
+class TestResolveDbPath:
+    def test_sqlite_url(self):
+        assert resolve_db_path_from_url("sqlite:///./tulip.db") == Path("./tulip.db").resolve()
+
+    def test_non_sqlite_refused(self):
+        with pytest.raises(BackupError, match="sqlite:///"):
+            resolve_db_path_from_url("postgresql://user:pass@host/db")
+
+
+# ---- CLI integration (subprocess) ----------------------------------------
+
+
+def _run_cli(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    full_env = dict(os.environ)
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=full_env,
+    )
+
+
+@pytest.mark.integration
+def test_cli_backup_restore_round_trip(tmp_path: Path):
+    """End-to-end: write a tiny seeded DB, `tulip backup`, then `tulip restore`."""
+    master_key_b64 = base64.b64encode(b"\x10" * 32).decode("ascii")
+    src_db = tmp_path / "tulip.db"
+    conn = sqlite3.connect(str(src_db))
+    try:
+        conn.execute("CREATE TABLE alembic_version (version_num TEXT NOT NULL)")
+        conn.execute("INSERT INTO alembic_version VALUES ('cliround')")
+        conn.execute("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)")
+        conn.execute("INSERT INTO notes VALUES (1, 'hi')")
+        conn.commit()
+    finally:
+        conn.close()
+    att_root = tmp_path / "attachments"
+    att_root.mkdir()
+    (att_root / "blob.bin").write_bytes(b"\x00\x01\x02")
+
+    backup_path = tmp_path / "backup.tar.gz"
+    env = {
+        "TULIP_MASTER_KEY": master_key_b64,
+        "TULIP_DATABASE_URL": f"sqlite:///{src_db}",
+        "TULIP_ATTACHMENT_ROOT": str(att_root),
+    }
+    result = _run_cli("backup", "--out", str(backup_path), env=env)
+    assert result.returncode == 0, result.stderr
+    assert backup_path.exists()
+    assert "wrote" in result.stdout
+
+    # Inspect via backup-inspect.
+    inspect = _run_cli("backup-inspect", str(backup_path), env=env)
+    assert inspect.returncode == 0, inspect.stderr
+    assert "cliround" in inspect.stdout
+
+    # Restore to fresh paths.
+    new_db = tmp_path / "restored.db"
+    new_att = tmp_path / "restored-att"
+    restore_env = {
+        "TULIP_MASTER_KEY": master_key_b64,
+        "TULIP_DATABASE_URL": f"sqlite:///{new_db}",
+        "TULIP_ATTACHMENT_ROOT": str(new_att),
+    }
+    restore = _run_cli("restore", str(backup_path), env=restore_env)
+    assert restore.returncode == 0, restore.stderr
+    # Verify content.
+    conn = sqlite3.connect(str(new_db))
+    try:
+        body = conn.execute("SELECT body FROM notes WHERE id = 1").fetchone()[0]
+    finally:
+        conn.close()
+    assert body == "hi"
+    assert (new_att / "blob.bin").read_bytes() == b"\x00\x01\x02"
+
+
+@pytest.mark.integration
+def test_cli_restore_wrong_key_exits_2(tmp_path: Path):
+    master_key_b64 = base64.b64encode(b"\x11" * 32).decode("ascii")
+    src_db = tmp_path / "tulip.db"
+    sqlite3.connect(str(src_db)).close()
+    att_root = tmp_path / "attachments"
+    att_root.mkdir()
+
+    backup_path = tmp_path / "backup.tar.gz"
+    env = {
+        "TULIP_MASTER_KEY": master_key_b64,
+        "TULIP_DATABASE_URL": f"sqlite:///{src_db}",
+        "TULIP_ATTACHMENT_ROOT": str(att_root),
+    }
+    _run_cli("backup", "--out", str(backup_path), env=env)
+
+    # Try restore with a different master key.
+    wrong_key = base64.b64encode(b"\x99" * 32).decode("ascii")
+    restore_env = {
+        "TULIP_MASTER_KEY": wrong_key,
+        "TULIP_DATABASE_URL": f"sqlite:///{tmp_path / 'restored.db'}",
+        "TULIP_ATTACHMENT_ROOT": str(tmp_path / "restored-att"),
+    }
+    result = _run_cli("restore", str(backup_path), env=restore_env)
+    assert result.returncode == 2
+    assert "envelope" in (result.stdout + result.stderr).lower()
+
+
+@pytest.mark.integration
+def test_cli_backup_no_master_key_exits_2(tmp_path: Path):
+    """Backup refuses without a configured master key — envelope verify would be meaningless."""
+    src_db = tmp_path / "tulip.db"
+    sqlite3.connect(str(src_db)).close()
+    env = {
+        "TULIP_DATABASE_URL": f"sqlite:///{src_db}",
+        "TULIP_ATTACHMENT_ROOT": str(tmp_path / "att"),
+    }
+    # Strip both env vars from the inherited environment.
+    env_with_keys_stripped = {
+        k: v
+        for k, v in {**os.environ, **env}.items()
+        if k not in ("TULIP_MASTER_KEY", "TULIP_KEY_FILE")
+    }
+    result = subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "backup", "--out", str(tmp_path / "x.tar.gz")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=env_with_keys_stripped,
+    )
+    assert result.returncode == 2
+    assert "master key" in (result.stdout + result.stderr).lower()


### PR DESCRIPTION
## Summary

Per [#121](https://github.com/rmwarriner/tulip-accounting/issues/121) Tier 1b: portable encrypted backup so first SQLite corruption doesn't lose everything.

The CLI is the entry point because backup is fundamentally a filesystem operation (the SQLite `.backup` API + the `attachment_root` tree); going through the API would require the API process to be running, which is exactly what disaster recovery doesn't have.

### New commands

- **`tulip backup --out PATH | --out -`** — streams a tar.gz to a file or stdout (pipeable into `gpg`/`age`/`curl`). Concurrent-safe — uses `sqlite3.Connection.backup()` so the API process can stay running.
- **`tulip restore BACKUP_PATH [--force]`** — reverses the operation. Refuses if (a) the manifest's key envelope doesn't match the current master key, (b) the manifest's alembic head differs from the current install, or (c) target db / attachment root is non-empty without `--force`.
- **`tulip backup-inspect BACKUP_PATH`** — prints the manifest without extracting anything.

### Backup format (locked design decisions per #121)

```
manifest.json                    — top-level: format_version, tulip_version,
                                    alembic_head, hostname, timestamp,
                                    key_envelope (base64 HMAC-SHA256)
db/tulip.db                      — SQLite snapshot via stdlib .backup API
attachments/<hash>/<file>        — full TULIP_ATTACHMENT_ROOT tree
```

- **Format**: tar.gz at the top level (chosen over an invented single-file format for ergonomics + scriptability).
- **Key envelope**: HMAC-SHA256 of a fixed constant under the master key. Restore recomputes and compares; mismatch refuses with a typed error. The key itself is never written into the backup — losing the backup file alone doesn't leak the key.
- **No double encryption** of the tarball itself (locked decision A): high-confidentiality fields (TOTP secrets, attachment bytes) are already field/file-encrypted; doubling up adds ergonomic friction for marginal gain. Revisit pre-external-beta.
- **Schema mismatch**: rather than auto-running alembic during restore (banned by the CLI architecture test), restore refuses with a typed error pointing at `alembic upgrade head` against the restored file.

### Architecture

`tulip_cli.backup` uses stdlib only (`sqlite3`, `tarfile`, `hmac`, `hashlib`, `json`, `base64`). The CLI architecture test bans `tulip_storage` / `sqlalchemy` / `alembic` — `sqlite3` stdlib is in scope.

## Test plan

- [x] `uv run pytest packages/tulip-cli/tests/test_backup_restore.py` → **24 passing** (16 unit + 5 round-trip + 3 CLI integration).
- [x] `just lint` → clean
- [x] `just typecheck` → clean across 174 source files
- [x] `just test` → 1163 passing, 1 pre-existing flake unrelated to this PR (`test_run_due_executes_handler`, tracked at #141 — reproduces on bare `main`).
- [ ] CI green on this PR (the flaky test will likely also fail in CI; if so, point at #141).

## Manual smoke test

```bash
#!/usr/bin/env bash
set -eu

# Set up a tiny fake install.
KEY=$(python -c 'import base64, secrets; print(base64.b64encode(secrets.token_bytes(32)).decode())')
DB=/tmp/smoke.db
ATT=/tmp/smoke-att

rm -rf "$DB" "$ATT"
mkdir -p "$ATT"
echo 'fake encrypted blob' > "$ATT/blob.bin"

export TULIP_MASTER_KEY="$KEY"
export TULIP_DATABASE_URL="sqlite:///$DB"
export TULIP_ATTACHMENT_ROOT="$ATT"

# Migrate so the DB has alembic_version.
uv run alembic -c packages/tulip-storage/alembic.ini upgrade head

# Backup.
uv run tulip backup --out /tmp/snap.tar.gz
uv run tulip backup-inspect /tmp/snap.tar.gz

# Restore to fresh paths.
DB2=/tmp/restored.db
ATT2=/tmp/restored-att
rm -rf "$DB2" "$ATT2"
TULIP_DATABASE_URL="sqlite:///$DB2" TULIP_ATTACHMENT_ROOT="$ATT2" uv run tulip restore /tmp/snap.tar.gz

# Verify.
test -f "$DB2" && echo "✓ DB restored"
test -f "$ATT2/blob.bin" && echo "✓ Attachment restored"
diff "$ATT/blob.bin" "$ATT2/blob.bin" && echo "✓ Attachment bytes match"

# Negative: wrong key refuses.
WRONG_KEY=$(python -c 'import base64, secrets; print(base64.b64encode(secrets.token_bytes(32)).decode())')
set +e
TULIP_MASTER_KEY="$WRONG_KEY" TULIP_DATABASE_URL="sqlite:///$DB2" TULIP_ATTACHMENT_ROOT="$ATT2" uv run tulip restore /tmp/snap.tar.gz --force
test $? -ne 0 && echo "✓ Wrong key refused"
set -e

# Negative: streamed-to-stdout works.
uv run tulip backup --out - > /tmp/streamed.tar.gz
test -s /tmp/streamed.tar.gz && echo "✓ Streamed backup"

rm -f "$DB" "$DB2" /tmp/snap.tar.gz /tmp/streamed.tar.gz
rm -rf "$ATT" "$ATT2"
echo "smoke test passed"
```

Closes #133. Refs #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)