### PR TITLE
feat: P7.3 — CSV output for all 9 reports

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -26,7 +26,7 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 **Tests:** 1478 passing · **CI:** green on `main`
 
-**Phase 7 (reports + journal export/import):** in flight — P7.1 shipped (9 reports in HTML), P7.2 in PR (same 9 reports now also render as PDF via weasyprint). Up next: P7.3 CSV, P7.4 journal export (hledger), P7.5 journal import. CLI subcommands deferred as P7.1.b.
+**Phase 7 (reports + journal export/import):** in flight — P7.1 (HTML) + P7.2 (PDF) shipped; P7.3 (CSV) in PR. Up next: P7.4 journal export (hledger), P7.5 journal import. CLI subcommands deferred as P7.1.b.
 
 ---
 
@@ -567,7 +567,40 @@ hledger-compatible journal export + basic journal import. "Workstream
 slicing": P7.1 HTML, P7.2 PDF, P7.3 CSV, P7.4 journal export, P7.5
 journal import.
 
-### P7.2 — PDF rendering via weasyprint — 🔄 *(in PR)*
+### P7.3 — CSV output for all 9 reports — 🔄 *(in PR)*
+
+Third Phase-7 slice. Layers CSV output on top of HTML (P7.1) and PDF
+(P7.2). No new dependencies — stdlib `csv` + `io.StringIO` handle
+RFC 4180 quoting/escaping per row.
+
+**Engine**:
+- `ReportRenderer.csv_bytes(headers, rows)` static helper — encodes
+  a list-of-lists table as UTF-8 CSV bytes with `\r\n` line
+  terminators.
+
+**Per-report**:
+- Each module gains `render_csv(data) -> bytes`. Shape varies per
+  report:
+  - Trial balance, envelope status, sinking-fund progress,
+    reconciliation summary, audit log → one row per data record.
+  - Balance sheet, income statement, cash flow → one row per
+    (section, account) with a `Section` column.
+  - Custom query → raw column headers + result rows.
+
+**HTTP**:
+- Each endpoint's `format` widened to
+  `Literal["json", "html", "pdf", "csv"]`.
+- CSV responses return `text/csv` with
+  `Content-Disposition: attachment; filename=<report>-<date>.csv`
+  (attachment, not inline — CSVs typically download).
+
+**Tests** — +8 (engine has no new tests since `csv_bytes` is a
+trivial wrapper; coverage comes from the parametrized integration
+tests + the trial-balance integration test).
+
+Full suite: 1495 passed locally.
+
+### P7.2 — PDF rendering via weasyprint — ✅ *(2026-05-12)*
 
 Second Phase-7 slice. P7.1 shipped the 9 reports as HTML; this
 slice layers PDF output on top via `weasyprint>=63`. Same templates,

--- a/packages/tulip-api/src/tulip_api/routers/reports.py
+++ b/packages/tulip-api/src/tulip_api/routers/reports.py
@@ -76,7 +76,7 @@ def trial_balance(
             "transactions on or before this date. Defaults to today."
         ),
     ),
-    format: Literal["json", "html", "pdf"] = Query(
+    format: Literal["json", "html", "pdf", "csv"] = Query(
         default="json",
         description=(
             "Response format. ``json`` (default) returns the structured "
@@ -139,7 +139,7 @@ def trial_balance(
     ]
 
     json_body = TrialBalanceRead(as_of=effective_as_of, rows=rows, totals_by_currency=totals)
-    if format in ("html", "pdf"):
+    if format in ("html", "pdf", "csv"):
         from tulip_reports.reports import trial_balance as report_module
 
         data = report_module.build(
@@ -153,7 +153,9 @@ def trial_balance(
             report_module.render_html,
             format,
             render_pdf=report_module.render_pdf,
+            render_csv=report_module.render_csv,
             pdf_filename=f"trial-balance-{effective_as_of.isoformat()}.pdf",
+            csv_filename=f"trial-balance-{effective_as_of.isoformat()}.csv",
         )
     return Response(
         content=json_body.model_dump_json(),
@@ -194,20 +196,15 @@ def _report_response(
     format: str,
     *,
     render_pdf: Callable[..., bytes] | None = None,
+    render_csv: Callable[..., bytes] | None = None,
     pdf_filename: str = "report.pdf",
+    csv_filename: str = "report.csv",
 ) -> Response:
-    """Common JSON / HTML / PDF branch used by the new report endpoints.
-
-    ``render_pdf`` defaults to None — the trial-balance endpoint that
-    constructs its data inline doesn't need it; the matrix of new
-    reports each pass the report module's ``render_pdf`` so PDF works
-    uniformly. When PDF is requested without a renderer, returns 400.
-    """
+    """Common JSON / HTML / PDF / CSV branch used by the report endpoints."""
     if format == "html":
         return HTMLResponse(content=render_html(data))
     if format == "pdf":
         if render_pdf is None:
-            from tulip_api.errors import TulipProblem
 
             class _PdfUnavailable(TulipProblem):
                 def __init__(self) -> None:
@@ -224,6 +221,24 @@ def _report_response(
             media_type="application/pdf",
             headers={"Content-Disposition": f'inline; filename="{pdf_filename}"'},
         )
+    if format == "csv":
+        if render_csv is None:
+
+            class _CsvUnavailable(TulipProblem):
+                def __init__(self) -> None:
+                    super().__init__(
+                        code="report.csv_not_supported",
+                        title="CSV not supported for this report",
+                        status=400,
+                        detail="This report doesn't have a CSV renderer wired up.",
+                    )
+
+            raise _CsvUnavailable()
+        return Response(
+            content=render_csv(data),
+            media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{csv_filename}"'},
+        )
     return Response(content=json.dumps(_to_jsonable(data)), media_type="application/json")
 
 
@@ -237,7 +252,7 @@ def _report_response(
 )
 def balance_sheet(
     as_of: date | None = Query(default=None),  # noqa: B008
-    format: Literal["json", "html", "pdf"] = Query(default="json"),
+    format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
@@ -256,6 +271,8 @@ def balance_sheet(
         format,
         render_pdf=report_module.render_pdf,
         pdf_filename="trial-balance.pdf",
+        render_csv=report_module.render_csv,
+        csv_filename="trial-balance.csv",
     )
 
 
@@ -272,7 +289,7 @@ def income_statement(
     end: date = Query(...),  # noqa: B008
     prior_start: date | None = Query(default=None),  # noqa: B008
     prior_end: date | None = Query(default=None),  # noqa: B008
-    format: Literal["json", "html", "pdf"] = Query(default="json"),
+    format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
@@ -294,6 +311,8 @@ def income_statement(
         format,
         render_pdf=report_module.render_pdf,
         pdf_filename="income-statement.pdf",
+        render_csv=report_module.render_csv,
+        csv_filename="income-statement.csv",
     )
 
 
@@ -308,7 +327,7 @@ def income_statement(
 def cash_flow(
     start: date = Query(...),  # noqa: B008
     end: date = Query(...),  # noqa: B008
-    format: Literal["json", "html", "pdf"] = Query(default="json"),
+    format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
@@ -328,6 +347,8 @@ def cash_flow(
         format,
         render_pdf=report_module.render_pdf,
         pdf_filename="cash-flow.pdf",
+        render_csv=report_module.render_csv,
+        csv_filename="cash-flow.csv",
     )
 
 
@@ -341,7 +362,7 @@ def cash_flow(
 )
 def envelope_status(
     as_of: date | None = Query(default=None),  # noqa: B008
-    format: Literal["json", "html", "pdf"] = Query(default="json"),
+    format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
@@ -355,6 +376,8 @@ def envelope_status(
         format,
         render_pdf=report_module.render_pdf,
         pdf_filename="envelope-status.pdf",
+        render_csv=report_module.render_csv,
+        csv_filename="envelope-status.csv",
     )
 
 
@@ -368,7 +391,7 @@ def envelope_status(
 )
 def sinking_fund_progress(
     as_of: date | None = Query(default=None),  # noqa: B008
-    format: Literal["json", "html", "pdf"] = Query(default="json"),
+    format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
@@ -382,6 +405,8 @@ def sinking_fund_progress(
         format,
         render_pdf=report_module.render_pdf,
         pdf_filename="sinking-fund-progress.pdf",
+        render_csv=report_module.render_csv,
+        csv_filename="sinking-fund-progress.csv",
     )
 
 
@@ -395,7 +420,7 @@ def sinking_fund_progress(
 )
 def reconciliation_summary(
     status_filter: str | None = Query(default=None, alias="status"),
-    format: Literal["json", "html", "pdf"] = Query(default="json"),
+    format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
@@ -413,6 +438,8 @@ def reconciliation_summary(
         format,
         render_pdf=report_module.render_pdf,
         pdf_filename="reconciliation-summary.pdf",
+        render_csv=report_module.render_csv,
+        csv_filename="reconciliation-summary.csv",
     )
 
 
@@ -431,7 +458,7 @@ def audit_log(
     entity_type: str | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
-    format: Literal["json", "html", "pdf"] = Query(default="json"),
+    format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
@@ -454,6 +481,8 @@ def audit_log(
         format,
         render_pdf=report_module.render_pdf,
         pdf_filename="audit-log.pdf",
+        render_csv=report_module.render_csv,
+        csv_filename="audit-log.csv",
     )
 
 
@@ -487,7 +516,7 @@ class CustomQueryUnsafeError(TulipProblem):
 )
 def custom_query(
     sql: str = Query(..., description="Read-only SELECT against AI views (P6.2)."),
-    format: Literal["json", "html", "pdf"] = Query(default="json"),
+    format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
@@ -510,4 +539,6 @@ def custom_query(
         format,
         render_pdf=report_module.render_pdf,
         pdf_filename="custom-query.pdf",
+        render_csv=report_module.render_csv,
+        csv_filename="custom-query.csv",
     )

--- a/packages/tulip-api/tests/test_balance_endpoints.py
+++ b/packages/tulip-api/tests/test_balance_endpoints.py
@@ -208,3 +208,20 @@ class TestTrialBalance:
         assert r.content.startswith(b"%PDF-")
         # Filename hint includes the as_of date.
         assert "trial-balance-" in r.headers.get("content-disposition", "")
+
+    def test_format_csv_returns_csv_response(self, client: TestClient, auth_h: dict[str, str]):
+        """``?format=csv`` returns text/csv with the rows + totals (P7.3)."""
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="12.50")
+
+        r = client.get("/v1/reports/trial-balance?format=csv", headers=auth_h)
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"].startswith("text/csv")
+        body = r.content.decode()
+        # Header row + at least one data row.
+        assert body.startswith("Code,Account,Type,Currency,Balance\r\n")
+        assert "Cash" in body
+        assert "Food" in body
+        assert "TOTAL" in body  # sentinel for currency totals
+        assert ".csv" in r.headers.get("content-disposition", "")

--- a/packages/tulip-api/tests/test_reports_endpoints.py
+++ b/packages/tulip-api/tests/test_reports_endpoints.py
@@ -120,6 +120,31 @@ class TestNewReportsPDF:
         assert "filename=" in r.headers.get("content-disposition", "")
 
 
+class TestNewReportsCSV:
+    """``?format=csv`` returns ``text/csv`` (P7.3)."""
+
+    @pytest.mark.parametrize(("path", "params"), _ENDPOINTS)
+    def test_csv_render(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        path: str,
+        params: dict[str, str],
+    ) -> None:
+        merged = dict(params)
+        merged["format"] = "csv"
+        r = client.get(path, headers=auth_h, params=merged)
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"].startswith("text/csv")
+        # CSV starts with the header row.
+        first_line = r.content.split(b"\r\n", 1)[0]
+        assert b"," in first_line  # header row has multiple columns
+        # Filename is sensible (.csv suffix).
+        cd = r.headers.get("content-disposition", "")
+        assert "filename=" in cd
+        assert ".csv" in cd
+
+
 class TestAuth:
     """All new report endpoints require auth."""
 

--- a/packages/tulip-reports/src/tulip_reports/engine.py
+++ b/packages/tulip-reports/src/tulip_reports/engine.py
@@ -112,6 +112,26 @@ class ReportRenderer:
         template = self._env.get_template(template_name)
         return template.render(**context)
 
+    @staticmethod
+    def csv_bytes(headers: list[str], rows: list[list[object]]) -> bytes:
+        r"""Encode tabular data as UTF-8 CSV bytes (P7.3).
+
+        Per-row cells go through ``str(cell)`` unless ``None`` (rendered
+        as empty). The stdlib ``csv`` module handles quoting + escaping
+        per RFC 4180. Output uses ``\r\n`` line terminators because the
+        CSV spec says so; most consumers handle either, but stdlib's
+        default is the safer choice.
+        """
+        import csv
+        import io
+
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(headers)
+        for row in rows:
+            writer.writerow(["" if cell is None else str(cell) for cell in row])
+        return buf.getvalue().encode("utf-8")
+
     def render_pdf(self, template_name: str, **context: object) -> bytes:
         """Render ``template_name`` to PDF bytes via weasyprint (P7.2).
 

--- a/packages/tulip-reports/src/tulip_reports/reports/audit_log.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/audit_log.py
@@ -137,10 +137,39 @@ def render_pdf(data: AuditLogData) -> bytes:
     )
 
 
+def render_csv(data: AuditLogData) -> bytes:
+    """Render audit log as CSV (P7.3): one row per audit entry."""
+    from tulip_reports.engine import ReportRenderer
+
+    headers = [
+        "Occurred at",
+        "Actor kind",
+        "Actor user id",
+        "Action",
+        "Entity type",
+        "Entity id",
+        "Request id",
+    ]
+    rows: list[list[object]] = [
+        [
+            row.occurred_at.isoformat(),
+            row.actor_kind,
+            row.actor_user_id or "",
+            row.action,
+            row.entity_type,
+            row.entity_id or "",
+            row.request_id or "",
+        ]
+        for row in data.rows
+    ]
+    return ReportRenderer.csv_bytes(headers, rows)
+
+
 __all__ = [
     "AuditLogData",
     "AuditLogRow",
     "build",
+    "render_csv",
     "render_html",
     "render_pdf",
 ]

--- a/packages/tulip-reports/src/tulip_reports/reports/balance_sheet.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/balance_sheet.py
@@ -149,11 +149,28 @@ def render_pdf(data: BalanceSheetData) -> bytes:
     )
 
 
+def render_csv(data: BalanceSheetData) -> bytes:
+    """Render balance sheet as CSV (P7.3): one row per (section, account)."""
+    from tulip_reports.engine import ReportRenderer
+
+    headers = ["Section", "Code", "Account", "Currency", "Balance"]
+    rows: list[list[object]] = []
+    for section in (data.assets, data.liabilities, data.equity):
+        for row in section.rows:
+            rows.append([section.title, row.code or "", row.name, row.currency, row.balance])
+        for currency, subtotal in section.subtotals_by_currency.items():
+            rows.append([section.title, "SUBTOTAL", "", currency, subtotal])
+    for currency, amount in data.retained_earnings.items():
+        rows.append(["Retained earnings", "", "", currency, amount])
+    return ReportRenderer.csv_bytes(headers, rows)
+
+
 __all__ = [
     "BalanceSheetData",
     "BalanceSheetRow",
     "BalanceSheetSection",
     "build",
+    "render_csv",
     "render_html",
     "render_pdf",
 ]

--- a/packages/tulip-reports/src/tulip_reports/reports/cash_flow.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/cash_flow.py
@@ -129,10 +129,26 @@ def render_pdf(data: CashFlowData) -> bytes:
     )
 
 
+def render_csv(data: CashFlowData) -> bytes:
+    """Render cash flow as CSV (P7.3): one row per (direction, account)."""
+    from tulip_reports.engine import ReportRenderer
+
+    headers = ["Direction", "Code", "Account", "Currency", "Net change"]
+    rows: list[list[object]] = []
+    for row in data.inflows:
+        rows.append(["inflow", row.code or "", row.name, row.currency, row.delta])
+    for row in data.outflows:
+        rows.append(["outflow", row.code or "", row.name, row.currency, row.delta])
+    for currency, net in data.net_by_currency.items():
+        rows.append(["NET", "", "", currency, net])
+    return ReportRenderer.csv_bytes(headers, rows)
+
+
 __all__ = [
     "CashFlowData",
     "CashFlowRow",
     "build",
+    "render_csv",
     "render_html",
     "render_pdf",
 ]

--- a/packages/tulip-reports/src/tulip_reports/reports/custom_query.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/custom_query.py
@@ -92,9 +92,17 @@ def render_pdf(data: CustomQueryData) -> bytes:
     )
 
 
+def render_csv(data: CustomQueryData) -> bytes:
+    """Render custom-query result as CSV (P7.3): the column headers + raw rows."""
+    from tulip_reports.engine import ReportRenderer
+
+    return ReportRenderer.csv_bytes(data.columns, [list(row) for row in data.rows])
+
+
 __all__ = [
     "CustomQueryData",
     "build",
+    "render_csv",
     "render_html",
     "render_pdf",
 ]

--- a/packages/tulip-reports/src/tulip_reports/reports/envelope_status.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/envelope_status.py
@@ -128,10 +128,41 @@ def render_pdf(data: EnvelopeStatusData) -> bytes:
     )
 
 
+def render_csv(data: EnvelopeStatusData) -> bytes:
+    """Render envelope status as CSV (P7.3): one row per envelope."""
+    from tulip_reports.engine import ReportRenderer
+
+    headers = [
+        "Envelope id",
+        "Name",
+        "Currency",
+        "Balance",
+        "Budget",
+        "Budget period",
+        "Rollover",
+        "Utilization %",
+    ]
+    rows: list[list[object]] = [
+        [
+            row.envelope_id,
+            row.name,
+            row.currency,
+            row.balance,
+            row.budget_amount if row.budget_amount is not None else "",
+            row.budget_period,
+            row.rollover_policy,
+            row.utilization_pct if row.utilization_pct is not None else "",
+        ]
+        for row in data.rows
+    ]
+    return ReportRenderer.csv_bytes(headers, rows)
+
+
 __all__ = [
     "EnvelopeStatusData",
     "EnvelopeStatusRow",
     "build",
+    "render_csv",
     "render_html",
     "render_pdf",
 ]

--- a/packages/tulip-reports/src/tulip_reports/reports/income_statement.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/income_statement.py
@@ -212,12 +212,34 @@ def render_pdf(data: IncomeStatementData) -> bytes:
     )
 
 
+def render_csv(data: IncomeStatementData) -> bytes:
+    """Render income statement as CSV (P7.3): one row per (period, section, account)."""
+    from tulip_reports.engine import ReportRenderer
+
+    headers = ["Period", "Section", "Code", "Account", "Currency", "Amount"]
+    rows: list[list[object]] = []
+    for label, period in [("current", data.current_period)] + (
+        [("prior", data.prior_period)] if data.prior_period else []
+    ):
+        for section in (period.revenue, period.expenses):
+            for row in section.rows:
+                rows.append(
+                    [label, section.title, row.code or "", row.name, row.currency, row.amount]
+                )
+            for currency, subtotal in section.subtotals_by_currency.items():
+                rows.append([label, section.title, "SUBTOTAL", "", currency, subtotal])
+        for currency, net in period.net_income_by_currency.items():
+            rows.append([label, "Net income", "", "", currency, net])
+    return ReportRenderer.csv_bytes(headers, rows)
+
+
 __all__ = [
     "IncomeStatementData",
     "IncomeStatementPeriod",
     "IncomeStatementRow",
     "IncomeStatementSection",
     "build",
+    "render_csv",
     "render_html",
     "render_pdf",
 ]

--- a/packages/tulip-reports/src/tulip_reports/reports/reconciliation_summary.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/reconciliation_summary.py
@@ -140,10 +140,47 @@ def render_pdf(data: ReconciliationSummaryData) -> bytes:
     )
 
 
+def render_csv(data: ReconciliationSummaryData) -> bytes:
+    """Render reconciliation summary as CSV (P7.3): one row per reconciliation."""
+    from tulip_reports.engine import ReportRenderer
+
+    headers = [
+        "Reconciliation id",
+        "Account code",
+        "Account name",
+        "Period start",
+        "Period end",
+        "Starting",
+        "Ending",
+        "Currency",
+        "Status",
+        "Matches",
+        "Carried forward",
+    ]
+    rows: list[list[object]] = [
+        [
+            row.reconciliation_id,
+            row.account_code or "",
+            row.account_name,
+            row.period_start.isoformat(),
+            row.period_end.isoformat(),
+            row.starting_balance,
+            row.ending_balance,
+            row.currency,
+            row.status,
+            row.match_count,
+            row.carry_forward_count,
+        ]
+        for row in data.rows
+    ]
+    return ReportRenderer.csv_bytes(headers, rows)
+
+
 __all__ = [
     "ReconciliationRow",
     "ReconciliationSummaryData",
     "build",
+    "render_csv",
     "render_html",
     "render_pdf",
 ]

--- a/packages/tulip-reports/src/tulip_reports/reports/sinking_fund_progress.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/sinking_fund_progress.py
@@ -128,10 +128,43 @@ def render_pdf(data: SinkingFundProgressData) -> bytes:
     )
 
 
+def render_csv(data: SinkingFundProgressData) -> bytes:
+    """Render sinking-fund progress as CSV (P7.3): one row per fund."""
+    from tulip_reports.engine import ReportRenderer
+
+    headers = [
+        "Fund id",
+        "Name",
+        "Currency",
+        "Balance",
+        "Target amount",
+        "Remaining",
+        "Target date",
+        "Days remaining",
+        "Progress %",
+    ]
+    rows: list[list[object]] = [
+        [
+            row.fund_id,
+            row.name,
+            row.currency,
+            row.balance,
+            row.target_amount,
+            row.remaining_to_target,
+            row.target_date.isoformat(),
+            row.days_remaining,
+            row.progress_pct,
+        ]
+        for row in data.rows
+    ]
+    return ReportRenderer.csv_bytes(headers, rows)
+
+
 __all__ = [
     "SinkingFundProgressData",
     "SinkingFundRow",
     "build",
+    "render_csv",
     "render_html",
     "render_pdf",
 ]

--- a/packages/tulip-reports/src/tulip_reports/reports/trial_balance.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/trial_balance.py
@@ -157,11 +157,38 @@ def render_pdf(data: TrialBalanceData) -> bytes:
     )
 
 
+def render_csv(data: TrialBalanceData) -> bytes:
+    """Render the report as CSV bytes (P7.3).
+
+    One row per (account, currency); per-currency totals at the end
+    with a sentinel ``Code`` value of ``TOTAL`` so consumers can
+    distinguish data rows from summary rows.
+    """
+    from tulip_reports.engine import ReportRenderer
+
+    headers = ["Code", "Account", "Type", "Currency", "Balance"]
+    rows: list[list[object]] = [
+        [row.code or "", row.name, row.type, row.currency, row.balance] for row in data.rows
+    ]
+    for total in data.totals_by_currency:
+        rows.append(
+            [
+                "TOTAL",
+                f"Debits / Credits in {total.currency}",
+                "",
+                total.currency,
+                f"DR {total.debits} / CR {total.credits}",
+            ]
+        )
+    return ReportRenderer.csv_bytes(headers, rows)
+
+
 __all__ = [
     "CurrencyTotal",
     "TrialBalanceData",
     "TrialBalanceRow",
     "build",
+    "render_csv",
     "render_html",
     "render_pdf",
 ]


### PR DESCRIPTION
Third Phase-7 slice. Layers CSV output on top of HTML (P7.1) and
PDF (P7.2). **No new dependencies** — stdlib ``csv`` + ``io.StringIO``
handle RFC 4180 quoting/escaping.

### What ships

- ``ReportRenderer.csv_bytes(headers, rows)`` — static helper encoding
  list-of-lists tables as UTF-8 CSV bytes with CRLF line terminators.
- Each of the 9 report modules gains ``render_csv(data) -> bytes``.
  Shape varies per report: list-style reports (trial balance,
  envelope status, etc.) emit one row per record; multi-section
  reports (balance sheet, income statement, cash flow) get a
  ``Section`` column to disambiguate.
- Each endpoint's ``format`` query widened to
  ``Literal["json", "html", "pdf", "csv"]``.
- CSV responses return ``text/csv`` with ``Content-Disposition:
  attachment; filename=<report>-<date>.csv`` so browsers download
  rather than inline.

## Test plan

- [x] ``uv run pytest packages/tulip-reports/tests packages/tulip-api/tests/test_balance_endpoints.py packages/tulip-api/tests/test_reports_endpoints.py`` — 71 pass (+8 CSV)
- [x] ``uv run mypy --strict ...`` — clean
- [x] ``just test`` — **1495 passed** in 3:41
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)