### PR TITLE
fix: --password-stdin hint when stdin is a TTY (closes #144)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/commands/auth.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/auth.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import sys
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Annotated, Any, Final
+from typing import Annotated, Any, Final, TextIO
 
 import typer
 
@@ -23,6 +24,34 @@ auth_app = typer.Typer(
 
 _MFA_REQUIRED_CODE: Final[str] = "auth.mfa_required"
 _MFA_ENROLLMENT_REQUIRED_CODE: Final[str] = "auth.mfa_enrollment_required"
+
+_PASSWORD_STDIN_TTY_HINT: Final[str] = (
+    "Enter password (input is visible; omit --password-stdin to hide):"  # noqa: S105 — UI hint, not a credential
+)
+
+NoticeFn = Callable[[str], None]
+
+
+def _notice(message: str) -> None:
+    typer.echo(message, err=True)
+
+
+def _read_password_from_stdin(
+    *,
+    stream: TextIO | None = None,
+    notice: NoticeFn = _notice,
+) -> str:
+    """Read one line of password from ``stream`` (default: real stdin).
+
+    When ``stream`` is a TTY (no redirection), emit a one-line hint to
+    ``notice`` first — without it, the CLI sits silently waiting and
+    looks hung. Pipe / heredoc callers (the script-friendly path) see no
+    extra output.
+    """
+    src = sys.stdin if stream is None else stream
+    if src.isatty():
+        notice(_PASSWORD_STDIN_TTY_HINT)
+    return src.readline().rstrip("\n")
 
 
 def _store_tokens(config: Config, email: str, body: dict[str, Any]) -> TokenSet:
@@ -71,7 +100,7 @@ def login(
     as_json: bool = ctx.obj["json"]
 
     if password_stdin:
-        password = sys.stdin.readline().rstrip("\n")
+        password = _read_password_from_stdin()
     else:
         password = typer.prompt("Password", hide_input=True)
 

--- a/packages/tulip-cli/src/tulip_cli/commands/register.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/register.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
-from typing import Annotated, Final
+from typing import Annotated, Final, TextIO
 
 import typer
 
@@ -25,6 +25,10 @@ _PASSWORDS_DIFFER_MESSAGE: Final[str] = "Passwords didn't match. Please try agai
 
 PromptFn = Callable[..., str]
 NoticeFn = Callable[[str], None]
+
+_PASSWORD_STDIN_TTY_HINT: Final[str] = (
+    "Enter password (input is visible; omit --password-stdin to hide):"  # noqa: S105 — UI hint, not a credential
+)
 
 
 def _acquire_password_interactive(
@@ -56,12 +60,26 @@ def _acquire_password_interactive(
         return password
 
 
-def _read_password_from_stdin() -> str:
-    return sys.stdin.readline().rstrip("\n")
-
-
 def _notice(message: str) -> None:
     typer.echo(message, err=True)
+
+
+def _read_password_from_stdin(
+    *,
+    stream: TextIO | None = None,
+    notice: NoticeFn = _notice,
+) -> str:
+    """Read one line of password from ``stream`` (default: real stdin).
+
+    When ``stream`` is a TTY (no redirection), emit a one-line hint to
+    ``notice`` first — without it, the CLI sits silently waiting and
+    looks hung. Pipe / heredoc callers (the script-friendly path) see no
+    extra output.
+    """
+    src = sys.stdin if stream is None else stream
+    if src.isatty():
+        notice(_PASSWORD_STDIN_TTY_HINT)
+    return src.readline().rstrip("\n")
 
 
 def register(

--- a/packages/tulip-cli/tests/test_auth_password_stdin.py
+++ b/packages/tulip-cli/tests/test_auth_password_stdin.py
@@ -1,0 +1,38 @@
+"""Unit tests for ``tulip auth login --password-stdin`` TTY-vs-pipe behaviour.
+
+The integration tests in ``test_auth_login.py`` always pipe stdin (subprocess
+with ``input=...``), which means they only exercise the non-TTY branch. These
+tests cover the TTY branch directly so we don't need a pty-driving subprocess.
+"""
+
+from __future__ import annotations
+
+import io
+
+from tulip_cli.commands.auth import _read_password_from_stdin
+
+
+class _FakeStream(io.StringIO):
+    def __init__(self, content: str, *, tty: bool) -> None:
+        super().__init__(content)
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+def test_read_password_from_stdin_emits_hint_when_tty() -> None:
+    stream = _FakeStream("hunter2hunter2\n", tty=True)
+    notices: list[str] = []
+    result = _read_password_from_stdin(stream=stream, notice=notices.append)
+    assert result == "hunter2hunter2"
+    assert len(notices) == 1
+    assert "password" in notices[0].lower()
+
+
+def test_read_password_from_stdin_silent_when_piped() -> None:
+    stream = _FakeStream("hunter2hunter2\n", tty=False)
+    notices: list[str] = []
+    result = _read_password_from_stdin(stream=stream, notice=notices.append)
+    assert result == "hunter2hunter2"
+    assert notices == []

--- a/packages/tulip-cli/tests/test_register_password_acquire.py
+++ b/packages/tulip-cli/tests/test_register_password_acquire.py
@@ -8,12 +8,25 @@ I/O.
 
 from __future__ import annotations
 
+import io
 from collections.abc import Iterable, Iterator
 
 from tulip_cli.commands.register import (
     PASSWORD_MIN_LENGTH,
     _acquire_password_interactive,
+    _read_password_from_stdin,
 )
+
+
+class _FakeStream(io.StringIO):
+    """StringIO with a controllable ``isatty()`` for branching tests."""
+
+    def __init__(self, content: str, *, tty: bool) -> None:
+        super().__init__(content)
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
 
 
 def _scripted_prompt(answers: Iterable[str]) -> Iterator[str]:
@@ -82,3 +95,22 @@ def test_acquire_password_validates_then_confirms_in_that_order() -> None:
     # confirmation prompt should appear exactly once — after a valid pw,
     # not after the short one.
     assert seen_prompts == ["Password", "Password", "Repeat for confirmation"]
+
+
+def test_read_password_from_stdin_emits_hint_when_tty() -> None:
+    """Interactive shell with no redirection: emit a hint so the CLI doesn't look hung."""
+    stream = _FakeStream("hunter2hunter2\n", tty=True)
+    notices: list[str] = []
+    result = _read_password_from_stdin(stream=stream, notice=notices.append)
+    assert result == "hunter2hunter2"
+    assert len(notices) == 1
+    assert "password" in notices[0].lower()
+
+
+def test_read_password_from_stdin_silent_when_piped() -> None:
+    """Pipe / heredoc: no hint, scripts get a clean stderr."""
+    stream = _FakeStream("hunter2hunter2\n", tty=False)
+    notices: list[str] = []
+    result = _read_password_from_stdin(stream=stream, notice=notices.append)
+    assert result == "hunter2hunter2"
+    assert notices == []


### PR DESCRIPTION
## Summary

- Detect TTY in the `--password-stdin` reader for `tulip register` and `tulip auth login`; emit a one-line hint to stderr so the CLI doesn't sit silently waiting for input.
- Pipe / heredoc callers (the script-friendly path the flag exists for) see no change — the hint only fires when `sys.stdin.isatty()` is true.
- Hint goes to stderr so `--json` callers' stdout stays clean.

The bug was surfaced during the docker-compose smoke test for #143: a fresh user running `tulip register --password-stdin` interactively had no signal the CLI was waiting for password input.

### Out of scope (per the issue)

- Switching `--password-stdin` to `getpass.getpass()` — would break the heredoc/pipe contract that's the whole point of the flag.
- A separate `--password-prompt` mode — default register/login already prompt via Click; users wanting hidden input should drop `--password-stdin`.
- The same TTY-vs-pipe gap exists on `--code-stdin` (MFA code reader). Not in #144's acceptance; can be a follow-up if it bites someone.

## Test plan

- [x] New unit tests cover the TTY-vs-pipe branch for both commands (`test_register_password_acquire.py` adds 2; new `test_auth_password_stdin.py` adds 2). All 8 unit tests pass.
- [x] `just lint` clean, `just typecheck` clean.
- [x] Full suite: 1168 passed, 1 skipped (pre-existing, unrelated).
- [ ] Manual smoke — pipe path (no hint expected):

  ` ``bash
  echo "this-is-a-strong-password" | TULIP_API_URL=http://127.0.0.1:8000 \
    uv run tulip register \
      --email pipe-smoke@example.com --household PipeSmoke \
      --display-name PipeSmoke --password-stdin 2>/tmp/tulip-smoke-pipe.err
  test ! -s /tmp/tulip-smoke-pipe.err && echo "PIPE OK: no hint"
  ` ``

- [ ] Manual smoke — TTY path (hint expected on stderr). Run in a real terminal, type the password at the silent line:

  ` ``bash
  TULIP_API_URL=http://127.0.0.1:8000 uv run tulip register \
    --email tty-smoke@example.com --household TtySmoke \
    --display-name TtySmoke --password-stdin
  ` ``

  Expected: `Enter password (input is visible; omit --password-stdin to hide):` printed to stderr before the readline blocks.

- [ ] CI green on this PR.