### PR TITLE
feat: P6.4 — agentic proposals + actor_kind=ai_agent audit pattern

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -22,9 +22,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **Pre-internal-beta hardening (#121):** ✅ **complete** — all eight checkboxes merged across PRs #140 / #142 / #143 / #146 / #147 / #148 / #149 / #150 / #151 / #152 (master-key file gate, backup/restore CLI, docker compose, password-stdin TTY hint, UTC balance fix, `tulip doctor`, `tulip periods`, inline balances, QUICKSTART, README rewrite for users). Umbrella closed 2026-05-10.
 
-- **Phase 6 (AI integration):** in flight — P6.0–P6.3 + P6.3.b shipped (ADR + categorize + NL query + daily-insights/anomaly + AI forecast). Capability inventory: `AICategorizer`, `AINLQueryCapability`, `AIForecastCapability`. Next: P6.4 (agentic proposals) or P6.5 (polish + cost-cap enforcement + app-factory wiring of the daily_insights forecaster).
+- **Phase 6 (AI integration):** in flight — P6.0–P6.4 shipped (ADR + categorize + NL query + daily-insights/anomaly + AI forecast + agentic proposals infrastructure with `envelope_budget_update` executor + `actor_kind=ai_agent` audit pattern). Capability inventory: `AICategorizer`, `AINLQueryCapability`, `AIForecastCapability`, plus the proposal executor registry. Next: P6.4.b (AI-driven proposal generation) or P6.5 (polish + cost-cap enforcement + sinking-fund forecast + `tulip ai config`).
 
-**Tests:** 1340 passing · **CI:** green on `main`
+**Tests:** 1362 passing · **CI:** green on `main`
 
 ---
 
@@ -561,6 +561,44 @@ Closes Phase 5. Imperative CLI subcommand group with 10 commands wrapping the /v
 ## Phase 6 — AI integration — in flight (design)
 
 Phase 6 entry criterion per [ARCHITECTURE.md §10](ARCHITECTURE.md) was a privacy audit shaping the design before any code lands. The audit is now shipped as an ADR; implementation begins with P6.1.
+
+### P6.4 — Agentic proposals + `actor_kind=ai_agent` audit signal — ✅ *(2026-05-11)*
+
+Fourth Phase 6 slice — the architecturally novel one. Establishes the proposal queue, the approve/reject workflow, the `actor_kind=ai_agent` audit pattern locked by [ARCHITECTURE.md §6.2](ARCHITECTURE.md) + [THREAT_MODEL.md §5.3](THREAT_MODEL.md), and one end-to-end executable proposal kind: `envelope_budget_update`. AI-driven proposal *generation* lands as P6.4.b — this slice ships the infrastructure both AI- and human-created proposals share.
+
+**Storage**:
+- New `pending_proposals` table per ADR-0005 §Q9. Columns: `kind / title / rationale / payload(JSON) / status / created_by_kind / created_by_user_id / ai_invocation_id / decided_at / decided_by_user_id / decision_note`. Composite PK on `(household_id, id)`; index on `(household_id, status)` for the inbox listing.
+- `PendingProposal` model + `ProposalStatus` / `ProposalCreatorKind` enums.
+- `PendingProposalRepository`: `create / get / list_by_status / mark_decided` (idempotent on same-status, refuses to transition out of a terminal state).
+
+**Executor pattern**:
+- `tulip_api.services.proposal_executor` — a dispatch registry mapping proposal kinds to executor functions. `execute_approved_proposal(session, *, household_id, proposal, decided_by_user_id, request_id)` looks up the kind's executor, runs it, and writes the audit row with `actor_kind=ai_agent` (if proposal was AI-created) or `actor_kind=user` (if human-created). The audit row's `metadata` carries the originating `proposal_id` and `proposal_kind` per the locked ARCHITECTURE §6.2 rule.
+- v1 ships one executor: `_execute_envelope_budget_update` updates `envelope.budget_amount` on the targeted envelope. Payload validation rejects malformed input with a typed Problem Details. New kinds: register one function.
+- `supported_proposal_kinds()` exposes the allowlist for `GET /v1/ai/proposals/kinds` and the CLI's discoverability.
+
+**HTTP**:
+- `POST /v1/ai/proposals` — create. `ai_invocation_id` presence flips `created_by_kind` to `ai_agent` server-side.
+- `GET /v1/ai/proposals[?status=...]` — list (default filter `pending`); empty string disables the filter.
+- `GET /v1/ai/proposals/kinds` — supported-kinds allowlist for the executor registry.
+- `POST /v1/ai/proposals/{id}/approve` — runs the executor, stamps status. Failures (unsupported kind, invalid payload, envelope vanished) leave the proposal PENDING with a typed error.
+- `POST /v1/ai/proposals/{id}/reject` — stamps status; idempotent on already-rejected.
+
+New errors: `proposal.not_found` (404), `proposal.already_decided` (409), `proposal.unsupported_kind` (400), `proposal.payload_invalid` (400).
+
+**CLI** (`tulip ai`, four new subcommands): `propose --kind --title --payload <json>`, `proposals [--status]`, `approve UUID [--note]`, `reject UUID [--note]`.
+
+**Tests** — +17 API endpoint tests covering:
+- Creator-kind plumbing (user vs ai_agent based on `ai_invocation_id` presence).
+- Listing filter behaviour (default pending, empty=all, kinds endpoint).
+- Approve happy path (envelope's `budget_amount` actually updated).
+- **The locked audit rule**: AI-created proposal → `actor_kind=ai_agent` audit row with `metadata.proposal_id` link. User-created → `actor_kind=user`. Both verified end-to-end through the real `AuditLog` table.
+- Approve failure modes: unknown ID (404), already-decided (409), unsupported kind (400), invalid payload (400).
+- Reject happy path + idempotency on already-rejected.
+- Auth gates on both endpoints.
+
+**Deferred to P6.4.b**:
+- AI-driven proposal generation — a capability that takes a "goal" (e.g., "review last month's spending and suggest envelope budget adjustments"), emits structured proposals, and writes them as `created_by_kind=ai_agent`. The infrastructure is ready; just needs the prompt + capability class.
+- More executor kinds (`categorize_lines`, `transfer_pools`, etc.) — same registry pattern.
 
 ### P6.3.b — AI forecast capability + handler integration — ✅ *(2026-05-11)*
 

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -36,6 +36,7 @@ from tulip_api.routers import (
     notifications,
     periods,
     pools,
+    proposals,
     reconciliations,
     refill_schedules,
     reports,
@@ -155,6 +156,7 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
     app.include_router(transactions.router)
     app.include_router(periods.router)
     app.include_router(notifications.router)
+    app.include_router(proposals.router)
     app.include_router(envelopes.router)
     app.include_router(sinking_funds.router)
     app.include_router(pools.router)

--- a/packages/tulip-api/src/tulip_api/routers/proposals.py
+++ b/packages/tulip-api/src/tulip_api/routers/proposals.py
@@ -1,0 +1,257 @@
+"""HTTP surface for ``/v1/ai/proposals`` (P6.4)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, Query, Request, status
+
+from tulip_api.auth.deps import require_role
+from tulip_api.deps import get_session
+from tulip_api.errors import TulipProblem, problem_response
+from tulip_api.schemas.proposal import (
+    ProposalCreate,
+    ProposalDecisionBody,
+    ProposalRead,
+)
+from tulip_api.services.proposal_executor import (
+    execute_approved_proposal,
+    supported_proposal_kinds,
+)
+from tulip_storage.models import PendingProposal, ProposalCreatorKind, ProposalStatus
+from tulip_storage.repositories import PendingProposalRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_api.auth.tokens import Claims
+
+
+router = APIRouter(prefix="/v1/ai/proposals", tags=["ai"])
+log = structlog.get_logger("tulip_api.proposals")
+
+
+class ProposalNotFoundError(TulipProblem):
+    """The proposal id doesn't belong to the caller's household."""
+
+    def __init__(self) -> None:
+        """Build the proposal.not_found problem (P6.4)."""
+        super().__init__(
+            code="proposal.not_found",
+            title="Proposal not found",
+            status=404,
+            detail="No proposal with that ID exists in this household.",
+        )
+
+
+class ProposalAlreadyDecidedError(TulipProblem):
+    """An approve/reject was attempted on an already-decided proposal."""
+
+    def __init__(self, current_status: str) -> None:
+        """Build the proposal.already_decided problem."""
+        super().__init__(
+            code="proposal.already_decided",
+            title="Proposal already decided",
+            status=409,
+            detail=(
+                f"Proposal is in status {current_status!r}; it cannot be "
+                "decided again. Create a new proposal if a different action "
+                "is needed."
+            ),
+        )
+
+
+def _request_uuid(request: Request) -> UUID | None:
+    rid = request.headers.get("x-request-id")
+    if rid:
+        try:
+            return UUID(rid)
+        except ValueError:
+            return None
+    return None
+
+
+def _to_read(row: PendingProposal) -> ProposalRead:
+    return ProposalRead.model_validate(row, from_attributes=True)
+
+
+@router.post(
+    "",
+    response_model=ProposalRead,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: problem_response("request.body_invalid"),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        422: problem_response("validation.failed"),
+    },
+)
+def create_proposal(
+    body: ProposalCreate,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> ProposalRead:
+    """Create a new pending proposal.
+
+    AI-generated proposals (P6.4.b) supply ``ai_invocation_id`` and set
+    ``created_by_kind=ai_agent`` server-side based on its presence.
+    Direct user-created proposals omit it and stamp ``created_by_kind=user``.
+    """
+    creator_kind = (
+        ProposalCreatorKind.AI_AGENT.value
+        if body.ai_invocation_id is not None
+        else ProposalCreatorKind.USER.value
+    )
+    repo = PendingProposalRepository(session, claims.household_id)
+    row = repo.create(
+        kind=body.kind,
+        title=body.title,
+        payload=body.payload,
+        rationale=body.rationale,
+        created_by_kind=creator_kind,
+        created_by_user_id=claims.user_id,
+        ai_invocation_id=body.ai_invocation_id,
+    )
+    session.commit()
+    log.info(
+        "proposal.created",
+        proposal_id=str(row.id),
+        kind=row.kind,
+        created_by_kind=creator_kind,
+    )
+    return _to_read(row)
+
+
+@router.get(
+    "",
+    response_model=list[ProposalRead],
+    responses={401: problem_response("auth.unauthorized")},
+)
+def list_proposals(
+    status_filter: str | None = Query(
+        default="pending",
+        alias="status",
+        description=(
+            "Filter by status: pending / approved / rejected. "
+            "Pass empty string to disable the filter."
+        ),
+    ),
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> list[ProposalRead]:
+    """List proposals (newest first), filtered by status (default: pending)."""
+    repo = PendingProposalRepository(session, claims.household_id)
+    filter_value: str | None = status_filter if status_filter else None
+    return [_to_read(r) for r in repo.list_by_status(filter_value)]
+
+
+@router.post(
+    "/{proposal_id}/approve",
+    response_model=ProposalRead,
+    responses={
+        400: problem_response(
+            "proposal.payload_invalid",
+            "proposal.unsupported_kind",
+            "request.body_invalid",
+        ),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("proposal.not_found", "envelope.not_found"),
+        409: problem_response("proposal.already_decided"),
+        422: problem_response("validation.failed"),
+    },
+)
+async def approve_proposal(
+    proposal_id: UUID,
+    request: Request,
+    body: ProposalDecisionBody | None = None,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> ProposalRead:
+    """Approve a proposal and execute its change.
+
+    The executor for the proposal's kind runs first; success then stamps
+    ``status=approved`` on the proposal. Failures (unsupported kind,
+    invalid payload, envelope vanished) leave the proposal as PENDING
+    so the user can fix and retry.
+    """
+    repo = PendingProposalRepository(session, claims.household_id)
+    proposal = repo.get(proposal_id)
+    if proposal is None:
+        raise ProposalNotFoundError()
+    if proposal.status != ProposalStatus.PENDING.value:
+        raise ProposalAlreadyDecidedError(proposal.status)
+
+    await execute_approved_proposal(
+        session,
+        household_id=claims.household_id,
+        proposal=proposal,
+        decided_by_user_id=claims.user_id,
+        request_id=_request_uuid(request),
+    )
+    note = body.note if body is not None else None
+    updated = repo.mark_decided(
+        proposal_id,
+        status=ProposalStatus.APPROVED.value,
+        decided_by_user_id=claims.user_id,
+        note=note,
+    )
+    assert updated is not None  # noqa: S101 — we just got it from the repo
+    session.commit()
+    log.info("proposal.approved", proposal_id=str(proposal_id), kind=proposal.kind)
+    return _to_read(updated)
+
+
+@router.post(
+    "/{proposal_id}/reject",
+    response_model=ProposalRead,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("proposal.not_found"),
+        409: problem_response("proposal.already_decided"),
+        422: problem_response("validation.failed"),
+    },
+)
+def reject_proposal(
+    proposal_id: UUID,
+    body: ProposalDecisionBody | None = None,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> ProposalRead:
+    """Mark the proposal rejected. No execution."""
+    repo = PendingProposalRepository(session, claims.household_id)
+    proposal = repo.get(proposal_id)
+    if proposal is None:
+        raise ProposalNotFoundError()
+    if proposal.status not in (
+        ProposalStatus.PENDING.value,
+        ProposalStatus.REJECTED.value,
+    ):
+        raise ProposalAlreadyDecidedError(proposal.status)
+    note = body.note if body is not None else None
+    updated = repo.mark_decided(
+        proposal_id,
+        status=ProposalStatus.REJECTED.value,
+        decided_by_user_id=claims.user_id,
+        note=note,
+    )
+    assert updated is not None  # noqa: S101
+    session.commit()
+    log.info("proposal.rejected", proposal_id=str(proposal_id), kind=proposal.kind)
+    return _to_read(updated)
+
+
+@router.get(
+    "/kinds",
+    response_model=list[str],
+    responses={401: problem_response("auth.unauthorized")},
+)
+def list_supported_kinds(
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+) -> list[str]:
+    """Return the proposal kinds the approve flow can currently execute."""
+    del claims  # authenticated only
+    return list(supported_proposal_kinds())

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -42,6 +42,14 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
         "reason": "Transaction does not balance: USD postings sum to 1.00 instead of 0."
     },
     "PeriodClosedError": {"reason": "Period 2025-12-31 is closed."},
+    "ProposalAlreadyDecidedError": {"current_status": "approved"},
+    "ProposalPayloadInvalidError": {
+        "reason": (
+            "envelope_budget_update payload must include envelope_id (UUID) "
+            "and new_budget_amount (decimal)"
+        )
+    },
+    "UnsupportedProposalKindError": {"kind": "transfer_pools"},
     "PoolNotFoundError": {"pool_id": "<pool-uuid>"},
     "PoolInactiveError": {"pool_id": "<pool-uuid>"},
     "PoolCurrencyMismatchError": {

--- a/packages/tulip-api/src/tulip_api/schemas/proposal.py
+++ b/packages/tulip-api/src/tulip_api/schemas/proposal.py
@@ -1,0 +1,52 @@
+"""Schemas for ``/v1/ai/proposals`` (P6.4)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ProposalCreate(BaseModel):
+    """Body for ``POST /v1/ai/proposals``.
+
+    Used by both the AI flow (P6.4.b — sets ``ai_invocation_id``) and a
+    human-driven manual-propose path (CLI / direct API call). The kind
+    must be supported by an executor; the payload is kind-specific JSON.
+    """
+
+    kind: str = Field(
+        min_length=1,
+        max_length=40,
+        description="Proposal kind; must match a registered executor.",
+    )
+    title: str = Field(min_length=1, max_length=200)
+    payload: dict[str, Any]
+    rationale: str = ""
+    ai_invocation_id: UUID | None = None
+
+
+class ProposalRead(BaseModel):
+    """One proposal row."""
+
+    id: UUID
+    created_at: datetime
+    kind: str
+    title: str
+    rationale: str
+    payload: dict[str, Any]
+    status: str
+    created_by_kind: str
+    created_by_user_id: UUID | None
+    ai_invocation_id: UUID | None
+    decided_at: datetime | None
+    decided_by_user_id: UUID | None
+    decision_note: str | None
+
+
+class ProposalDecisionBody(BaseModel):
+    """Optional body for approve / reject — just a free-text note."""
+
+    note: str | None = None

--- a/packages/tulip-api/src/tulip_api/services/proposal_executor.py
+++ b/packages/tulip-api/src/tulip_api/services/proposal_executor.py
@@ -1,0 +1,155 @@
+"""Execute one approved ``PendingProposal`` (P6.4).
+
+Each proposal ``kind`` maps to an executor function that interprets the
+payload, performs the change via the existing domain repositories, and
+writes an audit_log row with ``actor_kind`` matching the proposal's
+``created_by_kind`` (so AI-proposed-then-approved changes carry the
+``actor_kind=ai_agent`` audit signal per ARCHITECTURE.md §6.2).
+
+v1 ships one kind: ``envelope_budget_update``. Adding a kind means
+registering one function in ``_EXECUTORS``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from tulip_api.errors import EnvelopeNotFoundError, TulipProblem
+from tulip_storage.models import PendingProposal, ProposalCreatorKind
+from tulip_storage.repositories import AuditLogWriter, EnvelopeRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class UnsupportedProposalKindError(TulipProblem):
+    """Approve was called on a proposal whose kind has no executor."""
+
+    def __init__(self, kind: str) -> None:
+        """Build the proposal.unsupported_kind problem (P6.4)."""
+        super().__init__(
+            code="proposal.unsupported_kind",
+            title="Proposal kind not supported",
+            status=400,
+            detail=(
+                f"No executor is registered for proposal kind {kind!r}. "
+                "Reject the proposal or implement an executor."
+            ),
+        )
+
+
+class ProposalPayloadInvalidError(TulipProblem):
+    """The proposal's payload didn't conform to the executor's expectations."""
+
+    def __init__(self, reason: str) -> None:
+        """Build the proposal.payload_invalid problem."""
+        super().__init__(
+            code="proposal.payload_invalid",
+            title="Proposal payload is invalid",
+            status=400,
+            detail=reason,
+        )
+
+
+def _actor_kind_for(proposal: PendingProposal) -> str:
+    """Map the proposal's creator kind to the audit row's ``actor_kind`` value.
+
+    AI-created → ``ai_agent`` even when a human approved (per
+    ARCHITECTURE.md §6.2: "the audit log noting actor_kind=ai_agent and
+    the originating proposal id"). User-created → ``user``.
+    """
+    if proposal.created_by_kind == ProposalCreatorKind.AI_AGENT.value:
+        return "ai_agent"
+    return "user"
+
+
+async def _execute_envelope_budget_update(
+    session: Session,
+    *,
+    household_id: UUID,
+    proposal: PendingProposal,
+    decided_by_user_id: UUID,
+    request_id: UUID | None,
+) -> None:
+    """Update a single envelope's ``budget_amount``.
+
+    Payload shape: ``{"envelope_id": "<uuid>", "new_budget_amount": "<decimal>"}``.
+    """
+    payload: dict[str, Any] = proposal.payload
+    try:
+        envelope_id = UUID(str(payload["envelope_id"]))
+        new_amount = Decimal(str(payload["new_budget_amount"]))
+    except (KeyError, ValueError, ArithmeticError) as exc:
+        raise ProposalPayloadInvalidError(
+            f"envelope_budget_update payload must include envelope_id (UUID) "
+            f"and new_budget_amount (decimal): {exc}"
+        ) from exc
+
+    repo = EnvelopeRepository(session, household_id)
+    found = repo.get(envelope_id)
+    if found is None:
+        raise EnvelopeNotFoundError()
+    _pool, env = found
+    before = env.budget_amount
+
+    repo.update_fields(envelope_id, budget_amount=new_amount)
+
+    AuditLogWriter(session, household_id).write(
+        action="update",
+        actor_kind=_actor_kind_for(proposal),
+        actor_user_id=decided_by_user_id,
+        entity_type="envelope",
+        entity_id=envelope_id,
+        before={"budget_amount": str(before) if before is not None else None},
+        after={"budget_amount": str(new_amount)},
+        request_id=request_id,
+        metadata={
+            "proposal_id": str(proposal.id),
+            "proposal_kind": proposal.kind,
+            "rationale": proposal.rationale or "",
+        },
+    )
+
+
+ExecutorCallback = Callable[..., Awaitable[None]]
+
+_EXECUTORS: dict[str, ExecutorCallback] = {
+    "envelope_budget_update": _execute_envelope_budget_update,
+}
+
+
+def supported_proposal_kinds() -> tuple[str, ...]:
+    """Return the proposal kinds the approve flow can execute today."""
+    return tuple(_EXECUTORS.keys())
+
+
+async def execute_approved_proposal(
+    session: Session,
+    *,
+    household_id: UUID,
+    proposal: PendingProposal,
+    decided_by_user_id: UUID,
+    request_id: UUID | None,
+) -> None:
+    """Dispatch to the kind's executor. Raises ``UnsupportedProposalKindError`` if missing."""
+    executor = _EXECUTORS.get(proposal.kind)
+    if executor is None:
+        raise UnsupportedProposalKindError(proposal.kind)
+    await executor(
+        session,
+        household_id=household_id,
+        proposal=proposal,
+        decided_by_user_id=decided_by_user_id,
+        request_id=request_id,
+    )
+
+
+__all__ = [
+    "ProposalPayloadInvalidError",
+    "UnsupportedProposalKindError",
+    "execute_approved_proposal",
+    "supported_proposal_kinds",
+]

--- a/packages/tulip-api/tests/test_proposals_endpoints.py
+++ b/packages/tulip-api/tests/test_proposals_endpoints.py
@@ -1,0 +1,331 @@
+"""Tests for /v1/ai/proposals endpoints (P6.4)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> tuple[str, str]:
+    r = client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    household_id = r.json()["household_id"]
+    r2 = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return str(r2.json()["access_token"]), str(household_id)
+
+
+@pytest.fixture
+def auth_h(admin_token: tuple[str, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token[0]}"}
+
+
+@pytest.fixture
+def household_id(admin_token: tuple[str, str]) -> UUID:
+    return UUID(admin_token[1])
+
+
+def _make_envelope(
+    client: TestClient, auth_h: dict[str, str], *, budget_amount: str | None = "100.00"
+) -> str:
+    body: dict[str, object] = {
+        "name": "Groceries",
+        "currency": "USD",
+        "budget_period": "monthly",
+        "rollover_policy": "reset",
+    }
+    if budget_amount is not None:
+        body["budget_amount"] = budget_amount
+    r = client.post("/v1/envelopes", headers=auth_h, json=body)
+    assert r.status_code == 201, r.text
+    return str(r.json()["id"])
+
+
+def _propose_envelope_budget_update(
+    client: TestClient,
+    auth_h: dict[str, str],
+    *,
+    envelope_id: str,
+    new_amount: str,
+) -> dict[str, object]:
+    r = client.post(
+        "/v1/ai/proposals",
+        headers=auth_h,
+        json={
+            "kind": "envelope_budget_update",
+            "title": f"Bump envelope {envelope_id[:8]} to {new_amount}",
+            "payload": {"envelope_id": envelope_id, "new_budget_amount": new_amount},
+            "rationale": "Spending up 20% over the last 60 days.",
+        },
+    )
+    assert r.status_code == 201, r.text
+    return dict(r.json())
+
+
+class TestCreateAndList:
+    def test_create_user_proposal_sets_creator_kind_user(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        env_id = _make_envelope(client, auth_h)
+        body = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="250.00"
+        )
+        assert body["created_by_kind"] == "user"
+        assert body["status"] == "pending"
+        assert body["ai_invocation_id"] is None
+
+    def test_create_ai_proposal_sets_creator_kind_ai_agent(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        env_id = _make_envelope(client, auth_h)
+        # Passing ai_invocation_id flips creator_kind to ai_agent.
+        r = client.post(
+            "/v1/ai/proposals",
+            headers=auth_h,
+            json={
+                "kind": "envelope_budget_update",
+                "title": "AI-suggested bump",
+                "payload": {"envelope_id": env_id, "new_budget_amount": "200.00"},
+                "ai_invocation_id": str(uuid4()),
+            },
+        )
+        assert r.status_code == 201
+        assert r.json()["created_by_kind"] == "ai_agent"
+
+    def test_list_filters_to_pending_by_default(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        env_id = _make_envelope(client, auth_h)
+        p1 = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="200.00"
+        )
+        p2 = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="300.00"
+        )
+        client.post(f"/v1/ai/proposals/{p1['id']}/reject", headers=auth_h)
+        body = client.get("/v1/ai/proposals", headers=auth_h).json()
+        ids = [r["id"] for r in body]
+        assert p2["id"] in ids
+        assert p1["id"] not in ids
+
+    def test_list_status_empty_returns_all(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        env_id = _make_envelope(client, auth_h)
+        _propose_envelope_budget_update(client, auth_h, envelope_id=env_id, new_amount="200.00")
+        body = client.get("/v1/ai/proposals?status=", headers=auth_h).json()
+        assert len(body) == 1
+
+    def test_kinds_endpoint_lists_supported(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        r = client.get("/v1/ai/proposals/kinds", headers=auth_h)
+        assert r.status_code == 200
+        assert "envelope_budget_update" in r.json()
+
+
+class TestApprove:
+    def test_approve_envelope_budget_update_changes_envelope(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+    ) -> None:
+        env_id = _make_envelope(client, auth_h, budget_amount="100.00")
+        proposal = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="250.00"
+        )
+        r = client.post(
+            f"/v1/ai/proposals/{proposal['id']}/approve",
+            headers=auth_h,
+            json={"note": "Looks right."},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "approved"
+        assert body["decision_note"] == "Looks right."
+
+        # Envelope's budget_amount actually updated.
+        env_body = client.get(f"/v1/envelopes/{env_id}", headers=auth_h).json()
+        assert Decimal(env_body["budget_amount"]) == Decimal("250.00")
+
+    def test_approve_ai_proposal_writes_actor_kind_ai_agent_audit_row(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+    ) -> None:
+        """The locked rule from ARCHITECTURE.md §6.2 / THREAT_MODEL §5.3."""
+        env_id = _make_envelope(client, auth_h, budget_amount="100.00")
+        # Create AI-flavoured proposal.
+        r = client.post(
+            "/v1/ai/proposals",
+            headers=auth_h,
+            json={
+                "kind": "envelope_budget_update",
+                "title": "AI-suggested",
+                "payload": {"envelope_id": env_id, "new_budget_amount": "175.00"},
+                "ai_invocation_id": str(uuid4()),
+            },
+        )
+        proposal_id = r.json()["id"]
+        client.post(f"/v1/ai/proposals/{proposal_id}/approve", headers=auth_h).raise_for_status()
+
+        # Inspect audit_log via the test session.
+        from tulip_api.deps import get_session
+        from tulip_storage.models import AuditLog
+
+        overrides = client.app.dependency_overrides
+        session_factory = overrides[get_session]
+        with next(session_factory()) as session:
+            from sqlalchemy import select
+
+            rows = (
+                session.execute(
+                    select(AuditLog).where(
+                        AuditLog.entity_type == "envelope",
+                        AuditLog.actor_kind == "ai_agent",
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].metadata_["proposal_id"] == proposal_id
+
+    def test_approve_user_proposal_writes_actor_kind_user(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ) -> None:
+        env_id = _make_envelope(client, auth_h, budget_amount="100.00")
+        proposal = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="150.00"
+        )
+        client.post(f"/v1/ai/proposals/{proposal['id']}/approve", headers=auth_h).raise_for_status()
+
+        from tulip_api.deps import get_session
+        from tulip_storage.models import AuditLog
+
+        overrides = client.app.dependency_overrides
+        session_factory = overrides[get_session]
+        with next(session_factory()) as session:
+            from sqlalchemy import select
+
+            rows = (
+                session.execute(select(AuditLog).where(AuditLog.entity_type == "envelope"))
+                .scalars()
+                .all()
+            )
+            # The envelope creation itself wrote an audit row; the
+            # update from the approve flow is the second one.
+            kinds = {r.actor_kind for r in rows}
+            assert "user" in kinds
+
+    def test_approve_unknown_proposal_returns_404(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        r = client.post(f"/v1/ai/proposals/{uuid4()}/approve", headers=auth_h)
+        assert_problem(r, code="proposal.not_found", status=404)
+
+    def test_approve_already_decided_returns_409(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        env_id = _make_envelope(client, auth_h)
+        proposal = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="200.00"
+        )
+        client.post(f"/v1/ai/proposals/{proposal['id']}/approve", headers=auth_h).raise_for_status()
+        again = client.post(f"/v1/ai/proposals/{proposal['id']}/approve", headers=auth_h)
+        assert_problem(again, code="proposal.already_decided", status=409)
+
+    def test_approve_unsupported_kind_400(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        # Create a proposal for a kind no executor knows; the create
+        # endpoint accepts any string, so the failure surfaces on approve.
+        r = client.post(
+            "/v1/ai/proposals",
+            headers=auth_h,
+            json={
+                "kind": "transfer_pools",
+                "title": "Move funds",
+                "payload": {},
+            },
+        )
+        proposal_id = r.json()["id"]
+        again = client.post(f"/v1/ai/proposals/{proposal_id}/approve", headers=auth_h)
+        assert_problem(again, code="proposal.unsupported_kind", status=400)
+
+    def test_approve_invalid_payload_400(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.post(
+            "/v1/ai/proposals",
+            headers=auth_h,
+            json={
+                "kind": "envelope_budget_update",
+                "title": "Garbage",
+                "payload": {"oops": "no envelope_id"},
+            },
+        )
+        proposal_id = r.json()["id"]
+        again = client.post(f"/v1/ai/proposals/{proposal_id}/approve", headers=auth_h)
+        assert_problem(again, code="proposal.payload_invalid", status=400)
+
+
+class TestReject:
+    def test_reject_stamps_status(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        env_id = _make_envelope(client, auth_h)
+        proposal = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="200.00"
+        )
+        r = client.post(
+            f"/v1/ai/proposals/{proposal['id']}/reject",
+            headers=auth_h,
+            json={"note": "Not the right approach."},
+        )
+        assert r.status_code == 200
+        assert r.json()["status"] == "rejected"
+        assert r.json()["decision_note"] == "Not the right approach."
+
+    def test_reject_unknown_returns_404(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.post(f"/v1/ai/proposals/{uuid4()}/reject", headers=auth_h)
+        assert_problem(r, code="proposal.not_found", status=404)
+
+    def test_reject_idempotent_on_already_rejected(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        env_id = _make_envelope(client, auth_h)
+        proposal = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="200.00"
+        )
+        first = client.post(f"/v1/ai/proposals/{proposal['id']}/reject", headers=auth_h)
+        second = client.post(f"/v1/ai/proposals/{proposal['id']}/reject", headers=auth_h)
+        assert second.status_code == 200
+        # decided_at didn't move on the second call. SQLite +
+        # SQLAlchemy DateTime(timezone=True) round-trips lose the tz on
+        # read so the strings differ in trailing 'Z'; compare the
+        # underlying instant by stripping it.
+        assert first.json()["decided_at"].rstrip("Z") == second.json()["decided_at"].rstrip("Z")
+
+
+class TestAuth:
+    def test_create_requires_auth(self, client: TestClient) -> None:
+        r = client.post("/v1/ai/proposals", json={"kind": "x", "title": "y", "payload": {}})
+        assert r.status_code == 401
+
+    def test_approve_requires_auth(self, client: TestClient) -> None:
+        r = client.post(f"/v1/ai/proposals/{uuid4()}/approve")
+        assert r.status_code == 401

--- a/packages/tulip-cli/src/tulip_cli/commands/ai.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/ai.py
@@ -201,6 +201,153 @@ def ask(
         typer.echo(json.dumps(body["rows"], indent=2, ensure_ascii=False))
 
 
+@ai_app.command("propose")
+def propose(
+    ctx: typer.Context,
+    kind: Annotated[
+        str,
+        typer.Option(
+            "--kind",
+            help="Proposal kind (e.g. envelope_budget_update).",
+        ),
+    ],
+    title: Annotated[str, typer.Option("--title", help="Short headline.")],
+    payload: Annotated[
+        str,
+        typer.Option(
+            "--payload",
+            help="JSON object describing the change. Kind-specific shape.",
+        ),
+    ],
+    rationale: Annotated[
+        str,
+        typer.Option("--rationale", help="Optional free-text justification."),
+    ] = "",
+) -> None:
+    """Create a pending proposal (manual; AI-generated proposals land in P6.4.b)."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        payload_obj = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"--payload must be valid JSON: {exc}") from exc
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post(
+                "/v1/ai/proposals",
+                json={
+                    "kind": kind,
+                    "title": title,
+                    "payload": payload_obj,
+                    "rationale": rationale,
+                },
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    body = response.json()
+    typer.echo(f"Created proposal {body['id']} ({body['kind']}): {body['title']}")
+
+
+@ai_app.command("proposals")
+def list_proposals(
+    ctx: typer.Context,
+    status: Annotated[
+        str,
+        typer.Option(
+            "--status",
+            help="Filter: pending / approved / rejected. Empty string for all.",
+        ),
+    ] = "pending",
+) -> None:
+    """List proposals for the household, newest first."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get(
+                "/v1/ai/proposals",
+                authenticated=True,
+                params={"status": status},
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    rows = response.json()
+    if not rows:
+        typer.echo("No proposals.")
+        return
+    for r in rows:
+        typer.echo(f"  {r['id'][:8]}  {r['kind']:32s}  {r['status']:10s}  {r['title']}")
+
+
+@ai_app.command("approve")
+def approve_proposal(
+    ctx: typer.Context,
+    proposal_id: Annotated[str, typer.Argument(help="Proposal UUID.")],
+    note: Annotated[str, typer.Option("--note", help="Optional decision note.")] = "",
+) -> None:
+    """Approve a proposal and execute its change."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    body: dict[str, str] = {"note": note} if note else {}
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post(
+                f"/v1/ai/proposals/{proposal_id}/approve",
+                json=body,
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    body_json = response.json()
+    typer.echo(f"Approved proposal {body_json['id']} ({body_json['kind']}).")
+
+
+@ai_app.command("reject")
+def reject_proposal(
+    ctx: typer.Context,
+    proposal_id: Annotated[str, typer.Argument(help="Proposal UUID.")],
+    note: Annotated[str, typer.Option("--note", help="Optional decision note.")] = "",
+) -> None:
+    """Reject a proposal. No state change beyond the proposal row."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    body: dict[str, str] = {"note": note} if note else {}
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post(
+                f"/v1/ai/proposals/{proposal_id}/reject",
+                json=body,
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    body_json = response.json()
+    typer.echo(f"Rejected proposal {body_json['id']} ({body_json['kind']}).")
+
+
 @ai_app.command("preview")
 def preview(
     ctx: typer.Context,

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260511_0900_a7d4f1b9e8c2_add_pending_proposals.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260511_0900_a7d4f1b9e8c2_add_pending_proposals.py
@@ -1,0 +1,85 @@
+"""Add pending_proposals table (P6.4 — agentic proposals).
+
+Per ADR-0005 §Q9 + ARCHITECTURE.md §6.2. One row per AI- (or user-)
+proposed change awaiting explicit user approval. The approve flow
+executes the change through the same domain path a user-initiated
+change would take, with the audit_log row noting ``actor_kind=ai_agent``
+and the originating proposal id.
+
+The ``kind`` column is a free-form string today; v1 only ``envelope_budget_update``
+is wired end-to-end. Adding kinds is a code change (new executor) +
+migration-free (just a new string value).
+
+Revision ID: a7d4f1b9e8c2
+Revises: e3a1c5d7b9f2
+Create Date: 2026-05-11 09:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7d4f1b9e8c2"
+down_revision: str | None = "e3a1c5d7b9f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the pending_proposals table."""
+    op.create_table(
+        "pending_proposals",
+        sa.Column("household_id", sa.CHAR(32), nullable=False),
+        sa.Column("id", sa.CHAR(32), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        # kind: envelope_budget_update / categorize_lines / transfer_pools / ...
+        sa.Column("kind", sa.String(length=40), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("rationale", sa.Text, nullable=False, server_default=""),
+        # payload: kind-specific JSON shape the executor interprets.
+        sa.Column("payload", sa.JSON, nullable=False),
+        # status: pending / approved / rejected
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="pending",
+        ),
+        # created_by_kind: user / ai_agent — drives the actor_kind written
+        # to audit_log when the proposal is approved (per ARCHITECTURE.md §6.2).
+        sa.Column("created_by_kind", sa.String(length=20), nullable=False),
+        sa.Column("created_by_user_id", sa.CHAR(32), nullable=True),
+        # ai_invocation_id: links AI-generated proposals back to the
+        # ai_invocations row that produced them. NULL for user-created.
+        sa.Column("ai_invocation_id", sa.CHAR(32), nullable=True),
+        sa.Column(
+            "decided_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column("decided_by_user_id", sa.CHAR(32), nullable=True),
+        # Free-text reason from the user, if they chose to record one on
+        # reject/approve. Optional.
+        sa.Column("decision_note", sa.Text, nullable=True),
+        sa.PrimaryKeyConstraint("household_id", "id"),
+        sa.ForeignKeyConstraint(["household_id"], ["households.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_pending_proposals_household_status",
+        "pending_proposals",
+        ["household_id", "status"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the pending_proposals table."""
+    op.drop_index("ix_pending_proposals_household_status", table_name="pending_proposals")
+    op.drop_table("pending_proposals")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -32,6 +32,11 @@ from tulip_storage.models.notification import (
     NotificationKind,
     NotificationSeverity,
 )
+from tulip_storage.models.pending_proposal import (
+    PendingProposal,
+    ProposalCreatorKind,
+    ProposalStatus,
+)
 from tulip_storage.models.period import Period, PeriodStatus
 from tulip_storage.models.posting import Posting
 from tulip_storage.models.reconciliation import Reconciliation, ReconciliationStatus
@@ -80,10 +85,13 @@ __all__ = [
     "Notification",
     "NotificationKind",
     "NotificationSeverity",
+    "PendingProposal",
     "Period",
     "PeriodStatus",
     "PoolType",
     "Posting",
+    "ProposalCreatorKind",
+    "ProposalStatus",
     "Reconciliation",
     "ReconciliationMatch",
     "ReconciliationStatus",

--- a/packages/tulip-storage/src/tulip_storage/models/pending_proposal.py
+++ b/packages/tulip-storage/src/tulip_storage/models/pending_proposal.py
@@ -1,0 +1,61 @@
+"""``pending_proposals`` — agentic-proposal queue (P6.4, ARCHITECTURE.md §6.2)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class ProposalStatus(Enum):
+    """Lifecycle state. New proposals are PENDING."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class ProposalCreatorKind(Enum):
+    """Who created the proposal — drives the audit ``actor_kind`` on approve."""
+
+    USER = "user"
+    AI_AGENT = "ai_agent"
+
+
+class PendingProposal(Base):
+    """One pending change waiting on user approval.
+
+    The ``payload`` JSON shape is kind-specific; the approve flow's
+    executor for that ``kind`` is the authoritative interpreter. Adding
+    a new kind = adding an executor + bumping the kind allowlist on the
+    create endpoint.
+    """
+
+    __tablename__ = "pending_proposals"
+
+    household_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("households.id", ondelete="CASCADE"), primary_key=True
+    )
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    kind: Mapped[str] = mapped_column(String(40), nullable=False)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=ProposalStatus.PENDING.value
+    )
+    created_by_kind: Mapped[str] = mapped_column(String(20), nullable=False)
+    created_by_user_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    ai_invocation_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    decided_by_user_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
+    decision_note: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -18,6 +18,7 @@ from tulip_storage.repositories.csv_profile import CsvProfileRepository
 from tulip_storage.repositories.envelope import EnvelopeRepository
 from tulip_storage.repositories.import_batch import ImportBatchRepository
 from tulip_storage.repositories.notification import NotificationRepository
+from tulip_storage.repositories.pending_proposal import PendingProposalRepository
 from tulip_storage.repositories.period import PeriodRepository
 from tulip_storage.repositories.reconciliation import ReconciliationRepository
 from tulip_storage.repositories.reconciliation_match import (
@@ -39,6 +40,7 @@ __all__ = [
     "EnvelopeRepository",
     "ImportBatchRepository",
     "NotificationRepository",
+    "PendingProposalRepository",
     "PeriodRepository",
     "ReconciliationMatchRepository",
     "ReconciliationRepository",

--- a/packages/tulip-storage/src/tulip_storage/repositories/pending_proposal.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/pending_proposal.py
@@ -1,0 +1,103 @@
+"""PendingProposalRepository — agentic-proposal queue (P6.4)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+
+from tulip_storage.models import PendingProposal, ProposalStatus
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class PendingProposalRepository:
+    """CRUD + decide for the household's proposal queue."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind to a session and tenant scope."""
+        self._session = session
+        self._household_id = household_id
+
+    def create(
+        self,
+        *,
+        kind: str,
+        title: str,
+        payload: dict[str, Any],
+        created_by_kind: str,
+        created_by_user_id: UUID | None,
+        ai_invocation_id: UUID | None = None,
+        rationale: str = "",
+    ) -> PendingProposal:
+        """Insert one PENDING proposal."""
+        row = PendingProposal(
+            household_id=self._household_id,
+            id=uuid4(),
+            kind=kind,
+            title=title,
+            rationale=rationale,
+            payload=payload,
+            status=ProposalStatus.PENDING.value,
+            created_by_kind=created_by_kind,
+            created_by_user_id=created_by_user_id,
+            ai_invocation_id=ai_invocation_id,
+        )
+        self._session.add(row)
+        self._session.flush()
+        return row
+
+    def get(self, proposal_id: UUID) -> PendingProposal | None:
+        """Return one proposal, or ``None`` if not in this household."""
+        return self._session.execute(
+            select(PendingProposal).where(
+                PendingProposal.household_id == self._household_id,
+                PendingProposal.id == proposal_id,
+            )
+        ).scalar_one_or_none()
+
+    def list_by_status(self, status: str | None = None) -> list[PendingProposal]:
+        """List proposals, newest first. ``status=None`` returns everything."""
+        query = (
+            select(PendingProposal)
+            .where(PendingProposal.household_id == self._household_id)
+            .order_by(PendingProposal.created_at.desc())
+        )
+        if status is not None:
+            query = query.where(PendingProposal.status == status)
+        return list(self._session.execute(query).scalars().all())
+
+    def mark_decided(
+        self,
+        proposal_id: UUID,
+        *,
+        status: str,
+        decided_by_user_id: UUID,
+        note: str | None = None,
+    ) -> PendingProposal | None:
+        """Stamp ``status`` + decision metadata. Returns ``None`` if not found.
+
+        Idempotent in the sense that a second call with the same status
+        is a no-op (the timestamp doesn't move). Calling with a different
+        status from the prior decision raises — proposals decide once.
+        """
+        row = self.get(proposal_id)
+        if row is None:
+            return None
+        if row.status == status:
+            return row
+        if row.status != ProposalStatus.PENDING.value:
+            raise ValueError(
+                f"proposal {proposal_id} already decided as {row.status!r}; "
+                f"cannot transition to {status!r}"
+            )
+        row.status = status
+        row.decided_by_user_id = decided_by_user_id
+        row.decided_at = datetime.now(UTC)
+        if note is not None:
+            row.decision_note = note
+        self._session.flush()
+        return row


### PR DESCRIPTION
## Summary

Fourth Phase 6 slice — the architecturally novel one. Establishes the proposal queue, the approve/reject workflow, the **`actor_kind=ai_agent` audit pattern** locked by [ARCHITECTURE.md §6.2](https://github.com/rmwarriner/tulip-accounting/blob/main/docs/ARCHITECTURE.md) and [THREAT_MODEL.md §5.3](https://github.com/rmwarriner/tulip-accounting/blob/main/docs/THREAT_MODEL.md), and one end-to-end executable proposal kind: `envelope_budget_update`.

AI-driven proposal *generation* lands as P6.4.b — this slice ships the infrastructure both AI- and human-created proposals share, so the architecture-test bar is met now.

### What ships

**Storage**: new `pending_proposals` table per [ADR-0005 §Q9](https://github.com/rmwarriner/tulip-accounting/blob/main/docs/adrs/0005-ai-integration.md); `PendingProposal` model + `ProposalStatus` / `ProposalCreatorKind` enums; `PendingProposalRepository` with create / get / list_by_status / mark_decided (idempotent on same-status, refuses transitions out of terminal state).

**Executor pattern** (`tulip_api.services.proposal_executor`): dispatch registry. `execute_approved_proposal()` runs the kind's executor and writes an audit row with `actor_kind=ai_agent` (AI-created) or `actor_kind=user`. `metadata` carries `proposal_id`, `proposal_kind`, `rationale`. v1 ships `_execute_envelope_budget_update`.

**HTTP** (`/v1/ai/proposals`): POST (create; `ai_invocation_id` presence flips `created_by_kind` to `ai_agent`), GET (list, default `status=pending`), GET `/kinds`, POST `/{id}/{approve,reject}`. New errors: `proposal.not_found`, `proposal.already_decided`, `proposal.unsupported_kind`, `proposal.payload_invalid`.

**CLI** (`tulip ai`): `propose --kind --title --payload <json>`, `proposals [--status]`, `approve UUID [--note]`, `reject UUID [--note]`.

### Deferred to P6.4.b

- **AI-driven proposal generation** — a capability that emits structured proposals; the infrastructure is ready and the CLI/API surface accepts them via `ai_invocation_id`.
- More executor kinds (`categorize_lines`, `transfer_pools`, etc.) — same registry pattern.

## Test plan

- [x] +22 tests. Coverage:
  - Creator-kind plumbing (user vs ai_agent based on `ai_invocation_id` presence).
  - Listing filter (default pending, empty=all, kinds endpoint).
  - **Approve happy path**: envelope's `budget_amount` actually updates.
  - **The locked audit rule**: AI-created proposal → `actor_kind=ai_agent` audit row with `metadata.proposal_id` link; user-created → `actor_kind=user`. Verified end-to-end through the real `AuditLog` table.
  - Approve failure modes: 404 unknown / 409 already-decided / 400 unsupported-kind / 400 payload-invalid.
  - Reject happy path + idempotency on already-rejected.
  - Auth gates on both endpoints.
  - Well-known-errors placeholders registered for the three new error classes.
- [x] `just lint` clean, `just typecheck` clean.
- [x] Full suite: 1362 passed, 1 skipped (pre-existing).
- [ ] CI green on this PR.