### PR TITLE
feat: P7.1.b — tulip reports + tulip journal CLI

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -26,7 +26,7 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 **Tests:** 1478 passing · **CI:** green on `main`
 
-**Phase 7 (reports + journal export/import):** P7.1–P7.4 shipped; P7.5 (journal import) in PR — closes Phase 7. CLI subcommands deferred as P7.1.b.
+**Phase 7 (reports + journal export/import):** ✅ shipped — P7.1–P7.5 complete; P7.1.b (CLI subcommands) in PR.
 
 ---
 
@@ -560,14 +560,57 @@ Closes Phase 5. Imperative CLI subcommand group with 10 commands wrapping the /v
 
 ---
 
-## Phase 7 — Reports + journal export/import — in flight
+## Phase 7 — Reports + journal export/import — ✅ shipped
 
 Per ARCHITECTURE.md §8 + §10. v1 ships 9 reports in HTML+PDF+CSV, plus
 hledger-compatible journal export + basic journal import. "Workstream
 slicing": P7.1 HTML, P7.2 PDF, P7.3 CSV, P7.4 journal export, P7.5
-journal import.
+journal import. P7.1.b adds the CLI surface over both.
 
-### P7.5 — hledger journal import — 🔄 *(in PR; closes Phase 7)*
+### P7.1.b — `tulip reports` + `tulip journal` CLI — 🔄 *(in PR; closes #189)*
+
+Closes the deferred CLI surface from P7.1. Both report and journal
+endpoints were API-only after Phase 7 closed; this slice wires them
+into the imperative CLI per the existing client pattern (architecture
+test in `tulip-cli/tests/test_architecture.py` keeps the CLI a pure
+network client).
+
+**`tulip reports`** — Typer group with 9 subcommands, one per
+`/v1/reports/*` endpoint:
+- `trial-balance`, `balance-sheet`, `envelope-status`,
+  `sinking-fund-progress` — share `--as-of`.
+- `income-statement`, `cash-flow` — `--start` / `--end`
+  (income-statement also takes optional `--prior-start` / `--prior-end`).
+- `reconciliation-summary` — `--status` filter.
+- `audit-log` — `--start` / `--end` / `--actor` / `--entity-type` /
+  `--limit` / `--offset`.
+- `custom-query` — `--sql` (subject to the same SQL-safety gate as
+  `tulip ai query`).
+
+Each subcommand accepts `--format json|html|pdf|csv` (default `json`)
+and `--output PATH`. JSON/HTML default to stdout; PDF/CSV require
+`--output` since binary-to-terminal isn't useful. Date options are
+validated client-side with a `typer.BadParameter` for fast feedback.
+
+**`tulip journal`** — two subcommands:
+- `journal export` wraps `GET /v1/journal/export`. Accepts `--start`,
+  `--end`, `--output`. Writes to stdout by default.
+- `journal import FILE` wraps `POST /v1/journal/import`. Reads the
+  file's bytes, posts as `text/plain`, surfaces `{created, transaction_ids}`
+  or the typed Problem Details errors verbatim.
+
+**Tests** — +17 integration tests across two files:
+- `test_reports_command.py` (9 tests): trial-balance JSON/HTML/CSV-to-file/
+  PDF-requires-output paths; `--as-of` and invalid-date forwarding;
+  audit-log pagination; custom-query unsafe-SQL surfacing; auth gate.
+- `test_journal_command.py` (8 tests): export to stdout / file / date
+  range / invalid date; **export→import round-trip** (primary
+  acceptance); import parse-error surfacing; `--json` passthrough on
+  import; auth gate.
+
+Full suite: 1528 passed, 1 skipped in 4:01.
+
+### P7.5 — hledger journal import — ✅ *(2026-05-12)*
 
 Final Phase-7 slice. Closes the round-trip with P7.4: users can pull
 their ledger out as hledger journal text and push it back in. Imported
@@ -610,8 +653,8 @@ convention as the existing OFX / QIF / CSV importers (#74).
 
 Full suite: 1511 passed locally.
 
-**Phase 7 closes** after this slice merges. CLI subcommands
-(deferred from P7.1) remain as P7.1.b follow-up.
+**Phase 7 closes** with this slice. CLI subcommands tracked as P7.1.b
+follow-up (see below for the in-flight CLI slice).
 
 ### P7.4 — hledger-compatible journal export — ✅ *(2026-05-12)*
 
@@ -785,10 +828,10 @@ integration test (the foundational pattern), +35 across the new
 report endpoints (JSON shape, HTML response Content-Type, auth gate,
 date filters, custom-query SQL safety gate).
 
-**Out of scope** (deferred):
+**Out of scope** (deferred — all subsequently delivered):
 - PDF rendering via weasyprint — P7.2.
 - CSV output — P7.3.
-- CLI subcommands (`tulip reports <name>`) — P7.1.b.
+- CLI subcommands (`tulip reports <name>`, `tulip journal {export,import}`) — P7.1.b.
 - Journal export/import — P7.4 / P7.5.
 
 ---

--- a/packages/tulip-cli/src/tulip_cli/commands/journal.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/journal.py
@@ -1,0 +1,130 @@
+"""``tulip journal {export,import}`` — wrappers over ``/v1/journal/*`` (P7.1.b).
+
+* ``tulip journal export`` calls ``GET /v1/journal/export`` and writes
+  the hledger-formatted journal to stdout or ``--output``.
+* ``tulip journal import FILE`` posts the file's bytes to
+  ``POST /v1/journal/import`` as ``text/plain``. The API parses,
+  resolves account paths, and creates PENDING transactions through the
+  ``TransactionRepository.save_balanced`` chokepoint — matching the
+  OFX / QIF / CSV importer convention (#74).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date as date_type
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+journal_app = typer.Typer(
+    name="journal",
+    help="hledger-format journal export + import.",
+    no_args_is_help=True,
+)
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+def _validate_date(value: str | None, flag: str) -> None:
+    if value is None:
+        return
+    try:
+        date_type.fromisoformat(value)
+    except ValueError as exc:
+        raise typer.BadParameter(f"{flag} must be YYYY-MM-DD") from exc
+
+
+@journal_app.command("export")
+def export(
+    ctx: typer.Context,
+    start: Annotated[
+        str | None,
+        typer.Option("--start", help="Inclusive earliest tx date (YYYY-MM-DD)."),
+    ] = None,
+    end: Annotated[
+        str | None,
+        typer.Option("--end", help="Inclusive latest tx date (YYYY-MM-DD)."),
+    ] = None,
+    output: Annotated[
+        Path | None,
+        typer.Option(
+            "--output",
+            help="Write the journal text to this file instead of stdout.",
+        ),
+    ] = None,
+) -> None:
+    """Render the household ledger as hledger journal text."""
+    _validate_date(start, "--start")
+    _validate_date(end, "--end")
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    params: dict[str, str] = {}
+    if start is not None:
+        params["start"] = start
+    if end is not None:
+        params["end"] = end
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get("/v1/journal/export", authenticated=True, params=params)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if output is not None:
+        output.write_bytes(response.content)
+        if not as_json:
+            typer.echo(f"Wrote {len(response.content)} bytes to {output}")
+        return
+    sys.stdout.write(response.text)
+    if not response.text.endswith("\n"):
+        sys.stdout.write("\n")
+
+
+@journal_app.command("import")
+def import_(
+    ctx: typer.Context,
+    file_path: Annotated[
+        Path,
+        typer.Argument(
+            help="Path to an hledger-format journal file to import.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            metavar="FILE",
+        ),
+    ],
+) -> None:
+    """Upload a journal file; create PENDING transactions for review."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    body = file_path.read_bytes()
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.post_raw(
+                "/v1/journal/import",
+                body=body,
+                content_type="text/plain; charset=utf-8",
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    payload: dict[str, Any] = response.json()
+    typer.echo(f"Imported {payload.get('created', 0)} PENDING transaction(s) from {file_path}.")
+
+
+__all__ = ["journal_app"]

--- a/packages/tulip-cli/src/tulip_cli/commands/reports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/reports.py
@@ -1,0 +1,307 @@
+"""``tulip reports`` — wrappers over ``/v1/reports/*`` (P7.1.b).
+
+One subcommand per report (9 total). Each subcommand forwards its
+options to the matching query parameters on the report endpoint and
+renders the response body to stdout or to ``--output PATH``.
+
+Format selection:
+
+* ``--format json`` (default): pretty pass-through of the JSON body
+  (stdout) or written verbatim to ``--output``.
+* ``--format html``: HTML rendering. Writes to stdout (terminal-safe)
+  or ``--output``.
+* ``--format pdf`` / ``--format csv``: binary / structured. ``--output``
+  is required since piping these to a terminal isn't useful.
+
+The CLI is a pure network client — all rendering happens server-side
+in ``tulip_reports``. Architecture test
+``tests/test_architecture.py`` keeps it that way.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date as date_type
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+reports_app = typer.Typer(
+    name="reports",
+    help="Fetch the 9 ledger reports (JSON / HTML / PDF / CSV).",
+    no_args_is_help=True,
+)
+
+
+_BINARY_FORMATS = frozenset({"pdf", "csv"})
+
+
+def _client(config: Config, *, as_json: bool) -> TulipClient:
+    return TulipClient(config, token_store=default_token_store(), as_json=as_json)
+
+
+def _validate_date(value: str | None, flag: str) -> None:
+    if value is None:
+        return
+    try:
+        date_type.fromisoformat(value)
+    except ValueError as exc:
+        raise typer.BadParameter(f"{flag} must be YYYY-MM-DD") from exc
+
+
+def _fetch_and_emit(
+    ctx: typer.Context,
+    *,
+    endpoint: str,
+    params: dict[str, str],
+    fmt: str,
+    output: Path | None,
+) -> None:
+    """Shared GET-render-write flow used by every report subcommand."""
+    if fmt in _BINARY_FORMATS and output is None:
+        raise typer.BadParameter(
+            f"--format {fmt} requires --output PATH (binary output isn't terminal-safe)."
+        )
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    request_params = dict(params)
+    request_params["format"] = fmt
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get(endpoint, authenticated=True, params=request_params)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if output is not None:
+        output.write_bytes(response.content)
+        if not as_json:
+            typer.echo(f"Wrote {len(response.content)} bytes to {output}")
+        return
+
+    if fmt in _BINARY_FORMATS:  # pragma: no cover — guarded above
+        raise RuntimeError("unreachable: binary formats require --output")
+    sys.stdout.write(response.text)
+    if not response.text.endswith("\n"):
+        sys.stdout.write("\n")
+
+
+# -----------------------------------------------------------------------
+# trial-balance, balance-sheet, envelope-status, sinking-fund-progress
+# share a single shape (``--as-of``-only).
+# -----------------------------------------------------------------------
+
+
+def _as_of_only(
+    ctx: typer.Context,
+    endpoint: str,
+    *,
+    as_of: str | None,
+    fmt: str,
+    output: Path | None,
+) -> None:
+    _validate_date(as_of, "--as-of")
+    params: dict[str, str] = {}
+    if as_of is not None:
+        params["as_of"] = as_of
+    _fetch_and_emit(ctx, endpoint=endpoint, params=params, fmt=fmt, output=output)
+
+
+@reports_app.command("trial-balance")
+def trial_balance(
+    ctx: typer.Context,
+    as_of: Annotated[
+        str | None,
+        typer.Option("--as-of", help="Point-in-time date (YYYY-MM-DD). Defaults to today."),
+    ] = None,
+    fmt: Annotated[
+        str,
+        typer.Option("--format", help="Response format: json|html|pdf|csv.", case_sensitive=False),
+    ] = "json",
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", help="Write the response body to this file instead of stdout."),
+    ] = None,
+) -> None:
+    """Per-account balances + per-currency debit/credit totals."""
+    _as_of_only(ctx, "/v1/reports/trial-balance", as_of=as_of, fmt=fmt, output=output)
+
+
+@reports_app.command("balance-sheet")
+def balance_sheet(
+    ctx: typer.Context,
+    as_of: Annotated[str | None, typer.Option("--as-of")] = None,
+    fmt: Annotated[str, typer.Option("--format", case_sensitive=False)] = "json",
+    output: Annotated[Path | None, typer.Option("--output")] = None,
+) -> None:
+    """Assets / liabilities / equity snapshot at ``--as-of``."""
+    _as_of_only(ctx, "/v1/reports/balance-sheet", as_of=as_of, fmt=fmt, output=output)
+
+
+@reports_app.command("envelope-status")
+def envelope_status(
+    ctx: typer.Context,
+    as_of: Annotated[str | None, typer.Option("--as-of")] = None,
+    fmt: Annotated[str, typer.Option("--format", case_sensitive=False)] = "json",
+    output: Annotated[Path | None, typer.Option("--output")] = None,
+) -> None:
+    """Active envelopes: balance vs budget at ``--as-of``."""
+    _as_of_only(ctx, "/v1/reports/envelope-status", as_of=as_of, fmt=fmt, output=output)
+
+
+@reports_app.command("sinking-fund-progress")
+def sinking_fund_progress(
+    ctx: typer.Context,
+    as_of: Annotated[str | None, typer.Option("--as-of")] = None,
+    fmt: Annotated[str, typer.Option("--format", case_sensitive=False)] = "json",
+    output: Annotated[Path | None, typer.Option("--output")] = None,
+) -> None:
+    """Active sinking funds: balance vs target at ``--as-of``."""
+    _as_of_only(ctx, "/v1/reports/sinking-fund-progress", as_of=as_of, fmt=fmt, output=output)
+
+
+# -----------------------------------------------------------------------
+# income-statement + cash-flow take period boundaries.
+# -----------------------------------------------------------------------
+
+
+@reports_app.command("income-statement")
+def income_statement(
+    ctx: typer.Context,
+    start: Annotated[str, typer.Option("--start", help="Period start (YYYY-MM-DD).")],
+    end: Annotated[str, typer.Option("--end", help="Period end (YYYY-MM-DD).")],
+    prior_start: Annotated[
+        str | None,
+        typer.Option("--prior-start", help="Optional comparison period start (YYYY-MM-DD)."),
+    ] = None,
+    prior_end: Annotated[
+        str | None,
+        typer.Option("--prior-end", help="Optional comparison period end (YYYY-MM-DD)."),
+    ] = None,
+    fmt: Annotated[str, typer.Option("--format", case_sensitive=False)] = "json",
+    output: Annotated[Path | None, typer.Option("--output")] = None,
+) -> None:
+    """Revenue, expenses, and net income over a period."""
+    for value, flag in (
+        (start, "--start"),
+        (end, "--end"),
+        (prior_start, "--prior-start"),
+        (prior_end, "--prior-end"),
+    ):
+        _validate_date(value, flag)
+    params: dict[str, str] = {"start": start, "end": end}
+    if prior_start is not None:
+        params["prior_start"] = prior_start
+    if prior_end is not None:
+        params["prior_end"] = prior_end
+    _fetch_and_emit(
+        ctx, endpoint="/v1/reports/income-statement", params=params, fmt=fmt, output=output
+    )
+
+
+@reports_app.command("cash-flow")
+def cash_flow(
+    ctx: typer.Context,
+    start: Annotated[str, typer.Option("--start")],
+    end: Annotated[str, typer.Option("--end")],
+    fmt: Annotated[str, typer.Option("--format", case_sensitive=False)] = "json",
+    output: Annotated[Path | None, typer.Option("--output")] = None,
+) -> None:
+    """Net change per asset account over a period."""
+    _validate_date(start, "--start")
+    _validate_date(end, "--end")
+    _fetch_and_emit(
+        ctx,
+        endpoint="/v1/reports/cash-flow",
+        params={"start": start, "end": end},
+        fmt=fmt,
+        output=output,
+    )
+
+
+# -----------------------------------------------------------------------
+# reconciliation-summary, audit-log, custom-query: bespoke filters.
+# -----------------------------------------------------------------------
+
+
+@reports_app.command("reconciliation-summary")
+def reconciliation_summary(
+    ctx: typer.Context,
+    status: Annotated[
+        str | None,
+        typer.Option("--status", help="Optional status filter (e.g. open, complete)."),
+    ] = None,
+    fmt: Annotated[str, typer.Option("--format", case_sensitive=False)] = "json",
+    output: Annotated[Path | None, typer.Option("--output")] = None,
+) -> None:
+    """Reconciliations newest-first; filter by status."""
+    params: dict[str, str] = {}
+    if status is not None:
+        params["status"] = status
+    _fetch_and_emit(
+        ctx, endpoint="/v1/reports/reconciliation-summary", params=params, fmt=fmt, output=output
+    )
+
+
+@reports_app.command("audit-log")
+def audit_log(
+    ctx: typer.Context,
+    start: Annotated[str | None, typer.Option("--start")] = None,
+    end: Annotated[str | None, typer.Option("--end")] = None,
+    actor: Annotated[
+        str | None,
+        typer.Option("--actor", help="Filter by actor user UUID."),
+    ] = None,
+    entity_type: Annotated[
+        str | None,
+        typer.Option("--entity-type", help="Filter by entity type (e.g. transaction, account)."),
+    ] = None,
+    limit: Annotated[int, typer.Option("--limit", min=1, max=500)] = 100,
+    offset: Annotated[int, typer.Option("--offset", min=0)] = 0,
+    fmt: Annotated[str, typer.Option("--format", case_sensitive=False)] = "json",
+    output: Annotated[Path | None, typer.Option("--output")] = None,
+) -> None:
+    """Filtered, paginated audit-log entries."""
+    _validate_date(start, "--start")
+    _validate_date(end, "--end")
+    params: dict[str, str] = {"limit": str(limit), "offset": str(offset)}
+    if start is not None:
+        params["start"] = start
+    if end is not None:
+        params["end"] = end
+    if actor is not None:
+        params["actor_user_id"] = actor
+    if entity_type is not None:
+        params["entity_type"] = entity_type
+    _fetch_and_emit(ctx, endpoint="/v1/reports/audit-log", params=params, fmt=fmt, output=output)
+
+
+@reports_app.command("custom-query")
+def custom_query(
+    ctx: typer.Context,
+    sql: Annotated[
+        str,
+        typer.Option(
+            "--sql",
+            help=(
+                "Read-only SELECT against the AI views. Subject to the same "
+                "SQL-safety gate as ``tulip ai query``."
+            ),
+        ),
+    ],
+    fmt: Annotated[str, typer.Option("--format", case_sensitive=False)] = "json",
+    output: Annotated[Path | None, typer.Option("--output")] = None,
+) -> None:
+    """Render an ad-hoc SELECT as a tabular report."""
+    _fetch_and_emit(
+        ctx, endpoint="/v1/reports/custom-query", params={"sql": sql}, fmt=fmt, output=output
+    )
+
+
+__all__ = ["reports_app"]

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -26,6 +26,7 @@ from tulip_cli.commands.balance import balance as balance_command
 from tulip_cli.commands.doctor import doctor as doctor_command
 from tulip_cli.commands.envelopes import envelopes_app
 from tulip_cli.commands.imports import imports_app
+from tulip_cli.commands.journal import journal_app
 from tulip_cli.commands.notifications import notifications_app
 from tulip_cli.commands.periods import periods_app
 from tulip_cli.commands.pool_actions import (
@@ -40,6 +41,7 @@ from tulip_cli.commands.pool_actions import (
 from tulip_cli.commands.reconcile import reconcile_app
 from tulip_cli.commands.refills import refills_app
 from tulip_cli.commands.register import register as register_command
+from tulip_cli.commands.reports import reports_app
 from tulip_cli.commands.sinking_funds import sinking_funds_app
 from tulip_cli.commands.transactions import add as add_command
 from tulip_cli.commands.transactions import transactions_app
@@ -129,7 +131,9 @@ app.add_typer(refills_app, name="refills")
 # for back-compat with P5.2.a/b examples that used the singular form.
 app.add_typer(imports_app, name="imports")
 app.add_typer(imports_app, name="import")
+app.add_typer(journal_app, name="journal")
 app.add_typer(reconcile_app, name="reconcile")
+app.add_typer(reports_app, name="reports")
 app.command("backup")(backup_command)
 app.command("restore")(restore_command)
 app.command("backup-inspect")(manifest_command)

--- a/packages/tulip-cli/tests/test_journal_command.py
+++ b/packages/tulip-cli/tests/test_journal_command.py
@@ -1,0 +1,221 @@
+"""End-to-end tests for ``tulip journal {export,import}`` (P7.1.b).
+
+Round-trip is the primary acceptance criterion: export → write to file
+→ import — the same payload that survived /v1/journal/export must
+re-import as PENDING transactions.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=30,
+    )
+
+
+def _register_and_login(api_url: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{api_url}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    api_login = httpx.post(
+        f"{api_url}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    api_login.raise_for_status()
+    access = str(api_login.json()["access_token"])
+    cli_login = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=api_url,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert cli_login.returncode == 0, cli_login.stderr
+    return access
+
+
+def _seed_two_accounts_and_tx(api_url: str, access: str) -> None:
+    h = {"authorization": f"Bearer {access}"}
+    cash = httpx.post(
+        f"{api_url}/v1/accounts",
+        json={
+            "name": "Cash",
+            "type": "asset",
+            "currency": "USD",
+            "code": "1110",
+            "visibility": "shared",
+        },
+        headers=h,
+        timeout=10,
+    )
+    cash.raise_for_status()
+    food = httpx.post(
+        f"{api_url}/v1/accounts",
+        json={
+            "name": "Food",
+            "type": "expense",
+            "currency": "USD",
+            "code": "5100",
+            "visibility": "shared",
+        },
+        headers=h,
+        timeout=10,
+    )
+    food.raise_for_status()
+    httpx.post(
+        f"{api_url}/v1/transactions",
+        json={
+            "date": date(2026, 3, 1).isoformat(),
+            "description": "Lunch",
+            "postings": [
+                {"account_id": food.json()["id"], "amount": "8.75", "currency": "USD"},
+                {"account_id": cash.json()["id"], "amount": "-8.75", "currency": "USD"},
+            ],
+        },
+        headers=h,
+        timeout=10,
+    ).raise_for_status()
+
+
+@pytest.fixture
+def authed_session(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[str, str]:
+    access = _register_and_login(live_api, tmp_path, monkeypatch)
+    return live_api, access
+
+
+@pytest.mark.integration
+def test_export_default_writes_journal_to_stdout(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    _seed_two_accounts_and_tx(api_url, access)
+    r = _run_cli("journal", "export", api_url=api_url)
+    assert r.returncode == 0, r.stderr
+    assert "2026-03-01" in r.stdout
+    assert "Lunch" in r.stdout
+
+
+@pytest.mark.integration
+def test_export_to_file(authed_session: tuple[str, str], tmp_path: Path) -> None:
+    api_url, access = authed_session
+    _seed_two_accounts_and_tx(api_url, access)
+    out = tmp_path / "ledger.journal"
+    r = _run_cli("journal", "export", "--output", str(out), api_url=api_url)
+    assert r.returncode == 0, r.stderr
+    assert out.exists()
+    assert "Lunch" in out.read_text()
+    assert "Wrote" in r.stdout
+
+
+@pytest.mark.integration
+def test_export_date_range_forwarded(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    _seed_two_accounts_and_tx(api_url, access)
+    r = _run_cli(
+        "journal",
+        "export",
+        "--start",
+        "2026-01-01",
+        "--end",
+        "2026-02-01",
+        api_url=api_url,
+    )
+    assert r.returncode == 0, r.stderr
+    # The seeded tx is dated 2026-03-01, so the range excludes it.
+    assert "Lunch" not in r.stdout
+
+
+@pytest.mark.integration
+def test_export_invalid_date_rejected(authed_session: tuple[str, str]) -> None:
+    api_url, _ = authed_session
+    r = _run_cli("journal", "export", "--start", "13/45/26", api_url=api_url)
+    assert r.returncode != 0
+    assert "yyyy-mm-dd" in r.stderr.lower()
+
+
+@pytest.mark.integration
+def test_import_roundtrip(authed_session: tuple[str, str], tmp_path: Path) -> None:
+    api_url, access = authed_session
+    _seed_two_accounts_and_tx(api_url, access)
+    out = tmp_path / "ledger.journal"
+    exp = _run_cli("journal", "export", "--output", str(out), api_url=api_url)
+    assert exp.returncode == 0, exp.stderr
+    imp = _run_cli("journal", "import", str(out), api_url=api_url)
+    assert imp.returncode == 0, imp.stderr
+    assert "Imported 1" in imp.stdout
+    # Re-imported transaction should land as PENDING (not auto-posted).
+    pending = httpx.get(
+        f"{api_url}/v1/transactions",
+        params={"status": "pending"},
+        headers={"authorization": f"Bearer {access}"},
+        timeout=10,
+    )
+    pending.raise_for_status()
+    descs = [t["description"] for t in pending.json()]
+    assert "Lunch" in descs
+
+
+@pytest.mark.integration
+def test_import_parse_error_surfaces(authed_session: tuple[str, str], tmp_path: Path) -> None:
+    api_url, _ = authed_session
+    bad = tmp_path / "bad.journal"
+    bad.write_text("not-a-date no parse possible\n    foo  bar\n")
+    r = _run_cli("journal", "import", str(bad), api_url=api_url)
+    assert r.returncode != 0
+    combined = (r.stdout + r.stderr).lower()
+    assert "parse" in combined or "journal.parse_failed" in combined
+
+
+@pytest.mark.integration
+def test_import_json_passes_through_response(
+    authed_session: tuple[str, str], tmp_path: Path
+) -> None:
+    api_url, access = authed_session
+    _seed_two_accounts_and_tx(api_url, access)
+    out = tmp_path / "ledger.journal"
+    _run_cli("journal", "export", "--output", str(out), api_url=api_url)
+    r = _run_cli("--json", "journal", "import", str(out), api_url=api_url)
+    assert r.returncode == 0, r.stderr
+    payload = json.loads(r.stdout)
+    assert payload["created"] >= 1
+    assert "transaction_ids" in payload
+
+
+@pytest.mark.integration
+def test_journal_unauthenticated_fails_clearly(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    r = _run_cli("journal", "export", api_url=live_api)
+    assert r.returncode == 2
+    assert "not logged in" in r.stderr.lower() or "log in" in r.stderr.lower()

--- a/packages/tulip-cli/tests/test_reports_command.py
+++ b/packages/tulip-cli/tests/test_reports_command.py
@@ -1,0 +1,225 @@
+"""End-to-end tests for ``tulip reports`` (P7.1.b).
+
+Each subcommand is a thin wrapper over a ``/v1/reports/<name>``
+endpoint plus the shared format/output handling, so a representative
+sample (trial-balance + audit-log + custom-query) exercises every
+branch of the helper:
+
+* default ``--format json`` to stdout,
+* ``--format html`` to stdout,
+* ``--format pdf`` requiring ``--output``,
+* ``--format csv`` requiring ``--output``,
+* per-report options forwarded as query params,
+* auth error rendering.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=30,
+    )
+
+
+def _register_and_login(api_url: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{api_url}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    cli_login = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=api_url,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert cli_login.returncode == 0, cli_login.stderr
+    api_login = httpx.post(
+        f"{api_url}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    api_login.raise_for_status()
+    return str(api_login.json()["access_token"])
+
+
+def _seed_one_tx(api_url: str, access: str) -> None:
+    """Create cash + food + one posted transaction so reports have content."""
+    cash = httpx.post(
+        f"{api_url}/v1/accounts",
+        json={
+            "name": "Cash",
+            "type": "asset",
+            "currency": "USD",
+            "code": "1110",
+            "visibility": "shared",
+        },
+        headers={"authorization": f"Bearer {access}"},
+        timeout=10,
+    )
+    cash.raise_for_status()
+    food = httpx.post(
+        f"{api_url}/v1/accounts",
+        json={
+            "name": "Food",
+            "type": "expense",
+            "currency": "USD",
+            "code": "5100",
+            "visibility": "shared",
+        },
+        headers={"authorization": f"Bearer {access}"},
+        timeout=10,
+    )
+    food.raise_for_status()
+    httpx.post(
+        f"{api_url}/v1/transactions",
+        json={
+            "date": date(2026, 3, 1).isoformat(),
+            "description": "Grocery store",
+            "postings": [
+                {"account_id": food.json()["id"], "amount": "12.50", "currency": "USD"},
+                {"account_id": cash.json()["id"], "amount": "-12.50", "currency": "USD"},
+            ],
+        },
+        headers={"authorization": f"Bearer {access}"},
+        timeout=10,
+    ).raise_for_status()
+
+
+@pytest.fixture
+def authed_session(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[str, str]:
+    access = _register_and_login(live_api, tmp_path, monkeypatch)
+    return live_api, access
+
+
+@pytest.mark.integration
+def test_trial_balance_default_json_to_stdout(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    _seed_one_tx(api_url, access)
+    r = _run_cli("reports", "trial-balance", api_url=api_url)
+    assert r.returncode == 0, r.stderr
+    body = json.loads(r.stdout)
+    assert "rows" in body and "totals_by_currency" in body
+
+
+@pytest.mark.integration
+def test_trial_balance_html_to_stdout(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    _seed_one_tx(api_url, access)
+    r = _run_cli("reports", "trial-balance", "--format", "html", api_url=api_url)
+    assert r.returncode == 0, r.stderr
+    assert "<html" in r.stdout.lower() or "<!doctype" in r.stdout.lower()
+
+
+@pytest.mark.integration
+def test_trial_balance_pdf_requires_output(authed_session: tuple[str, str]) -> None:
+    api_url, _ = authed_session
+    r = _run_cli("reports", "trial-balance", "--format", "pdf", api_url=api_url)
+    assert r.returncode != 0
+    assert "--output" in r.stderr.lower() or "requires" in r.stderr.lower()
+
+
+@pytest.mark.integration
+def test_trial_balance_csv_writes_file(authed_session: tuple[str, str], tmp_path: Path) -> None:
+    api_url, access = authed_session
+    _seed_one_tx(api_url, access)
+    out = tmp_path / "tb.csv"
+    r = _run_cli(
+        "reports",
+        "trial-balance",
+        "--format",
+        "csv",
+        "--output",
+        str(out),
+        api_url=api_url,
+    )
+    assert r.returncode == 0, r.stderr
+    assert out.exists()
+    text = out.read_text()
+    assert "code" in text.lower() or "balance" in text.lower()
+    assert "Wrote" in r.stdout
+
+
+@pytest.mark.integration
+def test_trial_balance_as_of_forwarded(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    _seed_one_tx(api_url, access)
+    r = _run_cli("reports", "trial-balance", "--as-of", "2026-01-01", api_url=api_url)
+    assert r.returncode == 0, r.stderr
+    body = json.loads(r.stdout)
+    # Posted on 2026-03-01, so before-2026-01-01 has no rows.
+    assert body["rows"] == []
+
+
+@pytest.mark.integration
+def test_trial_balance_invalid_as_of_rejected(authed_session: tuple[str, str]) -> None:
+    api_url, _ = authed_session
+    r = _run_cli("reports", "trial-balance", "--as-of", "not-a-date", api_url=api_url)
+    assert r.returncode != 0
+    assert "yyyy-mm-dd" in r.stderr.lower()
+
+
+@pytest.mark.integration
+def test_audit_log_default_paginated(authed_session: tuple[str, str]) -> None:
+    api_url, access = authed_session
+    _seed_one_tx(api_url, access)
+    r = _run_cli("reports", "audit-log", "--limit", "5", api_url=api_url)
+    assert r.returncode == 0, r.stderr
+    body = json.loads(r.stdout)
+    # audit-log returns rows + metadata; just confirm structure surfaced.
+    assert isinstance(body, dict)
+
+
+@pytest.mark.integration
+def test_custom_query_unsafe_sql_surfaces_400(authed_session: tuple[str, str]) -> None:
+    api_url, _ = authed_session
+    r = _run_cli(
+        "reports",
+        "custom-query",
+        "--sql",
+        "DROP TABLE accounts",
+        api_url=api_url,
+    )
+    assert r.returncode != 0
+    combined = (r.stdout + r.stderr).lower()
+    assert "unsafe" in combined or "rejected" in combined or "not allowed" in combined
+
+
+@pytest.mark.integration
+def test_reports_unauthenticated(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    r = _run_cli("reports", "trial-balance", api_url=live_api)
+    assert r.returncode == 2
+    assert "not logged in" in r.stderr.lower() or "log in" in r.stderr.lower()


### PR DESCRIPTION
## Summary

Closes #189 — the Phase-7 deferred CLI surface. P7.1 landed 9 reports as REST endpoints and P7.4/P7.5 landed journal export/import as REST — this slice wires both into the imperative CLI per the existing pattern. With this merged, Phase 7 fully closes.

- **\`tulip reports\`** — Typer group with one subcommand per \`/v1/reports/<name>\` endpoint. Each accepts \`--format json|html|pdf|csv\` (default \`json\`) and \`--output PATH\`. JSON/HTML default to stdout; PDF/CSV require \`--output\` (binary-to-terminal isn't useful).
- **\`tulip journal export\`** — \`--start\` / \`--end\` / \`--output\` over \`GET /v1/journal/export\`.
- **\`tulip journal import FILE\`** — POSTs the file's bytes to \`/v1/journal/import\` as \`text/plain\`; surfaces \`{created, transaction_ids}\` or the typed Problem Details errors.
- Architecture-test allowlist unchanged: both modules import only from \`tulip_cli.*\` + stdlib + typer.
- PHASE_STATUS: Phase 7 marked shipped; P7.1.b detailed entry added; the stale ​"deferred" callouts updated.

## Test plan

- [x] \`just test\` → **1528 passed, 1 skipped** in 4:01 locally (+17 from the new tests).
- [x] \`just lint\` + \`just typecheck\` clean.
- [x] +17 new integration tests across \`test_reports_command.py\` (9) and \`test_journal_command.py\` (8) covering happy paths, format/output mechanics, error surfacing, and auth gates.
- [ ] CI green on this PR

### Manual smoke

\`\`\`bash
export TULIP_DB_URL='sqlite:///./smoke.db'
export TULIP_JWT_SECRET='dev-secret-do-not-use-in-prod'
uv run alembic upgrade head
uv run uvicorn tulip_api.main:app --port 8000 &
sleep 2

uv run tulip --api-url http://127.0.0.1:8000 auth register \
  --email a@x.test --password 'correct horse battery staple' \
  --display-name A --household 'Smoke'
uv run tulip --api-url http://127.0.0.1:8000 auth login \
  --email a@x.test --password-stdin <<< 'correct horse battery staple'

uv run tulip --api-url http://127.0.0.1:8000 accounts add \
  --name Cash --type asset --currency USD --code 1110
uv run tulip --api-url http://127.0.0.1:8000 accounts add \
  --name Food --type expense --currency USD --code 5100

uv run tulip --api-url http://127.0.0.1:8000 add \
  --date 2026-05-01 --description Lunch \
  --debit 5100 --credit 1110 --amount 8.75 --currency USD

uv run tulip --api-url http://127.0.0.1:8000 reports trial-balance
uv run tulip --api-url http://127.0.0.1:8000 reports trial-balance --format html --output tb.html
uv run tulip --api-url http://127.0.0.1:8000 reports trial-balance --format csv --output tb.csv
uv run tulip --api-url http://127.0.0.1:8000 journal export --output ledger.journal
uv run tulip --api-url http://127.0.0.1:8000 journal import ledger.journal

kill %1
rm -f smoke.db tb.html tb.csv ledger.journal
\`\`\`

Expected: JSON trial-balance to stdout; \`tb.html\` / \`tb.csv\` written ("Wrote N bytes to ..."); ledger.journal written with the seeded posting; \`journal import\` reports "Imported 1 PENDING transaction(s)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)