### PR TITLE
fix: balance endpoints use UTC "today" (closes #141)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -560,6 +560,10 @@ Closes Phase 5. Imperative CLI subcommand group with 10 commands wrapping the /v
 
 PR #30. Closed #26. Surfaced during P3.2.a smoke testing when a SQLAlchemy URL parse error escaped the Problem Details middleware and emitted Starlette's default `text/plain` 500. New `InternalServerError` (`server.internal_error`, 500) `TulipProblem` subclass; `install_problem_handlers` registers a fourth handler for the `Exception` base. Exception text and tracebacks stay in logs; clients get a generic detail with a `request_id` for support correlation.
 
+### Balance endpoints: resolve "today" via UTC, not server-local — ✅ *(2026-05-10)*
+
+Closed #141. The runner's `Clock` returns UTC (per ADR-0002 §6, "every other path uses real `datetime.now(UTC)`"); the `envelope_refill` handler stored shadow tx dates as `clock().date()` accordingly. The envelope/sinking-fund balance endpoints, however, defaulted `as_of = date.today()` — server-local. For any negative-offset timezone, between UTC midnight and local midnight the local "today" lags the handler's UTC "today", so a freshly-posted refill was filtered out by the `tx.date <= as_of` predicate. Surfaced as a flake on `test_run_due_executes_handler` between 17:00 PT and 23:59 PT. Fix: three balance-endpoint callsites (`envelopes.py`, `sinking_funds.py`) now use `datetime.now(UTC).date()`; deterministic regression test in `test_refill_schedules_endpoints.py::TestRunDue::test_run_due_balance_uses_utc_today_not_local` pins the local helper to a far-past date so the bug, if reintroduced, fails the test at any wall-clock time.
+
 ---
 
 ## Reference: full phase roadmap

--- a/packages/tulip-api/src/tulip_api/routers/envelopes.py
+++ b/packages/tulip-api/src/tulip_api/routers/envelopes.py
@@ -10,6 +10,7 @@ transaction (Unallocated -X / envelope +X) — see
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from datetime import date as date_type
 from decimal import Decimal
 from typing import TYPE_CHECKING
@@ -356,7 +357,7 @@ def get_envelope_balance(
     if not filter_for_role(pool, claims):
         raise EnvelopeNotFoundError()
 
-    effective_as_of = as_of or date_type.today()
+    effective_as_of = as_of or datetime.now(UTC).date()
     raw = ShadowTransactionRepository(session, claims.household_id).balance_for_pool(
         pool.id, currency=pool.currency, as_of=effective_as_of
     )
@@ -427,8 +428,10 @@ def refill_envelope(
 
     session.commit()
 
-    # Return the envelope's new balance for ergonomics.
-    effective_as_of = date_type.today()
+    # Return the envelope's new balance for ergonomics. UTC to match
+    # the runner's clock (#141) — the user-supplied body.date is also
+    # interpreted in UTC by the shadow ledger.
+    effective_as_of = datetime.now(UTC).date()
     raw = ShadowTransactionRepository(session, claims.household_id).balance_for_pool(
         pool.id, currency=pool.currency, as_of=effective_as_of
     )

--- a/packages/tulip-api/src/tulip_api/routers/sinking_funds.py
+++ b/packages/tulip-api/src/tulip_api/routers/sinking_funds.py
@@ -6,6 +6,7 @@ through transfer or — eventually — a scheduled-tx runner in P4.3).
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from datetime import date as date_type
 from decimal import Decimal
 from typing import TYPE_CHECKING
@@ -302,7 +303,7 @@ def get_sinking_fund_balance(
     if not filter_for_role(pool, claims):
         raise SinkingFundNotFoundError()
 
-    effective_as_of = as_of or date_type.today()
+    effective_as_of = as_of or datetime.now(UTC).date()
     raw = ShadowTransactionRepository(session, claims.household_id).balance_for_pool(
         pool.id, currency=pool.currency, as_of=effective_as_of
     )

--- a/packages/tulip-api/tests/test_refill_schedules_endpoints.py
+++ b/packages/tulip-api/tests/test_refill_schedules_endpoints.py
@@ -284,6 +284,64 @@ class TestRunDue:
         assert r.status_code == 200
         assert r.json()["fired"] == 0
 
+    def test_run_due_balance_uses_utc_today_not_local(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        app,
+        session_maker,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Regression for #141: balance endpoint must resolve "today" via UTC.
+
+        The runner stores ``shadow_tx.date = clock().date()`` (UTC). If
+        the balance endpoint defaults ``as_of`` to local ``date.today()``,
+        a refill posted at e.g. 00:30 UTC ends up filtered out for the
+        rest of the day in any negative-offset timezone — the existing
+        ``test_run_due_executes_handler`` flakes on PT clocks between
+        17:00 and 23:59 PT for this reason.
+
+        We pin the endpoint's local-time function to a far-past date so
+        the bug, if reintroduced, deterministically zeros the balance.
+        The fix bypasses ``date_type.today()`` entirely (reads
+        ``datetime.now(UTC).date()`` directly), so the patch is inert
+        post-fix.
+        """
+        from datetime import date as _date
+
+        from tulip_api.routers import envelopes as envelopes_module
+        from tulip_storage.runner.handlers import make_envelope_refill_handler
+
+        class _PinnedToFarPast:
+            @staticmethod
+            def today() -> _date:
+                return _date(1970, 1, 1)
+
+        monkeypatch.setattr(envelopes_module, "date_type", _PinnedToFarPast)
+
+        app.state.runner.register_handler(
+            "envelope_refill", make_envelope_refill_handler(session_maker)
+        )
+
+        env_id = _make_envelope_with_rule(client, auth_h)
+        client.post(
+            f"/v1/envelopes/{env_id}/refill-schedule",
+            headers=auth_h,
+            json={
+                "rrule": "FREQ=MONTHLY",
+                "start_at": date.today().isoformat() + "T00:00:00+00:00",
+            },
+        )
+        r = client.post("/v1/scheduled-jobs/run-due", headers=auth_h)
+        assert r.status_code == 200, r.text
+        assert r.json()["fired"] == 1
+
+        bal_r = client.get(f"/v1/envelopes/{env_id}/balance", headers=auth_h)
+        assert bal_r.status_code == 200
+        from decimal import Decimal
+
+        assert Decimal(bal_r.json()["balance"]) == Decimal("250.00")
+
 
 # ---- Unauthenticated ---------------------------------------------------
 


### PR DESCRIPTION
## Summary

- The `envelope_refill` runner handler stores shadow tx dates as `clock().date()` (UTC, per ADR-0002 §6).
- The envelope and sinking-fund balance endpoints defaulted `as_of` to local `date.today()`. Between UTC midnight and local midnight in any negative-offset timezone, the local "today" trails the handler's UTC "today" — and the `tx.date <= as_of` filter drops the just-posted refill.
- Three balance-endpoint callsites (`envelopes.py:359`, `envelopes.py:431`, `sinking_funds.py:305`) now use `datetime.now(UTC).date()`.
- New deterministic regression test (`test_run_due_balance_uses_utc_today_not_local`) pins the endpoint's local-time helper to a far-past date so the bug, if reintroduced, fails the test at any wall-clock time. The pre-existing `test_run_due_executes_handler` (the flake's symptom) is now also stable.
- PHASE_STATUS.md entry under "Other shipped fixes" per the issue's acceptance criteria.

### Why a behavior change is OK here

The handler stores shadow dates in UTC; the endpoint should read them in UTC. Self-hosters in non-UTC timezones may notice the day-boundary shift, but it's the same convention the rest of the runner-aware codebase uses, and the alternative (storing handler dates in local time) would diverge from ADR-0002.

### Out of scope

- `accounts.py:338`, `transactions.py:343`, `auth.py:145`, `reports.py:73` also call `date.today()`, but they touch the main ledger (whose dates come from user input, not a UTC clock) — no UTC/local mismatch to fix there.

## Test plan

- [x] `pytest packages/tulip-api/tests/test_refill_schedules_endpoints.py` — 17/17 pass (including the new regression and the previously-flaky test).
- [x] `just lint` clean, `just typecheck` clean.
- [x] Full suite: 1169 passed, 1 skipped (pre-existing).
- [x] Confirmed regression test fails on the unfixed code (committed test, then applied fix; bisected via `git stash`).
- [ ] CI green on this PR.