### PR TITLE
feat: P6.5.c — sinking-fund forecast extension; close Phase 6

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -22,7 +22,7 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **Pre-internal-beta hardening (#121):** ✅ **complete** — all eight checkboxes merged across PRs #140 / #142 / #143 / #146 / #147 / #148 / #149 / #150 / #151 / #152 (master-key file gate, backup/restore CLI, docker compose, password-stdin TTY hint, UTC balance fix, `tulip doctor`, `tulip periods`, inline balances, QUICKSTART, README rewrite for users). Umbrella closed 2026-05-10.
 
-- **Phase 6 (AI integration):** in flight — P6.0–P6.5.b shipped (ADR + categorize + NL query + daily-insights/anomaly + AI forecast + agentic proposals + AI-driven suggestions + cost-cap/rate-limit chokepoint + `tulip ai config` editor + `log_prompts` toggle + status polish). Capability inventory: `AICategorizer`, `AINLQueryCapability`, `AIForecastCapability`, `AIProposalCapability`, plus the proposal executor registry, the shared `enforce_pre_call` gate, and the new `GET|PUT /v1/ai/config` admin surface. Next: P6.5.c (sinking-fund forecast extension) — final Phase 6 slice.
+- **Phase 6 (AI integration):** ✅ shipped — P6.0–P6.5.c complete (ADR + categorize + NL query + daily-insights/anomaly + envelope AI forecast + sinking-fund AI forecast + agentic proposals + AI-driven suggestions + cost-cap/rate-limit chokepoint + `tulip ai config` editor + `log_prompts` toggle + status polish). Capability inventory: `AICategorizer`, `AINLQueryCapability`, `AIForecastCapability` (envelopes + sinking funds), `AIProposalCapability`, the proposal executor registry, the shared `enforce_pre_call` gate, and the `GET|PUT /v1/ai/config` admin surface. The daily-insights handler now forecasts both envelopes and sinking funds via a single `ForecastRequest` dataclass; production wiring of the forecaster into the runner is the only remaining no-op slot, intentionally deferred to a deploy-time toggle. Phase 6 closes.
 
 **Tests:** 1362 passing · **CI:** green on `main`
 
@@ -561,6 +561,56 @@ Closes Phase 5. Imperative CLI subcommand group with 10 commands wrapping the /v
 ## Phase 6 — AI integration — in flight (design)
 
 Phase 6 entry criterion per [ARCHITECTURE.md §10](ARCHITECTURE.md) was a privacy audit shaping the design before any code lands. The audit is now shipped as an ADR; implementation begins with P6.1.
+
+### P6.5.c — Sinking-fund forecast extension — ✅ *(2026-05-11)*
+
+Final Phase 6 slice. Closes ADR-0005's slice plan and the Phase 6
+umbrella. P6.3.b shipped `AIForecastCapability` with `target_amount` /
+`target_date` parameters but the `daily_insights` handler only looped
+envelopes; sinking funds — which actually *want* a target-relative
+"on-track / off-track / ahead" framing — were unwired.
+
+**Storage**:
+- New `ShadowTransactionRepository.daily_contribution_series_for_pool(...)`,
+  mirror of `daily_spend_series_for_pool` filtering on `amount > 0`
+  (inflows). Voided shadow transactions excluded by status filter;
+  returns sparse map keyed by date.
+
+**Handler refactor** (`tulip_storage.runner.handlers.daily_insights`):
+- New `ForecastRequest` dataclass carries the full forecast context:
+  `pool_kind ∈ {"envelope", "sinking_fund"}`, `series`,
+  optional `target_amount` / `target_date` / `current_balance`,
+  plus the existing pool fields. `ForecasterCallback` is now
+  `Callable[[ForecastRequest], Awaitable[str | None]]` — single arg.
+- Envelope path: builds `daily_spend_series_for_pool`, calls forecaster
+  with `pool_kind="envelope"` and target fields `None`. Same output
+  notification shape as before (`kind=forecast`, `entity_type=envelope`).
+- **Sinking-fund path** (new): loops `allocation_pools` joined to
+  `sinking_funds` where `pool_type=sinking_fund`. Builds
+  `daily_contribution_series_for_pool` over 60 days, fetches
+  `balance_for_pool` for the current balance, calls forecaster with
+  `pool_kind="sinking_fund"` and `target_amount` / `target_date` /
+  `current_balance` populated from the row. Writes
+  `kind=forecast` notifications with `entity_type=sinking_fund`.
+- The `AIForecastCapability` itself doesn't change — its prompt
+  already branches on `target_amount/target_date` presence.
+
+**Tests** — +8:
+- 5 repo unit tests for `daily_contribution_series_for_pool`: positive
+  postings only, sparse return, voided txs excluded, currency filter,
+  date range filter.
+- 3 handler integration tests: sinking-fund forecaster receives full
+  target context, forecaster returning None writes no row,
+  no-forecaster baseline means sinking funds produce zero notifications.
+- All 4 prior P6.3 / P6.3.b handler tests updated to the new
+  callback signature and still pass.
+
+**Out of scope** (deploy-time concern, not a code slice):
+- Wiring `AIForecastCapability` into the runner's handler registration
+  as the production `forecaster` callback. The slot is in place; what
+  remains is one line of glue at deployment to construct the
+  capability + adapter + session factory and pass it to
+  `make_daily_insights_handler(..., forecaster=...)`.
 
 ### P6.5.b — `tulip ai config` editor + `log_prompts` toggle + status polish — ✅ *(2026-05-11)*
 

--- a/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/shadow_transaction.py
@@ -251,6 +251,42 @@ class ShadowTransactionRepository:
         ).all()
         return {row_date: abs(Decimal(str(net))) for row_date, net in rows}
 
+    def daily_contribution_series_for_pool(
+        self,
+        pool_id: UUID,
+        *,
+        currency: str,
+        from_date: date_type,
+        to_date: date_type,
+    ) -> dict[date_type, Decimal]:
+        """Daily inflow totals on ``pool_id`` between ``from_date`` and ``to_date`` inclusive.
+
+        Mirror of :meth:`daily_spend_series_for_pool` for the sinking-fund
+        forecaster path (P6.5.c). Only positive postings count;
+        voided shadow transactions are excluded by the status filter.
+
+        Returns a sparse mapping — dates with no contribution aren't
+        keyed. Callers zero-fill if they need a uniform grid.
+        """
+        rows = self._session.execute(
+            select(
+                ShadowTransaction.date,
+                func.sum(ShadowPosting.amount).label("net"),
+            )
+            .join(ShadowTransaction, ShadowTransaction.id == ShadowPosting.shadow_transaction_id)
+            .where(
+                ShadowPosting.household_id == self._household_id,
+                ShadowPosting.pool_id == pool_id,
+                ShadowPosting.currency == currency,
+                ShadowTransaction.status.in_(_BALANCE_STATUSES),
+                ShadowTransaction.date >= from_date,
+                ShadowTransaction.date <= to_date,
+                ShadowPosting.amount > 0,
+            )
+            .group_by(ShadowTransaction.date)
+        ).all()
+        return {row_date: Decimal(str(net)) for row_date, net in rows}
+
     def void(self, shadow_tx_id: UUID, *, voided_at: datetime) -> ShadowTransaction:
         """Flip a POSTED shadow transaction's status to VOIDED.
 

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/daily_insights.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/daily_insights.py
@@ -1,28 +1,34 @@
-"""``daily_insights`` handler — runs anomaly detection over per-envelope spend (P6.3).
+"""``daily_insights`` handler — runs anomaly detection + AI forecasts (P6.3 / P6.5.c).
 
 Schedule one job per household (typically nightly via ``schedule_recurring``)
 with kind ``daily_insights``. The handler:
 
 1. Lists active envelopes for the household.
-2. For each envelope, builds a 60-day daily-amount series from POSTED
+2. For each envelope, builds a 60-day daily-spend series from POSTED
    shadow postings on that envelope's pool.
 3. Runs :func:`tulip_core.insights.find_anomalies` against the series.
 4. Writes one ``notifications`` row per detected anomaly.
+5. If a forecaster is wired in, calls it with an envelope-shaped
+   :class:`ForecastRequest`; on text return, writes a ``kind=forecast``
+   row with ``entity_type=envelope``.
+6. (P6.5.c) Lists active sinking funds for the household. For each,
+   builds a 60-day daily-contribution series, fetches the current
+   balance, and calls the forecaster with a sinking-fund-shaped
+   :class:`ForecastRequest` (target_amount / target_date / current_balance
+   populated). On text return, writes a ``kind=forecast`` row with
+   ``entity_type=sinking_fund``.
 
-The AI forecast capability (which would ride alongside the anomaly
-detector here) is deferred to a follow-up slice — the handler's
-structure leaves an obvious place to add it: after step 3, take the
-same series + envelope context and call into ``tulip_ai`` for a
-forecast. The notifications row distinguishes via ``kind`` (``anomaly``
-vs ``forecast``) so the two surfaces coexist cleanly.
+The notification rows distinguish envelopes from sinking funds via
+``entity_type`` so a single ``kind=forecast`` channel serves both.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
 from sqlalchemy import select
@@ -34,6 +40,7 @@ from tulip_storage.models import (
     NotificationKind,
     NotificationSeverity,
     PoolType,
+    SinkingFund,
 )
 from tulip_storage.repositories import NotificationRepository, ShadowTransactionRepository
 
@@ -48,15 +55,35 @@ if TYPE_CHECKING:
 _SERIES_DAYS = 60
 _PRODUCED_BY = "daily_insights"
 
+
+@dataclass(frozen=True, slots=True)
+class ForecastRequest:
+    """Everything the forecaster needs for one envelope or sinking fund (P6.5.c).
+
+    For envelopes, ``target_amount`` / ``target_date`` / ``current_balance``
+    are ``None`` and ``series`` is the daily spend series. For sinking
+    funds, all three are populated and ``series`` is the daily
+    contribution series. The forecaster owns prompt construction; the
+    handler just hands it the context.
+    """
+
+    household_id: UUID
+    pool_id: UUID
+    pool_name: str
+    pool_currency: str
+    pool_kind: Literal["envelope", "sinking_fund"]
+    series: list[tuple[date, Decimal]]
+    target_amount: Decimal | None
+    target_date: date | None
+    current_balance: Decimal | None
+
+
 #: Callback the handler invokes (when set) to obtain a forecast for one
-#: envelope. Returning ``None`` (or an empty string) skips the forecast
-#: notification for that envelope — the handler-side "AI not configured"
-#: signal. The callback owns its own provider call, audit row, and policy
+#: pool. Returning ``None`` (or an empty string) skips the forecast
+#: notification — the handler-side "AI not configured" signal. The
+#: callback owns its own provider call, audit row, and policy
 #: resolution; the handler just writes the notification row.
-ForecasterCallback = Callable[
-    [UUID, UUID, str, str, list[tuple[date, Decimal]]],
-    Awaitable[str | None],
-]
+ForecasterCallback = Callable[[ForecastRequest], Awaitable[str | None]]
 
 
 def make_daily_insights_handler(
@@ -130,13 +157,18 @@ async def _process(
                 entity_id=pool.id,
             )
         if forecaster is not None:
-            forecast_text = await forecaster(
-                job.household_id,
-                pool.id,
-                pool.name,
-                pool.currency,
-                series,
+            request = ForecastRequest(
+                household_id=job.household_id,
+                pool_id=pool.id,
+                pool_name=pool.name,
+                pool_currency=pool.currency,
+                pool_kind="envelope",
+                series=series,
+                target_amount=None,
+                target_date=None,
+                current_balance=None,
             )
+            forecast_text = await forecaster(request)
             if forecast_text:
                 notifications.create(
                     kind=NotificationKind.FORECAST.value,
@@ -147,7 +179,88 @@ async def _process(
                     entity_type="envelope",
                     entity_id=pool.id,
                 )
-        del envelope  # not yet used; sinking-fund targets land in a follow-up.
+        del envelope  # envelope-specific fields are inherited from the pool today.
+
+    if forecaster is not None:
+        await _forecast_sinking_funds(
+            session,
+            job=job,
+            today=today,
+            notifications=notifications,
+            forecaster=forecaster,
+        )
+
+
+async def _forecast_sinking_funds(
+    session: Session,
+    *,
+    job: ScheduledJob,
+    today: date,
+    notifications: NotificationRepository,
+    forecaster: ForecasterCallback,
+) -> None:
+    """Iterate active sinking funds; call the forecaster with target context.
+
+    Each sinking fund gets a 60-day daily-contribution series + its
+    current balance + its locked ``target_amount`` / ``target_date``.
+    On a non-empty forecast text, writes one ``kind=forecast`` /
+    ``entity_type=sinking_fund`` notification.
+    """
+    sinking_funds = session.execute(
+        select(AllocationPool, SinkingFund)
+        .join(
+            SinkingFund,
+            (SinkingFund.household_id == AllocationPool.household_id)
+            & (SinkingFund.pool_id == AllocationPool.id),
+        )
+        .where(
+            AllocationPool.household_id == job.household_id,
+            AllocationPool.pool_type == PoolType.SINKING_FUND,
+            AllocationPool.is_active.is_(True),
+        )
+    ).all()
+
+    shadow_repo = ShadowTransactionRepository(session, job.household_id)
+    cutoff = today - timedelta(days=_SERIES_DAYS - 1)
+
+    for pool, sinking_fund in sinking_funds:
+        contribution_map = shadow_repo.daily_contribution_series_for_pool(
+            pool.id,
+            currency=pool.currency,
+            from_date=cutoff,
+            to_date=today,
+        )
+        series = [
+            (
+                cutoff + timedelta(days=i),
+                contribution_map.get(cutoff + timedelta(days=i), Decimal("0")),
+            )
+            for i in range(_SERIES_DAYS)
+        ]
+        balances = shadow_repo.balance_for_pool(pool.id, currency=pool.currency)
+        current_balance = balances.get(pool.currency, Decimal("0"))
+        request = ForecastRequest(
+            household_id=job.household_id,
+            pool_id=pool.id,
+            pool_name=pool.name,
+            pool_currency=pool.currency,
+            pool_kind="sinking_fund",
+            series=series,
+            target_amount=sinking_fund.target_amount,
+            target_date=sinking_fund.target_date,
+            current_balance=current_balance,
+        )
+        forecast_text = await forecaster(request)
+        if forecast_text:
+            notifications.create(
+                kind=NotificationKind.FORECAST.value,
+                severity=NotificationSeverity.INFO.value,
+                title=f"Forecast for {pool.name}",
+                body=forecast_text,
+                produced_by=_PRODUCED_BY,
+                entity_type="sinking_fund",
+                entity_id=pool.id,
+            )
 
 
 def _daily_spend_series(
@@ -195,4 +308,4 @@ def _to_notification_severity(severity: object) -> str:
 _ = datetime, UTC
 
 
-__all__ = ["make_daily_insights_handler"]
+__all__ = ["ForecastRequest", "ForecasterCallback", "make_daily_insights_handler"]

--- a/packages/tulip-storage/tests/test_daily_insights_handler.py
+++ b/packages/tulip-storage/tests/test_daily_insights_handler.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from tulip_storage.models import (
     AllocationPool,
     BudgetPeriod,
+    ContributionStrategy,
     Envelope,
     Household,
     Notification,
@@ -22,8 +23,10 @@ from tulip_storage.models import (
     ShadowTransaction,
     ShadowTxReason,
     ShadowTxStatus,
+    SinkingFund,
 )
 from tulip_storage.runner.handlers import make_daily_insights_handler
+from tulip_storage.runner.handlers.daily_insights import ForecastRequest
 
 
 def _fixed_clock(when: datetime):  # type: ignore[no-untyped-def]
@@ -174,9 +177,17 @@ def test_forecaster_callback_produces_forecast_notification(
 
     forecast_calls: list[tuple] = []
 
-    async def fake_forecaster(household_id, envelope_id, envelope_name, currency, series) -> str:
-        forecast_calls.append((household_id, envelope_id, envelope_name, currency, len(series)))
-        return f"{envelope_name} is on track."
+    async def fake_forecaster(request) -> str:
+        forecast_calls.append(
+            (
+                request.household_id,
+                request.pool_id,
+                request.pool_name,
+                request.pool_currency,
+                len(request.series),
+            )
+        )
+        return f"{request.pool_name} is on track."
 
     handler = make_daily_insights_handler(session_maker, forecaster=fake_forecaster)
     asyncio.run(
@@ -209,7 +220,7 @@ def test_forecaster_returning_none_writes_no_forecast(
             amount=Decimal("10.00"),
         )
 
-    async def silent_forecaster(*_args: object) -> None:
+    async def silent_forecaster(_request: object) -> None:
         return None
 
     handler = make_daily_insights_handler(session_maker, forecaster=silent_forecaster)
@@ -264,3 +275,213 @@ def test_spike_produces_anomaly_notification(
         assert anom.entity_id == pool.id
         # The spike was big enough to land in warning or critical.
         assert anom.severity in {"warning", "critical"}
+
+
+# --- P6.5.c: sinking-fund forecasts --------------------------------------
+
+
+def _setup_sinking_fund(
+    session_maker: sessionmaker[Session],
+    household: Household,
+    *,
+    name: str = "Roof",
+    target_amount: Decimal = Decimal("5000"),
+    target_date: date = date(2027, 1, 1),
+) -> AllocationPool:
+    """Seed an active sinking fund on ``household``; return its pool row."""
+    pool_id = uuid4()
+    with session_maker() as s:
+        pool = AllocationPool(
+            household_id=household.id,
+            id=pool_id,
+            name=name,
+            pool_type=PoolType.SINKING_FUND,
+            currency="USD",
+            visibility="shared",
+            is_active=True,
+            is_system=False,
+        )
+        s.add(pool)
+        s.flush()
+        s.add(
+            SinkingFund(
+                household_id=household.id,
+                pool_id=pool_id,
+                target_amount=target_amount,
+                target_date=target_date,
+                contribution_strategy=ContributionStrategy.MANUAL,
+                contribution_amount=None,
+            )
+        )
+        s.commit()
+        s.refresh(pool)
+        return pool
+
+
+def _contribute(
+    session_maker: sessionmaker[Session],
+    *,
+    household_id,
+    pool_id,
+    when: date,
+    amount: Decimal,
+) -> None:
+    """Insert one POSTED inflow shadow posting on the sinking fund's pool."""
+    with session_maker() as s:
+        tx_id = uuid4()
+        s.add(
+            ShadowTransaction(
+                household_id=household_id,
+                id=tx_id,
+                date=when,
+                description="contribution",
+                reason=ShadowTxReason.REFILL,
+                status=ShadowTxStatus.PENDING,
+            )
+        )
+        s.flush()
+        s.add_all(
+            [
+                ShadowPosting(
+                    household_id=household_id,
+                    id=uuid4(),
+                    shadow_transaction_id=tx_id,
+                    pool_id=pool_id,
+                    amount=amount,
+                    currency="USD",
+                ),
+                ShadowPosting(
+                    household_id=household_id,
+                    id=uuid4(),
+                    shadow_transaction_id=tx_id,
+                    pool_id=pool_id,
+                    amount=-amount,
+                    currency="USD",
+                ),
+            ]
+        )
+        s.flush()
+        tx = s.get(ShadowTransaction, (household_id, tx_id))
+        assert tx is not None
+        tx.status = ShadowTxStatus.POSTED
+        s.commit()
+
+
+def test_sinking_fund_forecaster_receives_target_context(
+    session_maker: sessionmaker[Session],
+) -> None:
+    """The handler's sinking-fund loop forwards target + balance + series."""
+    household, _envelope = _setup_household(session_maker)
+    sinking_pool = _setup_sinking_fund(
+        session_maker,
+        household,
+        name="Vacation",
+        target_amount=Decimal("3000"),
+        target_date=date(2026, 12, 31),
+    )
+    today = date(2026, 5, 1)
+    for i in range(3):
+        _contribute(
+            session_maker,
+            household_id=household.id,
+            pool_id=sinking_pool.id,
+            when=today - timedelta(days=i * 10),
+            amount=Decimal("200"),
+        )
+
+    requests: list[ForecastRequest] = []
+
+    async def fake_forecaster(request: ForecastRequest) -> str:
+        requests.append(request)
+        if request.pool_kind == "sinking_fund":
+            return f"{request.pool_name} on track for {request.target_date}."
+        return f"{request.pool_name} (envelope) — no issues."
+
+    handler = make_daily_insights_handler(session_maker, forecaster=fake_forecaster)
+    asyncio.run(
+        handler(
+            _make_job(household.id),
+            _fixed_clock(datetime(2026, 5, 1, 12, 0, tzinfo=UTC)),
+        )
+    )
+
+    # Both pool kinds came through.
+    kinds = [r.pool_kind for r in requests]
+    assert kinds.count("envelope") == 1
+    assert kinds.count("sinking_fund") == 1
+
+    sf_request = next(r for r in requests if r.pool_kind == "sinking_fund")
+    assert sf_request.pool_name == "Vacation"
+    assert sf_request.target_amount == Decimal("3000")
+    assert sf_request.target_date == date(2026, 12, 31)
+    assert sf_request.current_balance == Decimal("0")  # net of balanced +/- pairs
+    assert len(sf_request.series) == 60
+
+    with session_maker() as s:
+        from sqlalchemy import select
+
+        rows = (
+            s.execute(
+                select(Notification).where(
+                    Notification.kind == "forecast",
+                    Notification.entity_type == "sinking_fund",
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].entity_id == sinking_pool.id
+        assert "on track for" in rows[0].body
+
+
+def test_sinking_fund_forecaster_returning_none_writes_no_row(
+    session_maker: sessionmaker[Session],
+) -> None:
+    """Forecaster returning None for a sinking fund skips the notification."""
+    household, _envelope = _setup_household(session_maker)
+    _setup_sinking_fund(session_maker, household)
+
+    async def silent_forecaster(_request: ForecastRequest) -> None:
+        return None
+
+    handler = make_daily_insights_handler(session_maker, forecaster=silent_forecaster)
+    asyncio.run(
+        handler(
+            _make_job(household.id),
+            _fixed_clock(datetime(2026, 5, 1, 12, 0, tzinfo=UTC)),
+        )
+    )
+    with session_maker() as s:
+        from sqlalchemy import select
+
+        rows = (
+            s.execute(select(Notification).where(Notification.entity_type == "sinking_fund"))
+            .scalars()
+            .all()
+        )
+        assert rows == []
+
+
+def test_no_forecaster_no_sinking_fund_calls(
+    session_maker: sessionmaker[Session],
+) -> None:
+    """Without a forecaster wired in, sinking funds produce no notifications."""
+    household, _envelope = _setup_household(session_maker)
+    _setup_sinking_fund(session_maker, household)
+    handler = make_daily_insights_handler(session_maker)
+    asyncio.run(
+        handler(
+            _make_job(household.id),
+            _fixed_clock(datetime(2026, 5, 1, 12, 0, tzinfo=UTC)),
+        )
+    )
+    with session_maker() as s:
+        from sqlalchemy import select
+
+        rows = (
+            s.execute(select(Notification).where(Notification.entity_type == "sinking_fund"))
+            .scalars()
+            .all()
+        )
+        assert rows == []

--- a/packages/tulip-storage/tests/test_shadow_transaction_repository_series.py
+++ b/packages/tulip-storage/tests/test_shadow_transaction_repository_series.py
@@ -1,0 +1,178 @@
+"""Tests for the daily series helpers on ShadowTransactionRepository (P6.5.c)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_storage.models import (
+    AllocationPool,
+    Household,
+    PoolType,
+    ShadowPosting,
+    ShadowTransaction,
+    ShadowTxReason,
+    ShadowTxStatus,
+)
+from tulip_storage.repositories import ShadowTransactionRepository
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+@pytest.fixture
+def pool(session: Session, household: Household) -> AllocationPool:
+    p = AllocationPool(
+        household_id=household.id,
+        id=uuid4(),
+        pool_type=PoolType.SINKING_FUND,
+        name="Roof",
+        currency="USD",
+        is_active=True,
+        is_system=False,
+    )
+    session.add(p)
+    session.commit()
+    return p
+
+
+def _post(
+    session: Session,
+    *,
+    household: Household,
+    pool: AllocationPool,
+    when: date,
+    amount: Decimal,
+    status: ShadowTxStatus = ShadowTxStatus.POSTED,
+) -> None:
+    """Insert a balanced shadow transaction with one ``amount``-signed posting on ``pool``."""
+    tx_id = uuid4()
+    session.add(
+        ShadowTransaction(
+            household_id=household.id,
+            id=tx_id,
+            date=when,
+            description="seed",
+            reason=ShadowTxReason.REFILL,
+            status=ShadowTxStatus.PENDING,
+        )
+    )
+    session.flush()
+    session.add_all(
+        [
+            ShadowPosting(
+                household_id=household.id,
+                id=uuid4(),
+                shadow_transaction_id=tx_id,
+                pool_id=pool.id,
+                amount=amount,
+                currency=pool.currency,
+            ),
+            ShadowPosting(
+                household_id=household.id,
+                id=uuid4(),
+                shadow_transaction_id=tx_id,
+                pool_id=pool.id,
+                amount=-amount,
+                currency=pool.currency,
+            ),
+        ]
+    )
+    session.flush()
+    tx = session.get(ShadowTransaction, (household.id, tx_id))
+    assert tx is not None
+    tx.status = status
+    session.commit()
+
+
+class TestDailyContributionSeriesForPool:
+    """``daily_contribution_series_for_pool`` returns daily inflow totals (P6.5.c)."""
+
+    def test_only_positive_postings_count(
+        self, session: Session, household: Household, pool: AllocationPool
+    ) -> None:
+        _post(session, household=household, pool=pool, when=date(2026, 5, 1), amount=Decimal("100"))
+        repo = ShadowTransactionRepository(session, household.id)
+        series = repo.daily_contribution_series_for_pool(
+            pool.id,
+            currency="USD",
+            from_date=date(2026, 5, 1),
+            to_date=date(2026, 5, 1),
+        )
+        # The balanced -amount posting must NOT count toward contributions.
+        assert series == {date(2026, 5, 1): Decimal("100")}
+
+    def test_sparse_return_zero_for_missing_dates(
+        self, session: Session, household: Household, pool: AllocationPool
+    ) -> None:
+        _post(session, household=household, pool=pool, when=date(2026, 5, 3), amount=Decimal("50"))
+        repo = ShadowTransactionRepository(session, household.id)
+        series = repo.daily_contribution_series_for_pool(
+            pool.id,
+            currency="USD",
+            from_date=date(2026, 5, 1),
+            to_date=date(2026, 5, 5),
+        )
+        # Sparse: only the date with a contribution is keyed.
+        assert series == {date(2026, 5, 3): Decimal("50")}
+
+    def test_voided_transactions_excluded(
+        self, session: Session, household: Household, pool: AllocationPool
+    ) -> None:
+        _post(
+            session,
+            household=household,
+            pool=pool,
+            when=date(2026, 5, 2),
+            amount=Decimal("75"),
+            status=ShadowTxStatus.VOIDED,
+        )
+        repo = ShadowTransactionRepository(session, household.id)
+        series = repo.daily_contribution_series_for_pool(
+            pool.id,
+            currency="USD",
+            from_date=date(2026, 5, 1),
+            to_date=date(2026, 5, 5),
+        )
+        assert series == {}
+
+    def test_currency_filter(
+        self, session: Session, household: Household, pool: AllocationPool
+    ) -> None:
+        _post(session, household=household, pool=pool, when=date(2026, 5, 1), amount=Decimal("100"))
+        repo = ShadowTransactionRepository(session, household.id)
+        # Pool is USD; asking for EUR returns empty.
+        series = repo.daily_contribution_series_for_pool(
+            pool.id,
+            currency="EUR",
+            from_date=date(2026, 5, 1),
+            to_date=date(2026, 5, 5),
+        )
+        assert series == {}
+
+    def test_date_range_filter(
+        self, session: Session, household: Household, pool: AllocationPool
+    ) -> None:
+        _post(
+            session, household=household, pool=pool, when=date(2026, 4, 15), amount=Decimal("100")
+        )
+        _post(
+            session, household=household, pool=pool, when=date(2026, 5, 15), amount=Decimal("200")
+        )
+        repo = ShadowTransactionRepository(session, household.id)
+        series = repo.daily_contribution_series_for_pool(
+            pool.id,
+            currency="USD",
+            from_date=date(2026, 5, 1),
+            to_date=date(2026, 5, 31),
+        )
+        assert series == {date(2026, 5, 15): Decimal("200")}


### PR DESCRIPTION
Closes #170. Closes Phase 6.

## Summary

Final Phase 6 slice. The ``daily_insights`` handler now forecasts both
envelopes and sinking funds via a single ``ForecastRequest`` dataclass.
The AI capability's existing ``target_amount`` / ``target_date``
parameters already branched the prompt — only the handler-side
plumbing was missing.

- **Storage**: ``ShadowTransactionRepository.daily_contribution_series_for_pool``
  — mirror of ``daily_spend_series_for_pool`` filtering on ``amount > 0``.
  Voided shadow txs excluded; sparse return.
- **Handler refactor**: ``ForecasterCallback`` is now
  ``Callable[[ForecastRequest], Awaitable[str | None]]``. The
  ``ForecastRequest`` dataclass carries ``pool_kind``, ``series``,
  optional ``target_amount`` / ``target_date`` / ``current_balance``,
  and the existing pool fields. Envelope path unchanged in behaviour.
- **New sinking-fund loop**: joins ``allocation_pools`` to
  ``sinking_funds`` where ``pool_type=sinking_fund``. Builds a 60-day
  contribution series, fetches ``balance_for_pool``, calls the
  forecaster with target context populated. Writes ``kind=forecast`` /
  ``entity_type=sinking_fund`` notifications.
- **``AIForecastCapability`` unchanged** — its prompt already handles
  target context from P6.3.b.
- **+8 tests**: 5 repo unit, 3 handler integration. Existing 4 P6.3 /
  P6.3.b handler tests updated to the new callback signature.

Production wiring of the forecaster into the runner is intentionally
out of scope — the slot is in place; the one-line glue to construct
``AIForecastCapability + LitellmAdapter`` and pass it as
``make_daily_insights_handler(forecaster=...)`` lands at deploy time.

## Test plan
- [x] ``uv run pytest packages/tulip-storage/tests/test_shadow_transaction_repository_series.py -x`` — 5 pass
- [x] ``uv run pytest packages/tulip-storage/tests/test_daily_insights_handler.py -x`` — 7 pass (3 new + 4 existing on new signature)
- [x] ``uv run mypy --strict packages/tulip-storage/src ...`` — clean
- [x] ``just test`` — **1426 passed**, 1 skipped
- [ ] CI green on this PR

### Manual smoke test

The forecaster has no production wiring yet, so end-to-end requires
constructing the capability + handler in a Python REPL. The
acceptance criteria for this slice are the unit + integration tests
above; deploy-time wiring is the separate concern flagged in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)