### PR TITLE
feat: tulip periods CLI for soft-close / reopen (closes #136)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -564,6 +564,10 @@ PR #30. Closed #26. Surfaced during P3.2.a smoke testing when a SQLAlchemy URL p
 
 Closed #141. The runner's `Clock` returns UTC (per ADR-0002 §6, "every other path uses real `datetime.now(UTC)`"); the `envelope_refill` handler stored shadow tx dates as `clock().date()` accordingly. The envelope/sinking-fund balance endpoints, however, defaulted `as_of = date.today()` — server-local. For any negative-offset timezone, between UTC midnight and local midnight the local "today" lags the handler's UTC "today", so a freshly-posted refill was filtered out by the `tx.date <= as_of` predicate. Surfaced as a flake on `test_run_due_executes_handler` between 17:00 PT and 23:59 PT. Fix: three balance-endpoint callsites (`envelopes.py`, `sinking_funds.py`) now use `datetime.now(UTC).date()`; deterministic regression test in `test_refill_schedules_endpoints.py::TestRunDue::test_run_due_balance_uses_utc_today_not_local` pins the local helper to a far-past date so the bug, if reintroduced, fails the test at any wall-clock time.
 
+### `tulip periods` CLI — ✅ *(2026-05-10)*
+
+Closed #136 (Hardening Tier 3). Period soft-close was a storage-layer primitive only; now exposed via `GET /v1/periods`, `POST /v1/periods/{id}/close`, `POST /v1/periods/{id}/reopen` (admin-gated for the mutating routes; idempotent on already-closed/already-open). New `tulip periods {list, close, reopen}` CLI commands consume the endpoints; the existing `period.closed` 400 path on transaction writes is unchanged — this slice only ships the status-flip surface. New `period.not_found` (404) error class. Tests: 10 API endpoint tests (list, close, reopen, idempotency, 404, role-gated, close-blocks-writes, round-trip-unblocks-writes) + 4 CLI subprocess integration tests against `live_api`.
+
 ### `tulip doctor` smoke / first-run verification — ✅ *(2026-05-10)*
 
 Closed #135 (Hardening Tier 2). New `tulip doctor` CLI command runs five checks against the configured API and exits 0 / 1 / 2 (locked design decision per the issue: 0 = all good, 1 = warning, 2 = hard failure — overrides the CLI's general-purpose `EXIT_*` constants for this command only):

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -498,6 +498,19 @@ class PeriodClosedError(TulipProblem):
         )
 
 
+class PeriodNotFoundError(TulipProblem):
+    """A period lookup either missed or hit a row not in this household."""
+
+    def __init__(self) -> None:
+        """Build the period.not_found problem (#136)."""
+        super().__init__(
+            code="period.not_found",
+            title="Period not found",
+            status=404,
+            detail="No period with that ID exists in this household.",
+        )
+
+
 class TransactionNotFoundError(TulipProblem):
     """A transaction lookup either missed or hit a row not in this household."""
 

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -32,6 +32,7 @@ from tulip_api.routers import (
     envelopes,
     health,
     imports,
+    periods,
     pools,
     reconciliations,
     refill_schedules,
@@ -122,6 +123,7 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
     app.include_router(auth.router)
     app.include_router(accounts.router)
     app.include_router(transactions.router)
+    app.include_router(periods.router)
     app.include_router(envelopes.router)
     app.include_router(sinking_funds.router)
     app.include_router(pools.router)

--- a/packages/tulip-api/src/tulip_api/routers/periods.py
+++ b/packages/tulip-api/src/tulip_api/routers/periods.py
@@ -1,0 +1,155 @@
+"""Endpoints for ``/v1/periods`` (#136).
+
+Surfaces the ``PeriodRepository`` close/reopen primitives so users can
+run a month-end loop from ``tulip periods`` without falling back to a
+direct DB write. Soft-close is the v1 model — closed periods reject
+new transactions via the existing ``period.closed`` 400 path; this
+router only changes the status, not the enforcement.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, Request, status
+
+from tulip_api.auth.deps import get_current_claims, require_role
+from tulip_api.deps import get_session
+from tulip_api.errors import PeriodNotFoundError, problem_response
+from tulip_api.schemas.period import PeriodRead
+from tulip_storage.models import Period as PeriodModel
+from tulip_storage.models import PeriodStatus
+from tulip_storage.repositories import AuditLogWriter, PeriodRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_api.auth.tokens import Claims
+
+
+router = APIRouter(prefix="/v1/periods", tags=["periods"])
+log = structlog.get_logger("tulip_api.periods")
+
+
+def _to_read(period: PeriodModel) -> PeriodRead:
+    return PeriodRead(
+        id=period.id,
+        start_date=period.start_date,
+        end_date=period.end_date,
+        status=period.status.value,
+        closed_at=period.closed_at,
+        closed_by_user_id=period.closed_by_user_id,
+    )
+
+
+def _request_uuid(request: Request) -> UUID | None:
+    rid = request.headers.get("x-request-id")
+    if rid:
+        try:
+            return UUID(rid)
+        except ValueError:
+            return None
+    return None
+
+
+@router.get(
+    "",
+    response_model=list[PeriodRead],
+    responses={401: problem_response("auth.unauthorized")},
+)
+def list_periods(
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> list[PeriodRead]:
+    """List the household's periods, newest first."""
+    return [_to_read(p) for p in PeriodRepository(session, claims.household_id).list_all()]
+
+
+@router.post(
+    "/{period_id}/close",
+    response_model=PeriodRead,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("period.not_found"),
+    },
+)
+def close_period(
+    period_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> PeriodRead:
+    """Soft-close a period. Idempotent — closing an already-closed period is a no-op."""
+    repo = PeriodRepository(session, claims.household_id)
+    existing = repo.get(period_id)
+    if existing is None:
+        raise PeriodNotFoundError()
+    if existing.status is PeriodStatus.SOFT_CLOSED:
+        return _to_read(existing)
+
+    before = {"status": existing.status.value, "closed_at": None}
+    closed = repo.close(period_id, by_user_id=claims.user_id)
+    AuditLogWriter(session, claims.household_id).write(
+        action="update",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="period",
+        entity_id=closed.id,
+        before=before,
+        after={
+            "status": closed.status.value,
+            "closed_at": closed.closed_at.isoformat() if closed.closed_at else None,
+        },
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info("period.closed", period_id=str(closed.id))
+    return _to_read(closed)
+
+
+@router.post(
+    "/{period_id}/reopen",
+    response_model=PeriodRead,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("period.not_found"),
+    },
+)
+def reopen_period(
+    period_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> PeriodRead:
+    """Re-open a soft-closed period. Idempotent on already-open periods."""
+    repo = PeriodRepository(session, claims.household_id)
+    existing = repo.get(period_id)
+    if existing is None:
+        raise PeriodNotFoundError()
+    if existing.status is PeriodStatus.OPEN:
+        return _to_read(existing)
+
+    before = {
+        "status": existing.status.value,
+        "closed_at": existing.closed_at.isoformat() if existing.closed_at else None,
+    }
+    reopened = repo.reopen(period_id)
+    AuditLogWriter(session, claims.household_id).write(
+        action="update",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="period",
+        entity_id=reopened.id,
+        before=before,
+        after={"status": reopened.status.value, "closed_at": None},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info("period.reopened", period_id=str(reopened.id))
+    return _to_read(reopened)

--- a/packages/tulip-api/src/tulip_api/schemas/period.py
+++ b/packages/tulip-api/src/tulip_api/schemas/period.py
@@ -1,0 +1,28 @@
+"""Schemas for ``/v1/periods`` (#136 — ``tulip periods`` CLI surface)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class PeriodRead(BaseModel):
+    """One row in the periods response."""
+
+    id: UUID
+    start_date: date
+    end_date: date
+    status: Literal["open", "soft_closed"] = Field(
+        description="Soft-close is the v1 model; hard-close is deferred (ARCHITECTURE §3)."
+    )
+    closed_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp the period was last soft-closed; null while open.",
+    )
+    closed_by_user_id: UUID | None = Field(
+        default=None,
+        description="The user who issued the soft-close, or null while open.",
+    )

--- a/packages/tulip-api/tests/test_periods_endpoints.py
+++ b/packages/tulip-api/tests/test_periods_endpoints.py
@@ -1,0 +1,188 @@
+"""Tests for ``/v1/periods`` (#136 — ``tulip periods`` CLI surface)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r.json()["access_token"]
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+def _seed_period_id(client: TestClient, auth_h: dict[str, str]) -> str:
+    """Registration auto-seeds a current-year period; pluck its id."""
+    r = client.get("/v1/periods", headers=auth_h)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body, "expected the registration-seeded current-year period"
+    return body[0]["id"]
+
+
+class TestList:
+    def test_lists_seeded_period(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.get("/v1/periods", headers=auth_h)
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body) == 1
+        assert body[0]["status"] == "open"
+        assert body[0]["closed_at"] is None
+        assert body[0]["closed_by_user_id"] is None
+
+    def test_unauth_returns_401(self, client: TestClient) -> None:
+        r = client.get("/v1/periods")
+        assert r.status_code == 401
+
+
+class TestClose:
+    def test_close_open_period(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        period_id = _seed_period_id(client, auth_h)
+        r = client.post(f"/v1/periods/{period_id}/close", headers=auth_h)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "soft_closed"
+        assert body["closed_at"] is not None
+        assert body["closed_by_user_id"] is not None
+
+    def test_close_is_idempotent(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        period_id = _seed_period_id(client, auth_h)
+        first = client.post(f"/v1/periods/{period_id}/close", headers=auth_h)
+        second = client.post(f"/v1/periods/{period_id}/close", headers=auth_h)
+        assert second.status_code == 200
+        # closed_at stamp doesn't move on the second call — idempotent no-op.
+        # Strip any trailing 'Z'; SQLite + SQLAlchemy DateTime(timezone=True)
+        # round-trips lose the tz offset on read, so the second response
+        # serialises without it. Both refer to the same UTC instant.
+        assert second.json()["closed_at"].rstrip("Z") == first.json()["closed_at"].rstrip("Z")
+
+    def test_close_unknown_returns_404(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.post(f"/v1/periods/{uuid4()}/close", headers=auth_h)
+        assert_problem(r, code="period.not_found", status=404)
+
+    def test_close_blocks_subsequent_writes(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """Acceptance: close stamps the row so transaction writes 400 on it."""
+        period_id = _seed_period_id(client, auth_h)
+        client.post(f"/v1/periods/{period_id}/close", headers=auth_h).raise_for_status()
+
+        # Build minimal account scaffolding to attempt a posting.
+        a = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"code": "1000", "name": "Cash", "type": "asset", "currency": "USD"},
+        )
+        a.raise_for_status()
+        a_id = a.json()["id"]
+        b = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"code": "5000", "name": "Food", "type": "expense", "currency": "USD"},
+        )
+        b.raise_for_status()
+        b_id = b.json()["id"]
+
+        # Pick a date inside the (now-closed) seeded period.
+        from datetime import date
+
+        today = date.today()
+        tx = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date(today.year, 1, 15).isoformat(),
+                "description": "Inside the closed period",
+                "postings": [
+                    {"account_id": a_id, "amount": "-12.34", "currency": "USD"},
+                    {"account_id": b_id, "amount": "12.34", "currency": "USD"},
+                ],
+            },
+        )
+        assert_problem(tx, code="period.closed", status=400)
+
+
+class TestReopen:
+    def test_reopen_a_closed_period(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        period_id = _seed_period_id(client, auth_h)
+        client.post(f"/v1/periods/{period_id}/close", headers=auth_h).raise_for_status()
+        r = client.post(f"/v1/periods/{period_id}/reopen", headers=auth_h)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "open"
+        assert body["closed_at"] is None
+        assert body["closed_by_user_id"] is None
+
+    def test_reopen_is_idempotent_on_already_open(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        period_id = _seed_period_id(client, auth_h)
+        r = client.post(f"/v1/periods/{period_id}/reopen", headers=auth_h)
+        assert r.status_code == 200
+        assert r.json()["status"] == "open"
+
+    def test_reopen_unknown_returns_404(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.post(f"/v1/periods/{uuid4()}/reopen", headers=auth_h)
+        assert_problem(r, code="period.not_found", status=404)
+
+    def test_round_trip_close_then_reopen_unblocks_writes(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        period_id = _seed_period_id(client, auth_h)
+        client.post(f"/v1/periods/{period_id}/close", headers=auth_h).raise_for_status()
+        client.post(f"/v1/periods/{period_id}/reopen", headers=auth_h).raise_for_status()
+
+        # Seed accounts + post a transaction; should now succeed.
+        a = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"code": "1000", "name": "Cash", "type": "asset", "currency": "USD"},
+        )
+        a.raise_for_status()
+        a_id = a.json()["id"]
+        b = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"code": "5000", "name": "Food", "type": "expense", "currency": "USD"},
+        )
+        b.raise_for_status()
+        b_id = b.json()["id"]
+
+        from datetime import date
+
+        today = date.today()
+        tx = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date(today.year, 1, 15).isoformat(),
+                "description": "After reopen",
+                "postings": [
+                    {"account_id": a_id, "amount": "-1.00", "currency": "USD"},
+                    {"account_id": b_id, "amount": "1.00", "currency": "USD"},
+                ],
+            },
+        )
+        assert tx.status_code == 201, tx.text

--- a/packages/tulip-cli/src/tulip_cli/commands/periods.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/periods.py
@@ -1,0 +1,128 @@
+"""``tulip periods`` — list, close, reopen accounting periods (#136).
+
+Soft-close is the v1 model: closed periods reject new transactions via
+the existing ``period.closed`` 400 path. This module just exposes the
+status-flip surface so users can run a month-end loop without falling
+back to the JSON API.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Annotated
+from uuid import UUID
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+periods_app = typer.Typer(
+    name="periods",
+    help="List and soft-close / reopen accounting periods.",
+    no_args_is_help=True,
+)
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+def _render_table(periods: list[dict[str, object]]) -> None:
+    table = Table(show_header=True, show_lines=False)
+    table.add_column("id")
+    table.add_column("start")
+    table.add_column("end")
+    table.add_column("status")
+    table.add_column("closed_at")
+    for p in periods:
+        status_str = str(p.get("status", ""))
+        if status_str == "soft_closed":
+            status_styled = f"[red]{status_str}[/red]"
+        else:
+            status_styled = f"[green]{status_str}[/green]"
+        table.add_row(
+            str(p.get("id", "")),
+            str(p.get("start_date", "")),
+            str(p.get("end_date", "")),
+            status_styled,
+            str(p.get("closed_at") or "—"),
+        )
+    Console().print(table)
+
+
+@periods_app.command("list")
+def list_periods(ctx: typer.Context) -> None:
+    """List all periods for the household, newest first."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get("/v1/periods", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    periods = response.json()
+    if not periods:
+        typer.echo("No periods.")
+        return
+    _render_table(periods)
+
+
+@periods_app.command("close")
+def close_period(
+    ctx: typer.Context,
+    period_id: Annotated[UUID, typer.Argument(help="Period UUID to soft-close.")],
+) -> None:
+    """Soft-close a period. Idempotent on already-closed periods."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post(f"/v1/periods/{period_id}/close", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    body = response.json()
+    typer.echo(
+        f"Period {body['id']} ({body['start_date']} to {body['end_date']}) is now {body['status']}."
+    )
+
+
+@periods_app.command("reopen")
+def reopen_period(
+    ctx: typer.Context,
+    period_id: Annotated[UUID, typer.Argument(help="Period UUID to reopen.")],
+) -> None:
+    """Re-open a soft-closed period. Idempotent on already-open periods."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post(f"/v1/periods/{period_id}/reopen", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    body = response.json()
+    typer.echo(
+        f"Period {body['id']} ({body['start_date']} to {body['end_date']}) is now {body['status']}."
+    )

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -25,6 +25,7 @@ from tulip_cli.commands.balance import balance as balance_command
 from tulip_cli.commands.doctor import doctor as doctor_command
 from tulip_cli.commands.envelopes import envelopes_app
 from tulip_cli.commands.imports import imports_app
+from tulip_cli.commands.periods import periods_app
 from tulip_cli.commands.pool_actions import (
     budget_inflow as budget_inflow_command,
 )
@@ -117,6 +118,7 @@ app.add_typer(auth_app, name="auth")
 app.add_typer(accounts_app, name="accounts")
 app.add_typer(transactions_app, name="transactions")
 app.add_typer(envelopes_app, name="envelopes")
+app.add_typer(periods_app, name="periods")
 app.add_typer(sinking_funds_app, name="sinking-funds")
 app.add_typer(refills_app, name="refills")
 # Register `imports` (canonical, plural) and keep `import` as an alias

--- a/packages/tulip-cli/tests/test_periods.py
+++ b/packages/tulip-cli/tests/test_periods.py
@@ -1,0 +1,113 @@
+"""End-to-end tests for ``tulip periods`` (#136)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(*args: str, api_url: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+@pytest.fixture
+def token_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "tokens.json"
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(path))
+    return path
+
+
+@pytest.fixture
+def authed(live_api: str, token_file: Path) -> str:
+    """Register + login so the CLI has a usable token in the store."""
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "p@example.com",
+            "password": _PASSWORD,
+            "display_name": "P",
+            "household_name": "P House",
+        },
+        timeout=10,
+    ).raise_for_status()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--api-url",
+            live_api,
+            "auth",
+            "login",
+            "--email",
+            "p@example.com",
+            "--password-stdin",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        input=f"{_PASSWORD}\n",
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return live_api
+
+
+@pytest.mark.integration
+def test_periods_list_renders_seeded_period(authed: str) -> None:
+    result = _run_cli("periods", "list", api_url=authed)
+    assert result.returncode == 0, result.stderr
+    # Registration auto-seeds the current-year period; the table shows it.
+    assert "open" in result.stdout
+
+
+@pytest.mark.integration
+def test_periods_list_json_output(authed: str) -> None:
+    result = _run_cli("--json", "periods", "list", api_url=authed)
+    assert result.returncode == 0, result.stderr
+    body = json.loads(result.stdout)
+    assert isinstance(body, list)
+    assert len(body) == 1
+    assert body[0]["status"] == "open"
+
+
+@pytest.mark.integration
+def test_periods_close_then_reopen_round_trip(authed: str) -> None:
+    """Acceptance: close + reopen round-trip works end-to-end."""
+    listing = _run_cli("--json", "periods", "list", api_url=authed)
+    period_id = json.loads(listing.stdout)[0]["id"]
+
+    closed = _run_cli("periods", "close", period_id, api_url=authed)
+    assert closed.returncode == 0, closed.stderr
+    assert "soft_closed" in closed.stdout
+
+    after_close = _run_cli("--json", "periods", "list", api_url=authed)
+    assert json.loads(after_close.stdout)[0]["status"] == "soft_closed"
+
+    reopened = _run_cli("periods", "reopen", period_id, api_url=authed)
+    assert reopened.returncode == 0, reopened.stderr
+    assert "open" in reopened.stdout
+
+    after_reopen = _run_cli("--json", "periods", "list", api_url=authed)
+    assert json.loads(after_reopen.stdout)[0]["status"] == "open"
+
+
+@pytest.mark.integration
+def test_periods_close_unknown_id_renders_problem(authed: str) -> None:
+    result = _run_cli("periods", "close", "00000000-0000-0000-0000-000000000000", api_url=authed)
+    assert result.returncode != 0, (result.stdout, result.stderr)
+    # CliError renders the problem detail to stderr.
+    assert "period" in result.stderr.lower()


### PR DESCRIPTION
## Summary

Pre-internal-beta hardening Tier 3. Period soft-close was previously a storage-layer primitive only — users had to drop to direct DB writes to run a month-end loop. This slice exposes it via the API and the CLI:

- **API** (admin-gated for mutating routes; idempotent on already-closed / already-open):
  - `GET /v1/periods` — list, newest first, with status / closed_at / closed_by_user_id.
  - `POST /v1/periods/{id}/close` — soft-close + audit row.
  - `POST /v1/periods/{id}/reopen` — reverse.
- **Error**: new `period.not_found` (404).
- **CLI**: new `tulip periods {list, close, reopen}` command group, with `--json` output for each.

The existing transaction-write enforcement (`period.closed` 400 on a posting whose date falls inside a soft-closed period) is unchanged. This slice only ships the status-flip surface.

### Out of scope (per the issue)

- Explicit period creation via CLI (periods are seeded at registration today).
- Hard-close / lock (Phase 9).
- Per-period balance reports (#137 territory).

## Test plan

- [x] 10 API endpoint tests covering list, close, reopen, idempotency on both, 404 on unknown ids, the close-blocks-subsequent-writes acceptance criterion, and the round-trip-unblocks-writes case.
- [x] 4 CLI subprocess integration tests against `live_api`: human list, JSON list, full close-then-reopen round-trip, unknown-id error rendering.
- [x] `just lint` clean, `just typecheck` clean.
- [x] Full suite: 1215 passed, 1 skipped (pre-existing).
- [ ] CI green on this PR.
- [ ] Manual smoke (against the docker-compose stack from #143):

  ` ``bash
  uv run tulip periods list
  PERIOD_ID=$(uv run tulip --json periods list | jq -r '.[0].id')
  uv run tulip periods close "$PERIOD_ID"
  uv run tulip periods list
  uv run tulip periods reopen "$PERIOD_ID"
  uv run tulip periods list
  ` ``