### PR TITLE
docs: bring docs current with Phase 6 close

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ When the command returns, the API is live on `http://127.0.0.1:8000`. The full w
 
 Honest expectations matter for internal-beta. The following are deliberately deferred:
 
-- **AI features** (auto-categorisation, summarisation). Wired into the architecture but disabled in v1; categorise manually for now.
 - **Web / mobile UI.** Tulip is API-first with a Typer CLI client; the web client lands as a separate phase. The CLI is the supported UI.
 - **Multi-tenant cloud hosting.** Tulip is single-machine, single-tenant SQLite for internal beta. Postgres + KMS + multi-tenant scaling is a future phase.
 - **Reverse-proxy / TLS tutorial.** Run behind Caddy or Tailscale Funnel; we don't ship a TLS setup guide.
-- **Reports beyond CLI tables.** PDF / HTML / journal export lands post-beta.
+- **Reports beyond CLI tables.** PDF / HTML / journal export lands in Phase 7.
+
+**Opt-in AI features** (auto-categorisation, NL queries, forecasts, agentic proposals) are now wired and shipped — disabled by default; bring your own provider key (Anthropic / OpenAI / local Ollama) via `tulip ai set-key` to enable. Per-household policy, per-user rate limits, monthly cost cap, and a `tulip ai status` summary all surface from the CLI. See the AI cookbook in [docs/QUICKSTART.md](docs/QUICKSTART.md) for the enablement walkthrough.
 
 The full deferred-features list and the ordered roadmap is the contributor-side concern; see *For contributors* below if you want it.
 
@@ -56,7 +57,7 @@ The full deferred-features list and the ordered roadmap is the contributor-side 
 
 ## For contributors
 
-> **Status:** Pre-alpha. Phases 0–5 complete (project bootstrap, storage + accounting engine, API surface, scriptable CLI, envelopes + sinking funds + scheduled refills, OFX/QIF/CSV importers + statement-driven reconciliation). Pre-internal-beta hardening track (#121) is in scope before Phase 6 (AI integration). See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
+> **Status:** Internal beta. Phases 0–6 complete (project bootstrap, storage + accounting engine, API surface, scriptable CLI, envelopes + sinking funds + scheduled refills, OFX/QIF/CSV importers + statement-driven reconciliation, opt-in AI integration with BYOK provider keys + cost-cap + rate limit + audited proposals). Next up: Phase 7 (reports + journal export/import). See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
 
 ### Architecture at a glance
 
@@ -89,7 +90,7 @@ git clone https://github.com/rmwarriner/tulip-accounting.git
 cd tulip-accounting
 uv sync --all-packages --dev     # installs all workspace packages + dev deps
 uv run pre-commit install        # enable pre-commit hooks
-just test                        # confirm tests pass (~1230 tests, ~4 min with xdist)
+just test                        # confirm tests pass (~1426 tests, ~4 min with xdist)
 ```
 
 > **Note for committers:** `main` is branch-protected and **requires every commit to be signed**. Configure SSH or GPG commit signing before your first push (`git config --global commit.gpgsign true` plus a signing key); see [CONTRIBUTING.md](CONTRIBUTING.md#branch-protection-on-main) for the diagnostic checklist when a push is rejected as unsigned.
@@ -126,13 +127,15 @@ TULIP_JWT_SECRET="$(uv run python -c 'import secrets; print(secrets.token_urlsaf
   uv run uvicorn tulip_api.main:create_app --factory --host 127.0.0.1 --port 8000
 ```
 
-Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.0.0.1:8000/openapi.json` for the OpenAPI spec. Endpoint surface (Phases 0–5):
+Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.0.0.1:8000/openapi.json` for the OpenAPI spec. Endpoint surface (Phases 0–6):
 
 - **Auth:** `POST /v1/auth/{register,login,login/mfa,login/recover,refresh,logout}`, `POST /v1/auth/mfa/{enroll,verify,recovery-codes/regenerate}`, `GET /v1/auth/mfa/recovery-codes/status`
 - **Accounts + transactions:** `GET/POST/PATCH/DELETE /v1/accounts[/{id}]`, `GET /v1/accounts/{id}/balance`, `GET/POST/PATCH/DELETE /v1/transactions[/{id}]`, `POST /v1/transactions/{id}/void`, `GET /v1/reports/trial-balance`
 - **Periods:** `GET /v1/periods`, `POST /v1/periods/{id}/{close,reopen}`
 - **Envelopes + sinking funds + pools:** `GET/POST/PATCH/DELETE /v1/envelopes[/{id}]`, `GET/POST/PATCH/DELETE /v1/sinking-funds[/{id}]`, `GET /v1/pools/{id}/balance`, `POST /v1/pools/{id}/{refill,transfer,budget-inflow}`, `POST /v1/pools/balances` (batched), `GET/POST/PATCH/DELETE /v1/refill-schedules[/{id}]`
 - **Importers + reconciliation:** `POST /v1/imports[?force=true]`, `GET /v1/imports/{id}`, `POST /v1/imports/{id}/{apply,lines/{line_id}/promote}`, `GET/POST/PATCH/DELETE /v1/imports/profiles[/{id_or_name}]` (CSV column-mapping profiles, YAML round-trip), `GET/POST/DELETE /v1/reconciliations[/{id}][?cascade=true]`, `POST /v1/reconciliations/{id}/{auto-match,complete,matches,carry-forward}`, `POST /v1/reconciliations/{id}/matches/{id}/reject`, `DELETE /v1/reconciliations/{id}/carry-forward/{tx_id}`
+- **AI (Phase 6, BYOK, admin-only configuration):** `POST/DELETE /v1/ai/keys/{provider}`, `GET /v1/ai/keys`, `GET/PUT /v1/ai/config`, `PUT /v1/ai/config/capabilities/{capability}`, `GET /v1/ai/status`, `POST /v1/ai/preview`, `POST /v1/ai/ask` (two-turn NL query), `GET/POST /v1/ai/proposals[?status=...]`, `GET /v1/ai/proposals/kinds`, `POST /v1/ai/proposals/{id}/{approve,reject}`, `POST /v1/ai/proposals/suggest/budget`
+- **Notifications:** `GET /v1/notifications[?status=...]`, `POST /v1/notifications/{id}/dismiss`
 - **Ops:** `GET /health`, `GET /v1/system/diagnostics` (consumed by `tulip doctor`)
 
 Every non-2xx response is `application/problem+json` per RFC 9457. In production, supply `TULIP_JWT_SECRET` and the master key from a secret store rather than generating fresh on every start (existing tokens and field-encrypted columns won't validate after a restart with new secrets). The master key can come from one of two sources, in this order of precedence:
@@ -173,7 +176,7 @@ uv run tulip reconcile complete "$RECON_ID"       # strict balance check, denorm
 
 `tulip add --edit` opens `$EDITOR` with a hledger-style template instead of taking flags. `tulip accounts list` renders a Rich tree when nesting exists, a flat table otherwise (`--flat` to force the table for scripting). Tokens persist in the OS keyring; the CLI exit-code map and full RFC 9457 error rendering are documented in [docs/ARCHITECTURE.md §7.8.5](docs/ARCHITECTURE.md).
 
-Other top-level commands: `tulip envelopes`, `tulip sinking-funds`, `tulip refills`, `tulip periods`, `tulip transfer`, `tulip refill`, `tulip budget-inflow`, `tulip transactions {show,edit,void,delete}`, `tulip imports {profiles,apply}`, `tulip backup`, `tulip restore`, `tulip doctor`. Each takes `--help`; the surface mirrors the API endpoints listed above.
+Other top-level commands: `tulip envelopes`, `tulip sinking-funds`, `tulip refills`, `tulip periods`, `tulip transfer`, `tulip refill`, `tulip budget-inflow`, `tulip transactions {show,edit,void,delete}`, `tulip imports {profiles,apply}`, `tulip notifications {list,dismiss}`, `tulip backup`, `tulip restore`, `tulip doctor`. The `tulip ai` group (Phase 6) covers BYOK + policy editing + the four capabilities: `tulip ai {set-key, forget-key, list-keys, status, preview, config {show,set,clear,set-capability,log-prompts}, ask, propose, proposals, approve, reject, suggest-budget}`. Each takes `--help`; the surface mirrors the API endpoints listed above.
 
 ### Development discipline
 
@@ -191,7 +194,7 @@ This project follows test-driven development. Every feature ships with tests wri
 - [Architecture](docs/ARCHITECTURE.md) — full system design, data model, phase roadmap, error-handling standard (§7.8)
 - [Phase Status](docs/PHASE_STATUS.md) — what's shipped, what's queued
 - [Threat Model](docs/THREAT_MODEL.md) — lightweight security checkpoint (deep audit deferred to Phase 8)
-- [ADRs](docs/adrs/) — architectural decision records (envelope shadow ledger, scheduler primitive, mutation testing, reconciliation)
+- [ADRs](docs/adrs/) — architectural decision records (envelope shadow ledger, scheduler primitive, mutation testing, reconciliation, AI integration / privacy contract)
 - [CONTRIBUTING.md](CONTRIBUTING.md) — TDD discipline, coverage gates, signed commits, manual smoke test format
 - [CLAUDE.md](CLAUDE.md) — operational notes for AI-assisted development on this repo
 - The OpenAPI spec at `/openapi.json` is the live contract for `tulip-api` until `docs/API.md` exists.
@@ -201,7 +204,7 @@ This project follows test-driven development. Every feature ships with tests wri
 - **Defense-in-depth encryption at rest:** SQLCipher for the whole DB (Phase 8), AES-256-GCM field-level for the most sensitive columns (TOTP secrets, attachments) today. No single key compromise leaks everything.
 - **Master key** is sourced from `TULIP_MASTER_KEY` (env var) or `TULIP_KEY_FILE` (0600 file); never written to disk by Tulip itself.
 - **MFA (TOTP)** required for admin users by default; optional for household members.
-- **AI privacy posture** is per-tenant + per-user policy, with audit logging of every model invocation. Defaults to permissive in v1; users can dial up restrictions or switch to local-only models (Ollama). AI is wired but disabled in v1.
+- **AI privacy posture** is per-tenant + per-user policy, with audit logging of every model invocation, a server-enforced monthly cost cap, and a per-user sliding-window rate limit. Defaults to permissive but a fresh household has no provider key — no provider is contacted until an admin opts in via `tulip ai set-key`. Users can dial up restrictions (per-capability `disabled` / `requires_approval`, `strict` / `local_only` redaction profiles) or switch to local-only models (Ollama). Prompt bodies are never stored by default; only metadata (model, latency, cost, success/fail) lands in `ai_invocations`. Full forensic prompt logging is opt-in via `tulip ai config log-prompts on`.
 
 The lightweight threat model is in [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md); a formal external audit is scheduled before external beta.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Tulip Accounting — Architectural Specification (v1)
 
-**Status:** Ready for handoff to Claude Code (Phases 0–5 complete; Phase 6 ADR pending)
+**Status:** Phases 0–6 complete (ADR-0005 AI integration shipped end-to-end). Internal-beta ready. Phase 7 (reports + journal export/import) is the next slice.
 **Document version:** 1.1
 **Date:** 2026-04-29 (original) · 2026-05-07 (Phase 5 close + roadmap refresh)
 
@@ -487,10 +487,10 @@ API keys are stored encrypted (field-level) per household. Per-user keys are als
 
 ### 6.2 Capabilities (all four, first-class)
 
-1. **Auto-categorization.** Classifier sees payee + amount + date + (optional) memo. Returns suggested account code and (optional) envelope. User reviews on import. Fallback: rule-based regex matcher tracked per household (also useful for offline/local-only mode).
-2. **Natural-language query.** User asks a question; system constructs a SQL query against a read-only view of their data; AI summarizes results. Query is logged; raw rows are returned to the user alongside the summary so they can verify.
-3. **Forecasting & anomaly detection.** Periodic job (daily) scans for anomalies (spending >2σ above rolling mean per envelope) and generates forecasts (envelope-runout dates, sinking-fund-on-track flags). Results are stored as `notifications`, not auto-acted-upon.
-4. **Agentic workflows.** AI may *propose* journal entries, restated budgets, or sinking-fund plans. Proposals are stored as `pending_proposals` and require explicit user approval. Once approved, they execute through the same accounting engine path as user-initiated actions, with the audit log noting `actor_kind=ai_agent` and the originating proposal id.
+1. **`categorize`.** `AICategorizer` plugs into the `Categorizer` Protocol DI seam from P5.3. Classifier sees payee + amount + date + currency + chart of accounts. Returns suggested account code and a confidence score. User reviews on import. Failures fall back silently to `Imbalance:Unknown` so importer flow never blocks on a flaky provider.
+2. **`nl_query`.** Two-turn flow per ADR-0005 §Q3: turn 1 emits SQL against a read-only AI view, `tulip_ai.sql_safety.validate_and_rewrite` (built on sqlglot) enforces SELECT-only + tenant-scope + a row cap; turn 2 summarises the results. Raw rows are returned to the user alongside the summary so they can verify.
+3. **`forecast` + anomaly detection.** Periodic `daily_insights` job (via the ADR-0002 runner) scans for anomalies (spending >2σ above rolling mean per envelope) and generates forecasts (envelope-runout dates, sinking-fund-on-track via `AIForecastCapability`). Results land in `notifications`; nothing auto-acts. Sinking-fund + envelope variants share a single `ForecastRequest` dataclass.
+4. **`agentic` workflows.** AI proposes journal entries, restated budgets, or sinking-fund plans via `AIProposalCapability`. Proposals are stored as `pending_proposals` and require explicit user approval. Once approved, they execute through the same accounting engine path as user-initiated actions, with the audit log noting `actor_kind=ai_agent`, `metadata.proposal_id`, and `ai_invocation_id` linking back to the originating AI call. v1 ships one executor (`envelope_budget_update`); new kinds register one function in `tulip_api.services.proposal_executor._EXECUTORS`.
 
 ### 6.3 Privacy Posture
 
@@ -505,9 +505,12 @@ Users can ratchet their own restriction *up* (more cautious than tenant policy) 
 
 ### 6.4 Audit & Cost Controls
 
-- Every AI invocation produces an `ai_invocations` row with provider, model, token counts, cost estimate, and outcome.
-- Per-household monthly cost cap (default $10/mo, configurable). Cap reached → capability degrades to local-only or disabled until reset.
-- Per-user rate limit (default 60 invocations/hour) to limit blast radius of a runaway loop or compromised credential.
+- Every AI invocation produces an `ai_invocations` row with provider, model, token counts, cost estimate, latency, outcome, and a SHA-256 hash of the redacted prompt (`prompt_hash`). Prompt bodies are NOT persisted by default; opt in via `households.ai_policy.log_prompts=true`.
+- Per-household monthly cost cap (default: unconfigured / unlimited; admin opts in via `tulip ai config set monthly_cost_cap_usd ...`). Cap reached → behaviour governed by `cost_cap_behaviour`:
+  - `degrade` (default when set): swap to `fallback_provider` (typically Ollama). Audit row records `provider=ollama` explicitly — per ADR-0005 §Q7 this is the only place a provider swap is permitted, and it's logged as a budget signal not a silent failover.
+  - `hard_fail`: raise `AICostCapped`; no swap.
+- Per-user rate limit (default 60 invocations/hour, sliding window) to bound the blast radius of a runaway loop or compromised credential. Configurable via `households.ai_policy.rate_limit_per_hour`.
+- Both gates run **pre-call** via `tulip_ai.cost.enforce_pre_call`. Blocked calls still write an `ai_invocations` row with `outcome=rate_limited` / `outcome=cost_capped` so capped capacity is observable.
 
 ### 6.5 Tenant AI Policy (`households.ai_policy` JSON shape)
 
@@ -515,19 +518,23 @@ Users can ratchet their own restriction *up* (more cautious than tenant policy) 
 {
   "default_provider": "anthropic",
   "default_model": "claude-opus-4-7",
-  "fallback_provider": "ollama",
-  "fallback_model": "llama3.1:70b",
+  "profile": "default",
   "monthly_cost_cap_usd": "10.00",
+  "cost_cap_behaviour": "degrade",
+  "rate_limit_per_hour": 60,
+  "fallback_provider": "ollama",
+  "fallback_model": "llama3:70b",
+  "log_prompts": false,
   "capabilities": {
-    "categorization":   { "policy": "permissive",        "provider": null, "model": null },
-    "nl_query":         { "policy": "permissive",        "provider": null, "model": null },
-    "forecasting":      { "policy": "permissive",        "provider": null, "model": null },
-    "agentic":          { "policy": "requires_approval", "provider": null, "model": null }
+    "categorize": { "policy": "permissive",        "provider": null, "model": null, "profile": null },
+    "nl_query":   { "policy": "permissive",        "provider": null, "model": null, "profile": null },
+    "forecast":   { "policy": "permissive",        "provider": null, "model": null, "profile": null },
+    "agentic":    { "policy": "requires_approval", "provider": null, "model": null, "profile": null }
   }
 }
 ```
 
-`provider`/`model` null means "use household default." Per-capability override allows e.g. agentic to always use a local model.
+Capability-level `null` inherits the household default. `profile` selects a redaction profile (`default` / `strict` / `local_only`); `local_only` pins the resolved provider to `fallback_provider` regardless of other config. Edit via `tulip ai config show / set / clear / set-capability / log-prompts`; the API surface is admin-only `GET/PUT /v1/ai/config` + `PUT /v1/ai/config/capabilities/{capability}`.
 
 ---
 
@@ -959,13 +966,17 @@ Per [ADR-0004](adrs/0004-reconciliation.md). Closed 2026-05-07 across nine sub-s
 - ✅ **P5.4.d** — `tulip reconcile` CLI (10 subcommands wrapping the endpoints) + new `GET /v1/reconciliations` list endpoint.
 - ✅ **Cleanup**: PR #129 (#127 — inbox surfacing prior-completed-recon lines), PR #130 (#114 — relax `import_batch` idempotency index, wire `?force=true`); #118 closed wontfix.
 
-### Phase 6 — AI integration
-- ✅ **P6.0** — Privacy audit / data-flow contract: [ADR-0005](adrs/0005-ai-integration.md). Closes #102. Resolves nine open questions (module structure, BYOK surface, per-capability prompt contracts, redaction profiles, policy resolution, audit-log shape, cost-cap enforcement, failure modes, slice ordering). No code; design only.
-- **P6.1** — `tulip-ai` package skeleton: `LitellmAdapter`, `PromptRedactor`, `AIInvocationWriter`, `AICategorizer` plugging into the existing `Categorizer` DI seam (P5.3). Migration for `ai_invocations`, `households.{ai_policy, ai_keys_encrypted}`, `users.ai_keys_encrypted`. CLI: `tulip ai {set-key, forget-key, list-keys, config, status, preview}`. API: `POST /v1/ai/preview`. End-to-end: register → set key → import OFX → categorize via AI → accept.
-- **P6.2** — NL query: read-only AI view + two-turn (SQL emission, summarisation) flow. `tulip ai ask`, `POST /v1/ai/ask`.
-- **P6.3** — Forecasting + anomaly detection via the runner (ADR-0002). New `notifications` table.
-- **P6.4** — Agentic proposals. `pending_proposals` table, `actor_kind=ai_agent` audit rows on approve.
-- **P6.5** — Polish + cost-cap behaviours UI + opt-in `log_prompts` toggle. Closes Phase 6.
+### Phase 6 — AI integration ✅ complete
+- ✅ **P6.0** — Privacy audit / data-flow contract: [ADR-0005](adrs/0005-ai-integration.md). Closes #102.
+- ✅ **P6.1** — `tulip-ai` package skeleton: `LitellmAdapter`, `PromptRedactor`, `AIInvocationWriter`, `AICategorizer` plugging into the `Categorizer` DI seam (P5.3). Migration for `ai_invocations`, `households.{ai_policy, ai_keys_encrypted}`, `users.ai_keys_encrypted`. CLI: `tulip ai {set-key, forget-key, list-keys, status, preview}`. API: `POST /v1/ai/preview`.
+- ✅ **P6.2** — NL query: read-only AI view + two-turn (SQL emission → summarisation) flow with `sqlglot`-validated SQL. `tulip ai ask`, `POST /v1/ai/ask`.
+- ✅ **P6.3** — Daily-insights scheduler + anomaly detector + `notifications` inbox (PR #156). `tulip notifications list/dismiss`.
+- ✅ **P6.3.b** — `AIForecastCapability` + forecaster wiring slot on the daily-insights handler (PR #157).
+- ✅ **P6.4** — Agentic proposals: `pending_proposals` table, `tulip ai propose/approve/reject`, `actor_kind=ai_agent` audit rows on approve (PR #158).
+- ✅ **P6.4.b** — AI-driven proposal generation: `AIProposalCapability` + `tulip ai suggest-budget` (PR #159).
+- ✅ **P6.5.a** — Pre-call cost-cap + per-user rate-limit chokepoint + `degrade`/`hard_fail` cost_cap_behaviour with explicit-audited fallback swap (PR #161).
+- ✅ **P6.5.b** — `tulip ai config` editor + `log_prompts` toggle + `tulip ai status` fallback-semantics callout. `GET/PUT /v1/ai/config` + `PUT /v1/ai/config/capabilities/{capability}` admin surface (PR #163).
+- ✅ **P6.5.c** — Sinking-fund forecast extension to the daily-insights handler via a single `ForecastRequest` dataclass (PR #171). Phase 6 closes.
 
 ### Phase 7 — Reports + journal export/import
 - All v1 reports rendered as HTML and PDF (weasyprint)

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-07 · `main` @ **Phase 5 complete + cleanup PRs landed** (#127, #114, #118 closed)
+**Last updated:** 2026-05-11 · `main` @ **Phase 6 complete** (P6.0–P6.5.c shipped)
 
 ---
 
@@ -24,7 +24,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **Phase 6 (AI integration):** ✅ shipped — P6.0–P6.5.c complete (ADR + categorize + NL query + daily-insights/anomaly + envelope AI forecast + sinking-fund AI forecast + agentic proposals + AI-driven suggestions + cost-cap/rate-limit chokepoint + `tulip ai config` editor + `log_prompts` toggle + status polish). Capability inventory: `AICategorizer`, `AINLQueryCapability`, `AIForecastCapability` (envelopes + sinking funds), `AIProposalCapability`, the proposal executor registry, the shared `enforce_pre_call` gate, and the `GET|PUT /v1/ai/config` admin surface. The daily-insights handler now forecasts both envelopes and sinking funds via a single `ForecastRequest` dataclass; production wiring of the forecaster into the runner is the only remaining no-op slot, intentionally deferred to a deploy-time toggle. Phase 6 closes.
 
-**Tests:** 1362 passing · **CI:** green on `main`
+**Tests:** 1426 passing · **CI:** green on `main`
+
+**Next:** Phase 7 — reports + journal export/import (per [ARCHITECTURE.md §10](ARCHITECTURE.md)). All v1 reports rendered as HTML + PDF, hledger-compatible journal export, basic journal import. Phase 7 entry is unblocked; no pre-phase gate.
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -327,6 +327,103 @@ Doctor should report `master key loaded from file`.
 
 ---
 
+## 10. Cookbook: enabling AI (optional)
+
+Phase 6 added four AI capabilities: transaction categorisation during
+imports, natural-language queries over your ledger, nightly forecast +
+anomaly notifications, and AI-suggested budget proposals you approve
+manually. Every capability is opt-in: a fresh household has no provider
+key, so no provider is contacted until you set one. All four capabilities
+respect a server-enforced monthly cost cap and a per-user sliding-window
+rate limit (per [ADR-0005](adrs/0005-ai-integration.md)).
+
+**Step 1.** Add a provider key. Tulip uses [litellm](https://docs.litellm.ai)
+under the hood, so any litellm-supported provider works. Anthropic,
+OpenAI, and local Ollama are the common targets. Keys are
+field-encrypted at rest with the master key:
+
+```bash
+uv run tulip ai set-key --provider anthropic --key-stdin <<< 'sk-ant-...'
+```
+
+(or `--provider ollama` with an empty value if running local-only against
+`http://localhost:11434`).
+
+**Step 2.** Configure household defaults. The defaults are conservative
+(no cost cap, default redaction profile, all capabilities permissive).
+Tighten them:
+
+```bash
+uv run tulip ai config set default_provider anthropic
+uv run tulip ai config set default_model claude-opus-4-7
+uv run tulip ai config set monthly_cost_cap_usd 10.00
+uv run tulip ai config set cost_cap_behaviour degrade   # or hard_fail
+uv run tulip ai config set rate_limit_per_hour 60       # per user
+uv run tulip ai config set fallback_provider ollama     # used on cost-cap degrade
+```
+
+The `degrade` behaviour swaps to the fallback provider (typically Ollama)
+when the monthly cap is exceeded — the audit row records `provider=ollama`
+explicitly per the [ADR-0005 §Q7 "no silent fallback" rule](adrs/0005-ai-integration.md).
+`hard_fail` instead raises a structured error and stops the call.
+
+Disable individual capabilities if a household member is uncomfortable
+with them:
+
+```bash
+uv run tulip ai config set-capability nl_query policy disabled
+uv run tulip ai config set-capability agentic profile strict
+```
+
+**Step 3.** Verify. `tulip ai status` renders the full resolved policy
+with month-to-date spend, fallback semantics, and rate-limit budget:
+
+```bash
+uv run tulip ai status
+```
+
+The output flags the cost-cap-only fallback semantics inline and warns
+if you've turned on `log_prompts` (which stores full prompts +
+responses in `ai_invocations` for forensics — privacy cost is real,
+hence the warning).
+
+**Step 4.** Try the capabilities. With a key + a non-disabled policy
+in place:
+
+- **Auto-categorise on import.** Re-run `tulip imports apply $BATCH_ID`
+  on a new batch; lines now arrive with AI-proposed account codes (still
+  PENDING — you review before they move to POSTED).
+- **Natural-language query.**
+  ```bash
+  uv run tulip ai ask "how much did I spend on groceries last month?"
+  ```
+  The CLI prints the model's textual answer + the underlying SQL (which
+  ran against a read-only view, never the writable ledger).
+- **Suggest an envelope budget.**
+  ```bash
+  ENV_ID=$(uv run tulip --json envelopes list | jq -r '.[0].id')
+  uv run tulip ai suggest-budget --envelope "$ENV_ID"
+  ```
+  Creates a `pending_proposal` row with `created_by_kind=ai_agent`.
+  Review with `tulip ai proposals`, approve with
+  `tulip ai approve <UUID>` (writes the change with
+  `actor_kind=ai_agent` on the audit row), or reject with
+  `tulip ai reject <UUID>`.
+- **Forecast + anomaly notifications.** These fire from the nightly
+  `daily_insights` scheduler job. Read your inbox via
+  `tulip notifications list`; dismiss noisy ones with
+  `tulip notifications dismiss <UUID>`. (The runner-side wiring of
+  the AI forecaster is a deploy-time toggle; see PHASE_STATUS P6.5.c
+  for the slot.)
+
+**Turning AI off** is symmetric. `tulip ai forget-key --provider X`
+removes the encrypted key blob; without a key, every capability writes
+a `provider_error` / `no api key configured` audit row and silently
+falls back to "AI unconfigured" behaviour. No data destruction; safe to
+toggle on and off as you experiment.
+
+---
+
 ## What's next
 
 - Run `tulip --help` to discover commands not covered here: `envelopes`,

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,8 +1,8 @@
 # Tulip Accounting — Threat Model Checkpoint
 
-**Status:** lightweight checkpoint, not a deep audit. **Deep audits** are scheduled per the [§10 audit cadence in ARCHITECTURE.md](ARCHITECTURE.md): privacy audit before Phase 6 (AI), deep security audit at Phase 8 (operations + hardening), pre-cloud re-audit at Phase 9.
+**Status:** lightweight checkpoint, not a deep audit. **Deep audits** are scheduled per the [§10 audit cadence in ARCHITECTURE.md](ARCHITECTURE.md): privacy audit before Phase 6 (AI) ✅ shipped as [ADR-0005](adrs/0005-ai-integration.md); deep security audit at Phase 8 (operations + hardening); pre-cloud re-audit at Phase 9.
 
-**Last updated:** 2026-05-07 · `main` @ Phase 5 complete
+**Last updated:** 2026-05-11 · `main` @ Phase 6 complete (AI integration shipped)
 
 This document captures what the system protects, what it doesn't, and the constraints Phase 4–6 work must not violate. It exists because the cheap moment to lock in trust boundaries is *before* envelopes / importers / AI add surface area, not after. Tracked as #56.
 
@@ -36,7 +36,7 @@ Five tiers, highest to lowest confidentiality:
 | **High** | Account balances, transaction descriptions, transaction references, account codes/names, audit log entries | unencrypted SQLite columns | This is "the ledger" — the actual financial data. Nothing about it is encrypted at rest today (Layer 1 SQLCipher deferred). Whoever can read the DB file reads the ledger. |
 | **High (integrity)** | `audit_log` rows | unencrypted SQLite | Append-only via `AuditLogWriter` (single chokepoint). Confidentiality is medium; integrity is high — a tampered audit log invalidates forensics. No DB-level immutability yet (deferred to the Postgres phase per ARCHITECTURE.md §1.1). |
 | **Medium** | Email addresses, household / display names, periods, account hierarchy structure | unencrypted SQLite | PII-ish but largely user-chosen labels. Logging redaction list (`logging_config.py`) keeps emails out of logs by default. |
-| **Highest (Phase 6)** | AI prompt bodies (proposed transactions, NL queries, household financial context fed to LLMs) | not yet — `tulip-ai` doesn't exist | This is why the privacy audit is pinned to **before Phase 6** rather than Phase 8 — Phase 6 is where data starts leaving the local boundary. |
+| **Highest (Phase 6)** | AI prompt bodies (proposed transactions, NL queries, household financial context fed to LLMs) | `ai_invocations.prompt_json` (NULL by default) + `prompt_hash` always populated | Phase 6 shipped 2026-05-11. Prompts never persisted by default; metadata + SHA-256 hash give forensics-light. Full prompt logging is opt-in via `tulip ai config log-prompts on` (warns the operator) — see §5.3. |
 
 Classification informs constraints in [§5](#5-constraints-for-phase-46-work).
 
@@ -55,7 +55,7 @@ Single-tenant local deployment scopes the actor list down hard:
 
 - **Network attacker** — single-tenant local. **Phase 9.**
 - **Cross-household attacker** — single-tenant local. **Phase 9** (cloud), but the design already has composite FKs to make this safe-by-construction.
-- **Compromised AI provider / prompt injection / model exfiltration** — no AI in flight. **Phase 6.**
+- **Compromised AI provider / prompt injection / model exfiltration** — Phase 6 shipped 2026-05-11. Now **in scope**: see §5.3 for the realised constraints (no-logging default, server-side redaction, no-silent-fallback, `actor_kind=ai_agent` audit chain, pre-call cost + rate gates).
 - **Compromised import source** — Phase 5 shipped 2026-05-07. Now **in scope**: see [§5.2](#52--phase-5-importers--reconciliation) for the constraints that landed (size cap, parser hardening, encrypted attachment storage).
 - **Stolen attachment / external-document exposure** — Phase 5 wired the encrypted attachment store. Now **in scope**; field-level AES-256-GCM via the master key per ARCHITECTURE.md §7.4 Layer 3.
 
@@ -117,15 +117,18 @@ What is **out of scope** of the Phase 5 threat model and explicitly deferred:
 - **Multi-currency reconciliation** — every Phase 5 endpoint asserts `account.currency == reconciliation.currency`; multi-currency is silently out of scope. Lifting this requires FX rate engine work first (per ARCHITECTURE.md §1.3 deferred items).
 - **Partial-of-one matches** (a $100 statement line matching $60 of a $100 ledger tx with $40 residual) — explicitly rejected for v1 per ADR-0004 §Q3. Manual match enforces `match_amount == line.amount`.
 
-### 5.3 — Phase 6 (AI integration)
+### 5.3 — Phase 6 (AI integration) — ✅ shipped
 
-This is the privacy inflection point and gets its own audit slot **before implementation begins**. The five constraints listed below are the entry criteria for Phase 6 work; the *authoritative* implementation contract is **[ADR-0005](adrs/0005-ai-integration.md)**, which closes [#102](https://github.com/rmwarriner/tulip-accounting/issues/102) and resolves these constraints into concrete designs.
+The privacy inflection point. All five entry constraints landed in
+Phase 6 implementation (P6.1–P6.5.c). The *authoritative* contract is
+**[ADR-0005](adrs/0005-ai-integration.md)**, which closes
+[#102](https://github.com/rmwarriner/tulip-accounting/issues/102).
 
-- **Prompt bodies are not logged by default.** Only metadata (model, latency, cost, tenant, user, success/fail). Tenant-level opt-in via `households.ai_policy` (see ARCHITECTURE.md §6.5). [ADR-0005 §Q6](adrs/0005-ai-integration.md) commits this to the `ai_invocations.prompt_json NULL` default + a `prompt_hash` column for "was the same prompt sent twice" without storing prompts.
-- **Redaction runs before the litellm call**, not after. PII-redaction policy is auditable as a separate function. [ADR-0005 §Q3, §Q4](adrs/0005-ai-integration.md) make the per-capability data-flow tables the authoritative contract, with a byte-faithful preview test that catches drift between the contract and the code.
-- **No silent provider fallback.** If the configured provider fails, the AI call fails — no implicit failover to another provider that might have a different data policy. [ADR-0005 §Q8](adrs/0005-ai-integration.md). The one explicit exception is the cost-cap `degrade` path, which is audited as `provider=ollama` and triggered only by a budget signal the household admin set.
-- **`actor_kind=ai_agent` audit rows** for every state-changing AI proposal that's approved, with a link to the originating proposal. ARCHITECTURE.md §6.4 specifies this; this constraint is the reminder. [ADR-0005 §Q6](adrs/0005-ai-integration.md) defines the `proposal_id` FK from `ai_invocations` to `pending_proposals` (P6.4).
-- **Cost / rate caps are enforced server-side**, not in the prompt or in the model. Phase 6 doesn't trust the model to self-limit. [ADR-0005 §Q7](adrs/0005-ai-integration.md): cost cap is a *pre-call* reservation; rate limit is per-user sliding window.
+- ✅ **Prompt bodies are not logged by default.** `ai_invocations.prompt_json` defaults to NULL; only metadata (model, latency, cost, tenant, user, success/fail) lands by default. Tenant-level opt-in via `households.ai_policy.log_prompts=true` (CLI: `tulip ai config log-prompts on`, which emits the privacy-cost warning to stderr). `prompt_hash` (SHA-256 over the redacted prompt) is always populated so "was the same prompt sent twice" is answerable without storing prompts. *Implemented:* P6.1 (PR #154) + P6.5.b (PR #163).
+- ✅ **Redaction runs before the litellm call**, not after. `PromptRedactor` runs server-side per capability; `POST /v1/ai/preview` is byte-faithful so operators can see exactly what would be sent before any provider call fires. *Implemented:* P6.1 (PR #154).
+- ✅ **No silent provider fallback.** Provider 5xx errors raise `AIProviderError` and stamp `outcome=provider_error` — no implicit failover. The one explicit exception is cost-cap `degrade` mode, which swaps to `fallback_provider` (typically Ollama) and **audits `provider=ollama` explicitly**. `tulip ai status` prints the locked callout: "applies on cost-cap degrade ONLY. Provider 5xx errors do NOT silently fall back." *Implemented:* P6.5.a (PR #161) + P6.5.b (PR #163).
+- ✅ **`actor_kind=ai_agent` audit rows** for every state-changing AI proposal that's approved, with `metadata.proposal_id` linking back to the originating `pending_proposal` and through to `ai_invocations.id` via `ai_invocation_id`. The architecture-test enforces the single chokepoint (`AuditLogWriter`); the executor stamps the correct `actor_kind` based on `pending_proposal.created_by_kind`. *Implemented:* P6.4 (PR #158) + P6.4.b (PR #159).
+- ✅ **Cost / rate caps are enforced server-side**, not in the prompt or in the model. `tulip_ai.cost.enforce_pre_call` runs *before* the adapter call: per-user sliding-window rate limit (default 60/hour) gates first, then the household-wide monthly cost cap. Both write `outcome=rate_limited` / `outcome=cost_capped` audit rows on the block path so capped capacity is observable in `ai_invocations`. *Implemented:* P6.5.a (PR #161).
 
 ## 6. Out of scope (explicitly)
 
@@ -134,7 +137,7 @@ These are real concerns, but not for this checkpoint:
 - **Penetration testing** — Phase 8.
 - **Cryptographic review** of `encrypt_field` (key derivation, nonce reuse risk, AEAD usage details) — Phase 8.
 - **Multi-tenant cloud threat model** — Phase 9.
-- **Privacy audit of AI flows** — before Phase 6 (separate slice, not yet scheduled because Phase 6 isn't imminent).
+- **Privacy audit of AI flows** — ✅ shipped as [ADR-0005](adrs/0005-ai-integration.md) (P6.0, 2026-05-11), implemented through P6.1–P6.5.c. See §5.3 above for the realised constraints.
 - **Backup/restore threat model** — backup pipeline doesn't exist yet (Phase 8).
 - **Supply chain / SBOM** — Phase 8 audit covers this.
 - **Side-channel / timing attacks** — out of v1 scope; relevant only to multi-tenant cloud (Phase 9).


### PR DESCRIPTION
## Summary

Phase 6 (AI integration) shipped end-to-end across P6.0–P6.5.c; the
project-level docs still described it as in-flight or pending. This
PR aligns the user-facing and contributor-facing docs with what
actually ships today.

- **README.md** — status line, deferred-features bullet, endpoint
  surface, CLI command list, AI privacy posture paragraph, test count.
- **docs/QUICKSTART.md** — new §10 cookbook entry "Enabling AI
  (optional)" with the full BYOK + config + capability walkthrough.
- **docs/PHASE_STATUS.md** — header timestamp + Phase 6 status; test
  count; explicit "Next: Phase 7" pointer.
- **docs/ARCHITECTURE.md** — §6.2 / §6.4 / §6.5 brought to ground
  truth (capability names, cost-cap behaviour, JSON shape, edit
  pointer); §10 Phase 6 slice list marked ✅ with PR refs per slice
  (P6.3.b, P6.4.b, P6.5.a/b/c added).
- **docs/THREAT_MODEL.md** — §2 data-classification entry for AI
  prompts; §3 in-scope move; §5.3 constraints reframed from "entry
  criteria" to "✅ shipped" with implementing PR refs; §6 out-of-scope
  privacy-audit item closed.

No code touched. Suite was 1426 passing at Phase 6 close (PR #171).

## Test plan
- [x] `just lint` — clean
- [x] Visual diff of each file
- [ ] CI green on this PR (docs-only changes; lint + paths checks only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)