### PR TITLE
chore(deps): pin litellm>=1.83.10 (CVE-2026-{40217,42203,42208,42271})

### DIFF
--- a/packages/tulip-ai/pyproject.toml
+++ b/packages/tulip-ai/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "tulip-core",
     "tulip-storage",
-    "litellm>=1.50",
+    "litellm>=1.83.10",
     "pydantic>=2.7",
     # sqlglot parses + validates the model-emitted SQL on the NL-query
     # capability (P6.2). We reject anything that isn't a single SELECT

--- a/uv.lock
+++ b/uv.lock
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "litellm", specifier = ">=1.50" },
+    { name = "litellm", specifier = ">=1.83.10" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "sqlglot", specifier = ">=27" },
     { name = "tulip-core", editable = "packages/tulip-core" },
@@ -3242,7 +3242,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "tulip-core", editable = "packages/tulip-core" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20260510" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

litellm 1.83.0-1.83.6 carry CVE-2026-42203 / -42208 / -42271 (fixed in
1.83.7) and 1.83.0-1.83.9 carry CVE-2026-40217 (fixed in 1.83.10).
The current constraint is ``>=1.50``, which lets the resolver pick
any post-1.50 release — and dependabot has now twice landed on the
vulnerable 1.83.0 during unrelated rebases (most recently on #167's
pydantic[email] bump, which forced the solver to downgrade
litellm 1.83.14 -> 1.83.0 to satisfy the new pydantic floor).

Tighten the package's pyproject constraint to ``>=1.83.10`` so any
future resolution path must stay on the post-fix line.

## Test plan
- [x] ``just audit`` — was 4 CVEs, now ``No known vulnerabilities found``
- [x] ``uv lock`` clean
- [ ] CI green on this PR
- [ ] Subsequent dependabot rebases (#167, etc.) inherit the floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)