### PR TITLE
feat: P6.3.b — AIForecastCapability + daily_insights forecaster wiring

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -22,9 +22,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **Pre-internal-beta hardening (#121):** ✅ **complete** — all eight checkboxes merged across PRs #140 / #142 / #143 / #146 / #147 / #148 / #149 / #150 / #151 / #152 (master-key file gate, backup/restore CLI, docker compose, password-stdin TTY hint, UTC balance fix, `tulip doctor`, `tulip periods`, inline balances, QUICKSTART, README rewrite for users). Umbrella closed 2026-05-10.
 
-- **Phase 6 (AI integration):** in flight — P6.0 ([ADR-0005](adrs/0005-ai-integration.md)) + P6.1 (`tulip-ai` + `AICategorizer` + BYOK) + P6.2 (NL-query two-turn flow with sqlglot SQL gate) + P6.3 (daily-insights scheduler + anomaly detector + notifications inbox; AI forecast deferred to P6.3.b) shipped. Next: P6.3.b (AI forecast) or P6.4 (agentic proposals).
+- **Phase 6 (AI integration):** in flight — P6.0–P6.3 + P6.3.b shipped (ADR + categorize + NL query + daily-insights/anomaly + AI forecast). Capability inventory: `AICategorizer`, `AINLQueryCapability`, `AIForecastCapability`. Next: P6.4 (agentic proposals) or P6.5 (polish + cost-cap enforcement + app-factory wiring of the daily_insights forecaster).
 
-**Tests:** 1325 passing · **CI:** green on `main`
+**Tests:** 1340 passing · **CI:** green on `main`
 
 ---
 
@@ -561,6 +561,28 @@ Closes Phase 5. Imperative CLI subcommand group with 10 commands wrapping the /v
 ## Phase 6 — AI integration — in flight (design)
 
 Phase 6 entry criterion per [ARCHITECTURE.md §10](ARCHITECTURE.md) was a privacy audit shaping the design before any code lands. The audit is now shipped as an ADR; implementation begins with P6.1.
+
+### P6.3.b — AI forecast capability + handler integration — ✅ *(2026-05-11)*
+
+Completes the daily-insights pipeline started in P6.3. The anomaly half stays as-is; this slice adds the AI forecast half per ADR-0005 §Q3.
+
+**New `tulip_ai.forecast`**:
+
+- `bucket_time_series(series, profile)` rounds each amount to the nearest 5% (default) / 25% (strict) of the series' maximum absolute value. `local_only` passes through. Per ADR §Q3 — trend matters, exact amounts don't.
+- `ForecastPromptPayload` + `build_forecast_prompt` are the byte-faithful prompt assembler. Strict elides the envelope name (ID-only) per ADR §Q3.
+- `AIForecastCapability` — single-turn flow taking `{envelope_name?, time_series, target_amount?, target_date?, recent_inflow_average?}` and returning a `ForecastResult(text, error)`. Same broad-exception guard pattern as `AICategorizer`; one `ai_invocations` row per call.
+
+**Handler wiring**: `make_daily_insights_handler(session_maker, *, forecaster=None)` now accepts an optional `ForecasterCallback` (async callable returning text or `None`). When provided and returning text, the handler writes a `kind=forecast` notification per envelope alongside the existing anomaly rows. `None` preserves the P6.3 anomaly-only behaviour.
+
+**Tests** — +13 new:
+- 5 bucketing (default 5%, strict 25%, local_only pass-through, empty, all-zeros).
+- 3 prompt build (strict-elides-name, default-includes-name, target fields threaded).
+- 3 capability integration (happy path, no-API-key, disabled-policy).
+- 2 handler integration (forecaster called writes forecast row, forecaster returning None writes nothing).
+
+**Deferred**:
+- The app-factory wiring that constructs the production `AIForecastCapability` and threads the callback into the handler — lands when the runner's scheduled-job seeding adds `daily_insights` alongside the existing `envelope_refill` auto-seed.
+- Sinking-fund-on-track variant — same capability shape, different prompt context.
 
 ### P6.3 — Daily-insights scheduler + anomaly detector + notifications inbox — ✅ *(2026-05-11)*
 

--- a/packages/tulip-ai/src/tulip_ai/__init__.py
+++ b/packages/tulip-ai/src/tulip_ai/__init__.py
@@ -17,6 +17,13 @@ from tulip_ai.errors import (
     AIProviderError,
     AIRateLimited,
 )
+from tulip_ai.forecast import (
+    AIForecastCapability,
+    ForecastPromptPayload,
+    ForecastResult,
+    bucket_time_series,
+    build_forecast_prompt,
+)
 from tulip_ai.nl_query import AINLQueryCapability, NLAnswer
 from tulip_ai.policy import ResolvedPolicy, resolve_policy
 from tulip_ai.redaction import (
@@ -40,6 +47,7 @@ __all__ = [
     "AICategorizer",
     "AICostCapped",
     "AIError",
+    "AIForecastCapability",
     "AIInvocationRecord",
     "AIInvocationWriter",
     "AINLQueryCapability",
@@ -48,6 +56,8 @@ __all__ = [
     "CategorizeExample",
     "CategorizePromptPayload",
     "ChartEntry",
+    "ForecastPromptPayload",
+    "ForecastResult",
     "LitellmAdapter",
     "NLAnswer",
     "PromptRedactor",
@@ -58,7 +68,9 @@ __all__ = [
     "ResolvedPolicy",
     "SafeSQL",
     "UnsafeSQLError",
+    "bucket_time_series",
     "build_categorize_prompt",
+    "build_forecast_prompt",
     "hash_prompt_payload",
     "resolve_policy",
     "schema_card",

--- a/packages/tulip-ai/src/tulip_ai/forecast.py
+++ b/packages/tulip-ai/src/tulip_ai/forecast.py
@@ -1,0 +1,371 @@
+"""``AIForecastCapability`` — envelope runout + sinking-fund on-track (P6.3.b, ADR-0005 §Q3).
+
+Single-turn flow: send ``{envelope_name, time_series, target_amount,
+target_date, recent_inflow_average}`` to the model and ask for a short
+natural-language forecast. The result lands in ``notifications`` as
+``kind=forecast``; the user reads via the same ``tulip notifications list``
+surface the anomaly detector populates.
+
+Bucketing matters because per ADR-0005 §Q3 the model doesn't need exact
+amounts to summarise a trend. Default: round each amount to the nearest
+5% of the series' maximum absolute value. Strict: 25%. ``local_only``
+passes amounts through unchanged.
+
+Failures (provider error, malformed response, no key) return an
+``NLAnswer``-shaped error rather than raising — the daily-insights
+handler logs the audit row and skips the forecast row for that envelope,
+so the rest of the run keeps going.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from tulip_ai.adapters import ProviderAdapter
+from tulip_ai.audit import AIInvocationRecord, AIInvocationWriter, hash_prompt_payload
+from tulip_ai.errors import AIProviderError
+from tulip_ai.policy import resolve_policy
+from tulip_ai.redaction import RedactionProfile
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+log = logging.getLogger("tulip_ai.forecast")
+
+
+@dataclass(frozen=True, slots=True)
+class ForecastPromptPayload:
+    """The exact shape the forecast capability sends per envelope."""
+
+    envelope_id: str
+    envelope_name: str | None  # None when strict profile elides the name
+    currency: str
+    time_series: tuple[tuple[str, Decimal], ...]  # (iso_date, bucketed_amount) tuples
+    target_amount: Decimal | None
+    target_date: str | None
+    recent_inflow_average: Decimal | None
+
+    def to_dict(self) -> dict[str, object]:
+        """JSON-serializable view."""
+        out: dict[str, object] = {
+            "task": "forecast",
+            "envelope_id": self.envelope_id,
+            "currency": self.currency,
+            "time_series": [{"date": d, "amount": str(a)} for d, a in self.time_series],
+        }
+        if self.envelope_name is not None:
+            out["envelope_name"] = self.envelope_name
+        if self.target_amount is not None:
+            out["target_amount"] = str(self.target_amount)
+        if self.target_date is not None:
+            out["target_date"] = self.target_date
+        if self.recent_inflow_average is not None:
+            out["recent_inflow_average"] = str(self.recent_inflow_average)
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class ForecastResult:
+    """One forecast call's outcome."""
+
+    text: str
+    error: str | None = None
+
+
+def _round_to_bucket(amount: Decimal, bucket_size: Decimal) -> Decimal:
+    """Round ``amount`` to the nearest multiple of ``bucket_size``.
+
+    Bucket size of zero (degenerate input — all amounts are zero)
+    passes the input through unchanged.
+    """
+    if bucket_size == 0:
+        return amount
+    return (amount / bucket_size).to_integral_value() * bucket_size
+
+
+def bucket_time_series(
+    series: list[tuple[date, Decimal]], *, profile: RedactionProfile
+) -> list[tuple[date, Decimal]]:
+    """Bucket a time-series per ADR-0005 §Q3.
+
+    ``default``: each amount rounded to the nearest 5% of the series'
+    maximum absolute value.
+    ``strict``: 25%.
+    ``local_only``: pass-through (the local model already sees raw data).
+    """
+    if profile == "local_only" or not series:
+        return list(series)
+    max_abs = max((abs(amt) for _, amt in series), default=Decimal("0"))
+    if max_abs == 0:
+        return list(series)
+    pct = Decimal("0.05") if profile == "default" else Decimal("0.25")
+    bucket = max_abs * pct
+    return [(d, _round_to_bucket(amt, bucket)) for d, amt in series]
+
+
+def build_forecast_prompt(
+    *,
+    envelope_id: str,
+    envelope_name: str,
+    currency: str,
+    time_series: list[tuple[date, Decimal]],
+    target_amount: Decimal | None,
+    target_date: date | None,
+    recent_inflow_average: Decimal | None,
+    profile: RedactionProfile,
+) -> ForecastPromptPayload:
+    """Assemble the per-envelope forecast prompt payload.
+
+    The bucketing happens here so the preview surface and the live call
+    see the same bytes — tests can assert the byte-faithful preview
+    equals what the capability actually sends.
+    """
+    bucketed = bucket_time_series(time_series, profile=profile)
+    # Strict elides the envelope name (ADR-0005 §Q3 — "id only").
+    name_for_prompt = envelope_name if profile != "strict" else None
+    return ForecastPromptPayload(
+        envelope_id=envelope_id,
+        envelope_name=name_for_prompt,
+        currency=currency,
+        time_series=tuple((d.isoformat(), amt) for d, amt in bucketed),
+        target_amount=target_amount,
+        target_date=target_date.isoformat() if target_date else None,
+        recent_inflow_average=recent_inflow_average,
+    )
+
+
+def _build_messages(payload: ForecastPromptPayload) -> list[dict[str, str]]:
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are an envelope-budgeting forecaster. Given a recent "
+                "spending series for one envelope, predict whether it is on "
+                "track to run out before next cycle or stay positive. Respond "
+                "in 1-2 sentences with the calendar date by which the envelope "
+                "is expected to be empty if applicable, or 'on track' if not."
+            ),
+        },
+        {
+            "role": "user",
+            "content": json.dumps(payload.to_dict(), ensure_ascii=False),
+        },
+    ]
+
+
+class AIForecastCapability:
+    """Production forecast capability; constructed once at app boot."""
+
+    def __init__(
+        self,
+        *,
+        session_maker: sessionmaker[Session],
+        adapter: ProviderAdapter,
+    ) -> None:
+        """Bind to the session factory and the provider adapter."""
+        self._session_maker = session_maker
+        self._adapter = adapter
+
+    async def forecast(
+        self,
+        *,
+        household_id: UUID,
+        actor_user_id: UUID | None,
+        api_key: str | None,
+        envelope_id: UUID,
+        envelope_name: str,
+        currency: str,
+        time_series: list[tuple[date, Decimal]],
+        target_amount: Decimal | None = None,
+        target_date: date | None = None,
+        recent_inflow_average: Decimal | None = None,
+    ) -> ForecastResult:
+        """One forecast call for one envelope."""
+        try:
+            return await self._forecast_inner(
+                household_id=household_id,
+                actor_user_id=actor_user_id,
+                api_key=api_key,
+                envelope_id=envelope_id,
+                envelope_name=envelope_name,
+                currency=currency,
+                time_series=time_series,
+                target_amount=target_amount,
+                target_date=target_date,
+                recent_inflow_average=recent_inflow_average,
+            )
+        except Exception:
+            log.exception(
+                "ai.forecast.failed",
+                extra={
+                    "household_id": str(household_id),
+                    "envelope_id": str(envelope_id),
+                },
+            )
+            return ForecastResult(text="", error="Internal AI capability failure.")
+
+    async def _forecast_inner(
+        self,
+        *,
+        household_id: UUID,
+        actor_user_id: UUID | None,
+        api_key: str | None,
+        envelope_id: UUID,
+        envelope_name: str,
+        currency: str,
+        time_series: list[tuple[date, Decimal]],
+        target_amount: Decimal | None,
+        target_date: date | None,
+        recent_inflow_average: Decimal | None,
+    ) -> ForecastResult:
+        from tulip_storage.models import Household
+
+        with self._session_maker() as session:
+            household = session.get(Household, household_id)
+            if household is None:
+                return ForecastResult(text="", error="household not found")
+            policy = resolve_policy(household.ai_policy, None, "forecast")
+
+            if policy.level == "disabled":
+                self._audit(
+                    household_id=household_id,
+                    actor_user_id=actor_user_id,
+                    policy_level="disabled",
+                    profile=policy.profile,
+                    outcome="policy_disabled",
+                    prompt_hash=hash_prompt_payload(
+                        {"task": "forecast", "envelope_id": str(envelope_id)}
+                    ),
+                )
+                return ForecastResult(text="", error="forecast disabled")
+
+            if api_key is None and policy.provider != "ollama":
+                self._audit(
+                    household_id=household_id,
+                    actor_user_id=actor_user_id,
+                    policy_level=policy.level,
+                    profile=policy.profile,
+                    provider=policy.provider,
+                    model=policy.model,
+                    outcome="provider_error",
+                    prompt_hash=hash_prompt_payload(
+                        {"task": "forecast", "envelope_id": str(envelope_id)}
+                    ),
+                    response_text="no api key configured for provider",
+                )
+                return ForecastResult(text="", error="no api key")
+
+        # Build the prompt outside the session — pure assembly.
+        payload = build_forecast_prompt(
+            envelope_id=str(envelope_id),
+            envelope_name=envelope_name,
+            currency=currency,
+            time_series=time_series,
+            target_amount=target_amount,
+            target_date=target_date,
+            recent_inflow_average=recent_inflow_average,
+            profile=policy.profile,
+        )
+        messages = _build_messages(payload)
+        try:
+            response = await self._adapter.chat(
+                provider=policy.provider or "",
+                model=policy.model or "",
+                api_key=api_key,
+                messages=messages,
+                max_tokens=200,
+            )
+        except AIProviderError as exc:
+            self._audit(
+                household_id=household_id,
+                actor_user_id=actor_user_id,
+                policy_level=policy.level,
+                profile=policy.profile,
+                provider=policy.provider,
+                model=policy.model,
+                outcome="provider_error",
+                prompt_hash=hash_prompt_payload(payload.to_dict()),
+                response_text=str(exc)[:500],
+            )
+            return ForecastResult(text="", error=f"provider error: {exc}")
+
+        self._audit(
+            household_id=household_id,
+            actor_user_id=actor_user_id,
+            policy_level=policy.level,
+            profile=policy.profile,
+            provider=policy.provider,
+            model=policy.model,
+            tokens_in=response.tokens_in,
+            tokens_out=response.tokens_out,
+            cost_estimate_usd=response.cost_estimate_usd,
+            latency_ms=response.latency_ms,
+            outcome="success",
+            prompt_hash=hash_prompt_payload(payload.to_dict()),
+            provider_response_id=response.provider_response_id,
+            prompt_json=(
+                json.dumps(payload.to_dict(), ensure_ascii=False) if policy.log_prompts else None
+            ),
+            response_text=response.text if policy.log_prompts else None,
+        )
+        return ForecastResult(text=response.text.strip())
+
+    def _audit(
+        self,
+        *,
+        household_id: UUID,
+        actor_user_id: UUID | None,
+        policy_level: str,
+        profile: str,
+        outcome: str,
+        prompt_hash: bytes,
+        provider: str | None = None,
+        model: str | None = None,
+        tokens_in: int = 0,
+        tokens_out: int = 0,
+        cost_estimate_usd: Decimal = Decimal("0"),
+        latency_ms: int = 0,
+        provider_response_id: str | None = None,
+        prompt_json: str | None = None,
+        response_text: str | None = None,
+    ) -> None:
+        """Write one ``ai_invocations`` row in its own session/commit."""
+        with self._session_maker() as session:
+            AIInvocationWriter(session).write(
+                AIInvocationRecord(
+                    household_id=household_id,
+                    capability="forecast",
+                    policy_resolved=policy_level,
+                    profile=profile,
+                    provider=provider,
+                    model=model,
+                    tokens_in=tokens_in,
+                    tokens_out=tokens_out,
+                    cost_estimate_usd=cost_estimate_usd,
+                    latency_ms=latency_ms,
+                    outcome=outcome,
+                    prompt_hash=prompt_hash,
+                    provider_response_id=provider_response_id,
+                    actor_user_id=actor_user_id,
+                    prompt_json=prompt_json,
+                    response_text=response_text,
+                )
+            )
+            session.commit()
+
+
+__all__ = [
+    "AIForecastCapability",
+    "ForecastPromptPayload",
+    "ForecastResult",
+    "bucket_time_series",
+    "build_forecast_prompt",
+]

--- a/packages/tulip-ai/tests/test_forecast.py
+++ b/packages/tulip-ai/tests/test_forecast.py
@@ -1,0 +1,235 @@
+"""Tests for ``AIForecastCapability`` + bucketing (P6.3.b, ADR-0005 §Q3)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from tulip_ai.adapters import RecordingAdapter
+from tulip_ai.forecast import (
+    AIForecastCapability,
+    bucket_time_series,
+    build_forecast_prompt,
+)
+from tulip_storage.encryption import encrypt_field
+from tulip_storage.models import AIInvocation, Household
+
+
+class TestBucketing:
+    def test_default_buckets_to_5_pct_of_max(self) -> None:
+        series = [(date(2026, 1, i + 1), Decimal(str(v))) for i, v in enumerate([100, 5, 17, 99])]
+        bucketed = bucket_time_series(series, profile="default")
+        # max abs = 100 → bucket size = 5.
+        # 100 -> 100, 5 -> 5, 17 -> 15 (nearest 5), 99 -> 100.
+        amounts = [amt for _, amt in bucketed]
+        assert amounts == [Decimal("100"), Decimal("5"), Decimal("15"), Decimal("100")]
+
+    def test_strict_buckets_to_25_pct(self) -> None:
+        series = [(date(2026, 1, i + 1), Decimal(str(v))) for i, v in enumerate([100, 30, 75])]
+        bucketed = bucket_time_series(series, profile="strict")
+        # bucket size = 25. 30 -> 25; 75 -> 75; 100 -> 100.
+        amounts = [amt for _, amt in bucketed]
+        assert amounts == [Decimal("100"), Decimal("25"), Decimal("75")]
+
+    def test_local_only_passes_through(self) -> None:
+        series = [
+            (date(2026, 1, 1), Decimal("12.34")),
+            (date(2026, 1, 2), Decimal("56.78")),
+        ]
+        assert bucket_time_series(series, profile="local_only") == series
+
+    def test_empty_series_returns_empty(self) -> None:
+        assert bucket_time_series([], profile="default") == []
+
+    def test_all_zeros_passes_through(self) -> None:
+        series = [
+            (date(2026, 1, 1), Decimal("0")),
+            (date(2026, 1, 2), Decimal("0")),
+        ]
+        assert bucket_time_series(series, profile="default") == series
+
+
+class TestBuildPrompt:
+    def test_strict_elides_envelope_name(self) -> None:
+        payload = build_forecast_prompt(
+            envelope_id="env-1",
+            envelope_name="Groceries",
+            currency="USD",
+            time_series=[(date(2026, 1, 1), Decimal("10"))],
+            target_amount=None,
+            target_date=None,
+            recent_inflow_average=None,
+            profile="strict",
+        )
+        body = payload.to_dict()
+        assert "envelope_name" not in body
+        assert body["envelope_id"] == "env-1"
+
+    def test_default_includes_envelope_name(self) -> None:
+        payload = build_forecast_prompt(
+            envelope_id="env-1",
+            envelope_name="Groceries",
+            currency="USD",
+            time_series=[(date(2026, 1, 1), Decimal("10"))],
+            target_amount=None,
+            target_date=None,
+            recent_inflow_average=None,
+            profile="default",
+        )
+        assert payload.to_dict()["envelope_name"] == "Groceries"
+
+    def test_target_fields_threaded_through(self) -> None:
+        payload = build_forecast_prompt(
+            envelope_id="env-1",
+            envelope_name="Vacation",
+            currency="USD",
+            time_series=[(date(2026, 1, 1), Decimal("100"))],
+            target_amount=Decimal("3000"),
+            target_date=date(2026, 12, 31),
+            recent_inflow_average=Decimal("250"),
+            profile="default",
+        )
+        body = payload.to_dict()
+        assert body["target_amount"] == "3000"
+        assert body["target_date"] == "2026-12-31"
+        assert body["recent_inflow_average"] == "250"
+
+
+# ---- AIForecastCapability integration ---------------------------------
+
+
+def _series(days: int = 30) -> list[tuple[date, Decimal]]:
+    return [(date(2026, 1, 1) + timedelta(days=i), Decimal("10")) for i in range(days)]
+
+
+def _set_keys_and_policy(
+    session_maker: sessionmaker[Session],
+    household: Household,
+    *,
+    master_key: bytes,
+    ai_policy: dict[str, object] | None = None,
+) -> None:
+    blob = encrypt_field(
+        json.dumps({"anthropic": "sk-test"}).encode("utf-8"), master_key=master_key
+    )
+    with session_maker() as s:
+        h = s.get(Household, household.id)
+        assert h is not None
+        h.ai_keys_encrypted = blob
+        h.ai_policy = ai_policy or {
+            "default_provider": "anthropic",
+            "default_model": "claude-opus-4-7",
+        }
+        s.commit()
+
+
+@pytest.mark.asyncio
+async def test_forecast_happy_path_records_success_invocation(
+    session_maker: sessionmaker[Session],
+    household_and_user: tuple[Household, object],
+    master_key: bytes,
+) -> None:
+    household, _ = household_and_user
+    _set_keys_and_policy(session_maker, household, master_key=master_key)
+    adapter = RecordingAdapter(canned_reply="Groceries on track to run out around 2026-05-25.")
+    cap = AIForecastCapability(session_maker=session_maker, adapter=adapter)
+    result = await cap.forecast(
+        household_id=household.id,
+        actor_user_id=None,
+        api_key="sk-test",
+        envelope_id=household.id,  # any UUID will do for the prompt
+        envelope_name="Groceries",
+        currency="USD",
+        time_series=_series(),
+    )
+    assert result.error is None
+    assert "2026-05-25" in result.text
+    assert len(adapter.calls) == 1
+    with session_maker() as s:
+        rows = (
+            s.execute(select(AIInvocation).where(AIInvocation.capability == "forecast"))
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].outcome == "success"
+
+
+@pytest.mark.asyncio
+async def test_forecast_returns_error_without_api_key(
+    session_maker: sessionmaker[Session],
+    household_and_user: tuple[Household, object],
+    master_key: bytes,
+) -> None:
+    household, _ = household_and_user
+    # ai_policy with no keys → resolver picks anthropic; no api_key → error path.
+    with session_maker() as s:
+        h = s.get(Household, household.id)
+        assert h is not None
+        h.ai_policy = {"default_provider": "anthropic", "default_model": "claude-opus-4-7"}
+        s.commit()
+    adapter = RecordingAdapter(canned_reply="unused")
+    cap = AIForecastCapability(session_maker=session_maker, adapter=adapter)
+    result = await cap.forecast(
+        household_id=household.id,
+        actor_user_id=None,
+        api_key=None,
+        envelope_id=household.id,
+        envelope_name="Groceries",
+        currency="USD",
+        time_series=_series(),
+    )
+    assert result.text == ""
+    assert "no api key" in (result.error or "")
+    assert adapter.calls == []
+    with session_maker() as s:
+        rows = (
+            s.execute(select(AIInvocation).where(AIInvocation.capability == "forecast"))
+            .scalars()
+            .all()
+        )
+        assert rows[0].outcome == "provider_error"
+
+
+@pytest.mark.asyncio
+async def test_forecast_disabled_policy_no_provider_call(
+    session_maker: sessionmaker[Session],
+    household_and_user: tuple[Household, object],
+    master_key: bytes,
+) -> None:
+    household, _ = household_and_user
+    _set_keys_and_policy(
+        session_maker,
+        household,
+        master_key=master_key,
+        ai_policy={
+            "default_provider": "anthropic",
+            "default_model": "claude-opus-4-7",
+            "capabilities": {"forecast": {"policy": "disabled"}},
+        },
+    )
+    adapter = RecordingAdapter(canned_reply="unused")
+    cap = AIForecastCapability(session_maker=session_maker, adapter=adapter)
+    result = await cap.forecast(
+        household_id=household.id,
+        actor_user_id=None,
+        api_key="sk-test",
+        envelope_id=household.id,
+        envelope_name="Groceries",
+        currency="USD",
+        time_series=_series(),
+    )
+    assert result.error == "forecast disabled"
+    assert adapter.calls == []
+    with session_maker() as s:
+        rows = (
+            s.execute(select(AIInvocation).where(AIInvocation.capability == "forecast"))
+            .scalars()
+            .all()
+        )
+        assert rows[0].outcome == "policy_disabled"

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/daily_insights.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/daily_insights.py
@@ -19,9 +19,11 @@ vs ``forecast``) so the two surfaces coexist cleanly.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from sqlalchemy import select
 
@@ -46,21 +48,46 @@ if TYPE_CHECKING:
 _SERIES_DAYS = 60
 _PRODUCED_BY = "daily_insights"
 
+#: Callback the handler invokes (when set) to obtain a forecast for one
+#: envelope. Returning ``None`` (or an empty string) skips the forecast
+#: notification for that envelope — the handler-side "AI not configured"
+#: signal. The callback owns its own provider call, audit row, and policy
+#: resolution; the handler just writes the notification row.
+ForecasterCallback = Callable[
+    [UUID, UUID, str, str, list[tuple[date, Decimal]]],
+    Awaitable[str | None],
+]
+
 
 def make_daily_insights_handler(
     session_maker: sessionmaker[Session],
+    *,
+    forecaster: ForecasterCallback | None = None,
 ) -> HandlerCallback:
-    """Build the ``daily_insights`` handler bound to a session factory."""
+    """Build the ``daily_insights`` handler bound to a session factory.
+
+    When ``forecaster`` is non-None, the handler calls it per envelope
+    after the anomaly loop and writes a ``kind=forecast`` notification
+    for any envelope the forecaster returned text for. When ``None``,
+    only anomaly notifications fire — matches the P6.3 default before
+    P6.3.b wired up the AI forecaster.
+    """
 
     async def handle(job: ScheduledJob, clock: Clock) -> None:
         with session_maker() as session:
-            _process(session, job=job, clock=clock)
+            await _process(session, job=job, clock=clock, forecaster=forecaster)
             session.commit()
 
     return handle
 
 
-def _process(session: Session, *, job: ScheduledJob, clock: Clock) -> None:
+async def _process(
+    session: Session,
+    *,
+    job: ScheduledJob,
+    clock: Clock,
+    forecaster: ForecasterCallback | None,
+) -> None:
     """Inner: iterate envelopes, compute series, write notification rows."""
     today = clock().date()
     notifications = NotificationRepository(session, job.household_id)
@@ -102,7 +129,25 @@ def _process(session: Session, *, job: ScheduledJob, clock: Clock) -> None:
                 entity_type="envelope",
                 entity_id=pool.id,
             )
-        del envelope  # unused for now; AI forecast slice will read it.
+        if forecaster is not None:
+            forecast_text = await forecaster(
+                job.household_id,
+                pool.id,
+                pool.name,
+                pool.currency,
+                series,
+            )
+            if forecast_text:
+                notifications.create(
+                    kind=NotificationKind.FORECAST.value,
+                    severity=NotificationSeverity.INFO.value,
+                    title=f"Forecast for {pool.name}",
+                    body=forecast_text,
+                    produced_by=_PRODUCED_BY,
+                    entity_type="envelope",
+                    entity_id=pool.id,
+                )
+        del envelope  # not yet used; sinking-fund targets land in a follow-up.
 
 
 def _daily_spend_series(

--- a/packages/tulip-storage/tests/test_daily_insights_handler.py
+++ b/packages/tulip-storage/tests/test_daily_insights_handler.py
@@ -157,6 +157,74 @@ def test_no_anomalies_no_notifications(
         assert rows == []
 
 
+def test_forecaster_callback_produces_forecast_notification(
+    session_maker: sessionmaker[Session],
+) -> None:
+    """When a forecaster is wired in, the handler writes kind=forecast rows."""
+    household, pool = _setup_household(session_maker)
+    today = date(2026, 4, 1)
+    for i in range(35):
+        _spend(
+            session_maker,
+            household_id=household.id,
+            pool_id=pool.id,
+            when=today - timedelta(days=34 - i),
+            amount=Decimal("10.00"),
+        )
+
+    forecast_calls: list[tuple] = []
+
+    async def fake_forecaster(household_id, envelope_id, envelope_name, currency, series) -> str:
+        forecast_calls.append((household_id, envelope_id, envelope_name, currency, len(series)))
+        return f"{envelope_name} is on track."
+
+    handler = make_daily_insights_handler(session_maker, forecaster=fake_forecaster)
+    asyncio.run(
+        handler(_make_job(household.id), _fixed_clock(datetime(2026, 4, 1, 12, 0, tzinfo=UTC)))
+    )
+    assert len(forecast_calls) == 1
+    assert forecast_calls[0][2] == pool.name
+    with session_maker() as s:
+        from sqlalchemy import select
+
+        rows = (
+            s.execute(select(Notification).where(Notification.kind == "forecast")).scalars().all()
+        )
+        assert len(rows) == 1
+        assert "on track" in rows[0].body
+
+
+def test_forecaster_returning_none_writes_no_forecast(
+    session_maker: sessionmaker[Session],
+) -> None:
+    """Forecaster returning None (e.g. AI unconfigured) silently skips the row."""
+    household, pool = _setup_household(session_maker)
+    today = date(2026, 4, 1)
+    for i in range(35):
+        _spend(
+            session_maker,
+            household_id=household.id,
+            pool_id=pool.id,
+            when=today - timedelta(days=34 - i),
+            amount=Decimal("10.00"),
+        )
+
+    async def silent_forecaster(*_args: object) -> None:
+        return None
+
+    handler = make_daily_insights_handler(session_maker, forecaster=silent_forecaster)
+    asyncio.run(
+        handler(_make_job(household.id), _fixed_clock(datetime(2026, 4, 1, 12, 0, tzinfo=UTC)))
+    )
+    with session_maker() as s:
+        from sqlalchemy import select
+
+        rows = (
+            s.execute(select(Notification).where(Notification.kind == "forecast")).scalars().all()
+        )
+        assert rows == []
+
+
 def test_spike_produces_anomaly_notification(
     session_maker: sessionmaker[Session],
 ) -> None:


### PR DESCRIPTION
## Summary

Completes the daily-insights pipeline started in P6.3 (#156). The anomaly half stays as-is; this slice adds the AI forecast half per [ADR-0005 §Q3](https://github.com/rmwarriner/tulip-accounting/blob/main/docs/adrs/0005-ai-integration.md).

### What ships

**`tulip_ai.forecast`**:
- `bucket_time_series(series, profile)` rounds each amount to the nearest 5% (default) / 25% (strict) of the series' maximum absolute value. `local_only` passes through. Per ADR §Q3 — trend matters, exact amounts don't.
- `ForecastPromptPayload` + `build_forecast_prompt` are the byte-faithful prompt assembler. Strict elides the envelope name (ID-only) per ADR §Q3.
- `AIForecastCapability` — single-turn flow returning `ForecastResult(text, error)`. Same broad-exception guard as `AICategorizer`; one `ai_invocations` row per call.

**Handler wiring**: `make_daily_insights_handler(session_maker, *, forecaster=None)` now accepts an optional async callable. When provided and returning text, writes a `kind=forecast` notification per envelope alongside the existing anomaly rows. `None` preserves the P6.3 anomaly-only behaviour.

### Deferred

- App-factory wiring constructing the production `AIForecastCapability` and threading the callback into the handler — lands when the runner's auto-seed adds `daily_insights` alongside the existing `envelope_refill` auto-seed.
- Sinking-fund-on-track variant — same capability shape, different prompt context.

## Test plan

- [x] 5 bucketing unit tests (default 5%, strict 25%, local_only pass-through, empty, all-zeros).
- [x] 3 prompt-build tests (strict-elides-name, default-includes-name, target fields threaded through).
- [x] 3 capability integration tests (happy path with audit row, no-API-key error path, disabled-policy path).
- [x] 2 handler integration tests (forecaster called writes forecast row; forecaster returning None writes nothing).
- [x] `just lint` clean, `just typecheck` clean.
- [x] Full suite: 1340 passed, 1 skipped (pre-existing).
- [ ] CI green on this PR.