### PR TITLE
feat: P6.4.b — AI-driven proposal generation (suggest-budget)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -22,7 +22,7 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **Pre-internal-beta hardening (#121):** ✅ **complete** — all eight checkboxes merged across PRs #140 / #142 / #143 / #146 / #147 / #148 / #149 / #150 / #151 / #152 (master-key file gate, backup/restore CLI, docker compose, password-stdin TTY hint, UTC balance fix, `tulip doctor`, `tulip periods`, inline balances, QUICKSTART, README rewrite for users). Umbrella closed 2026-05-10.
 
-- **Phase 6 (AI integration):** in flight — P6.0–P6.4 shipped (ADR + categorize + NL query + daily-insights/anomaly + AI forecast + agentic proposals infrastructure with `envelope_budget_update` executor + `actor_kind=ai_agent` audit pattern). Capability inventory: `AICategorizer`, `AINLQueryCapability`, `AIForecastCapability`, plus the proposal executor registry. Next: P6.4.b (AI-driven proposal generation) or P6.5 (polish + cost-cap enforcement + sinking-fund forecast + `tulip ai config`).
+- **Phase 6 (AI integration):** in flight — P6.0–P6.4.b shipped (ADR + categorize + NL query + daily-insights/anomaly + AI forecast + agentic proposals infrastructure + `AIProposalCapability` for AI-driven `envelope_budget_update` suggestions). Capability inventory: `AICategorizer`, `AINLQueryCapability`, `AIForecastCapability`, `AIProposalCapability`, plus the proposal executor registry. Next: P6.5 (polish + cost-cap enforcement + sinking-fund forecast + `tulip ai config`).
 
 **Tests:** 1362 passing · **CI:** green on `main`
 
@@ -561,6 +561,64 @@ Closes Phase 5. Imperative CLI subcommand group with 10 commands wrapping the /v
 ## Phase 6 — AI integration — in flight (design)
 
 Phase 6 entry criterion per [ARCHITECTURE.md §10](ARCHITECTURE.md) was a privacy audit shaping the design before any code lands. The audit is now shipped as an ADR; implementation begins with P6.1.
+
+### P6.4.b — AI-driven proposal generation (`AIProposalCapability` + `suggest-budget`) — ✅ *(2026-05-11)*
+
+The "AI as proposal generator" half of P6.4: an asynchronous capability that
+takes an envelope + its recent spend series, calls the LLM via the existing
+`LitellmAdapter`, parses the structured suggestion, audits the call, and
+returns a `ProposedChange` ready for the queue. The HTTP/CLI surface persists
+it as a `created_by_kind=ai_agent` proposal linked to the
+capability's audit row via `ai_invocation_id` — so when the user approves it
+through the standard inbox flow, the locked
+[ARCHITECTURE.md §6.2](ARCHITECTURE.md) +
+[THREAT_MODEL.md §5.3](THREAT_MODEL.md) chain
+(`actor_kind=ai_agent` audit row, `metadata.proposal_id`,
+`metadata.proposal_kind`, originating `ai_invocations.id`) all line up.
+
+**Capability** (`tulip_ai.proposals.AIProposalCapability`):
+- One method: `suggest_envelope_budget(*, household_id, actor_user_id, api_key,
+  envelope_id, envelope_name, currency, current_budget, recent_spend_series)`.
+- Prompt asks for a JSON object with `new_budget_amount` (decimal string) +
+  `rationale` (string). Tolerates code-fenced JSON; rejects garbage with a
+  structured `error` and a `provider_error` audit row.
+- Audit row always written (success, parse-fail, provider error, policy
+  disabled, no key) — `capability="agentic"`, prompt SHA-256, no prompt
+  text per ADR-0005 §Q5.
+- Returns `SuggestionResult(proposal: ProposedChange | None, error: str | None)`.
+  `ProposedChange` mirrors the `POST /v1/ai/proposals` body shape so the
+  router can hand it straight to `PendingProposalRepository.create`.
+
+**HTTP**:
+- New `POST /v1/ai/proposals/suggest/budget` (admin / member). Body:
+  `{"envelope_id": "<uuid>"}`. Pulls the envelope's last 60 days of spend
+  via a new `ShadowTransactionRepository.daily_spend_series_for_pool()`
+  writer-side query, decrypts the household's provider key, calls the
+  capability, and on success creates a `created_by_kind=ai_agent` proposal
+  with the `ai_invocation_id` link. On any capability failure (no key,
+  policy disabled, unparseable response), returns
+  `{"proposal": null, "error": "<reason>"}` with 200 — the audit row still
+  landed, the user just learns why no proposal was queued.
+
+**CLI**: `tulip ai suggest-budget --envelope <UUID>`. On success prints the
+new proposal id, rationale, and a hint to approve/reject via the existing
+`tulip ai approve` / `tulip ai reject` commands. On structured error, writes
+to stderr and exits 1.
+
+**Tests** — +5 capability unit tests + 3 endpoint integration tests + 1 CLI
+integration test:
+- Capability: happy path returns `ProposedChange` with parsed payload,
+  no-key path returns error + `provider_error` audit, unparseable response
+  records error + `provider_error` audit, disabled-policy path returns
+  error + `policy_disabled` audit, code-fenced JSON tolerated.
+- Endpoint: unauthenticated returns 401, unknown envelope returns 404,
+  no-key returns 200 with structured error.
+- CLI: no-key path exits 1 with the structured error on stderr.
+
+Architecture-test allowlist: `daily_insights.py` already imports
+`ScheduledJob` + `ShadowPosting`; the new `daily_spend_series_for_pool`
+lives on `ShadowTransactionRepository` so the suggest-budget endpoint
+itself stays within the existing repository boundary.
 
 ### P6.4 — Agentic proposals + `actor_kind=ai_agent` audit signal — ✅ *(2026-05-11)*
 

--- a/packages/tulip-ai/src/tulip_ai/__init__.py
+++ b/packages/tulip-ai/src/tulip_ai/__init__.py
@@ -26,6 +26,11 @@ from tulip_ai.forecast import (
 )
 from tulip_ai.nl_query import AINLQueryCapability, NLAnswer
 from tulip_ai.policy import ResolvedPolicy, resolve_policy
+from tulip_ai.proposals import (
+    AIProposalCapability,
+    ProposedChange,
+    SuggestionResult,
+)
 from tulip_ai.redaction import (
     CategorizeExample,
     CategorizePromptPayload,
@@ -51,6 +56,7 @@ __all__ = [
     "AIInvocationRecord",
     "AIInvocationWriter",
     "AINLQueryCapability",
+    "AIProposalCapability",
     "AIProviderError",
     "AIRateLimited",
     "CategorizeExample",
@@ -61,12 +67,14 @@ __all__ = [
     "LitellmAdapter",
     "NLAnswer",
     "PromptRedactor",
+    "ProposedChange",
     "ProviderAdapter",
     "ProviderResponse",
     "RecordingAdapter",
     "RedactionProfile",
     "ResolvedPolicy",
     "SafeSQL",
+    "SuggestionResult",
     "UnsafeSQLError",
     "bucket_time_series",
     "build_categorize_prompt",

--- a/packages/tulip-ai/src/tulip_ai/proposals.py
+++ b/packages/tulip-ai/src/tulip_ai/proposals.py
@@ -1,0 +1,343 @@
+"""``AIProposalCapability`` — AI-driven proposal generation (P6.4.b, ADR-0005 §Q3).
+
+The "agentic" capability from the ADR's data-flow contract. Each method
+produces a structured proposal that the API layer wraps in a
+``PendingProposal`` row (with ``created_by_kind=ai_agent`` and the
+``ai_invocation_id`` link back to the audit row this call wrote).
+
+v1 ships one suggestion kind: ``suggest_envelope_budget``. Same pattern
+applies to future suggestion kinds — the capability stays close to the
+data and just returns ``ProposedChange`` payloads; the user-side review
+flow (P6.4) handles approval / rejection.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from tulip_ai.adapters import ProviderAdapter
+from tulip_ai.audit import AIInvocationRecord, AIInvocationWriter, hash_prompt_payload
+from tulip_ai.errors import AIProviderError
+from tulip_ai.forecast import bucket_time_series
+from tulip_ai.policy import resolve_policy
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+log = logging.getLogger("tulip_ai.proposals")
+
+
+@dataclass(frozen=True, slots=True)
+class ProposedChange:
+    """A capability-generated proposal ready for the queue.
+
+    Mirrors the body the ``POST /v1/ai/proposals`` endpoint takes — kind,
+    title, payload, rationale — plus the ``ai_invocation_id`` link the
+    capability stamped on its audit row.
+    """
+
+    kind: str
+    title: str
+    payload: dict[str, object]
+    rationale: str
+    ai_invocation_id: UUID | None
+
+
+@dataclass(frozen=True, slots=True)
+class SuggestionResult:
+    """Capability outcome — either a proposed change or a structured error."""
+
+    proposal: ProposedChange | None
+    error: str | None = None
+
+
+class AIProposalCapability:
+    """Production proposal-generation capability."""
+
+    def __init__(
+        self,
+        *,
+        session_maker: sessionmaker[Session],
+        adapter: ProviderAdapter,
+    ) -> None:
+        """Bind to the session factory and the provider adapter."""
+        self._session_maker = session_maker
+        self._adapter = adapter
+
+    async def suggest_envelope_budget(
+        self,
+        *,
+        household_id: UUID,
+        actor_user_id: UUID | None,
+        api_key: str | None,
+        envelope_id: UUID,
+        envelope_name: str,
+        currency: str,
+        current_budget: Decimal | None,
+        recent_spend_series: list[tuple[date, Decimal]],
+    ) -> SuggestionResult:
+        """Suggest a new ``budget_amount`` for one envelope.
+
+        Wide try/except at the boundary mirrors the other capabilities —
+        AI-stack failures never crash the API request that asked for a
+        suggestion; the user gets a structured error instead.
+        """
+        try:
+            return await self._suggest_envelope_budget_inner(
+                household_id=household_id,
+                actor_user_id=actor_user_id,
+                api_key=api_key,
+                envelope_id=envelope_id,
+                envelope_name=envelope_name,
+                currency=currency,
+                current_budget=current_budget,
+                recent_spend_series=recent_spend_series,
+            )
+        except Exception:
+            log.exception(
+                "ai.suggest_envelope_budget.failed",
+                extra={
+                    "household_id": str(household_id),
+                    "envelope_id": str(envelope_id),
+                },
+            )
+            return SuggestionResult(proposal=None, error="Internal AI capability failure.")
+
+    async def _suggest_envelope_budget_inner(
+        self,
+        *,
+        household_id: UUID,
+        actor_user_id: UUID | None,
+        api_key: str | None,
+        envelope_id: UUID,
+        envelope_name: str,
+        currency: str,
+        current_budget: Decimal | None,
+        recent_spend_series: list[tuple[date, Decimal]],
+    ) -> SuggestionResult:
+        from tulip_storage.models import Household
+
+        with self._session_maker() as session:
+            household = session.get(Household, household_id)
+            if household is None:
+                return SuggestionResult(proposal=None, error="household not found")
+            policy = resolve_policy(household.ai_policy, None, "agentic")
+
+            if policy.level == "disabled":
+                self._audit(
+                    household_id=household_id,
+                    actor_user_id=actor_user_id,
+                    policy_level="disabled",
+                    profile=policy.profile,
+                    outcome="policy_disabled",
+                    prompt_hash=hash_prompt_payload(
+                        {"task": "suggest_envelope_budget", "envelope_id": str(envelope_id)}
+                    ),
+                )
+                return SuggestionResult(proposal=None, error="agentic disabled")
+
+            if api_key is None and policy.provider != "ollama":
+                self._audit(
+                    household_id=household_id,
+                    actor_user_id=actor_user_id,
+                    policy_level=policy.level,
+                    profile=policy.profile,
+                    provider=policy.provider,
+                    model=policy.model,
+                    outcome="provider_error",
+                    prompt_hash=hash_prompt_payload(
+                        {"task": "suggest_envelope_budget", "envelope_id": str(envelope_id)}
+                    ),
+                    response_text="no api key configured for provider",
+                )
+                return SuggestionResult(proposal=None, error="no api key")
+
+        bucketed = bucket_time_series(recent_spend_series, profile=policy.profile)
+        prompt_body: dict[str, object] = {
+            "task": "suggest_envelope_budget",
+            "envelope_id": str(envelope_id),
+            "currency": currency,
+            "current_budget": str(current_budget) if current_budget is not None else None,
+            "recent_spend_series": [{"date": d.isoformat(), "amount": str(a)} for d, a in bucketed],
+        }
+        if policy.profile != "strict":
+            prompt_body["envelope_name"] = envelope_name
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are an envelope-budgeting analyst. Given an envelope's "
+                    "recent spending series and its current budget, propose a new "
+                    "budget_amount that reflects observed spending plus a small "
+                    "buffer. Respond with a strict JSON object: "
+                    '{"new_budget_amount": "<decimal>", "rationale": "<short>"}. '
+                    "Do not include code fences or commentary."
+                ),
+            },
+            {"role": "user", "content": json.dumps(prompt_body, ensure_ascii=False)},
+        ]
+
+        try:
+            response = await self._adapter.chat(
+                provider=policy.provider or "",
+                model=policy.model or "",
+                api_key=api_key,
+                messages=messages,
+                max_tokens=300,
+            )
+        except AIProviderError as exc:
+            self._audit(
+                household_id=household_id,
+                actor_user_id=actor_user_id,
+                policy_level=policy.level,
+                profile=policy.profile,
+                provider=policy.provider,
+                model=policy.model,
+                outcome="provider_error",
+                prompt_hash=hash_prompt_payload(prompt_body),
+                response_text=str(exc)[:500],
+            )
+            return SuggestionResult(proposal=None, error=f"provider error: {exc}")
+
+        parsed = _parse_suggestion(response.text, currency=currency)
+        if parsed is None:
+            self._audit(
+                household_id=household_id,
+                actor_user_id=actor_user_id,
+                policy_level=policy.level,
+                profile=policy.profile,
+                provider=policy.provider,
+                model=policy.model,
+                outcome="provider_error",
+                prompt_hash=hash_prompt_payload(prompt_body),
+                response_text=f"unparseable suggestion: {response.text[:300]}",
+                tokens_in=response.tokens_in,
+                tokens_out=response.tokens_out,
+                cost_estimate_usd=response.cost_estimate_usd,
+                latency_ms=response.latency_ms,
+            )
+            return SuggestionResult(proposal=None, error="model returned unparseable suggestion")
+
+        new_amount, rationale = parsed
+        invocation_id = self._audit(
+            household_id=household_id,
+            actor_user_id=actor_user_id,
+            policy_level=policy.level,
+            profile=policy.profile,
+            provider=policy.provider,
+            model=policy.model,
+            tokens_in=response.tokens_in,
+            tokens_out=response.tokens_out,
+            cost_estimate_usd=response.cost_estimate_usd,
+            latency_ms=response.latency_ms,
+            outcome="success",
+            prompt_hash=hash_prompt_payload(prompt_body),
+            provider_response_id=response.provider_response_id,
+            prompt_json=(
+                json.dumps(prompt_body, ensure_ascii=False) if policy.log_prompts else None
+            ),
+            response_text=response.text if policy.log_prompts else None,
+        )
+
+        proposal = ProposedChange(
+            kind="envelope_budget_update",
+            title=f"Adjust {envelope_name} budget to {new_amount} {currency}",
+            payload={
+                "envelope_id": str(envelope_id),
+                "new_budget_amount": str(new_amount),
+            },
+            rationale=rationale,
+            ai_invocation_id=invocation_id,
+        )
+        return SuggestionResult(proposal=proposal)
+
+    def _audit(
+        self,
+        *,
+        household_id: UUID,
+        actor_user_id: UUID | None,
+        policy_level: str,
+        profile: str,
+        outcome: str,
+        prompt_hash: bytes,
+        provider: str | None = None,
+        model: str | None = None,
+        tokens_in: int = 0,
+        tokens_out: int = 0,
+        cost_estimate_usd: Decimal = Decimal("0"),
+        latency_ms: int = 0,
+        provider_response_id: str | None = None,
+        prompt_json: str | None = None,
+        response_text: str | None = None,
+    ) -> UUID | None:
+        """Write one ``ai_invocations`` row and return its id."""
+        with self._session_maker() as session:
+            row = AIInvocationWriter(session).write(
+                AIInvocationRecord(
+                    household_id=household_id,
+                    capability="agentic",
+                    policy_resolved=policy_level,
+                    profile=profile,
+                    provider=provider,
+                    model=model,
+                    tokens_in=tokens_in,
+                    tokens_out=tokens_out,
+                    cost_estimate_usd=cost_estimate_usd,
+                    latency_ms=latency_ms,
+                    outcome=outcome,
+                    prompt_hash=prompt_hash,
+                    provider_response_id=provider_response_id,
+                    actor_user_id=actor_user_id,
+                    prompt_json=prompt_json,
+                    response_text=response_text,
+                )
+            )
+            session.commit()
+            return row.id
+
+
+def _parse_suggestion(text: str, *, currency: str) -> tuple[Decimal, str] | None:
+    """Pull ``new_budget_amount`` + ``rationale`` from the model response."""
+    del currency  # reserved for future cross-currency validation
+    cleaned = text.strip()
+    # Tolerate fenced JSON despite the system prompt.
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        if "\n" in cleaned:
+            first, _, rest = cleaned.partition("\n")
+            if first.strip().lower() in ("json", "javascript"):
+                cleaned = rest
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        return None
+    try:
+        parsed = json.loads(cleaned[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    amount_raw = parsed.get("new_budget_amount")
+    rationale = parsed.get("rationale", "")
+    if amount_raw is None:
+        return None
+    try:
+        amount = Decimal(str(amount_raw))
+    except (ArithmeticError, ValueError):
+        return None
+    if amount < 0:
+        return None
+    return amount, str(rationale)
+
+
+__all__ = [
+    "AIProposalCapability",
+    "ProposedChange",
+    "SuggestionResult",
+]

--- a/packages/tulip-ai/tests/test_proposals.py
+++ b/packages/tulip-ai/tests/test_proposals.py
@@ -1,0 +1,217 @@
+"""Tests for ``AIProposalCapability`` (P6.4.b)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from tulip_ai.adapters import RecordingAdapter
+from tulip_ai.proposals import AIProposalCapability
+from tulip_storage.encryption import encrypt_field
+from tulip_storage.models import AIInvocation, Household
+
+
+def _series(days: int = 30, amount: str = "5.00") -> list[tuple[date, Decimal]]:
+    return [(date(2026, 1, 1) + timedelta(days=i), Decimal(amount)) for i in range(days)]
+
+
+def _set_policy(
+    session_maker: sessionmaker[Session],
+    household: Household,
+    *,
+    master_key: bytes,
+    policy_extra: dict[str, object] | None = None,
+    set_key: bool = True,
+) -> None:
+    if set_key:
+        blob = encrypt_field(
+            json.dumps({"anthropic": "sk-test"}).encode("utf-8"),
+            master_key=master_key,
+        )
+    else:
+        blob = None
+    policy: dict[str, object] = {
+        "default_provider": "anthropic",
+        "default_model": "claude-opus-4-7",
+    }
+    if policy_extra:
+        policy.update(policy_extra)
+    with session_maker() as s:
+        h = s.get(Household, household.id)
+        assert h is not None
+        h.ai_keys_encrypted = blob
+        h.ai_policy = policy
+        s.commit()
+
+
+@pytest.mark.asyncio
+async def test_suggest_budget_happy_path_returns_proposed_change(
+    session_maker: sessionmaker[Session],
+    household_and_user: tuple[Household, object],
+    master_key: bytes,
+) -> None:
+    household, _ = household_and_user
+    _set_policy(session_maker, household, master_key=master_key)
+    adapter = RecordingAdapter(
+        canned_reply=(
+            '{"new_budget_amount": "250.00", '
+            '"rationale": "Spending has trended up; 250 covers the new normal."}'
+        )
+    )
+    cap = AIProposalCapability(session_maker=session_maker, adapter=adapter)
+    result = await cap.suggest_envelope_budget(
+        household_id=household.id,
+        actor_user_id=None,
+        api_key="sk-test",
+        envelope_id=household.id,  # any UUID works for the prompt
+        envelope_name="Groceries",
+        currency="USD",
+        current_budget=Decimal("200"),
+        recent_spend_series=_series(),
+    )
+    assert result.error is None
+    assert result.proposal is not None
+    assert result.proposal.kind == "envelope_budget_update"
+    assert result.proposal.payload["new_budget_amount"] == "250.00"
+    assert "Spending has trended up" in result.proposal.rationale
+    assert result.proposal.ai_invocation_id is not None
+
+    with session_maker() as s:
+        rows = (
+            s.execute(select(AIInvocation).where(AIInvocation.capability == "agentic"))
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].outcome == "success"
+
+
+@pytest.mark.asyncio
+async def test_suggest_budget_no_key_returns_error(
+    session_maker: sessionmaker[Session],
+    household_and_user: tuple[Household, object],
+    master_key: bytes,
+) -> None:
+    household, _ = household_and_user
+    _set_policy(session_maker, household, master_key=master_key, set_key=False)
+    adapter = RecordingAdapter(canned_reply="unused")
+    cap = AIProposalCapability(session_maker=session_maker, adapter=adapter)
+    result = await cap.suggest_envelope_budget(
+        household_id=household.id,
+        actor_user_id=None,
+        api_key=None,
+        envelope_id=household.id,
+        envelope_name="Groceries",
+        currency="USD",
+        current_budget=None,
+        recent_spend_series=_series(),
+    )
+    assert result.proposal is None
+    assert "no api key" in (result.error or "")
+    assert adapter.calls == []
+    with session_maker() as s:
+        rows = (
+            s.execute(select(AIInvocation).where(AIInvocation.capability == "agentic"))
+            .scalars()
+            .all()
+        )
+        assert rows[0].outcome == "provider_error"
+
+
+@pytest.mark.asyncio
+async def test_suggest_budget_unparseable_response_records_error(
+    session_maker: sessionmaker[Session],
+    household_and_user: tuple[Household, object],
+    master_key: bytes,
+) -> None:
+    household, _ = household_and_user
+    _set_policy(session_maker, household, master_key=master_key)
+    adapter = RecordingAdapter(canned_reply="not JSON at all!")
+    cap = AIProposalCapability(session_maker=session_maker, adapter=adapter)
+    result = await cap.suggest_envelope_budget(
+        household_id=household.id,
+        actor_user_id=None,
+        api_key="sk-test",
+        envelope_id=household.id,
+        envelope_name="Groceries",
+        currency="USD",
+        current_budget=None,
+        recent_spend_series=_series(),
+    )
+    assert result.proposal is None
+    assert "unparseable" in (result.error or "")
+    with session_maker() as s:
+        rows = (
+            s.execute(select(AIInvocation).where(AIInvocation.capability == "agentic"))
+            .scalars()
+            .all()
+        )
+        assert rows[0].outcome == "provider_error"
+
+
+@pytest.mark.asyncio
+async def test_suggest_budget_disabled_policy(
+    session_maker: sessionmaker[Session],
+    household_and_user: tuple[Household, object],
+    master_key: bytes,
+) -> None:
+    household, _ = household_and_user
+    _set_policy(
+        session_maker,
+        household,
+        master_key=master_key,
+        policy_extra={"capabilities": {"agentic": {"policy": "disabled"}}},
+    )
+    adapter = RecordingAdapter(canned_reply="unused")
+    cap = AIProposalCapability(session_maker=session_maker, adapter=adapter)
+    result = await cap.suggest_envelope_budget(
+        household_id=household.id,
+        actor_user_id=None,
+        api_key="sk-test",
+        envelope_id=household.id,
+        envelope_name="Groceries",
+        currency="USD",
+        current_budget=None,
+        recent_spend_series=_series(),
+    )
+    assert result.proposal is None
+    assert result.error == "agentic disabled"
+    assert adapter.calls == []
+    with session_maker() as s:
+        rows = (
+            s.execute(select(AIInvocation).where(AIInvocation.capability == "agentic"))
+            .scalars()
+            .all()
+        )
+        assert rows[0].outcome == "policy_disabled"
+
+
+@pytest.mark.asyncio
+async def test_suggest_budget_handles_codefence_response(
+    session_maker: sessionmaker[Session],
+    household_and_user: tuple[Household, object],
+    master_key: bytes,
+) -> None:
+    household, _ = household_and_user
+    _set_policy(session_maker, household, master_key=master_key)
+    adapter = RecordingAdapter(
+        canned_reply='```json\n{"new_budget_amount": "175.50", "rationale": "ok"}\n```'
+    )
+    cap = AIProposalCapability(session_maker=session_maker, adapter=adapter)
+    result = await cap.suggest_envelope_budget(
+        household_id=household.id,
+        actor_user_id=None,
+        api_key="sk-test",
+        envelope_id=household.id,
+        envelope_name="Groceries",
+        currency="USD",
+        current_budget=None,
+        recent_spend_series=_series(),
+    )
+    assert result.proposal is not None
+    assert result.proposal.payload["new_budget_amount"] == "175.50"

--- a/packages/tulip-api/src/tulip_api/routers/proposals.py
+++ b/packages/tulip-api/src/tulip_api/routers/proposals.py
@@ -15,6 +15,8 @@ from tulip_api.schemas.proposal import (
     ProposalCreate,
     ProposalDecisionBody,
     ProposalRead,
+    SuggestBudgetRequest,
+    SuggestBudgetResponse,
 )
 from tulip_api.services.proposal_executor import (
     execute_approved_proposal,
@@ -255,3 +257,110 @@ def list_supported_kinds(
     """Return the proposal kinds the approve flow can currently execute."""
     del claims  # authenticated only
     return list(supported_proposal_kinds())
+
+
+@router.post(
+    "/suggest/budget",
+    response_model=SuggestBudgetResponse,
+    responses={
+        400: problem_response("request.body_invalid"),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("envelope.not_found"),
+        422: problem_response("validation.failed"),
+    },
+)
+async def suggest_envelope_budget(
+    body: SuggestBudgetRequest,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> SuggestBudgetResponse:
+    """AI-suggest a new ``budget_amount`` for one envelope (P6.4.b).
+
+    Pulls the envelope's 60-day spending series, calls
+    ``AIProposalCapability.suggest_envelope_budget``, and writes the
+    returned proposal to the queue with
+    ``created_by_kind=ai_agent`` + the capability's audit row linked via
+    ``ai_invocation_id``. The user then approves / rejects via the
+    standard inbox flow.
+
+    Failures (capability error, envelope missing) leave no proposal but
+    do leave the ``ai_invocations`` audit row the capability wrote.
+    """
+    from datetime import UTC, datetime, timedelta
+    from datetime import date as date_type
+    from decimal import Decimal
+
+    from sqlalchemy.orm import sessionmaker as _sessionmaker
+
+    from tulip_ai import AIProposalCapability, LitellmAdapter
+    from tulip_api.config import get_settings
+    from tulip_storage.models import Household
+    from tulip_storage.repositories import EnvelopeRepository, ShadowTransactionRepository
+
+    found = EnvelopeRepository(session, claims.household_id).get(body.envelope_id)
+    if found is None:
+        from tulip_api.errors import EnvelopeNotFoundError
+
+        raise EnvelopeNotFoundError()
+    pool, envelope = found
+
+    today = datetime.now(UTC).date()
+    cutoff = today - timedelta(days=59)
+    spend_map = ShadowTransactionRepository(
+        session, claims.household_id
+    ).daily_spend_series_for_pool(pool.id, currency=pool.currency, from_date=cutoff, to_date=today)
+    series: list[tuple[date_type, Decimal]] = [
+        (
+            cutoff + timedelta(days=i),
+            spend_map.get(cutoff + timedelta(days=i), Decimal("0")),
+        )
+        for i in range(60)
+    ]
+
+    settings = get_settings()
+    household = session.get(Household, claims.household_id)
+    assert household is not None  # noqa: S101
+    api_key: str | None = None
+    if household.ai_keys_encrypted:
+        from tulip_api.routers.ai import _load_household_keys
+
+        keys = _load_household_keys(household, settings.master_key)
+        provider = household.ai_policy.get("default_provider")
+        if isinstance(provider, str):
+            api_key = keys.get(provider)
+
+    bind = session.get_bind()
+    cap_session_maker = _sessionmaker(bind, expire_on_commit=False)
+    capability = AIProposalCapability(session_maker=cap_session_maker, adapter=LitellmAdapter())
+    result = await capability.suggest_envelope_budget(
+        household_id=claims.household_id,
+        actor_user_id=claims.user_id,
+        api_key=api_key,
+        envelope_id=pool.id,
+        envelope_name=pool.name,
+        currency=pool.currency,
+        current_budget=envelope.budget_amount,
+        recent_spend_series=series,
+    )
+    if result.proposal is None:
+        return SuggestBudgetResponse(proposal=None, error=result.error)
+
+    repo = PendingProposalRepository(session, claims.household_id)
+    row = repo.create(
+        kind=result.proposal.kind,
+        title=result.proposal.title,
+        payload=result.proposal.payload,
+        rationale=result.proposal.rationale,
+        created_by_kind=ProposalCreatorKind.AI_AGENT.value,
+        created_by_user_id=claims.user_id,
+        ai_invocation_id=result.proposal.ai_invocation_id,
+    )
+    session.commit()
+    log.info(
+        "proposal.suggested",
+        proposal_id=str(row.id),
+        kind=row.kind,
+        envelope_id=str(pool.id),
+    )
+    return SuggestBudgetResponse(proposal=_to_read(row), error=None)

--- a/packages/tulip-api/src/tulip_api/schemas/proposal.py
+++ b/packages/tulip-api/src/tulip_api/schemas/proposal.py
@@ -50,3 +50,22 @@ class ProposalDecisionBody(BaseModel):
     """Optional body for approve / reject — just a free-text note."""
 
     note: str | None = None
+
+
+class SuggestBudgetRequest(BaseModel):
+    """Body for ``POST /v1/ai/proposals/suggest/budget`` (P6.4.b)."""
+
+    envelope_id: UUID
+
+
+class SuggestBudgetResponse(BaseModel):
+    """Result of an AI budget suggestion run.
+
+    On success ``proposal`` carries the newly created ``PendingProposal``
+    row; ``error`` is populated only when the capability could not
+    produce a suggestion (no key, disabled policy, malformed model
+    response). The ai_invocations audit row exists either way.
+    """
+
+    proposal: ProposalRead | None
+    error: str | None = None

--- a/packages/tulip-api/tests/test_proposals_endpoints.py
+++ b/packages/tulip-api/tests/test_proposals_endpoints.py
@@ -329,3 +329,43 @@ class TestAuth:
     def test_approve_requires_auth(self, client: TestClient) -> None:
         r = client.post(f"/v1/ai/proposals/{uuid4()}/approve")
         assert r.status_code == 401
+
+
+class TestSuggestBudget:
+    """``POST /v1/ai/proposals/suggest/budget`` (P6.4.b).
+
+    The endpoint instantiates ``LitellmAdapter`` inline (no DI hook), so
+    happy-path adapter behaviour is covered by the capability unit tests
+    in ``tulip-ai/tests/test_proposals.py``. These tests cover the HTTP
+    contract: missing api key surfaces a structured error, missing envelope
+    is a 404, and unauthenticated callers are rejected.
+    """
+
+    def test_requires_auth(self, client: TestClient) -> None:
+        r = client.post(
+            "/v1/ai/proposals/suggest/budget",
+            json={"envelope_id": str(uuid4())},
+        )
+        assert r.status_code == 401
+
+    def test_unknown_envelope_returns_404(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.post(
+            "/v1/ai/proposals/suggest/budget",
+            headers=auth_h,
+            json={"envelope_id": str(uuid4())},
+        )
+        assert_problem(r, code="envelope.not_found", status=404)
+
+    def test_no_api_key_returns_structured_error(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        env_id = _make_envelope(client, auth_h)
+        r = client.post(
+            "/v1/ai/proposals/suggest/budget",
+            headers=auth_h,
+            json={"envelope_id": env_id},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["proposal"] is None
+        assert "no api key" in (body["error"] or "").lower()

--- a/packages/tulip-cli/src/tulip_cli/commands/ai.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/ai.py
@@ -292,6 +292,54 @@ def list_proposals(
         typer.echo(f"  {r['id'][:8]}  {r['kind']:32s}  {r['status']:10s}  {r['title']}")
 
 
+@ai_app.command("suggest-budget")
+def suggest_budget(
+    ctx: typer.Context,
+    envelope_id: Annotated[
+        str,
+        typer.Option(
+            "--envelope",
+            help="Envelope UUID. Use `tulip envelopes list` to find it.",
+        ),
+    ],
+) -> None:
+    """Ask AI to propose a new budget for ``envelope`` based on recent spend (P6.4.b).
+
+    On success the suggestion lands in your proposal inbox as
+    ``kind=envelope_budget_update`` with ``created_by_kind=ai_agent``.
+    Approve via ``tulip ai approve UUID`` or reject via
+    ``tulip ai reject UUID``.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post(
+                "/v1/ai/proposals/suggest/budget",
+                json={"envelope_id": envelope_id},
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    body = response.json()
+    if body.get("error"):
+        typer.echo(f"ai suggest-budget: {body['error']}", err=True)
+        raise typer.Exit(1)
+    proposal = body["proposal"]
+    typer.echo(f"Created proposal {proposal['id']}: {proposal['title']}")
+    if proposal.get("rationale"):
+        typer.echo(f"  rationale: {proposal['rationale']}")
+    typer.echo(
+        f"  Review with `tulip ai approve {proposal['id']}` or `tulip ai reject {proposal['id']}`."
+    )
+
+
 @ai_app.command("approve")
 def approve_proposal(
     ctx: typer.Context,

--- a/packages/tulip-cli/tests/test_ai.py
+++ b/packages/tulip-cli/tests/test_ai.py
@@ -162,3 +162,30 @@ def test_ai_preview_renders_payload(authed: str) -> None:
     assert body["payload"]["line"]["amount"] == "-87.42"
     chart_codes = sorted(c["code"] for c in body["payload"]["chart"])
     assert chart_codes == ["5100"]
+
+
+@pytest.mark.integration
+def test_ai_suggest_budget_without_key_reports_error(authed: str) -> None:
+    """``tulip ai suggest-budget`` surfaces the structured error when no key is configured."""
+    # Need a pool + envelope to point the command at.
+    httpx_token = httpx.post(
+        f"{authed}/v1/auth/login",
+        json={"email": "admin@example.com", "password": _PASSWORD},
+        timeout=10,
+    ).json()["access_token"]
+    headers = {"Authorization": f"Bearer {httpx_token}"}
+    env = httpx.post(
+        f"{authed}/v1/envelopes",
+        headers=headers,
+        json={
+            "name": "Groceries",
+            "currency": "USD",
+            "budget_period": "monthly",
+            "rollover_policy": "reset",
+            "budget_amount": "100.00",
+        },
+        timeout=10,
+    ).json()
+    result = _run_cli("ai", "suggest-budget", "--envelope", env["id"], api_url=authed)
+    assert result.returncode == 1
+    assert "no api key" in result.stderr.lower()


### PR DESCRIPTION
## Summary

The "AI as proposal generator" half of P6.4 — pairs with P6.4 (#158)
to close the AI proposal loop end-to-end.

- **`tulip_ai.proposals.AIProposalCapability`** — async capability that
  takes an envelope + 60-day spend series, calls the LLM via the
  existing `LitellmAdapter`, parses a `{new_budget_amount, rationale}`
  JSON suggestion (tolerates code fences), and returns a
  `SuggestionResult(proposal, error)`. Always writes an
  `ai_invocations` audit row whose `outcome` matches the path taken
  (`success`, `provider_error`, `policy_disabled`).
- **`POST /v1/ai/proposals/suggest/budget`** — admin/member only. Pulls
  the envelope's last 60 days of shadow spend via a new
  `ShadowTransactionRepository.daily_spend_series_for_pool()`, decrypts
  the household's provider key, runs the capability, and on success
  creates a `created_by_kind=ai_agent` proposal with `ai_invocation_id`
  linked to the capability's audit row. So when the user approves it
  via the existing inbox flow, the locked
  [ARCHITECTURE.md §6.2](docs/ARCHITECTURE.md) +
  [THREAT_MODEL.md §5.3](docs/THREAT_MODEL.md) chain
  (`actor_kind=ai_agent` + `metadata.proposal_id` + originating
  `ai_invocations.id`) lines up end-to-end.
- **`tulip ai suggest-budget --envelope <UUID>`** — success prints
  proposal id + rationale + approve/reject hint; structured error →
  stderr + exit 1.
- **+9 tests**: 5 capability units, 3 endpoint integration, 1 CLI
  integration.

## Test plan
- [x] `uv run pytest packages/tulip-ai/tests/test_proposals.py -x` — 5 pass
- [x] `uv run pytest packages/tulip-api/tests/test_proposals_endpoints.py::TestSuggestBudget -x` — 3 pass
- [x] `uv run pytest packages/tulip-cli/tests/test_ai.py::test_ai_suggest_budget_without_key_reports_error -x` — 1 pass
- [x] `uv run mypy --strict packages/tulip-ai/src packages/tulip-api/src packages/tulip-cli/src` — clean
- [x] `just test` — **1372 passed**, 1 skipped (openapi path-collision)
- [ ] CI green on this PR

### Manual smoke test

Spin up the API locally, register, log in, create an envelope, ask AI
for a budget suggestion (without a key the call is structured-error
rather than a real provider hit — confirms the contract end-to-end
without touching anthropic.com).

```bash
export TULIP_KEY=$(uv run python -c 'import secrets; print(secrets.token_urlsafe(32))')
export TULIP_DB=sqlite:///./smoke-p64b.db
rm -f ./smoke-p64b.db
uv run --package tulip-api uvicorn tulip_api.main:app --port 8000 &
API_PID=$!
sleep 2
curl -s -X POST http://localhost:8000/v1/auth/register -H 'content-type: application/json' -d '{"email":"a@b.com","password":"long-enough-password","display_name":"A","household_name":"H"}' >/dev/null
TOKEN=$(curl -s -X POST http://localhost:8000/v1/auth/login -H 'content-type: application/json' -d '{"email":"a@b.com","password":"long-enough-password"}' | uv run python -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
ENV_ID=$(curl -s -X POST http://localhost:8000/v1/envelopes -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' -d '{"name":"Groceries","currency":"USD","budget_period":"monthly","rollover_policy":"reset","budget_amount":"100.00"}' | uv run python -c 'import sys,json; print(json.load(sys.stdin)["id"])')
echo "Envelope: $ENV_ID"
curl -s -X POST http://localhost:8000/v1/ai/proposals/suggest/budget -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' -d "{\"envelope_id\":\"$ENV_ID\"}"
echo
kill $API_PID; wait $API_PID 2>/dev/null || true
rm -f ./smoke-p64b.db
```

Expect:

```
Envelope: <uuid>
{"proposal":null,"error":"no api key configured for provider 'anthropic'"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)