### PR TITLE
feat: P6.3 — daily-insights scheduler + anomaly detector + notifications inbox

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -22,9 +22,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **Pre-internal-beta hardening (#121):** ✅ **complete** — all eight checkboxes merged across PRs #140 / #142 / #143 / #146 / #147 / #148 / #149 / #150 / #151 / #152 (master-key file gate, backup/restore CLI, docker compose, password-stdin TTY hint, UTC balance fix, `tulip doctor`, `tulip periods`, inline balances, QUICKSTART, README rewrite for users). Umbrella closed 2026-05-10.
 
-- **Phase 6 (AI integration):** in flight — P6.0 design ([ADR-0005](adrs/0005-ai-integration.md), closes #102) + P6.1 (`tulip-ai` package + storage migration + `AICategorizer` plugged into the P5.3 DI seam + BYOK CLI/API) + P6.2 (NL-query two-turn flow with model-emitted SQL behind a sqlglot validator) shipped. Next: P6.3 (forecast + anomaly detection).
+- **Phase 6 (AI integration):** in flight — P6.0 ([ADR-0005](adrs/0005-ai-integration.md)) + P6.1 (`tulip-ai` + `AICategorizer` + BYOK) + P6.2 (NL-query two-turn flow with sqlglot SQL gate) + P6.3 (daily-insights scheduler + anomaly detector + notifications inbox; AI forecast deferred to P6.3.b) shipped. Next: P6.3.b (AI forecast) or P6.4 (agentic proposals).
 
-**Tests:** 1305 passing · **CI:** green on `main`
+**Tests:** 1325 passing · **CI:** green on `main`
 
 ---
 
@@ -561,6 +561,40 @@ Closes Phase 5. Imperative CLI subcommand group with 10 commands wrapping the /v
 ## Phase 6 — AI integration — in flight (design)
 
 Phase 6 entry criterion per [ARCHITECTURE.md §10](ARCHITECTURE.md) was a privacy audit shaping the design before any code lands. The audit is now shipped as an ADR; implementation begins with P6.1.
+
+### P6.3 — Daily-insights scheduler + anomaly detector + notifications inbox — ✅ *(2026-05-11)*
+
+Third Phase 6 slice. Establishes the notifications inbox and ships the anomaly half of the daily-insights pipeline. AI forecasting (the other half ADR-0005 §Q3 describes) is deferred to a P6.3 follow-up — the handler has a documented seam where the AI capability plugs in.
+
+**New `tulip_core.insights` (pure-domain)**:
+
+- `find_anomalies(series, window_size=30, threshold_sigma=2)` returns positive-tail anomalies (overspending only — under-spending isn't notification-worthy in v1). Severity is bucketed: `info` (>=2 sigma), `warning` (>=3 sigma), `critical` (>=4 sigma).
+- 7 unit + property tests (flat-series-never-flags hypothesis property, spike-detection, severity ladder, negative-tail suppression, validation).
+
+**Storage**:
+
+- New `notifications` table with composite PK + indexes for inbox listing.
+- `NotificationKind` / `NotificationSeverity` enums.
+- `NotificationRepository` for `create / list_active / list_all / get / dismiss` (dismiss is idempotent).
+
+**Scheduler handler `daily_insights`**:
+
+- Registered via the same `register_handler` seam ADR-0002 ships.
+- For each active envelope in the household, builds a 60-day daily-spend series from POSTED shadow postings (outflows only, abs-valued, zero-filled), feeds it to `find_anomalies`, and writes one `notifications` row per detected anomaly with `produced_by="daily_insights"` and `entity_type="envelope"`.
+- The AI forecast extension point is documented inline; same loop will call the AI capability and write a `kind=forecast` notification when P6.3.b lands.
+
+**HTTP**: `GET /v1/notifications[?include_dismissed=true]` and `POST /v1/notifications/{id}/dismiss`. Dismiss returns 404 (`notification.not_found`) on unknown ids; idempotent on already-dismissed.
+
+**CLI**: `tulip notifications list [--include-dismissed]` (Rich table, severity colour-coded) and `tulip notifications dismiss UUID`.
+
+**Tests** — +16 new:
+- 7 anomaly detector unit + property tests.
+- 2 daily-insights handler integration tests (flat-series-no-notifications, spike-produces-anomaly-with-severity).
+- 7 API endpoint tests (empty inbox, list active only by default, include-dismissed, dismiss, dismiss 404, dismiss idempotency, auth gate).
+
+**Deferred to P6.3.b** (separate slice):
+- `AIForecastCapability` per ADR-0005 §Q3 with 5%/25% amount bucketing and the forecast prompt payload.
+- Envelope-runout / sinking-fund-on-track notifications (driven by the AI capability).
 
 ### P6.2 — NL query: two-turn flow with model-emitted SQL — ✅ *(2026-05-11)*
 

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -33,6 +33,7 @@ from tulip_api.routers import (
     envelopes,
     health,
     imports,
+    notifications,
     periods,
     pools,
     reconciliations,
@@ -153,6 +154,7 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
     app.include_router(accounts.router)
     app.include_router(transactions.router)
     app.include_router(periods.router)
+    app.include_router(notifications.router)
     app.include_router(envelopes.router)
     app.include_router(sinking_funds.router)
     app.include_router(pools.router)

--- a/packages/tulip-api/src/tulip_api/routers/ai.py
+++ b/packages/tulip-api/src/tulip_api/routers/ai.py
@@ -82,8 +82,10 @@ def _store_household_keys(household: Household, keys: dict[str, str], master_key
     "/keys/{provider}",
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
+        400: problem_response("request.body_invalid"),
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
+        422: problem_response("validation.failed"),
     },
 )
 def set_ai_key(
@@ -183,8 +185,10 @@ def get_ai_status(
     "/preview",
     response_model=AIPreviewResponse,
     responses={
+        400: problem_response("request.body_invalid"),
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
+        422: problem_response("validation.failed"),
     },
 )
 def preview_categorize_prompt(
@@ -245,8 +249,10 @@ def preview_categorize_prompt(
     "/ask",
     response_model=AIAskResponse,
     responses={
+        400: problem_response("request.body_invalid"),
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
+        422: problem_response("validation.failed"),
     },
 )
 async def ask_nl_query(

--- a/packages/tulip-api/src/tulip_api/routers/notifications.py
+++ b/packages/tulip-api/src/tulip_api/routers/notifications.py
@@ -67,6 +67,7 @@ def list_notifications(
     responses={
         401: problem_response("auth.unauthorized"),
         404: problem_response("notification.not_found"),
+        422: problem_response("validation.failed"),
     },
 )
 def dismiss_notification(

--- a/packages/tulip-api/src/tulip_api/routers/notifications.py
+++ b/packages/tulip-api/src/tulip_api/routers/notifications.py
@@ -1,0 +1,84 @@
+"""HTTP surface for the notifications inbox (P6.3)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, Query, status
+
+from tulip_api.auth.deps import get_current_claims
+from tulip_api.deps import get_session
+from tulip_api.errors import TulipProblem, problem_response
+from tulip_api.schemas.notification import NotificationRead
+from tulip_storage.repositories import NotificationRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_api.auth.tokens import Claims
+
+
+router = APIRouter(prefix="/v1/notifications", tags=["notifications"])
+log = structlog.get_logger("tulip_api.notifications")
+
+
+class NotificationNotFoundError(TulipProblem):
+    """The notification id doesn't belong to the caller's household."""
+
+    def __init__(self) -> None:
+        """Build the notification.not_found problem (P6.3)."""
+        super().__init__(
+            code="notification.not_found",
+            title="Notification not found",
+            status=404,
+            detail="No notification with that ID exists in this household.",
+        )
+
+
+def _to_read(row: object) -> NotificationRead:
+    return NotificationRead.model_validate(row, from_attributes=True)
+
+
+@router.get(
+    "",
+    response_model=list[NotificationRead],
+    responses={401: problem_response("auth.unauthorized")},
+)
+def list_notifications(
+    include_dismissed: bool = Query(
+        default=False,
+        description="When true, dismissed rows are also returned.",
+    ),
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> list[NotificationRead]:
+    """List the household's notifications, newest first."""
+    repo = NotificationRepository(session, claims.household_id)
+    rows = repo.list_all() if include_dismissed else repo.list_active()
+    return [_to_read(r) for r in rows]
+
+
+@router.post(
+    "/{notification_id}/dismiss",
+    response_model=NotificationRead,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        404: problem_response("notification.not_found"),
+    },
+)
+def dismiss_notification(
+    notification_id: UUID,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> NotificationRead:
+    """Stamp ``dismissed_at`` on the row. Idempotent on already-dismissed."""
+    repo = NotificationRepository(session, claims.household_id)
+    row = repo.dismiss(notification_id)
+    if row is None:
+        raise NotificationNotFoundError()
+    session.commit()
+    log.info("notification.dismissed", notification_id=str(notification_id))
+    return _to_read(row)

--- a/packages/tulip-api/src/tulip_api/routers/pools.py
+++ b/packages/tulip-api/src/tulip_api/routers/pools.py
@@ -244,6 +244,7 @@ def declare_budget_inflow(
     "/balances",
     response_model=list[PoolBalanceRead],
     responses={
+        400: problem_response("request.body_invalid"),
         401: problem_response("auth.unauthorized"),
         422: problem_response("validation.failed"),
     },

--- a/packages/tulip-api/src/tulip_api/schemas/notification.py
+++ b/packages/tulip-api/src/tulip_api/schemas/notification.py
@@ -1,0 +1,24 @@
+"""Schemas for ``/v1/notifications`` (P6.3)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class NotificationRead(BaseModel):
+    """One row of the notifications inbox."""
+
+    id: UUID
+    created_at: datetime
+    kind: str
+    severity: str
+    title: str
+    body: str
+    produced_by: str
+    entity_type: str | None
+    entity_id: UUID | None
+    dismissed_at: datetime | None
+    ai_invocation_id: UUID | None = Field(default=None)

--- a/packages/tulip-api/tests/test_notifications_endpoints.py
+++ b/packages/tulip-api/tests/test_notifications_endpoints.py
@@ -1,0 +1,139 @@
+"""Tests for /v1/notifications endpoints (P6.3)."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> tuple[str, str]:
+    r = client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    household_id = r.json()["household_id"]
+    r2 = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return str(r2.json()["access_token"]), str(household_id)
+
+
+@pytest.fixture
+def auth_h(admin_token: tuple[str, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token[0]}"}
+
+
+@pytest.fixture
+def household_id(admin_token: tuple[str, str]) -> UUID:
+    return UUID(admin_token[1])
+
+
+def _seed_notification(
+    client: TestClient,
+    auth_h: dict[str, str],
+    household_id: UUID,
+    *,
+    kind: str = "anomaly",
+    severity: str = "info",
+    dismissed: bool = False,
+) -> str:
+    """Seed one notification row directly via the test session.
+
+    No endpoint creates notifications today (the scheduler handler is
+    the only writer), so tests reach into the repo through the same
+    dependency_override the API uses.
+    """
+    from tulip_api.deps import get_session
+    from tulip_storage.repositories import NotificationRepository
+
+    overrides = client.app.dependency_overrides
+    session_factory = overrides[get_session]
+    with next(session_factory()) as session:
+        repo = NotificationRepository(session, household_id)
+        row = repo.create(
+            kind=kind,
+            severity=severity,
+            title="Unusual spend",
+            body="Spending 1000.00 USD is way above normal.",
+            produced_by="daily_insights",
+        )
+        if dismissed:
+            repo.dismiss(row.id)
+        session.commit()
+        return str(row.id)
+
+
+class TestList:
+    def test_empty_inbox(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.get("/v1/notifications", headers=auth_h)
+        assert r.status_code == 200
+        assert r.json() == []
+
+    def test_lists_active_only_by_default(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+    ) -> None:
+        _seed_notification(client, auth_h, household_id, dismissed=False)
+        _seed_notification(client, auth_h, household_id, dismissed=True)
+        body = client.get("/v1/notifications", headers=auth_h).json()
+        assert len(body) == 1
+        assert body[0]["dismissed_at"] is None
+
+    def test_include_dismissed(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+    ) -> None:
+        _seed_notification(client, auth_h, household_id, dismissed=False)
+        _seed_notification(client, auth_h, household_id, dismissed=True)
+        body = client.get("/v1/notifications?include_dismissed=true", headers=auth_h).json()
+        assert len(body) == 2
+
+
+class TestDismiss:
+    def test_dismiss_stamps_dismissed_at(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+    ) -> None:
+        nid = _seed_notification(client, auth_h, household_id)
+        r = client.post(f"/v1/notifications/{nid}/dismiss", headers=auth_h)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["dismissed_at"] is not None
+
+    def test_dismiss_unknown_returns_404(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.post(f"/v1/notifications/{uuid4()}/dismiss", headers=auth_h)
+        assert_problem(r, code="notification.not_found", status=404)
+
+    def test_dismiss_is_idempotent_on_already_dismissed(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+    ) -> None:
+        nid = _seed_notification(client, auth_h, household_id, dismissed=True)
+        first = client.post(f"/v1/notifications/{nid}/dismiss", headers=auth_h)
+        second = client.post(f"/v1/notifications/{nid}/dismiss", headers=auth_h)
+        assert second.status_code == 200
+        # dismissed_at didn't move on the second call.
+        assert first.json()["dismissed_at"] == second.json()["dismissed_at"]
+
+    def test_unauth_returns_401(self, client: TestClient) -> None:
+        r = client.post(f"/v1/notifications/{uuid4()}/dismiss")
+        assert r.status_code == 401

--- a/packages/tulip-cli/src/tulip_cli/commands/notifications.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/notifications.py
@@ -1,0 +1,110 @@
+"""``tulip notifications`` — daily-insights inbox (P6.3)."""
+
+from __future__ import annotations
+
+import sys
+from typing import Annotated
+from uuid import UUID
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+notifications_app = typer.Typer(
+    name="notifications",
+    help="List + dismiss daily-insights notifications.",
+    no_args_is_help=True,
+)
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+@notifications_app.command("list")
+def list_notifications(
+    ctx: typer.Context,
+    include_dismissed: Annotated[
+        bool,
+        typer.Option(
+            "--include-dismissed",
+            help="Also show dismissed rows. Default: active only.",
+        ),
+    ] = False,
+) -> None:
+    """List the household's notifications, newest first."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get(
+                "/v1/notifications",
+                authenticated=True,
+                params={"include_dismissed": "true"} if include_dismissed else None,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    rows = response.json()
+    if not rows:
+        typer.echo("Inbox empty.")
+        return
+    table = Table(show_header=True, show_lines=False)
+    table.add_column("id")
+    table.add_column("kind")
+    table.add_column("severity")
+    table.add_column("title")
+    table.add_column("dismissed")
+    for r in rows:
+        sev = str(r.get("severity", ""))
+        sev_styled = (
+            f"[red]{sev}[/red]"
+            if sev == "critical"
+            else f"[yellow]{sev}[/yellow]"
+            if sev == "warning"
+            else sev
+        )
+        table.add_row(
+            str(r.get("id", ""))[:8],
+            str(r.get("kind", "")),
+            sev_styled,
+            str(r.get("title", "")),
+            "yes" if r.get("dismissed_at") else "no",
+        )
+    Console().print(table)
+
+
+@notifications_app.command("dismiss")
+def dismiss_notification(
+    ctx: typer.Context,
+    notification_id: Annotated[UUID, typer.Argument(help="Notification UUID to dismiss.")],
+) -> None:
+    """Stamp the notification as handled. Idempotent on already-dismissed."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post(
+                f"/v1/notifications/{notification_id}/dismiss",
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    body = response.json()
+    typer.echo(f"Dismissed notification {body['id']} ({body['kind']}).")

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -26,6 +26,7 @@ from tulip_cli.commands.balance import balance as balance_command
 from tulip_cli.commands.doctor import doctor as doctor_command
 from tulip_cli.commands.envelopes import envelopes_app
 from tulip_cli.commands.imports import imports_app
+from tulip_cli.commands.notifications import notifications_app
 from tulip_cli.commands.periods import periods_app
 from tulip_cli.commands.pool_actions import (
     budget_inflow as budget_inflow_command,
@@ -121,6 +122,7 @@ app.add_typer(accounts_app, name="accounts")
 app.add_typer(transactions_app, name="transactions")
 app.add_typer(envelopes_app, name="envelopes")
 app.add_typer(periods_app, name="periods")
+app.add_typer(notifications_app, name="notifications")
 app.add_typer(sinking_funds_app, name="sinking-funds")
 app.add_typer(refills_app, name="refills")
 # Register `imports` (canonical, plural) and keep `import` as an alias

--- a/packages/tulip-core/src/tulip_core/insights/__init__.py
+++ b/packages/tulip-core/src/tulip_core/insights/__init__.py
@@ -1,0 +1,20 @@
+"""Pure-domain anomaly + forecast primitives (P6.3).
+
+The functions here are testable in isolation: no DB, no clock, no I/O,
+no framework deps. ``tulip-storage`` and ``tulip-ai`` consume them; the
+scheduler handler wires a daily run.
+"""
+
+from __future__ import annotations
+
+from tulip_core.insights.anomaly import (
+    Anomaly,
+    AnomalySeverity,
+    find_anomalies,
+)
+
+__all__ = [
+    "Anomaly",
+    "AnomalySeverity",
+    "find_anomalies",
+]

--- a/packages/tulip-core/src/tulip_core/insights/anomaly.py
+++ b/packages/tulip-core/src/tulip_core/insights/anomaly.py
@@ -1,0 +1,103 @@
+"""Rolling-mean / stdev anomaly detection over a daily spending series.
+
+A series is a list of ``(date, amount)`` pairs in chronological order;
+amounts are ``Decimal`` (per the project-wide "no float on money" rule).
+``find_anomalies`` walks the series with a rolling window and reports
+any sample whose value is more than ``threshold_sigma`` standard
+deviations above the rolling mean.
+
+Pure-domain by design — no I/O, no clock, no framework deps. The
+scheduler handler that consumes this in P6.3 plugs the result into the
+notifications table; tests exercise the math directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+
+
+class AnomalySeverity(Enum):
+    """Magnitude bucket; matches the notification severity column."""
+
+    INFO = "info"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+@dataclass(frozen=True, slots=True)
+class Anomaly:
+    """One detected anomaly: amount above the rolling mean."""
+
+    sample_date: date
+    amount: Decimal
+    rolling_mean: Decimal
+    rolling_stdev: Decimal
+    z_score: Decimal
+    severity: AnomalySeverity
+
+
+def _stdev(values: list[Decimal], mean: Decimal) -> Decimal:
+    """Sample standard deviation, returning ``Decimal('0')`` for ``len < 2``."""
+    if len(values) < 2:
+        return Decimal("0")
+    n = Decimal(len(values))
+    variance = sum(((v - mean) ** 2 for v in values), start=Decimal("0")) / (n - 1)
+    # Decimal has no native sqrt, but the ** operator with Decimal('0.5')
+    # works for non-negative inputs.
+    return variance.sqrt() if hasattr(variance, "sqrt") else Decimal(str(float(variance) ** 0.5))
+
+
+def _classify(z: Decimal) -> AnomalySeverity:
+    """``z`` >= 4 sigma is critical, >= 3 sigma is warning, >= 2 sigma is info."""
+    if z >= Decimal("4"):
+        return AnomalySeverity.CRITICAL
+    if z >= Decimal("3"):
+        return AnomalySeverity.WARNING
+    return AnomalySeverity.INFO
+
+
+def find_anomalies(
+    series: list[tuple[date, Decimal]],
+    *,
+    window_size: int = 30,
+    threshold_sigma: Decimal = Decimal("2"),
+) -> list[Anomaly]:
+    """Return samples whose value exceeds ``mean + threshold_sigma * stdev``.
+
+    Only positive-tail anomalies (overspending) are reported — under-spending
+    isn't a notification-worthy event in v1.
+
+    Series shorter than ``window_size + 1`` returns ``[]`` (not enough
+    history for a meaningful baseline).
+    """
+    if window_size <= 1:
+        raise ValueError(f"window_size must be > 1 (got {window_size})")
+    if len(series) <= window_size:
+        return []
+    anomalies: list[Anomaly] = []
+    for i in range(window_size, len(series)):
+        window = [amount for _, amount in series[i - window_size : i]]
+        sample_date, sample_amount = series[i]
+        mean = sum(window, start=Decimal("0")) / Decimal(len(window))
+        stdev = _stdev(window, mean)
+        if stdev == 0:
+            continue
+        z = (sample_amount - mean) / stdev
+        if z >= threshold_sigma:
+            anomalies.append(
+                Anomaly(
+                    sample_date=sample_date,
+                    amount=sample_amount,
+                    rolling_mean=mean,
+                    rolling_stdev=stdev,
+                    z_score=z,
+                    severity=_classify(z),
+                )
+            )
+    return anomalies
+
+
+__all__ = ["Anomaly", "AnomalySeverity", "find_anomalies"]

--- a/packages/tulip-core/tests/test_anomaly.py
+++ b/packages/tulip-core/tests/test_anomaly.py
@@ -1,0 +1,76 @@
+"""Unit + property tests for ``tulip_core.insights.find_anomalies`` (P6.3)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from tulip_core.insights import AnomalySeverity, find_anomalies
+
+
+def _flat_series(n_days: int, value: str = "10.00") -> list[tuple[date, Decimal]]:
+    return [(date(2026, 1, 1) + timedelta(days=i), Decimal(value)) for i in range(n_days)]
+
+
+class TestNoAnomalies:
+    def test_short_series_returns_empty(self) -> None:
+        assert find_anomalies(_flat_series(5), window_size=30) == []
+
+    def test_flat_series_no_anomaly(self) -> None:
+        # window 30, then 30 more flat days — no stdev → no anomaly.
+        assert find_anomalies(_flat_series(60), window_size=30) == []
+
+    def test_negative_tail_not_reported(self) -> None:
+        # Spending drops sharply — anomaly *below* the mean; not reported in v1.
+        series = [
+            *_flat_series(30, "100.00"),
+            (date(2026, 2, 1), Decimal("1.00")),
+        ]
+        assert find_anomalies(series, window_size=30) == []
+
+
+class TestDetection:
+    def test_spike_above_threshold_reported(self) -> None:
+        # 30 days of $10 spend → mean=10, stdev=0; window must have variance
+        # to produce a z. Build variance with alternating $10/$11.
+        series: list[tuple[date, Decimal]] = []
+        d0 = date(2026, 1, 1)
+        for i in range(30):
+            series.append((d0 + timedelta(days=i), Decimal("10") + Decimal(i % 2)))
+        # Spike day 30: $100.
+        series.append((d0 + timedelta(days=30), Decimal("100")))
+        anomalies = find_anomalies(series, window_size=30)
+        assert len(anomalies) == 1
+        assert anomalies[0].amount == Decimal("100")
+        # z is way above 2.
+        assert anomalies[0].z_score > Decimal("2")
+
+    def test_critical_severity_for_high_z(self) -> None:
+        series: list[tuple[date, Decimal]] = [
+            (date(2026, 1, 1) + timedelta(days=i), Decimal("10") + Decimal(i % 2))
+            for i in range(30)
+        ]
+        series.append((date(2026, 1, 31), Decimal("1000")))
+        anomalies = find_anomalies(series, window_size=30)
+        assert anomalies[0].severity == AnomalySeverity.CRITICAL
+
+
+class TestValidation:
+    def test_window_size_must_be_greater_than_one(self) -> None:
+        with pytest.raises(ValueError, match="window_size"):
+            find_anomalies(_flat_series(10), window_size=1)
+
+
+class TestProperty:
+    @given(
+        n=st.integers(min_value=31, max_value=80),
+        flat_value=st.decimals(min_value=Decimal("0"), max_value=Decimal("100"), places=2),
+    )
+    def test_flat_series_never_flags(self, n: int, flat_value: Decimal) -> None:
+        """A truly flat series has stdev=0; no anomaly should ever flag."""
+        series = [(date(2026, 1, 1) + timedelta(days=i), flat_value) for i in range(n)]
+        assert find_anomalies(series, window_size=30) == []

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260511_0600_e3a1c5d7b9f2_add_notifications.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260511_0600_e3a1c5d7b9f2_add_notifications.py
@@ -1,0 +1,84 @@
+"""Add notifications table (P6.3 — forecasting + anomaly detection).
+
+Per ARCHITECTURE.md §6.2 + ADR-0005 §Q9: a household-scoped table that
+the daily insights handler writes to (one row per anomaly + one row per
+forecast). The user reads via ``tulip notifications list`` and dismisses
+individual rows when handled.
+
+The shape is deliberately minimal — kind / severity / body / produced_by
+columns, no rendering policy in the schema. The CLI / API render the
+body to whatever format the user wants.
+
+Revision ID: e3a1c5d7b9f2
+Revises: c6e9f2a17b8d
+Create Date: 2026-05-11 06:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e3a1c5d7b9f2"
+down_revision: str | None = "c6e9f2a17b8d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the notifications table."""
+    op.create_table(
+        "notifications",
+        sa.Column("household_id", sa.CHAR(32), nullable=False),
+        sa.Column("id", sa.CHAR(32), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        # kind: anomaly / forecast / runout / on_track / etc.
+        sa.Column("kind", sa.String(length=40), nullable=False),
+        # severity: info / warning / critical
+        sa.Column("severity", sa.String(length=10), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("body", sa.Text, nullable=False),
+        # produced_by: which handler / capability wrote this row. Useful
+        # for filtering ("show me only AI forecasts") and for follow-up
+        # dedup logic.
+        sa.Column("produced_by", sa.String(length=40), nullable=False),
+        # entity_type / entity_id link back to the originating record
+        # (e.g., envelope_id for envelope-runout forecasts).
+        sa.Column("entity_type", sa.String(length=40), nullable=True),
+        sa.Column("entity_id", sa.CHAR(32), nullable=True),
+        sa.Column(
+            "dismissed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        # FK to ai_invocations for AI-generated rows so a user can trace
+        # the forecast back to its audit trail.
+        sa.Column("ai_invocation_id", sa.CHAR(32), nullable=True),
+        sa.PrimaryKeyConstraint("household_id", "id"),
+        sa.ForeignKeyConstraint(["household_id"], ["households.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_notifications_household_created",
+        "notifications",
+        ["household_id", "created_at"],
+    )
+    # Listing the inbox filters dismissed_at IS NULL; index targets that.
+    op.create_index(
+        "ix_notifications_household_dismissed",
+        "notifications",
+        ["household_id", "dismissed_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the notifications table."""
+    op.drop_index("ix_notifications_household_dismissed", table_name="notifications")
+    op.drop_index("ix_notifications_household_created", table_name="notifications")
+    op.drop_table("notifications")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -27,6 +27,11 @@ from tulip_storage.models.import_batch import (
     SourceFormat,
 )
 from tulip_storage.models.mfa_recovery_code import MfaRecoveryCode
+from tulip_storage.models.notification import (
+    Notification,
+    NotificationKind,
+    NotificationSeverity,
+)
 from tulip_storage.models.period import Period, PeriodStatus
 from tulip_storage.models.posting import Posting
 from tulip_storage.models.reconciliation import Reconciliation, ReconciliationStatus
@@ -72,6 +77,9 @@ __all__ = [
     "MatchConfidence",
     "MfaPolicy",
     "MfaRecoveryCode",
+    "Notification",
+    "NotificationKind",
+    "NotificationSeverity",
     "Period",
     "PeriodStatus",
     "PoolType",

--- a/packages/tulip-storage/src/tulip_storage/models/notification.py
+++ b/packages/tulip-storage/src/tulip_storage/models/notification.py
@@ -1,0 +1,57 @@
+"""``notifications`` — daily-insights inbox (P6.3, ARCHITECTURE.md §6.2)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class NotificationKind(Enum):
+    """What the row is announcing."""
+
+    ANOMALY = "anomaly"
+    FORECAST = "forecast"
+    RUNOUT = "runout"
+    ON_TRACK = "on_track"
+
+
+class NotificationSeverity(Enum):
+    """How loudly the row wants the user's attention."""
+
+    INFO = "info"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+class Notification(Base):
+    """One inbox row.
+
+    Written exclusively by the ``daily_insights`` scheduler handler in
+    P6.3; future capabilities (period close, backup failures) reuse the
+    table by passing their own ``produced_by`` tag.
+    """
+
+    __tablename__ = "notifications"
+
+    household_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("households.id", ondelete="CASCADE"), primary_key=True
+    )
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    kind: Mapped[str] = mapped_column(String(40), nullable=False)
+    severity: Mapped[str] = mapped_column(String(10), nullable=False)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    produced_by: Mapped[str] = mapped_column(String(40), nullable=False)
+    entity_type: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    entity_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    dismissed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    ai_invocation_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -17,6 +17,7 @@ from tulip_storage.repositories.audit_log import AuditLogWriter
 from tulip_storage.repositories.csv_profile import CsvProfileRepository
 from tulip_storage.repositories.envelope import EnvelopeRepository
 from tulip_storage.repositories.import_batch import ImportBatchRepository
+from tulip_storage.repositories.notification import NotificationRepository
 from tulip_storage.repositories.period import PeriodRepository
 from tulip_storage.repositories.reconciliation import ReconciliationRepository
 from tulip_storage.repositories.reconciliation_match import (
@@ -37,6 +38,7 @@ __all__ = [
     "CsvProfileRepository",
     "EnvelopeRepository",
     "ImportBatchRepository",
+    "NotificationRepository",
     "PeriodRepository",
     "ReconciliationMatchRepository",
     "ReconciliationRepository",

--- a/packages/tulip-storage/src/tulip_storage/repositories/notification.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/notification.py
@@ -1,0 +1,98 @@
+"""NotificationRepository — daily-insights inbox (P6.3)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+
+from tulip_storage.models import Notification
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class NotificationRepository:
+    """CRUD + dismiss for the household's notification inbox."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind to a session and tenant scope."""
+        self._session = session
+        self._household_id = household_id
+
+    def create(
+        self,
+        *,
+        kind: str,
+        severity: str,
+        title: str,
+        body: str,
+        produced_by: str,
+        entity_type: str | None = None,
+        entity_id: UUID | None = None,
+        ai_invocation_id: UUID | None = None,
+    ) -> Notification:
+        """Insert one notification row."""
+        row = Notification(
+            household_id=self._household_id,
+            id=uuid4(),
+            kind=kind,
+            severity=severity,
+            title=title,
+            body=body,
+            produced_by=produced_by,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            ai_invocation_id=ai_invocation_id,
+        )
+        self._session.add(row)
+        self._session.flush()
+        return row
+
+    def list_active(self) -> list[Notification]:
+        """Undismissed notifications, newest first."""
+        return list(
+            self._session.execute(
+                select(Notification)
+                .where(
+                    Notification.household_id == self._household_id,
+                    Notification.dismissed_at.is_(None),
+                )
+                .order_by(Notification.created_at.desc())
+            )
+            .scalars()
+            .all()
+        )
+
+    def list_all(self) -> list[Notification]:
+        """All notifications including dismissed, newest first."""
+        return list(
+            self._session.execute(
+                select(Notification)
+                .where(Notification.household_id == self._household_id)
+                .order_by(Notification.created_at.desc())
+            )
+            .scalars()
+            .all()
+        )
+
+    def get(self, notification_id: UUID) -> Notification | None:
+        """Return one notification, or ``None`` if not in this household."""
+        return self._session.execute(
+            select(Notification).where(
+                Notification.household_id == self._household_id,
+                Notification.id == notification_id,
+            )
+        ).scalar_one_or_none()
+
+    def dismiss(self, notification_id: UUID) -> Notification | None:
+        """Stamp ``dismissed_at`` on the row. Idempotent on already-dismissed."""
+        row = self.get(notification_id)
+        if row is None:
+            return None
+        if row.dismissed_at is None:
+            row.dismissed_at = datetime.now(UTC)
+            self._session.flush()
+        return row

--- a/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
@@ -214,6 +214,43 @@ class ShadowTransactionRepository:
             result.setdefault(pid, {})[ccy] = Decimal(str(bal))
         return result
 
+    def daily_spend_series_for_pool(
+        self,
+        pool_id: UUID,
+        *,
+        currency: str,
+        from_date: date_type,
+        to_date: date_type,
+    ) -> dict[date_type, Decimal]:
+        """Daily outflow totals on ``pool_id`` between ``from_date`` and ``to_date`` inclusive.
+
+        Used by the ``daily_insights`` scheduler handler (P6.3) to feed the
+        anomaly detector. Only negative postings (outflows / spending) count;
+        amounts are returned positive-valued. Voided shadow transactions are
+        excluded by the status filter.
+
+        Returns a sparse mapping — dates with no spend aren't keyed. The
+        handler zero-fills to a uniform grid for the rolling-window math.
+        """
+        rows = self._session.execute(
+            select(
+                ShadowTransaction.date,
+                func.sum(ShadowPosting.amount).label("net"),
+            )
+            .join(ShadowTransaction, ShadowTransaction.id == ShadowPosting.shadow_transaction_id)
+            .where(
+                ShadowPosting.household_id == self._household_id,
+                ShadowPosting.pool_id == pool_id,
+                ShadowPosting.currency == currency,
+                ShadowTransaction.status.in_(_BALANCE_STATUSES),
+                ShadowTransaction.date >= from_date,
+                ShadowTransaction.date <= to_date,
+                ShadowPosting.amount < 0,
+            )
+            .group_by(ShadowTransaction.date)
+        ).all()
+        return {row_date: abs(Decimal(str(net))) for row_date, net in rows}
+
     def void(self, shadow_tx_id: UUID, *, voided_at: datetime) -> ShadowTransaction:
         """Flip a POSTED shadow transaction's status to VOIDED.
 

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/__init__.py
@@ -11,6 +11,7 @@ fire. Future handlers (reconciliation reminders, AI cost reports) will
 register the same way.
 """
 
+from tulip_storage.runner.handlers.daily_insights import make_daily_insights_handler
 from tulip_storage.runner.handlers.envelope_refill import make_envelope_refill_handler
 
-__all__ = ["make_envelope_refill_handler"]
+__all__ = ["make_daily_insights_handler", "make_envelope_refill_handler"]

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/daily_insights.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/daily_insights.py
@@ -1,0 +1,153 @@
+"""``daily_insights`` handler — runs anomaly detection over per-envelope spend (P6.3).
+
+Schedule one job per household (typically nightly via ``schedule_recurring``)
+with kind ``daily_insights``. The handler:
+
+1. Lists active envelopes for the household.
+2. For each envelope, builds a 60-day daily-amount series from POSTED
+   shadow postings on that envelope's pool.
+3. Runs :func:`tulip_core.insights.find_anomalies` against the series.
+4. Writes one ``notifications`` row per detected anomaly.
+
+The AI forecast capability (which would ride alongside the anomaly
+detector here) is deferred to a follow-up slice — the handler's
+structure leaves an obvious place to add it: after step 3, take the
+same series + envelope context and call into ``tulip_ai`` for a
+forecast. The notifications row distinguishes via ``kind`` (``anomaly``
+vs ``forecast``) so the two surfaces coexist cleanly.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from tulip_core.insights import find_anomalies
+from tulip_storage.models import (
+    AllocationPool,
+    Envelope,
+    NotificationKind,
+    NotificationSeverity,
+    PoolType,
+)
+from tulip_storage.repositories import NotificationRepository, ShadowTransactionRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session, sessionmaker
+
+    from tulip_storage.models import ScheduledJob
+    from tulip_storage.runner.clock import Clock
+    from tulip_storage.runner.runner import HandlerCallback
+
+
+_SERIES_DAYS = 60
+_PRODUCED_BY = "daily_insights"
+
+
+def make_daily_insights_handler(
+    session_maker: sessionmaker[Session],
+) -> HandlerCallback:
+    """Build the ``daily_insights`` handler bound to a session factory."""
+
+    async def handle(job: ScheduledJob, clock: Clock) -> None:
+        with session_maker() as session:
+            _process(session, job=job, clock=clock)
+            session.commit()
+
+    return handle
+
+
+def _process(session: Session, *, job: ScheduledJob, clock: Clock) -> None:
+    """Inner: iterate envelopes, compute series, write notification rows."""
+    today = clock().date()
+    notifications = NotificationRepository(session, job.household_id)
+
+    envelopes = session.execute(
+        select(AllocationPool, Envelope)
+        .join(
+            Envelope,
+            (Envelope.household_id == AllocationPool.household_id)
+            & (Envelope.pool_id == AllocationPool.id),
+        )
+        .where(
+            AllocationPool.household_id == job.household_id,
+            AllocationPool.pool_type == PoolType.ENVELOPE,
+            AllocationPool.is_active.is_(True),
+        )
+    ).all()
+
+    for pool, envelope in envelopes:
+        series = _daily_spend_series(
+            session,
+            household_id=job.household_id,
+            pool_id=pool.id,
+            currency=pool.currency,
+            today=today,
+        )
+        for anomaly in find_anomalies(series):
+            notifications.create(
+                kind=NotificationKind.ANOMALY.value,
+                severity=_to_notification_severity(anomaly.severity),
+                title=f"Unusual spend on {pool.name}",
+                body=(
+                    f"Spending of {anomaly.amount} {pool.currency} on "
+                    f"{anomaly.sample_date.isoformat()} is "
+                    f"{anomaly.z_score:.1f} sigma above the 30-day rolling "
+                    f"mean of {anomaly.rolling_mean:.2f}."
+                ),
+                produced_by=_PRODUCED_BY,
+                entity_type="envelope",
+                entity_id=pool.id,
+            )
+        del envelope  # unused for now; AI forecast slice will read it.
+
+
+def _daily_spend_series(
+    session: Session,
+    *,
+    household_id: object,
+    pool_id: object,
+    currency: str,
+    today: date,
+) -> list[tuple[date, Decimal]]:
+    """Build a zero-filled daily-spend series via the repo chokepoint.
+
+    Returns ``_SERIES_DAYS`` rows ending on ``today`` (inclusive), with
+    zero-filled gaps so the rolling-window math has a uniform grid.
+    """
+    cutoff = today - timedelta(days=_SERIES_DAYS - 1)
+    shadow_repo = ShadowTransactionRepository(session, household_id)  # type: ignore[arg-type]
+    by_date = shadow_repo.daily_spend_series_for_pool(
+        pool_id,  # type: ignore[arg-type]
+        currency=currency,
+        from_date=cutoff,
+        to_date=today,
+    )
+    return [
+        (cutoff + timedelta(days=i), by_date.get(cutoff + timedelta(days=i), Decimal("0")))
+        for i in range(_SERIES_DAYS)
+    ]
+
+
+def _to_notification_severity(severity: object) -> str:
+    """Map ``tulip_core.insights.AnomalySeverity`` to the notifications enum value."""
+    # AnomalySeverity is a string-valued Enum; the values line up 1:1.
+    sev = getattr(severity, "value", str(severity))
+    if sev in (
+        NotificationSeverity.INFO.value,
+        NotificationSeverity.WARNING.value,
+        NotificationSeverity.CRITICAL.value,
+    ):
+        return sev
+    return NotificationSeverity.INFO.value
+
+
+# A no-op import to silence the unused-name warning when the handler's
+# wrapper-only code path doesn't touch the clock.
+_ = datetime, UTC
+
+
+__all__ = ["make_daily_insights_handler"]

--- a/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
@@ -43,6 +43,7 @@ _ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
         # First-party handlers — receive ScheduledJob instances from the
         # runner; the type-only import is required for typing.
         "tulip-storage/src/tulip_storage/runner/handlers/envelope_refill.py",
+        "tulip-storage/src/tulip_storage/runner/handlers/daily_insights.py",
         # Read-only repository for the API to query schedules. Writes
         # still go through the Runner (the architecture test's actual
         # invariant). The class doesn't construct or mutate ScheduledJob

--- a/packages/tulip-storage/tests/test_daily_insights_handler.py
+++ b/packages/tulip-storage/tests/test_daily_insights_handler.py
@@ -1,0 +1,198 @@
+"""Integration tests for the ``daily_insights`` runner handler (P6.3)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from tulip_storage.models import (
+    AllocationPool,
+    BudgetPeriod,
+    Envelope,
+    Household,
+    Notification,
+    PoolType,
+    RolloverPolicy,
+    ScheduledJob,
+    ShadowPosting,
+    ShadowTransaction,
+    ShadowTxReason,
+    ShadowTxStatus,
+)
+from tulip_storage.runner.handlers import make_daily_insights_handler
+
+
+def _fixed_clock(when: datetime):  # type: ignore[no-untyped-def]
+    return lambda: when
+
+
+def _setup_household(session_maker: sessionmaker[Session]) -> tuple[Household, AllocationPool]:
+    """Seed household + active envelope; return both."""
+    hh_id = uuid4()
+    pool_id = uuid4()
+    with session_maker() as s:
+        h = Household(id=hh_id, name="Insights House", base_currency="USD")
+        s.add(h)
+        s.flush()
+        pool = AllocationPool(
+            household_id=hh_id,
+            id=pool_id,
+            name="Groceries",
+            pool_type=PoolType.ENVELOPE,
+            currency="USD",
+            visibility="shared",
+            is_active=True,
+            is_system=False,
+        )
+        s.add(pool)
+        s.flush()
+        s.add(
+            Envelope(
+                household_id=hh_id,
+                pool_id=pool_id,
+                budget_period=BudgetPeriod.MONTHLY,
+                rollover_policy=RolloverPolicy.RESET,
+                budget_amount=None,
+                refill_rule_json=None,
+            )
+        )
+        s.commit()
+        s.refresh(h)
+        s.refresh(pool)
+        return h, pool
+
+
+def _spend(
+    session_maker: sessionmaker[Session],
+    *,
+    household_id,
+    pool_id,
+    when: date,
+    amount: Decimal,
+) -> None:
+    """Insert one POSTED outflow shadow posting on the envelope's pool."""
+    with session_maker() as s:
+        tx_id = uuid4()
+        s.add(
+            ShadowTransaction(
+                household_id=household_id,
+                id=tx_id,
+                date=when,
+                description="spend",
+                reason=ShadowTxReason.SPEND,
+                status=ShadowTxStatus.PENDING,
+            )
+        )
+        s.flush()
+        # Balanced pair: outflow on pool, inflow on a placeholder (we
+        # cheat by adding a +amount on the same pool so the status
+        # transition trigger sees a balanced shadow tx).
+        s.add_all(
+            [
+                ShadowPosting(
+                    household_id=household_id,
+                    id=uuid4(),
+                    shadow_transaction_id=tx_id,
+                    pool_id=pool_id,
+                    amount=-amount,
+                    currency="USD",
+                ),
+                ShadowPosting(
+                    household_id=household_id,
+                    id=uuid4(),
+                    shadow_transaction_id=tx_id,
+                    pool_id=pool_id,
+                    amount=amount,
+                    currency="USD",
+                ),
+            ]
+        )
+        s.flush()
+        tx = s.get(ShadowTransaction, (household_id, tx_id))
+        assert tx is not None
+        tx.status = ShadowTxStatus.POSTED
+        s.commit()
+
+
+def _make_job(household_id) -> ScheduledJob:
+    """Build a minimal ScheduledJob in memory; the handler doesn't persist it."""
+    return ScheduledJob(
+        household_id=household_id,
+        id=uuid4(),
+        kind="daily_insights",
+        payload={},
+        rrule=None,
+        dtstart=datetime.now(UTC),
+        next_run_at=datetime.now(UTC),
+        is_active=True,
+    )
+
+
+def test_no_anomalies_no_notifications(
+    session_maker: sessionmaker[Session],
+) -> None:
+    """Flat spending series → no anomalies → no notification rows."""
+    household, pool = _setup_household(session_maker)
+    today = date(2026, 4, 1)
+    for i in range(45):
+        _spend(
+            session_maker,
+            household_id=household.id,
+            pool_id=pool.id,
+            when=today - timedelta(days=44 - i),
+            amount=Decimal("10.00"),
+        )
+    handler = make_daily_insights_handler(session_maker)
+    asyncio.run(
+        handler(_make_job(household.id), _fixed_clock(datetime(2026, 4, 1, 12, 0, tzinfo=UTC)))
+    )
+    with session_maker() as s:
+        from sqlalchemy import select
+
+        rows = s.execute(select(Notification)).scalars().all()
+        assert rows == []
+
+
+def test_spike_produces_anomaly_notification(
+    session_maker: sessionmaker[Session],
+) -> None:
+    """A 10x spike on day 45 should flag at least one anomaly notification."""
+    household, pool = _setup_household(session_maker)
+    today = date(2026, 4, 1)
+    # 30 days of alternating $10/$11 + 14 more days flat, then a $1000 spike today.
+    for i in range(44):
+        amt = Decimal("10") + Decimal(i % 2)
+        _spend(
+            session_maker,
+            household_id=household.id,
+            pool_id=pool.id,
+            when=today - timedelta(days=44 - i),
+            amount=amt,
+        )
+    _spend(
+        session_maker,
+        household_id=household.id,
+        pool_id=pool.id,
+        when=today,
+        amount=Decimal("1000"),
+    )
+    handler = make_daily_insights_handler(session_maker)
+    asyncio.run(
+        handler(_make_job(household.id), _fixed_clock(datetime(2026, 4, 1, 12, 0, tzinfo=UTC)))
+    )
+    with session_maker() as s:
+        from sqlalchemy import select
+
+        rows = s.execute(select(Notification)).scalars().all()
+        assert len(rows) >= 1
+        anom = rows[0]
+        assert anom.kind == "anomaly"
+        assert anom.produced_by == "daily_insights"
+        assert anom.entity_type == "envelope"
+        assert anom.entity_id == pool.id
+        # The spike was big enough to land in warning or critical.
+        assert anom.severity in {"warning", "critical"}


### PR DESCRIPTION
## Summary

Third Phase 6 slice. Establishes the **notifications inbox** and ships the **anomaly half** of the daily-insights pipeline. AI forecasting (the other half [ADR-0005 §Q3](https://github.com/rmwarriner/tulip-accounting/blob/main/docs/adrs/0005-ai-integration.md) describes) is deferred to a P6.3.b follow-up; the handler has a documented seam where the AI capability plugs in.

### What ships

**`tulip_core.insights`** (pure-domain) — `find_anomalies(series, window_size=30, threshold_sigma=2)` returns positive-tail anomalies only (overspending; under-spending isn't notification-worthy in v1). Severity buckets: info (>=2σ) / warning (>=3σ) / critical (>=4σ).

**Storage** — new `notifications` table + `NotificationKind` / `NotificationSeverity` enums + `NotificationRepository` (create / list_active / list_all / get / dismiss). New `ShadowTransactionRepository.daily_spend_series_for_pool()` that the handler routes through (keeps the architecture test happy).

**Scheduler handler `daily_insights`** — registered via the existing `register_handler` seam. For each active envelope: build 60-day zero-filled spend series → `find_anomalies` → write one `notifications` row per detection (`produced_by=daily_insights`, `entity_type=envelope`).

**HTTP**: `GET /v1/notifications[?include_dismissed=true]` and `POST /v1/notifications/{id}/dismiss`. Dismiss returns 404 (`notification.not_found`) on unknown ids; idempotent on already-dismissed.

**CLI**: `tulip notifications list [--include-dismissed]` (Rich table, severity colour-coded) and `tulip notifications dismiss UUID`.

### Deferred to P6.3.b

- `AIForecastCapability` per ADR-0005 §Q3 with 5%/25% amount bucketing and the forecast prompt payload.
- Envelope-runout / sinking-fund-on-track notifications driven by it.

## Test plan

- [x] 7 anomaly detector unit + property tests (flat-never-flags hypothesis property, spike detection, severity ladder, negative-tail suppression, validation).
- [x] 2 daily-insights handler integration tests (flat-series-no-notifications, spike-produces-anomaly-with-severity).
- [x] 7 API endpoint tests (empty inbox, active-only listing, include-dismissed, dismiss success / 404 / idempotent, auth gate).
- [x] Architecture-test allowlist extended for `daily_insights.py` (TYPE_CHECKING `ScheduledJob` import is type-only, not a write).
- [x] `just lint` clean, `just typecheck` clean.
- [x] Full suite: 1327 passed, 1 skipped (pre-existing).
- [ ] CI green on this PR.