### PR TITLE
docs(ADR-0006): record option 2 outcome (reverted)

### DIFF
--- a/docs/adrs/0006-ci-test-runtime.md
+++ b/docs/adrs/0006-ci-test-runtime.md
@@ -76,32 +76,68 @@ bottlenecks. Don't optimise based on sequential profiles.
 
 ## Options considered (with revised priority)
 
-### Option 2 — Session-scoped uvicorn + UUID-based test isolation *(highest measured leverage)*
+### Option 2 — Session-scoped uvicorn + UUID-based test isolation *(implemented and reverted)*
 
 Hoist the ``live_api`` fixture from ``scope=function`` to
 ``scope="session"``. One uvicorn per xdist worker × 4 workers = 4
 boots total instead of ~150 (one per CLI test that uses the fixture).
-Per-worker savings ≈ ~70 tests × 800ms boot avg = ~55s; wall-clock
-delta with 4 workers ≈ **same ~55s** since each worker independently
-amortises.
+Per-worker savings ≈ ~70 tests × 800ms boot avg = ~55s.
 
-What it requires:
+**Status: tried 2026-05-11, reverted.** Measured wall-clock dropped
+~50% (sequential 7m37s → 3m40s; CI extrapolation 14 min → ~7 min),
+but the implementation introduces a **persistent ~25-50% flake rate**
+that smaller mitigations did not eliminate. Documented here so a
+future attempt has the full forensics.
 
-- Every CLI test that registers a household must use a **unique email +
-  household name** per test (e.g. ``f"user-{uuid4().hex[:8]}@example.com"``).
-  Today tests assume a fresh DB and reuse ``me@example.com`` /
-  ``admin@example.com``. Refactor: ~30–50 tests, mechanical.
-- The ``live_api`` fixture's underlying DB still needs to start fresh
-  per worker (so worker A doesn't see worker B's data). That's
-  naturally session-scoped already if we session-scope the fixture.
-- Tests that depend on a *specific* DB state (e.g. "an empty
-  household") need an explicit per-test reset. Most CLI tests are
-  insert-only and don't care.
+What was implemented:
 
-Cost: medium (refactor the ~30–50 tests that hard-code emails / names).
-Risk: medium (test isolation failure shows up as flaky tests; needs
-careful audit). Reward: ~55s wall-clock, gets the test job under
-~9 minutes.
+- ``live_api`` fixture changed to ``scope="session"`` per xdist worker.
+- New shared fixtures in ``conftest.py``: ``unique_id`` (per-test 8-hex
+  string) and ``registered_user`` (UUID-derived email + household +
+  per-test token store).
+- Every CLI test file's local ``authed_session`` / ``access_token``
+  fixtures refactored to derive their email + household name from
+  ``unique_id`` so concurrent tests don't collide.
+- ``test_auth_login.py``'s helper-based pattern got a bespoke
+  refactor (each test gets an ``email = f"alice-{unique_id}..."``
+  local variable threaded through).
+- CLI subprocess timeouts bumped from 10s/15s/20s → 30s across all
+  ~99 ``subprocess.run`` call sites.
+- ``TulipClient`` default HTTP timeout bumped 10s → 30s.
+
+What broke:
+
+- Login operations occasionally exceed even 30s under load.
+- The root cause is **CPU contention from argon2id password
+  verification**. Tulip's API uses argon2id at OWASP-2024 minimum
+  parameters (memory ≈ 19MiB, time ≈ 2). Under xdist with 4 workers
+  each running their own uvicorn (so 8+ Python processes on a
+  4-core machine), argon2id verifications queue and starve the
+  uvicorn asyncio loop.
+- Reducing xdist to 2 workers reduced flake rate but didn't
+  eliminate it (~30-50% per-run rate at 2 workers, vs ~25-50% at 4).
+- Bumping HTTP timeouts to 30s only partially helps because the
+  delays sometimes exceed even that bound.
+
+What would need to happen to make option 2 work:
+
+1. **Add an env-driven argon2 parameter knob** (e.g.
+   ``TULIP_ARGON2_TEST_MODE=1`` selects ``time_cost=1, memory_cost=128``
+   for tests). This is intrusive but eliminates the CPU contention
+   class. The production parameters stay at OWASP-2024 minimum.
+2. **Or add ``pytest-rerunfailures`` retry** as a safety net. Standard
+   industry pattern for genuinely-flaky-under-load suites. Re-runs
+   each timeout failure once before reporting. Tolerates the contention
+   without changing it.
+3. **Or run uvicorn with multiple workers** so concurrent argon2
+   verifications can run in parallel processes. Adds boot complexity
+   to the fixture; uvicorn ``--workers N`` doesn't compose cleanly
+   with ``--factory`` in dev/test setups.
+
+Without one of those mitigations, option 2 trades 50% wall-clock for
+unacceptable flake rate. The git history of branch
+``perf/p2-session-live-api`` (since deleted) has the full
+implementation if anyone wants to reproduce the measurement.
 
 ### Option 3 — Per-package CI matrix *(zero test changes, modest wall-clock win)*
 
@@ -153,15 +189,17 @@ total but not visibly. Skip unless it later becomes a long pole.
 
 ## Recommendation
 
-Roughly in priority order:
+After the option 2 experiment (2026-05-11):
 
-1. **Option 2** (session-scoped uvicorn) is the single highest-leverage
-   change. The refactor is mechanical (UUID-ify the household-creating
-   test code paths) but touches a number of files. Best ROI per LoC.
-2. **Option 3** (CI matrix) layered on top of option 2 reduces
-   wall-clock further by parallelising the packages. Zero test
-   changes.
-3. **Option 4** (coverage shard) is independent and complementary.
+1. **Option 3 (CI matrix)** is now the highest-ROI next step. Zero
+   code changes, no flake risk, modest wall-clock win. Layered with
+   option 4 it could reasonably hit 4-6 min CI without touching tests.
+2. **Option 2 (session-scoped uvicorn)** is **not recommended as-is**
+   — see the "What broke" subsection above. Worth revisiting only if
+   paired with one of the three mitigations listed there (argon2 test
+   parameters, ``pytest-rerunfailures``, or uvicorn multi-worker).
+3. **Option 4 (coverage shard)** is independent and complementary to
+   either of the above.
 
 **Do NOT do Option 1** (template-DB). Measured negative under xdist;
 the documentation here is to prevent rediscovering this.
@@ -173,15 +211,19 @@ If revisiting CI runtime:
 1. **First, re-measure.** The baseline shifts as tests are added.
    ``time just test`` and ``time uv run pytest packages/tulip-cli/tests/
    -n auto --maxprocesses 4 -q`` against current ``main``.
-2. **If wall-clock is dominated by a single package** (likely
-   ``tulip-cli``): option 2 is the target.
-3. **If wall-clock is spread roughly evenly across packages**:
-   option 3 is the target.
-4. **If both look similar**: option 2 first (it reduces real CPU work,
-   not just parallelism), then option 3 if needed.
-5. **Always re-measure after each change.** xdist behaviour is
+2. **Default next step: Option 3** (CI matrix). It's the only
+   remaining option that has no flake risk and requires no test
+   refactoring. Start there.
+3. **If option 3 plus option 4 (coverage shard) isn't enough** to hit
+   the desired wall-clock: revisit option 2 *but only after*
+   introducing argon2 test-mode parameters or
+   ``pytest-rerunfailures``. The plain session-scoped fixture is
+   measurably flaky.
+4. **Always re-measure after each change.** xdist behaviour is
    counter-intuitive; "obvious" optimisations like option 1 can
-   regress.
+   regress. The 2026-05-11 option-2 attempt looked like a 50%
+   wall-clock win in single runs but degraded into a flake parade
+   across repeated runs.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

Implemented option 2 from ADR-0006 (session-scoped ``live_api`` + UUID
test isolation), measured it, and reverted. Updating the ADR with the
forensics so a future session knows what's needed before re-attempting.

**Wall-clock win was real** (~50%, sequential 7m37s → 3m40s; CI
extrapolation 14 min → ~7 min) **but introduced a ~25-50% flake rate**
that smaller mitigations didn't eliminate. Root cause: argon2id
password verification at OWASP-2024 minimum parameters, combined with
4-worker xdist concurrency on a 4-core machine, causes login
operations to exceed even bumped HTTP timeouts (30s) under load.

ADR-0006 now records:

- What was implemented (conftest fixtures, file-level refactor scope, ~99 timeout bumps)
- What broke (login timeouts under contention; flake rate measured across multiple runs)
- Three concrete mitigations for any future attempt:
  1. Env-driven argon2 test parameters (weak args in tests, prod stays at OWASP minimum)
  2. ``pytest-rerunfailures`` retry safety net
  3. uvicorn multi-worker boot in the fixture
- Updated recommendation: **option 3 (CI matrix) is now the highest-ROI next step**. Zero code changes, no flake risk. Option 2 not recommended as-is.

## Test plan

- [x] Local ``just lint`` clean
- [x] No code change in this PR (docs only) — should match #172/#174's path-conditional skipping
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)