### PR TITLE
feat: tulip doctor smoke / first-run verification (closes #135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ uv run tulip reconcile complete "$RECON_ID"       # strict balance check, denorm
 
 Other top-level commands: `tulip envelopes`, `tulip sinking-funds`, `tulip refills`, `tulip transfer`, `tulip refill`, `tulip budget-inflow`, `tulip transactions {show,edit,void,delete}`, `tulip imports {profiles,apply}`. Each takes `--help`; the surface mirrors the API endpoints listed above.
 
+`tulip doctor` runs five smoke checks against the configured API (reachability, master-key loaded, migration head, attachment-root writable, token store reachable) and exits 0 / 1 / 2 for all-good / warnings / hard failure. Run it first when something looks off; full QUICKSTART integration lands with [#138](https://github.com/rmwarriner/tulip-accounting/issues/138).
+
 ## Development discipline
 
 This project follows test-driven development. Every feature ships with tests written **before** the implementation (red → green → refactor). PRs that don't include tests for new code paths are rejected by CI policy.

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -564,6 +564,23 @@ PR #30. Closed #26. Surfaced during P3.2.a smoke testing when a SQLAlchemy URL p
 
 Closed #141. The runner's `Clock` returns UTC (per ADR-0002 §6, "every other path uses real `datetime.now(UTC)`"); the `envelope_refill` handler stored shadow tx dates as `clock().date()` accordingly. The envelope/sinking-fund balance endpoints, however, defaulted `as_of = date.today()` — server-local. For any negative-offset timezone, between UTC midnight and local midnight the local "today" lags the handler's UTC "today", so a freshly-posted refill was filtered out by the `tx.date <= as_of` predicate. Surfaced as a flake on `test_run_due_executes_handler` between 17:00 PT and 23:59 PT. Fix: three balance-endpoint callsites (`envelopes.py`, `sinking_funds.py`) now use `datetime.now(UTC).date()`; deterministic regression test in `test_refill_schedules_endpoints.py::TestRunDue::test_run_due_balance_uses_utc_today_not_local` pins the local helper to a far-past date so the bug, if reintroduced, fails the test at any wall-clock time.
 
+### `tulip doctor` smoke / first-run verification — ✅ *(2026-05-10)*
+
+Closed #135 (Hardening Tier 2). New `tulip doctor` CLI command runs five checks against the configured API and exits 0 / 1 / 2 (locked design decision per the issue: 0 = all good, 1 = warning, 2 = hard failure — overrides the CLI's general-purpose `EXIT_*` constants for this command only):
+
+1. **API reachability** — `GET /health` returns 200.
+2. **Master-key loaded** — `master_key_source != "ephemeral"`; ephemeral fallback is a hard failure.
+3. **Migration head** — DB's alembic revision matches the head bundled in the running API package; mismatch is a warning ("run `alembic upgrade head`").
+4. **Attachment-root writable** — API probe creates and removes a zero-byte file at `attachment_root`.
+5. **Token store** — CLI-side check that the token-store path is reachable; missing/empty is a warning, not a failure (user might just need to log in).
+
+Supporting changes:
+
+- New unauthenticated endpoint `GET /v1/system/diagnostics` aggregates probes 2–4 server-side and is consumed by the CLI. Booleans only — no paths or key bytes leak. Auth-free by design so the doctor runs *before* any user has registered.
+- New `tulip_storage.migrations_meta.expected_alembic_head()` helper reads the bundled migrations directory via alembic's `ScriptDirectory` so the API can compare DB head to wheel head without invoking the alembic CLI.
+- `Settings.master_key_source: Literal["env", "file", "ephemeral"]` tracks which env path produced the key.
+- Brief mention added to README; full QUICKSTART integration deferred to [#138](https://github.com/rmwarriner/tulip-accounting/issues/138).
+
 ---
 
 ## Reference: full phase roadmap

--- a/packages/tulip-api/src/tulip_api/config.py
+++ b/packages/tulip-api/src/tulip_api/config.py
@@ -9,8 +9,13 @@ import os
 import secrets
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 log = logging.getLogger("tulip_api.config")
+
+#: Where the master key came from. Surfaced in ``GET /v1/system/diagnostics``
+#: so the doctor CLI can flag ephemeral fallback as a hard failure (#135).
+MasterKeySource = Literal["env", "file", "ephemeral"]
 
 
 def _default_jwt_secret() -> str:
@@ -99,6 +104,21 @@ def _default_master_key() -> bytes:
     return secrets.token_bytes(32)
 
 
+def _default_master_key_source() -> MasterKeySource:
+    """Side-effect-free peek at which env source is configured.
+
+    Mirrors the resolution order in :func:`_default_master_key` but does
+    not load files, decode keys, or emit warnings — it's a pure inspection
+    of env vars. Side effects belong to ``_default_master_key`` so they
+    fire exactly once per ``Settings()`` construction.
+    """
+    if os.environ.get("TULIP_MASTER_KEY") is not None:
+        return "env"
+    if os.environ.get("TULIP_KEY_FILE"):
+        return "file"
+    return "ephemeral"
+
+
 @dataclass(frozen=True, slots=True)
 class Settings:
     """Read-only runtime settings."""
@@ -106,6 +126,7 @@ class Settings:
     database_url: str = field(default_factory=_default_db_url)
     jwt_secret: str = field(default_factory=_default_jwt_secret)
     master_key: bytes = field(default_factory=_default_master_key)
+    master_key_source: MasterKeySource = field(default_factory=_default_master_key_source)
     attachment_root: Path = field(default_factory=_default_attachment_root)
 
 

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -37,6 +37,7 @@ from tulip_api.routers import (
     refill_schedules,
     reports,
     sinking_funds,
+    system,
     transactions,
     well_known_errors,
 )
@@ -116,6 +117,7 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
     # Top-level health probe — kept off /v1 so monitors don't break across
     # major-version cuts.
     app.include_router(health.router)
+    app.include_router(system.router)
     app.include_router(well_known_errors.router)
     app.include_router(auth.router)
     app.include_router(accounts.router)

--- a/packages/tulip-api/src/tulip_api/routers/system.py
+++ b/packages/tulip-api/src/tulip_api/routers/system.py
@@ -1,0 +1,77 @@
+"""``GET /v1/system/diagnostics`` — surface area for ``tulip doctor`` (#135).
+
+Unauthenticated by design — internal-beta self-hosters run the doctor
+*before* registering / logging in to confirm the install is healthy.
+The response only exposes booleans + a migration revision id; no paths,
+no key bytes, no PII. The marginal information disclosure (a remote
+caller can confirm "API up, key loaded, DB migrated") is comparable to
+what ``GET /health`` already implies.
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import text
+
+from tulip_api.config import Settings, get_settings
+from tulip_api.deps import get_session
+from tulip_api.schemas.diagnostics import SystemDiagnosticsRead
+from tulip_storage.migrations_meta import expected_alembic_head
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+router = APIRouter(prefix="/v1/system", tags=["meta"])
+
+
+def _read_alembic_head_in_db(session: Session) -> str | None:
+    """Return ``alembic_version.version_num`` or ``None`` if the table is absent."""
+    try:
+        row = session.execute(text("SELECT version_num FROM alembic_version LIMIT 1")).first()
+    except Exception:
+        return None
+    return str(row[0]) if row else None
+
+
+def _probe_attachment_root_writable(settings: Settings) -> bool:
+    """Create + delete a zero-byte file at ``attachment_root``.
+
+    Creates the directory if it doesn't exist (matches the API's
+    on-first-use behaviour for attachment uploads). Random filename to
+    avoid collisions if multiple doctor probes race.
+    """
+    root = settings.attachment_root
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        probe = root / f".tulip-doctor-{uuid.UUID(bytes=secrets.token_bytes(16)).hex}"
+        probe.write_bytes(b"")
+        probe.unlink()
+    except OSError:
+        return False
+    return True
+
+
+@router.get(
+    "/diagnostics",
+    response_model=SystemDiagnosticsRead,
+)
+def get_system_diagnostics(
+    session: Session = Depends(get_session),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+) -> SystemDiagnosticsRead:
+    """Aggregate environment + storage probes consumed by ``tulip doctor``."""
+    head_in_db = _read_alembic_head_in_db(session)
+    head_expected = expected_alembic_head()
+    return SystemDiagnosticsRead(
+        alembic_head_in_db=head_in_db,
+        alembic_head_expected=head_expected,
+        alembic_head_match=head_in_db == head_expected,
+        master_key_source=settings.master_key_source,
+        master_key_loaded=settings.master_key_source != "ephemeral",
+        attachment_root_writable=_probe_attachment_root_writable(settings),
+    )

--- a/packages/tulip-api/src/tulip_api/schemas/diagnostics.py
+++ b/packages/tulip-api/src/tulip_api/schemas/diagnostics.py
@@ -1,0 +1,51 @@
+"""Schemas for ``GET /v1/system/diagnostics`` (#135).
+
+The doctor CLI (``tulip doctor``) consumes this shape. Field semantics
+are stable; new diagnostic fields may be added but never removed.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class SystemDiagnosticsRead(BaseModel):
+    """Health-plus-configuration probe used by ``tulip doctor``."""
+
+    alembic_head_in_db: str | None = Field(
+        description=(
+            "Current alembic revision stamped in the database, or ``null`` "
+            "if the alembic_version table is missing (un-migrated DB)."
+        )
+    )
+    alembic_head_expected: str = Field(
+        description=("Head revision of the migration scripts bundled with the running API package.")
+    )
+    alembic_head_match: bool = Field(
+        description=(
+            "True iff the DB is at the head this build expects. False ⇒ run "
+            "``alembic upgrade head`` against the deployed database."
+        )
+    )
+    master_key_source: Literal["env", "file", "ephemeral"] = Field(
+        description=(
+            "Which env path produced the master key. ``ephemeral`` means no "
+            "key was configured and a per-process random key is in use — "
+            "field-encrypted columns will not survive a restart."
+        )
+    )
+    master_key_loaded: bool = Field(
+        description=(
+            "True iff a non-ephemeral master key is in use (i.e. "
+            "``master_key_source != 'ephemeral'``). Doctored as a hard "
+            "failure on the CLI side."
+        )
+    )
+    attachment_root_writable: bool = Field(
+        description=(
+            "True iff the configured ``attachment_root`` accepted a probe "
+            "create + delete at request time."
+        )
+    )

--- a/packages/tulip-api/tests/test_config.py
+++ b/packages/tulip-api/tests/test_config.py
@@ -130,3 +130,43 @@ class TestMasterKeyFile:
             s = Settings()
         assert len(s.master_key) == 32
         mock_log.warning.assert_called_once()
+
+
+class TestMasterKeySource:
+    """``Settings.master_key_source`` reports which env path was used (#135).
+
+    Surfaced through ``GET /v1/system/diagnostics`` so the doctor CLI can
+    flag the ephemeral fallback as a hard failure.
+    """
+
+    def test_env_source_when_master_key_env_var_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("TULIP_MASTER_KEY", base64.b64encode(b"\x01" * 32).decode("ascii"))
+        assert Settings().master_key_source == "env"
+
+    def test_file_source_when_only_key_file_set(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        from pathlib import Path
+
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        key_file = Path(tmp_path) / "master.key"
+        key_file.write_text(base64.b64encode(b"\x02" * 32).decode("ascii"))
+        key_file.chmod(0o600)
+        monkeypatch.setenv("TULIP_KEY_FILE", str(key_file))
+        assert Settings().master_key_source == "file"
+
+    def test_ephemeral_source_when_neither_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        monkeypatch.delenv("TULIP_KEY_FILE", raising=False)
+        with patch("tulip_api.config.log"):  # silence the warning
+            assert Settings().master_key_source == "ephemeral"
+
+    def test_env_source_wins_when_both_set(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        from pathlib import Path
+
+        monkeypatch.setenv("TULIP_MASTER_KEY", base64.b64encode(b"\x06" * 32).decode("ascii"))
+        key_file = Path(tmp_path) / "master.key"
+        key_file.write_text(base64.b64encode(b"\x07" * 32).decode("ascii"))
+        key_file.chmod(0o600)
+        monkeypatch.setenv("TULIP_KEY_FILE", str(key_file))
+        # Mirrors the resolution order: env wins over file for both
+        # the bytes and the source label.
+        assert Settings().master_key_source == "env"

--- a/packages/tulip-api/tests/test_system_diagnostics_endpoint.py
+++ b/packages/tulip-api/tests/test_system_diagnostics_endpoint.py
@@ -1,0 +1,135 @@
+"""Tests for ``GET /v1/system/diagnostics`` (#135).
+
+Endpoint is unauthenticated by design — the doctor CLI runs it before
+the user has any tokens. The settings fixture is overridden per-test
+because the diagnostics shape depends on environment-derived state
+(master-key source, attachment-root writability) that the default
+fixture intentionally leaves at "ephemeral".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tulip_api.config import Settings, get_settings
+from tulip_storage.migrations_meta import expected_alembic_head
+
+
+def _override_settings(app: FastAPI, settings: Settings) -> None:
+    app.dependency_overrides[get_settings] = lambda: settings
+
+
+class TestHappyPath:
+    def test_healthy_install_returns_all_green(
+        self, app: FastAPI, client: TestClient, tmp_path: Path
+    ) -> None:
+        _override_settings(
+            app,
+            Settings(
+                database_url="sqlite:///:memory:",
+                jwt_secret="test-secret-32bytes-test-secret!!",
+                master_key=b"\xab" * 32,
+                master_key_source="env",
+                attachment_root=tmp_path / "attachments",
+            ),
+        )
+        r = client.get("/v1/system/diagnostics")
+        assert r.status_code == 200
+        body = r.json()
+
+        assert body["alembic_head_in_db"] == expected_alembic_head()
+        assert body["alembic_head_expected"] == expected_alembic_head()
+        assert body["alembic_head_match"] is True
+        assert body["master_key_source"] == "env"
+        assert body["master_key_loaded"] is True
+        assert body["attachment_root_writable"] is True
+
+    def test_file_master_key_source_reported(
+        self, app: FastAPI, client: TestClient, tmp_path: Path
+    ) -> None:
+        _override_settings(
+            app,
+            Settings(
+                database_url="sqlite:///:memory:",
+                jwt_secret="test-secret-32bytes-test-secret!!",
+                master_key=b"\xcd" * 32,
+                master_key_source="file",
+                attachment_root=tmp_path / "attachments",
+            ),
+        )
+        body = client.get("/v1/system/diagnostics").json()
+        assert body["master_key_source"] == "file"
+        assert body["master_key_loaded"] is True
+
+    def test_no_auth_required(self, client: TestClient) -> None:
+        """Unauthenticated by design — the doctor runs before login."""
+        r = client.get("/v1/system/diagnostics")
+        assert r.status_code == 200
+
+
+class TestDegradedStates:
+    def test_ephemeral_master_key_reports_not_loaded(
+        self, app: FastAPI, client: TestClient, tmp_path: Path
+    ) -> None:
+        _override_settings(
+            app,
+            Settings(
+                database_url="sqlite:///:memory:",
+                jwt_secret="test-secret-32bytes-test-secret!!",
+                master_key=b"\x99" * 32,
+                master_key_source="ephemeral",
+                attachment_root=tmp_path / "attachments",
+            ),
+        )
+        body = client.get("/v1/system/diagnostics").json()
+        assert body["master_key_source"] == "ephemeral"
+        assert body["master_key_loaded"] is False
+
+    def test_unwritable_attachment_root_reports_false(
+        self, app: FastAPI, client: TestClient, tmp_path: Path
+    ) -> None:
+        # Create a file at the path so mkdir(parents=True, exist_ok=True)
+        # raises NotADirectoryError → probe returns False.
+        bogus = tmp_path / "definitely-not-a-dir"
+        bogus.write_text("blocking the path")
+        _override_settings(
+            app,
+            Settings(
+                database_url="sqlite:///:memory:",
+                jwt_secret="test-secret-32bytes-test-secret!!",
+                master_key=b"\xee" * 32,
+                master_key_source="env",
+                attachment_root=bogus / "subdir",
+            ),
+        )
+        body = client.get("/v1/system/diagnostics").json()
+        assert body["attachment_root_writable"] is False
+
+    def test_alembic_head_mismatch_reports_false(
+        self,
+        app: FastAPI,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from tulip_api.routers import system as system_router
+
+        monkeypatch.setattr(system_router, "expected_alembic_head", lambda: "deadbeef0000")
+        _override_settings(
+            app,
+            Settings(
+                database_url="sqlite:///:memory:",
+                jwt_secret="test-secret-32bytes-test-secret!!",
+                master_key=b"\x77" * 32,
+                master_key_source="env",
+                attachment_root=tmp_path / "attachments",
+            ),
+        )
+        body = client.get("/v1/system/diagnostics").json()
+        assert body["alembic_head_match"] is False
+        assert body["alembic_head_expected"] == "deadbeef0000"
+        assert body["alembic_head_in_db"] != "deadbeef0000"

--- a/packages/tulip-cli/src/tulip_cli/commands/doctor.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/doctor.py
@@ -1,0 +1,277 @@
+"""``tulip doctor`` — first-run smoke / configuration verification (#135).
+
+Internal-beta self-hosters run this immediately after ``docker compose
+up``. The five checks (API reachability, master-key loaded, migration
+head, attachment-root writable, token store reachable) cover the
+mistakes that would otherwise surface as opaque 500s after the user has
+already registered and started entering data.
+
+Exit codes (locked design decision per #135):
+
+* ``0`` — all checks passed.
+* ``1`` — at least one warning, no hard failure.
+* ``2`` — at least one hard failure.
+
+These semantics override the CLI's general-purpose ``EXIT_*`` constants
+(``EXIT_USER=1``, ``EXIT_AUTH=2``) for *this command only*. The doctor's
+job is to *diagnose* configuration problems, so a server-side auth
+issue here means "your install is broken", not "you typed the wrong
+password" — the literal 0/1/2 ladder is what compose / supervisor
+scripts expect.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from typing import Annotated, Final, Literal
+
+import typer
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+#: Severity ordered low → high. ``aggregate_status`` returns the max.
+CheckSeverity = Literal["pass", "warn", "fail"]
+
+_SEVERITY_RANK: Final[dict[CheckSeverity, int]] = {"pass": 0, "warn": 1, "fail": 2}
+_EXIT_BY_SEVERITY: Final[dict[CheckSeverity, int]] = {"pass": 0, "warn": 1, "fail": 2}
+
+
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    """One row in the doctor's output."""
+
+    name: str
+    status: CheckSeverity
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Render the result as a JSON-serializable dict for ``--json`` output."""
+        return {"name": self.name, "status": self.status, "message": self.message}
+
+
+def aggregate_status(results: list[CheckResult]) -> CheckSeverity:
+    """Return the maximum severity across ``results`` (``"pass"`` if empty)."""
+    if not results:
+        return "pass"
+    return max(results, key=lambda r: _SEVERITY_RANK[r.status]).status
+
+
+# ---- Individual checks --------------------------------------------------
+
+
+def _check_api_reachable(client: TulipClient, api_url: str) -> CheckResult:
+    name = "API reachability"
+    try:
+        response = client.get("/health")
+    except CliError as err:
+        return CheckResult(
+            name=name,
+            status="fail",
+            message=(
+                f"GET /health failed: {err.problem.get('detail', 'network error')}. "
+                f"Confirm the API is running at {api_url} and reachable from this host."
+            ),
+        )
+    if response.status_code != 200:
+        return CheckResult(
+            name=name,
+            status="fail",
+            message=f"GET /health returned {response.status_code}; expected 200.",
+        )
+    return CheckResult(name=name, status="pass", message="GET /health → 200 OK")
+
+
+def _check_diagnostics(client: TulipClient) -> tuple[dict[str, object] | None, CheckResult]:
+    """Fetch ``/v1/system/diagnostics``; return ``(body, fetch_result)``.
+
+    On fetch failure the body is ``None`` and downstream checks should
+    short-circuit with a "skipped — diagnostics unreachable" result.
+    """
+    name = "Diagnostics endpoint"
+    try:
+        response = client.get("/v1/system/diagnostics")
+    except CliError as err:
+        return None, CheckResult(
+            name=name,
+            status="fail",
+            message=(
+                f"GET /v1/system/diagnostics failed: "
+                f"{err.problem.get('detail', 'network error')}. "
+                "Doctor cannot verify the master key, migrations, or attachment root."
+            ),
+        )
+    body = response.json()
+    return body, CheckResult(
+        name=name, status="pass", message="GET /v1/system/diagnostics → 200 OK"
+    )
+
+
+def _check_master_key(diagnostics: dict[str, object]) -> CheckResult:
+    name = "Master-key loaded"
+    source = diagnostics.get("master_key_source")
+    if source == "ephemeral":
+        return CheckResult(
+            name=name,
+            status="fail",
+            message=(
+                "API is using an ephemeral master key; field-encrypted columns "
+                "(TOTP secrets, attachments) will not survive a restart. Set "
+                "TULIP_MASTER_KEY or TULIP_KEY_FILE on the API process and restart."
+            ),
+        )
+    return CheckResult(
+        name=name,
+        status="pass",
+        message=f"master key loaded from {source}",
+    )
+
+
+def _check_migration_head(diagnostics: dict[str, object]) -> CheckResult:
+    name = "Migration head"
+    if diagnostics.get("alembic_head_match"):
+        return CheckResult(
+            name=name,
+            status="pass",
+            message=f"DB at expected revision {diagnostics.get('alembic_head_in_db')}",
+        )
+    in_db = diagnostics.get("alembic_head_in_db") or "(none)"
+    expected = diagnostics.get("alembic_head_expected")
+    return CheckResult(
+        name=name,
+        status="warn",
+        message=(
+            f"DB at revision {in_db}; this build expects {expected}. "
+            "Run `alembic upgrade head` against the deployed database."
+        ),
+    )
+
+
+def _check_attachment_root(diagnostics: dict[str, object]) -> CheckResult:
+    name = "Attachment root writable"
+    if diagnostics.get("attachment_root_writable"):
+        return CheckResult(
+            name=name,
+            status="pass",
+            message="API probe wrote and removed a zero-byte file successfully",
+        )
+    return CheckResult(
+        name=name,
+        status="fail",
+        message=(
+            "API cannot create files under the configured attachment root. "
+            "Check TULIP_ATTACHMENT_ROOT and the directory's filesystem permissions."
+        ),
+    )
+
+
+def _check_token_store(config: Config) -> CheckResult:
+    name = "Token store"
+    try:
+        tokens = default_token_store().load(config.api_url)
+    except Exception as exc:
+        return CheckResult(
+            name=name,
+            status="warn",
+            message=(
+                f"Token store unreachable: {exc}. You'll be unable to log in until "
+                "this resolves; set TULIP_TOKEN_STORE to a writable file path as a "
+                "workaround."
+            ),
+        )
+    if tokens is None:
+        return CheckResult(
+            name=name,
+            status="warn",
+            message=(
+                "Token store reachable but empty. Run `tulip auth login` (or "
+                "`tulip register` if this is a fresh install) to populate it."
+            ),
+        )
+    return CheckResult(
+        name=name,
+        status="pass",
+        message=f"token store has credentials for {tokens.email}",
+    )
+
+
+# ---- Output rendering ----------------------------------------------------
+
+
+_GLYPH: Final[dict[CheckSeverity, str]] = {"pass": "✓", "warn": "!", "fail": "✗"}
+
+
+def _render_human(results: list[CheckResult], overall: CheckSeverity) -> None:
+    passed = sum(1 for r in results if r.status == "pass")
+    total = len(results)
+    if overall == "pass":
+        typer.echo(f"tulip doctor: all checks passed ({passed}/{total})")
+    elif overall == "warn":
+        typer.echo(f"tulip doctor: {passed}/{total} passed — see warnings below")
+    else:
+        typer.echo(f"tulip doctor: FAILED — {passed}/{total} passed", err=True)
+
+    for result in results:
+        glyph = _GLYPH[result.status]
+        line = f"  {glyph} {result.name}: {result.message}"
+        # Warnings + failures land on stderr so a redirected stdout still
+        # gives a clean machine-readable summary on the first line.
+        out = sys.stderr if result.status != "pass" else sys.stdout
+        out.write(line + "\n")
+
+
+def _render_json(results: list[CheckResult], overall: CheckSeverity) -> None:
+    payload = {
+        "overall": overall,
+        "exit_code": _EXIT_BY_SEVERITY[overall],
+        "checks": [r.to_dict() for r in results],
+        "summary": {
+            "passed": sum(1 for r in results if r.status == "pass"),
+            "warned": sum(1 for r in results if r.status == "warn"),
+            "failed": sum(1 for r in results if r.status == "fail"),
+            "total": len(results),
+        },
+    }
+    sys.stdout.write(json.dumps(payload) + "\n")
+
+
+# ---- Entry point ---------------------------------------------------------
+
+
+def doctor(
+    ctx: typer.Context,
+    timeout: Annotated[
+        float,
+        typer.Option(
+            "--timeout",
+            help="HTTP timeout in seconds for each probe.",
+        ),
+    ] = 5.0,
+) -> None:
+    """Verify the configured Tulip install. Run me first if something looks off."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+
+    results: list[CheckResult] = []
+    with TulipClient(config, as_json=as_json, timeout=timeout) as client:
+        reach = _check_api_reachable(client, config.api_url)
+        results.append(reach)
+        if reach.status != "fail":
+            diagnostics_body, fetch_result = _check_diagnostics(client)
+            results.append(fetch_result)
+            if diagnostics_body is not None:
+                results.append(_check_master_key(diagnostics_body))
+                results.append(_check_migration_head(diagnostics_body))
+                results.append(_check_attachment_root(diagnostics_body))
+    results.append(_check_token_store(config))
+
+    overall = aggregate_status(results)
+    if as_json:
+        _render_json(results, overall)
+    else:
+        _render_human(results, overall)
+    raise typer.Exit(_EXIT_BY_SEVERITY[overall])

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -22,6 +22,7 @@ from tulip_cli.commands.backup_restore import (
     restore_command,
 )
 from tulip_cli.commands.balance import balance as balance_command
+from tulip_cli.commands.doctor import doctor as doctor_command
 from tulip_cli.commands.envelopes import envelopes_app
 from tulip_cli.commands.imports import imports_app
 from tulip_cli.commands.pool_actions import (
@@ -126,6 +127,7 @@ app.add_typer(reconcile_app, name="reconcile")
 app.command("backup")(backup_command)
 app.command("restore")(restore_command)
 app.command("backup-inspect")(manifest_command)
+app.command("doctor")(doctor_command)
 
 
 if __name__ == "__main__":

--- a/packages/tulip-cli/tests/test_doctor.py
+++ b/packages/tulip-cli/tests/test_doctor.py
@@ -1,0 +1,197 @@
+"""Tests for ``tulip doctor`` (#135).
+
+Two layers:
+
+* Unit tests for the aggregator and the individual check helpers — fast,
+  cover the matrix of pass/warn/fail combinations directly.
+* Integration tests that spawn ``tulip doctor`` as a subprocess against
+  the ``live_api`` fixture — confirm exit codes and stdout/stderr
+  separation actually behave the way ``docker compose`` health probes
+  expect.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from tulip_cli.commands.doctor import (
+    CheckResult,
+    _check_attachment_root,
+    _check_master_key,
+    _check_migration_head,
+    aggregate_status,
+)
+
+_PASSWORD = "long-enough-password"
+
+
+# ---- Unit tests ---------------------------------------------------------
+
+
+class TestAggregateStatus:
+    def test_empty_returns_pass(self) -> None:
+        assert aggregate_status([]) == "pass"
+
+    def test_all_pass_returns_pass(self) -> None:
+        rs = [CheckResult("a", "pass", ""), CheckResult("b", "pass", "")]
+        assert aggregate_status(rs) == "pass"
+
+    def test_any_warning_promotes_to_warn(self) -> None:
+        rs = [CheckResult("a", "pass", ""), CheckResult("b", "warn", "")]
+        assert aggregate_status(rs) == "warn"
+
+    def test_any_failure_promotes_to_fail(self) -> None:
+        rs = [
+            CheckResult("a", "pass", ""),
+            CheckResult("b", "warn", ""),
+            CheckResult("c", "fail", ""),
+        ]
+        assert aggregate_status(rs) == "fail"
+
+
+class TestIndividualChecks:
+    def test_master_key_ephemeral_is_failure(self) -> None:
+        result = _check_master_key({"master_key_source": "ephemeral"})
+        assert result.status == "fail"
+        assert "ephemeral" in result.message.lower()
+
+    def test_master_key_env_or_file_is_pass(self) -> None:
+        for src in ("env", "file"):
+            result = _check_master_key({"master_key_source": src})
+            assert result.status == "pass"
+            assert src in result.message
+
+    def test_migration_head_match_is_pass(self) -> None:
+        result = _check_migration_head({"alembic_head_match": True, "alembic_head_in_db": "abc123"})
+        assert result.status == "pass"
+        assert "abc123" in result.message
+
+    def test_migration_head_mismatch_is_warning(self) -> None:
+        result = _check_migration_head(
+            {
+                "alembic_head_match": False,
+                "alembic_head_in_db": "old123",
+                "alembic_head_expected": "new456",
+            }
+        )
+        assert result.status == "warn"
+        assert "alembic upgrade head" in result.message.lower()
+
+    def test_attachment_root_writable_is_pass(self) -> None:
+        result = _check_attachment_root({"attachment_root_writable": True})
+        assert result.status == "pass"
+
+    def test_attachment_root_unwritable_is_failure(self) -> None:
+        result = _check_attachment_root({"attachment_root_writable": False})
+        assert result.status == "fail"
+
+
+# ---- Integration tests --------------------------------------------------
+
+
+def _run_cli(*args: str, api_url: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
+@pytest.fixture
+def token_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Per-test JSON-file token store; never touch the OS keyring."""
+    path = tmp_path / "tokens.json"
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(path))
+    return path
+
+
+def _register_and_login(api_url: str) -> None:
+    """Register a user and login so the token store is populated for the doctor."""
+    httpx.post(
+        f"{api_url}/v1/auth/register",
+        json={
+            "email": "doc@example.com",
+            "password": _PASSWORD,
+            "display_name": "Doctor Tester",
+            "household_name": "Doctor House",
+        },
+        timeout=10,
+    ).raise_for_status()
+    # Use the CLI to login so it writes the token file in our chosen format.
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--api-url",
+            api_url,
+            "auth",
+            "login",
+            "--email",
+            "doc@example.com",
+            "--password-stdin",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        input=f"{_PASSWORD}\n",
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.integration
+def test_doctor_green_path_against_healthy_install(live_api: str, token_file: Path) -> None:
+    _register_and_login(live_api)
+    result = _run_cli("doctor", api_url=live_api)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "all checks passed" in result.stdout.lower()
+
+
+@pytest.mark.integration
+def test_doctor_json_output_against_healthy_install(live_api: str, token_file: Path) -> None:
+    _register_and_login(live_api)
+    result = _run_cli("--json", "doctor", api_url=live_api)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["overall"] == "pass"
+    assert payload["exit_code"] == 0
+    assert payload["summary"]["failed"] == 0
+    assert payload["summary"]["warned"] == 0
+    # Five checks: reachability + diagnostics fetch + key + migrations + attachment + token store.
+    assert payload["summary"]["total"] == 6
+    names = {c["name"] for c in payload["checks"]}
+    assert "API reachability" in names
+    assert "Master-key loaded" in names
+
+
+@pytest.mark.integration
+def test_doctor_warns_when_token_store_empty(live_api: str, token_file: Path) -> None:
+    """No login yet → the token-store check is a warning (exit 1).
+
+    All API-side checks pass, so the overall severity is `warn` — exactly the
+    case the issue's acceptance calls out.
+    """
+    # token_file fixture sets TULIP_TOKEN_STORE but does not populate it.
+    assert not token_file.exists()
+    result = _run_cli("doctor", api_url=live_api)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "token store" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_doctor_fails_when_api_unreachable(token_file: Path) -> None:
+    """Point at a port nobody's listening on → exit 2 (hard failure)."""
+    bogus_url = "http://127.0.0.1:1"  # nobody listens on port 1
+    result = _run_cli("doctor", api_url=bogus_url)
+    assert result.returncode == 2, (result.stdout, result.stderr)
+    assert "api reachability" in result.stderr.lower()
+    assert "failed" in result.stderr.lower()

--- a/packages/tulip-storage/src/tulip_storage/migrations_meta.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations_meta.py
@@ -1,0 +1,40 @@
+"""Read-only metadata about the alembic migrations bundled with this package.
+
+The doctor CLI (#135) compares the head of the bundled migrations against
+the head currently stamped in a deployed database; mismatches surface as
+"DB is behind the wheel — run ``alembic upgrade head``". This module
+exposes that lookup without booting the alembic CLI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic.config import Config as AlembicConfig
+from alembic.script import ScriptDirectory
+
+_MIGRATIONS_DIR: Path = Path(__file__).parent / "migrations"
+
+
+def expected_alembic_head() -> str:
+    """Return the head revision of the migrations bundled in this package.
+
+    Raises:
+        RuntimeError: if the migrations directory has no head revision —
+            should only happen if the package is mis-built.
+
+    """
+    cfg = AlembicConfig()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    script = ScriptDirectory.from_config(cfg)
+    head = script.get_current_head()
+    if head is None:
+        msg = (
+            f"No alembic head found in bundled migrations at {_MIGRATIONS_DIR}. "
+            "This is a packaging bug — the wheel is missing migration scripts."
+        )
+        raise RuntimeError(msg)
+    return head
+
+
+__all__ = ["expected_alembic_head"]

--- a/packages/tulip-storage/tests/test_migrations_meta.py
+++ b/packages/tulip-storage/tests/test_migrations_meta.py
@@ -1,0 +1,53 @@
+"""Tests for ``tulip_storage.migrations_meta`` (#135)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_storage.migrations_meta import expected_alembic_head
+
+
+def test_returns_a_revision_id() -> None:
+    """The bundled migrations have a head; revision IDs are 12-char hex."""
+    head = expected_alembic_head()
+    assert isinstance(head, str)
+    assert len(head) == 12
+    assert all(c in "0123456789abcdef" for c in head)
+
+
+def test_matches_a_real_migration_file() -> None:
+    """The reported head must correspond to a versions/*.py file.
+
+    Catches the case where the helper drifts from the actual bundled
+    migrations (e.g. the package was repackaged without the scripts).
+    """
+    from pathlib import Path
+
+    head = expected_alembic_head()
+    versions_dir = (
+        Path(__file__).parent.parent / "src" / "tulip_storage" / "migrations" / "versions"
+    )
+    matches = list(versions_dir.glob(f"*_{head}_*.py"))
+    assert matches, f"head {head!r} not found in {versions_dir}"
+
+
+def test_consistent_across_calls() -> None:
+    """Pure read; no caching gotchas."""
+    assert expected_alembic_head() == expected_alembic_head()
+
+
+def test_raises_when_migrations_dir_empty(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Mis-built package (no version scripts) → RuntimeError, not silent ''."""
+    from pathlib import Path
+
+    from tulip_storage import migrations_meta
+
+    empty_migrations = tmp_path / "migrations"
+    empty_migrations.mkdir()
+    (empty_migrations / "versions").mkdir()
+    (empty_migrations / "env.py").write_text("")
+    (empty_migrations / "script.py.mako").write_text("")
+
+    monkeypatch.setattr(migrations_meta, "_MIGRATIONS_DIR", Path(empty_migrations))
+    with pytest.raises(RuntimeError, match="No alembic head"):
+        expected_alembic_head()


### PR DESCRIPTION
## Summary

Pre-internal-beta hardening Tier 2. New `tulip doctor` runs five smoke checks against the configured API and exits 0 / 1 / 2 (locked design decision per #135 — overrides the CLI's general-purpose `EXIT_*` constants for this command only):

1. **API reachability** — `GET /health` returns 200.
2. **Master-key loaded** — diagnostics reports source ≠ `"ephemeral"`; ephemeral fallback is a hard failure.
3. **Migration head** — DB's alembic revision matches the head bundled in the running API package; mismatch is a warning (`run alembic upgrade head`).
4. **Attachment-root writable** — server-side probe creates and removes a zero-byte file at `attachment_root`.
5. **Token store** — CLI-side check that the token-store path is reachable; missing/empty is a warning, not a failure (user might just need to log in).

### Supporting changes

- **New unauthenticated endpoint `GET /v1/system/diagnostics`** aggregates probes 2–4 server-side. Booleans only — no paths or key bytes leak. Auth-free by design so the doctor runs *before* any user has registered.
- **`tulip_storage.migrations_meta.expected_alembic_head()`** helper reads the bundled migrations dir via alembic's `ScriptDirectory`.
- **`Settings.master_key_source: Literal[\"env\", \"file\", \"ephemeral\"]`** records which env path produced the key. Side-effect-free factory so the warning-on-ephemeral fires exactly once per `Settings()` construction.
- **README**: brief mention of `tulip doctor`. Full QUICKSTART integration deferred to #138.

### Out of scope

- QUICKSTART rewrite (#138) — keeps this PR scoped to the command itself.
- README rewrite for users (#139) — same.
- Any check beyond the five locked into the issue's acceptance.

## Test plan

- [x] Unit tests: 4 for `aggregate_status`, 6 for individual check helpers, 4 for `expected_alembic_head()`, 4 for `Settings.master_key_source`.
- [x] API endpoint tests: 6 (happy path × 3, degraded states × 3 covering ephemeral key, unwritable attachment root, alembic-head mismatch).
- [x] CLI integration tests via `live_api` subprocess: green path (exit 0), JSON output, warning branch (exit 1, token-store empty), failure branch (exit 2, unreachable API).
- [x] `just lint` clean, `just typecheck` clean.
- [x] Full suite: 1198 passed, 1 skipped (pre-existing).
- [ ] CI green on this PR.
- [ ] Manual smoke (against the docker-compose stack from #143):

  ` ``bash
  docker compose up -d
  uv run tulip doctor
  uv run tulip --json doctor | jq .
  ` ``

  Expected: `tulip doctor: all checks passed (6/6)` on a healthy install (after `tulip register` + `tulip auth login` populate the token store).