### PR TITLE
feat: P7.5 — hledger journal import; close Phase 7

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -26,7 +26,7 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 **Tests:** 1478 passing · **CI:** green on `main`
 
-**Phase 7 (reports + journal export/import):** in flight — P7.1 (HTML) + P7.2 (PDF) + P7.3 (CSV) shipped; P7.4 (hledger journal export) in PR. Up next: P7.5 journal import. CLI subcommands deferred as P7.1.b.
+**Phase 7 (reports + journal export/import):** P7.1–P7.4 shipped; P7.5 (journal import) in PR — closes Phase 7. CLI subcommands deferred as P7.1.b.
 
 ---
 
@@ -567,7 +567,53 @@ hledger-compatible journal export + basic journal import. "Workstream
 slicing": P7.1 HTML, P7.2 PDF, P7.3 CSV, P7.4 journal export, P7.5
 journal import.
 
-### P7.4 — hledger-compatible journal export — 🔄 *(in PR)*
+### P7.5 — hledger journal import — 🔄 *(in PR; closes Phase 7)*
+
+Final Phase-7 slice. Closes the round-trip with P7.4: users can pull
+their ledger out as hledger journal text and push it back in. Imported
+transactions land in **PENDING status** for user review — same
+convention as the existing OFX / QIF / CSV importers (#74).
+
+**Parsing** (`tulip_reports.journal.parse`):
+- `parse_journal(text) -> ParsedJournal` — pure function, no DB
+  access. Accepts the subset of hledger that `export_journal` emits
+  plus forgiveness for hand-edits (extra blank lines, comments).
+- Errors don't abort parsing; they're collected with line numbers
+  so the user can fix and retry.
+
+**Resolution** (`tulip_reports.journal.import_`):
+- `resolve_journal(session, *, household_id, parsed) -> ImportResult`
+  maps each posting's `<Type>:<code>:<name>` path back to a tulip
+  account. By code first (most reliable), then by exact `(type, name)`.
+- Validates: every account resolves, posting currency matches
+  account currency, postings balance per currency.
+
+**HTTP** (`tulip_api.routers.journal`):
+- `POST /v1/journal/import` accepts plain-text body (5 MB cap),
+  parses + resolves, inserts as PENDING transactions via
+  `TransactionRepository.save_balanced`. Response carries
+  `created` count + the `transaction_ids` array.
+- Parse errors → `journal.parse_failed` (400) with `errors`
+  extension array.
+- Resolve errors → `journal.import_failed` (400) with the same shape.
+
+**Tests** — +8 in `test_journal_import.py`:
+- Happy path: minimal two-posting tx creates one PENDING transaction.
+- **Export → import round-trip** through the existing transactions
+  endpoint — the primary acceptance criterion.
+- Parse error: non-date header surfaces with line number.
+- Resolve error: unknown account path.
+- Resolve error: unbalanced postings.
+- Resolve error: currency mismatch.
+- Empty body returns 201 with `created: 0`.
+- Auth gate.
+
+Full suite: 1511 passed locally.
+
+**Phase 7 closes** after this slice merges. CLI subcommands
+(deferred from P7.1) remain as P7.1.b follow-up.
+
+### P7.4 — hledger-compatible journal export — ✅ *(2026-05-12)*
 
 Fourth Phase-7 slice. Adds a plain-text export of the household
 ledger in hledger journal format — the de-facto standard for the

--- a/packages/tulip-api/src/tulip_api/routers/journal.py
+++ b/packages/tulip-api/src/tulip_api/routers/journal.py
@@ -1,11 +1,11 @@
-"""GET /v1/journal/export — hledger-compatible journal export (P7.4).
+"""hledger-compatible journal export + import (P7.4 / P7.5).
 
-Renders the household's posted transactions as a plain-text hledger
-journal file. The format is described in
-``tulip_reports.journal.export`` — the API endpoint is a thin wrapper.
+GET ``/v1/journal/export`` renders the household's posted transactions
+as plain-text hledger journal text.
 
-Pending and voided transactions are excluded, matching the trial-
-balance / income-statement conventions.
+POST ``/v1/journal/import`` accepts a journal file body and creates
+**pending** transactions ready for review — same convention as the
+existing OFX / QIF / CSV importers (#74).
 """
 
 from __future__ import annotations
@@ -13,12 +13,12 @@ from __future__ import annotations
 from datetime import date as date_type
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import Response
 
-from tulip_api.auth.deps import get_current_claims
+from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.deps import get_session
-from tulip_api.errors import problem_response
+from tulip_api.errors import TulipProblem, problem_response
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -27,6 +27,45 @@ if TYPE_CHECKING:
 
 
 router = APIRouter(prefix="/v1/journal", tags=["journal"])
+
+
+_MAX_JOURNAL_BYTES = 5 * 1024 * 1024  # 5 MB — matches the OFX cap (#74).
+
+
+class JournalParseFailedError(TulipProblem):
+    """The uploaded journal couldn't be parsed (P7.5)."""
+
+    def __init__(self, errors: list[dict[str, object]]) -> None:
+        """Build the journal.parse_failed problem."""
+        super().__init__(
+            code="journal.parse_failed",
+            title="Journal parsing failed",
+            status=400,
+            detail=(
+                f"{len(errors)} parse error(s) in the uploaded journal. "
+                "See ``errors`` for line numbers + messages."
+            ),
+            extensions={"errors": errors},
+        )
+
+
+class JournalImportFailedError(TulipProblem):
+    """Resolution / validation failed during journal import (P7.5)."""
+
+    def __init__(self, errors: list[dict[str, object]]) -> None:
+        """Build the journal.import_failed problem."""
+        super().__init__(
+            code="journal.import_failed",
+            title="Journal import failed",
+            status=400,
+            detail=(
+                f"{len(errors)} error(s) resolving the journal. Each error "
+                "names a line number + the issue (unknown account, balance "
+                "mismatch, currency mismatch). Fix the journal or seed the "
+                "missing accounts and retry."
+            ),
+            extensions={"errors": errors},
+        )
 
 
 @router.get(
@@ -86,4 +125,117 @@ def export(
     )
 
 
-__all__ = ["router"]
+@router.post(
+    "/import",
+    response_model=None,
+    responses={
+        201: {"description": "Journal parsed + resolved; pending transactions created."},
+        400: problem_response(
+            "journal.parse_failed",
+            "journal.import_failed",
+            "request.body_invalid",
+            "request.payload_too_large",
+        ),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+    },
+)
+async def import_journal(
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> Response:
+    """Accept a hledger-format journal body; create pending transactions.
+
+    The body is parsed via :func:`tulip_reports.journal.parse.parse_journal`
+    and resolved against the household's chart of accounts via
+    :func:`tulip_reports.journal.import_.resolve_journal`. Any parse or
+    resolve errors short-circuit the import and return a typed Problem
+    Details with per-line error annotations.
+
+    On success, transactions land in **PENDING status** through the
+    existing ``TransactionRepository.create`` chokepoint so the user
+    reviews before promoting to POSTED. The response carries the
+    created transaction IDs.
+    """
+    body = await request.body()
+    if len(body) > _MAX_JOURNAL_BYTES:
+        from tulip_api.errors import RequestPayloadTooLargeError
+
+        raise RequestPayloadTooLargeError(max_bytes=_MAX_JOURNAL_BYTES)
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise JournalParseFailedError(
+            errors=[{"line": 0, "message": f"journal body must be UTF-8: {exc}"}]
+        ) from exc
+
+    from tulip_reports.journal import parse_journal, resolve_journal
+
+    parsed = parse_journal(text)
+    if parsed.errors:
+        raise JournalParseFailedError(
+            errors=[{"line": e.line_number, "message": e.message} for e in parsed.errors]
+        )
+
+    resolved = resolve_journal(session, household_id=claims.household_id, parsed=parsed)
+    if resolved.errors:
+        raise JournalImportFailedError(
+            errors=[{"line": e.line_number, "message": e.message} for e in resolved.errors]
+        )
+
+    # Insert as PENDING transactions via the repo chokepoint. PENDING
+    # is the same convention the OFX / QIF / CSV importers use (#74) —
+    # the user reviews before promoting to POSTED.
+    from uuid import uuid4
+
+    from tulip_core.money import Money
+    from tulip_core.transactions import (
+        Posting as DomainPosting,
+    )
+    from tulip_core.transactions import (
+        Transaction as DomainTransaction,
+    )
+    from tulip_core.transactions import (
+        TransactionStatus as DomainTxStatus,
+    )
+    from tulip_storage.repositories import TransactionRepository
+
+    repo = TransactionRepository(session, claims.household_id)
+    created_ids: list[str] = []
+    for tx in resolved.transactions:
+        domain_tx = DomainTransaction(
+            id=uuid4(),
+            household_id=claims.household_id,
+            date=tx.date,
+            description=tx.description,
+            reference=tx.reference,
+            postings=tuple(
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=p.account_id,
+                    amount=Money(p.amount, p.currency),
+                )
+                for p in tx.postings
+            ),
+            status=DomainTxStatus.PENDING,
+            created_by_user_id=claims.user_id,
+        )
+        created = repo.save_balanced(domain_tx)
+        created_ids.append(str(created.id))
+    session.commit()
+
+    import json as _json
+
+    return Response(
+        status_code=201,
+        content=_json.dumps({"created": len(created_ids), "transaction_ids": created_ids}),
+        media_type="application/json",
+    )
+
+
+__all__ = [
+    "JournalImportFailedError",
+    "JournalParseFailedError",
+    "router",
+]

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -51,6 +51,14 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
     },
     "UnsupportedProposalKindError": {"kind": "transfer_pools"},
     "CustomQueryUnsafeError": {"reason": "table 'users' is not in the AI view allowlist"},
+    "JournalParseFailedError": {
+        "errors": [{"line": 7, "message": "malformed posting line"}],
+    },
+    "JournalImportFailedError": {
+        "errors": [
+            {"line": 3, "message": "could not resolve account path 'Expense:9999:Nonexistent'"},
+        ],
+    },
     "PoolNotFoundError": {"pool_id": "<pool-uuid>"},
     "PoolInactiveError": {"pool_id": "<pool-uuid>"},
     "PoolCurrencyMismatchError": {

--- a/packages/tulip-api/tests/test_journal_import.py
+++ b/packages/tulip-api/tests/test_journal_import.py
@@ -1,0 +1,196 @@
+"""Tests for POST /v1/journal/import (P7.5).
+
+Round-trip through GET /v1/journal/export → POST /v1/journal/import
+is the primary acceptance criterion: the export round-trips back
+into the same household as PENDING transactions.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return str(r.json()["access_token"])
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+def _account(client: TestClient, headers: dict[str, str], **extra: object) -> str:
+    body = {"name": "X", "type": "asset", "currency": "USD"}
+    body.update(extra)
+    return str(client.post("/v1/accounts", headers=headers, json=body).json()["id"])
+
+
+def _post_journal(client: TestClient, headers: dict[str, str], text: str) -> object:
+    """Helper: POST /v1/journal/import with a plain-text body."""
+    return client.post(
+        "/v1/journal/import",
+        headers={**headers, "content-type": "text/plain"},
+        content=text,
+    )
+
+
+class TestImportHappyPath:
+    def test_minimal_two_posting_tx_creates_pending(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        _account(client, auth_h, name="Cash", code="1110")
+        _account(client, auth_h, name="Food", type="expense", code="5100")
+
+        body = "\n".join(
+            [
+                "2026-05-01 Grocery store",
+                "    Expense:5100:Food  12.50 USD",
+                "    Asset:1110:Cash  -12.50 USD",
+                "",
+            ]
+        )
+        r = _post_journal(client, auth_h, body)
+        assert r.status_code == 201, r.text
+        payload = r.json()
+        assert payload["created"] == 1
+        assert len(payload["transaction_ids"]) == 1
+
+        # And the transaction shows up as PENDING.
+        listing = client.get("/v1/transactions", headers=auth_h, params={"status": "pending"})
+        items = listing.json()
+        descs = [t["description"] for t in items]
+        assert "Grocery store" in descs
+
+    def test_export_then_import_roundtrip(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        """Round-trip: post a tx → export → import the export → both surface as pending."""
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": "2026-05-01",
+                "description": "Round-trip test",
+                "postings": [
+                    {"account_id": food, "amount": "7.25", "currency": "USD"},
+                    {"account_id": cash, "amount": "-7.25", "currency": "USD"},
+                ],
+            },
+        )
+        assert r.status_code == 201
+
+        # Export and re-import.
+        exported = client.get("/v1/journal/export", headers=auth_h).text
+        r2 = _post_journal(client, auth_h, exported)
+        assert r2.status_code == 201, r2.text
+        assert r2.json()["created"] == 1  # one tx survived the round-trip
+
+
+class TestImportErrors:
+    def test_parse_error_returns_400_with_line_numbers(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        body = "\n".join(
+            [
+                "not-a-date no parse possible",
+                "    foo  bar",
+            ]
+        )
+        r = _post_journal(client, auth_h, body)
+        assert r.status_code == 400
+        payload = r.json()
+        assert payload["code"] == "journal.parse_failed"
+        assert payload["errors"]
+        assert "line" in payload["errors"][0]
+
+    def test_unknown_account_returns_400_with_line_number(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        body = "\n".join(
+            [
+                "2026-05-01 Unknown accounts",
+                "    Expense:9999:Nonexistent  5.00 USD",
+                "    Asset:9998:NoSuchCash  -5.00 USD",
+                "",
+            ]
+        )
+        r = _post_journal(client, auth_h, body)
+        assert r.status_code == 400
+        payload = r.json()
+        assert payload["code"] == "journal.import_failed"
+        assert any("could not resolve" in e["message"] for e in payload["errors"])
+
+    def test_unbalanced_postings_return_400(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        del cash, food  # ensure accounts seeded; assertion comes via account paths
+        body = "\n".join(
+            [
+                "2026-05-01 Unbalanced",
+                "    Expense:5100:Food  10.00 USD",
+                "    Asset:1110:Cash  -8.00 USD",
+                "",
+            ]
+        )
+        r = _post_journal(client, auth_h, body)
+        assert r.status_code == 400
+        payload = r.json()
+        assert payload["code"] == "journal.import_failed"
+        assert any("not balance" in e["message"] for e in payload["errors"])
+
+    def test_currency_mismatch_returns_400(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        _account(client, auth_h, name="Cash", code="1110")
+        _account(client, auth_h, name="Food", type="expense", code="5100")
+        body = "\n".join(
+            [
+                "2026-05-01 Wrong currency",
+                "    Expense:5100:Food  10.00 EUR",  # account is USD
+                "    Asset:1110:Cash  -10.00 EUR",
+                "",
+            ]
+        )
+        r = _post_journal(client, auth_h, body)
+        assert r.status_code == 400
+        payload = r.json()
+        assert payload["code"] == "journal.import_failed"
+
+    def test_empty_body_creates_no_transactions(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        r = _post_journal(client, auth_h, "")
+        # Empty body has no transactions and no errors → 201 with zero created.
+        assert r.status_code == 201
+        assert r.json()["created"] == 0
+
+    def test_no_token_returns_unauthorized(self, client: TestClient) -> None:
+        r = client.post(
+            "/v1/journal/import",
+            headers={"content-type": "text/plain"},
+            content="2026-05-01 desc\n    A:B  1.00 USD\n    A:C  -1.00 USD\n",
+        )
+        assert r.status_code == 401
+
+
+# Keep the date import in scope (used implicitly by some test bodies).
+_ = date

--- a/packages/tulip-reports/src/tulip_reports/journal/__init__.py
+++ b/packages/tulip-reports/src/tulip_reports/journal/__init__.py
@@ -1,9 +1,31 @@
-"""hledger-compatible journal export / import (P7.4 / P7.5).
-
-The :mod:`tulip_reports.journal.export` module is the export side;
-imports land in P7.5.
-"""
+"""hledger-compatible journal export / import (P7.4 / P7.5)."""
 
 from tulip_reports.journal.export import export_journal
+from tulip_reports.journal.import_ import (
+    ImportError_,
+    ImportResult,
+    ResolvedPosting,
+    ResolvedTransaction,
+    resolve_journal,
+)
+from tulip_reports.journal.parse import (
+    JournalParseError,
+    ParsedJournal,
+    ParsedPosting,
+    ParsedTransaction,
+    parse_journal,
+)
 
-__all__ = ["export_journal"]
+__all__ = [
+    "ImportError_",
+    "ImportResult",
+    "JournalParseError",
+    "ParsedJournal",
+    "ParsedPosting",
+    "ParsedTransaction",
+    "ResolvedPosting",
+    "ResolvedTransaction",
+    "export_journal",
+    "parse_journal",
+    "resolve_journal",
+]

--- a/packages/tulip-reports/src/tulip_reports/journal/import_.py
+++ b/packages/tulip-reports/src/tulip_reports/journal/import_.py
@@ -1,0 +1,212 @@
+"""hledger journal import side (P7.5).
+
+Takes ``ParsedJournal`` from :mod:`tulip_reports.journal.parse` and
+resolves each posting's account path to a tulip account ID. Account
+resolution rules:
+
+1. Strip the leading ``<Type>:`` token and try matching the remaining
+   path as ``<code>:<name>`` first (export's preferred shape).
+2. Fall back to matching by exact account name within the matched
+   type.
+3. Unmappable paths surface as ``ImportError`` entries with line
+   numbers so the user can fix the journal or create the missing
+   account before retrying.
+
+The import itself is "build a list of pending transactions" — the
+actual database write happens through the existing
+``TransactionRepository.create`` (and lands in PENDING status, never
+POSTED, so the user reviews before promoting). That keeps the import
+flow consistent with the existing OFX / QIF / CSV importers (#74).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import date as date_type
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_reports.journal.parse import ParsedJournal
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedPosting:
+    """One posting with its account_path resolved to a tulip account_id."""
+
+    account_id: UUID
+    amount: Decimal
+    currency: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedTransaction:
+    """One transaction with all postings resolved + ready to insert."""
+
+    date: date_type
+    description: str
+    reference: str | None
+    postings: list[ResolvedPosting]
+
+
+@dataclass(frozen=True, slots=True)
+class ImportError_:
+    """One import-side error: an account couldn't be mapped, or postings unbalanced."""
+
+    line_number: int
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class ImportResult:
+    """The full resolve+validate output for one parsed journal."""
+
+    transactions: list[ResolvedTransaction]
+    errors: list[ImportError_] = field(default_factory=list)
+
+
+def _resolve_account_path(
+    accounts_by_code: Mapping[str, object],
+    accounts_by_type_name: Mapping[tuple[str, str], object],
+    path: str,
+) -> tuple[UUID, str] | None:
+    """Resolve a hledger account path back to a tulip account.
+
+    Returns ``(account_id, currency)`` on success, ``None`` on failure.
+    The currency is returned because the account model has a single
+    declared currency that must match the posting's currency.
+    """
+    # Format: "<Type>:<code>:<name>" or "<Type>:<name>".
+    parts = path.split(":", 2)
+    if len(parts) < 2:
+        return None
+    type_token = parts[0].lower()  # "Expense" -> "expense"
+    rest = ":".join(parts[1:])  # "5100:Food" or "Food"
+
+    # Try by code first if the rest starts with a numeric-looking token.
+    code_candidate = rest.split(":", 1)[0]
+    if code_candidate in accounts_by_code:
+        acct = accounts_by_code[code_candidate]
+        # Type must match too — different households can reuse code values.
+        if getattr(acct.type, "value", str(acct.type)) == type_token:  # type: ignore[attr-defined]
+            return acct.id, acct.currency  # type: ignore[attr-defined]
+
+    # Fall back to exact (type, name) match.
+    # If `rest` looked like "code:name", take the name portion.
+    name_candidate = rest.split(":", 1)[-1] if ":" in rest else rest
+    acct2 = accounts_by_type_name.get((type_token, name_candidate))
+    if acct2 is not None:
+        return acct2.id, acct2.currency  # type: ignore[attr-defined]
+
+    return None
+
+
+def resolve_journal(
+    session: Session,
+    *,
+    household_id: UUID,
+    parsed: ParsedJournal,
+) -> ImportResult:
+    """Resolve parsed account paths to tulip accounts; validate balance.
+
+    Returns ``ImportResult.transactions`` (the resolved-and-balanced
+    transactions ready for insertion) and ``ImportResult.errors``
+    (per-tx or per-posting errors). The caller decides whether to
+    proceed if any errors are present.
+
+    Validation:
+    - Every posting's account_path must resolve.
+    - Posting currency must match account currency.
+    - Postings must sum to zero per currency (balance invariant).
+    """
+    from sqlalchemy import select
+
+    from tulip_storage.models import Account
+
+    accounts = (
+        session.execute(select(Account).where(Account.household_id == household_id)).scalars().all()
+    )
+    by_code: dict[str, Account] = {a.code: a for a in accounts if a.code is not None}
+    by_type_name: dict[tuple[str, str], Account] = {(a.type.value, a.name): a for a in accounts}
+
+    resolved_txs: list[ResolvedTransaction] = []
+    errors: list[ImportError_] = []
+
+    for tx in parsed.transactions:
+        resolved_postings: list[ResolvedPosting] = []
+        tx_errors: list[ImportError_] = []
+
+        for posting in tx.postings:
+            match = _resolve_account_path(by_code, by_type_name, posting.account_path)
+            if match is None:
+                tx_errors.append(
+                    ImportError_(
+                        line_number=posting.line_number,
+                        message=(f"could not resolve account path {posting.account_path!r}"),
+                    )
+                )
+                continue
+            account_id, account_currency = match
+            if account_currency != posting.currency:
+                tx_errors.append(
+                    ImportError_(
+                        line_number=posting.line_number,
+                        message=(
+                            f"posting currency {posting.currency!r} does not match "
+                            f"account currency {account_currency!r}"
+                        ),
+                    )
+                )
+                continue
+            resolved_postings.append(
+                ResolvedPosting(
+                    account_id=account_id,
+                    amount=posting.amount,
+                    currency=posting.currency,
+                )
+            )
+
+        if tx_errors:
+            errors.extend(tx_errors)
+            continue
+
+        # Balance check: per-currency posting sum must be zero.
+        sums_by_currency: dict[str, Decimal] = {}
+        for p in resolved_postings:
+            sums_by_currency[p.currency] = sums_by_currency.get(p.currency, Decimal("0")) + p.amount
+        unbalanced = {c: s for c, s in sums_by_currency.items() if s != 0}
+        if unbalanced:
+            errors.append(
+                ImportError_(
+                    line_number=tx.line_number,
+                    message=(
+                        "postings do not balance: "
+                        + ", ".join(f"{c}={s}" for c, s in unbalanced.items())
+                    ),
+                )
+            )
+            continue
+
+        resolved_txs.append(
+            ResolvedTransaction(
+                date=tx.date,
+                description=tx.description,
+                reference=tx.reference,
+                postings=resolved_postings,
+            )
+        )
+
+    return ImportResult(transactions=resolved_txs, errors=errors)
+
+
+__all__ = [
+    "ImportError_",
+    "ImportResult",
+    "ResolvedPosting",
+    "ResolvedTransaction",
+    "resolve_journal",
+]

--- a/packages/tulip-reports/src/tulip_reports/journal/parse.py
+++ b/packages/tulip-reports/src/tulip_reports/journal/parse.py
@@ -1,0 +1,218 @@
+"""Parse hledger journal text → structured transactions (P7.5).
+
+This is the inverse of :mod:`tulip_reports.journal.export`. The
+parser is intentionally restrictive: it accepts the subset of the
+hledger language that ``export_journal`` emits, plus a little
+forgiveness for hand-edited files (extra blank lines, mixed
+indentation, trailing whitespace). The full hledger grammar
+(directives, cost / price annotations, virtual postings) is out of
+scope for v1.
+
+Format we accept:
+
+    ; comments start with semicolons; ignored
+    2026-05-01 description
+        Account:Path  12.50 USD
+        Other:Path  -12.50 USD
+
+    2026-05-15 (REF-123) description with reference
+        ...
+
+The parser is pure — given text it returns a structured result; it
+does NOT touch the database. The :mod:`tulip_reports.journal.import_`
+side maps account paths to tulip account IDs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date as date_type
+from decimal import Decimal, InvalidOperation
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedPosting:
+    """One posting line from a parsed hledger entry."""
+
+    account_path: str  # e.g. "Expense:5100:Food"
+    amount: Decimal
+    currency: str
+    line_number: int
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedTransaction:
+    """One transaction block from a parsed hledger entry."""
+
+    date: date_type
+    description: str
+    reference: str | None
+    postings: list[ParsedPosting]
+    line_number: int  # 1-indexed line of the header
+
+
+@dataclass(frozen=True, slots=True)
+class JournalParseError:
+    """One parse-error annotation with a line number for the operator to fix."""
+
+    line_number: int
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedJournal:
+    """The full result: transactions + any parse errors we encountered."""
+
+    transactions: list[ParsedTransaction]
+    errors: list[JournalParseError] = field(default_factory=list)
+
+
+_HEADER_RE = re.compile(
+    r"""
+    ^(?P<date>\d{4}-\d{2}-\d{2})    # ISO date
+    \s+
+    (?:\((?P<ref>[^)]+)\)\s+)?      # optional (reference) prefix
+    (?P<description>.+?)            # the rest of the line is the description
+    \s*$
+    """,
+    re.VERBOSE,
+)
+
+
+_POSTING_RE = re.compile(
+    r"""
+    ^\s+                              # leading whitespace (indented)
+    (?P<account>\S+(?:\s\S+)*?)       # account path: tokens joined by single spaces
+    \s{2,}                            # at least two spaces separator (hledger spec)
+    (?P<amount>-?\d+(?:\.\d+)?)       # decimal amount, optionally negative
+    \s+
+    (?P<currency>[A-Z]{3,5})          # currency code (3-5 uppercase letters)
+    \s*$
+    """,
+    re.VERBOSE,
+)
+
+
+def parse_journal(text: str) -> ParsedJournal:
+    """Parse hledger journal ``text``; return transactions + any errors.
+
+    Errors don't abort parsing — the result carries both whatever was
+    successfully parsed and the errors so the user can fix and retry.
+    A balanced-posting check is the responsibility of the import side;
+    here we just extract structure.
+    """
+    transactions: list[ParsedTransaction] = []
+    errors: list[JournalParseError] = []
+
+    current_header: tuple[int, date_type, str, str | None] | None = None
+    current_postings: list[ParsedPosting] = []
+
+    def flush() -> None:
+        if current_header is None:
+            return
+        line_num, dt, desc, ref = current_header
+        if not current_postings:
+            errors.append(
+                JournalParseError(
+                    line_number=line_num,
+                    message="transaction has no postings",
+                )
+            )
+            return
+        transactions.append(
+            ParsedTransaction(
+                date=dt,
+                description=desc,
+                reference=ref,
+                postings=list(current_postings),
+                line_number=line_num,
+            )
+        )
+
+    for line_num, raw_line in enumerate(text.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith(";"):
+            # Blank line ends the current transaction; comments are ignored.
+            if not stripped and current_header is not None:
+                flush()
+                current_header = None
+                current_postings = []
+            continue
+
+        header_match = _HEADER_RE.match(raw_line)
+        if header_match and not raw_line.startswith((" ", "\t")):
+            # New transaction header. Flush any previous.
+            if current_header is not None:
+                flush()
+                current_postings = []
+            try:
+                dt = date_type.fromisoformat(header_match.group("date"))
+            except ValueError:
+                errors.append(
+                    JournalParseError(
+                        line_number=line_num,
+                        message=f"invalid date {header_match.group('date')!r}",
+                    )
+                )
+                current_header = None
+                continue
+            description = header_match.group("description").strip()
+            ref = header_match.group("ref")
+            current_header = (line_num, dt, description, ref)
+            continue
+
+        # Posting line (must follow a header).
+        if current_header is None:
+            errors.append(
+                JournalParseError(
+                    line_number=line_num,
+                    message="posting line outside of a transaction block",
+                )
+            )
+            continue
+
+        posting_match = _POSTING_RE.match(raw_line)
+        if not posting_match:
+            errors.append(
+                JournalParseError(
+                    line_number=line_num,
+                    message="malformed posting line",
+                )
+            )
+            continue
+
+        try:
+            amount = Decimal(posting_match.group("amount"))
+        except InvalidOperation:
+            errors.append(
+                JournalParseError(
+                    line_number=line_num,
+                    message=f"invalid amount {posting_match.group('amount')!r}",
+                )
+            )
+            continue
+
+        current_postings.append(
+            ParsedPosting(
+                account_path=posting_match.group("account").strip(),
+                amount=amount,
+                currency=posting_match.group("currency"),
+                line_number=line_num,
+            )
+        )
+
+    # EOF flush.
+    if current_header is not None:
+        flush()
+
+    return ParsedJournal(transactions=transactions, errors=errors)
+
+
+__all__ = [
+    "JournalParseError",
+    "ParsedJournal",
+    "ParsedPosting",
+    "ParsedTransaction",
+    "parse_journal",
+]


### PR DESCRIPTION
## Summary

Closes #187 — the final Phase-7 slice. Round-trips the journal: P7.4 emitted hledger text out, this one ingests it back.

- **POST /v1/journal/import** accepts a text/plain hledger journal body (5 MB cap, matching OFX). Returns 201 with `{created, transaction_ids}`.
- New module `tulip_reports.journal.parse` — pure parser, no DB. Collects errors with line numbers rather than aborting on first failure.
- New module `tulip_reports.journal.import_` — resolves `<Type>:<code>:<name>` paths back to tulip account IDs (by code first, then by exact `(type, name)`). Validates account match, currency match, and per-currency balance.
- Imported transactions land in **PENDING** status via `TransactionRepository.save_balanced` — same convention as the OFX / QIF / CSV importers (#74), so the user reviews before promoting.
- Two new typed Problem Details (`journal.parse_failed`, `journal.import_failed`), both 400 with `[{line, message}, …]` extensions. Both auto-publish at `/.well-known/errors/` via the placeholder-args registry.
- PHASE_STATUS updated: Phase 7 closes with this merge. CLI subcommands remain as the deferred P7.1.b follow-up.

## Test plan

- [x] `just test` → **1511 passed, 1 skipped** in 4:24 locally.
- [x] +8 new integration tests (`packages/tulip-api/tests/test_journal_import.py`): happy path, **export → import round-trip** (primary acceptance), parse error w/ line numbers, unknown account, unbalanced postings, currency mismatch, empty body 201, missing-token 401.
- [ ] CI green on this PR

### Manual smoke

```bash
export TULIP_DB_URL='sqlite:///./smoke.db'
export TULIP_JWT_SECRET='dev-secret-do-not-use-in-prod'
uv run alembic upgrade head
uv run uvicorn tulip_api.main:app --port 8000 &
sleep 2
curl -s localhost:8000/v1/auth/register -H 'content-type: application/json' \
  -d '{"email":"a@x.test","password":"correct horse battery staple","display_name":"A","household_name":"H"}' >/dev/null
TOKEN=\$(curl -s localhost:8000/v1/auth/login -H 'content-type: application/json' \
  -d '{"email":"a@x.test","password":"correct horse battery staple"}' | jq -r .access_token)
AUTH="Authorization: Bearer \$TOKEN"
curl -s localhost:8000/v1/accounts -H "\$AUTH" -H 'content-type: application/json' \
  -d '{"name":"Cash","type":"asset","currency":"USD","code":"1110"}' >/dev/null
curl -s localhost:8000/v1/accounts -H "\$AUTH" -H 'content-type: application/json' \
  -d '{"name":"Food","type":"expense","currency":"USD","code":"5100"}' >/dev/null
printf '2026-05-01 Lunch\n    Expense:5100:Food  12.50 USD\n    Asset:1110:Cash  -12.50 USD\n' | \
  curl -sf -X POST localhost:8000/v1/journal/import -H "\$AUTH" -H 'content-type: text/plain' --data-binary @- | jq .
printf 'totally-not-a-journal\n' | \
  curl -s -X POST localhost:8000/v1/journal/import -H "\$AUTH" -H 'content-type: text/plain' --data-binary @- | jq .code
kill %1
rm -f smoke.db
```

Expected: first curl prints `{ "created": 1, "transaction_ids": [...] }`; second prints `"journal.parse_failed"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)