### PR TITLE
chore: gitignore .claude/ session-scratch dir

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"2ab3450d-e3c9-4f23-bc22-ab7585399490","pid":73934,"procStart":"Sun May 10 17:18:14 2026","acquiredAt":1778534622302}

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ junit.xml
 # OS
 .DS_Store
 Thumbs.db
+
+# Claude Code session scratch (transient, never committed)
+.claude/


### PR DESCRIPTION
Quick cleanup of an accidental commit from #180.

PR #180 inadvertently committed `.claude/scheduled_tasks.lock` — a per-machine Claude Code session-state file. Removing from the index and adding `.claude/` to `.gitignore` so future PRs don't repeat the mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)