### PR TITLE
docs: bring docs current with Phase 7 close

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Honest expectations matter for internal-beta. The following are deliberately def
 - **Web / mobile UI.** Tulip is API-first with a Typer CLI client; the web client lands as a separate phase. The CLI is the supported UI.
 - **Multi-tenant cloud hosting.** Tulip is single-machine, single-tenant SQLite for internal beta. Postgres + KMS + multi-tenant scaling is a future phase.
 - **Reverse-proxy / TLS tutorial.** Run behind Caddy or Tailscale Funnel; we don't ship a TLS setup guide.
-- **Reports beyond CLI tables.** PDF / HTML / journal export lands in Phase 7.
+- **Reports beyond CLI tables.** HTML / PDF / CSV rendering for all nine reports ships in Phase 7, together with `tulip journal {export,import}` for hledger round-tripping.
 
 **Opt-in AI features** (auto-categorisation, NL queries, forecasts, agentic proposals) are now wired and shipped — disabled by default; bring your own provider key (Anthropic / OpenAI / local Ollama) via `tulip ai set-key` to enable. Per-household policy, per-user rate limits, monthly cost cap, and a `tulip ai status` summary all surface from the CLI. See the AI cookbook in [docs/QUICKSTART.md](docs/QUICKSTART.md) for the enablement walkthrough.
 
@@ -57,7 +57,7 @@ The full deferred-features list and the ordered roadmap is the contributor-side 
 
 ## For contributors
 
-> **Status:** Internal beta. Phases 0–6 complete (project bootstrap, storage + accounting engine, API surface, scriptable CLI, envelopes + sinking funds + scheduled refills, OFX/QIF/CSV importers + statement-driven reconciliation, opt-in AI integration with BYOK provider keys + cost-cap + rate limit + audited proposals). Next up: Phase 7 (reports + journal export/import). See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
+> **Status:** Internal beta. Phases 0–7 complete (project bootstrap, storage + accounting engine, API surface, scriptable CLI, envelopes + sinking funds + scheduled refills, OFX/QIF/CSV importers + statement-driven reconciliation, opt-in AI integration with BYOK provider keys + cost-cap + rate limit + audited proposals, nine reports in HTML/PDF/CSV + hledger journal export/import + `tulip reports` and `tulip journal` CLI). See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
 
 ### Architecture at a glance
 
@@ -90,7 +90,7 @@ git clone https://github.com/rmwarriner/tulip-accounting.git
 cd tulip-accounting
 uv sync --all-packages --dev     # installs all workspace packages + dev deps
 uv run pre-commit install        # enable pre-commit hooks
-just test                        # confirm tests pass (~1426 tests, ~4 min with xdist)
+just test                        # confirm tests pass (~1545 tests, ~4 min with xdist)
 ```
 
 > **Note for committers:** `main` is branch-protected and **requires every commit to be signed**. Configure SSH or GPG commit signing before your first push (`git config --global commit.gpgsign true` plus a signing key); see [CONTRIBUTING.md](CONTRIBUTING.md#branch-protection-on-main) for the diagnostic checklist when a push is rejected as unsigned.
@@ -127,14 +127,16 @@ TULIP_JWT_SECRET="$(uv run python -c 'import secrets; print(secrets.token_urlsaf
   uv run uvicorn tulip_api.main:create_app --factory --host 127.0.0.1 --port 8000
 ```
 
-Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.0.0.1:8000/openapi.json` for the OpenAPI spec. Endpoint surface (Phases 0–6):
+Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.0.0.1:8000/openapi.json` for the OpenAPI spec. Endpoint surface (Phases 0–7):
 
 - **Auth:** `POST /v1/auth/{register,login,login/mfa,login/recover,refresh,logout}`, `POST /v1/auth/mfa/{enroll,verify,recovery-codes/regenerate}`, `GET /v1/auth/mfa/recovery-codes/status`
-- **Accounts + transactions:** `GET/POST/PATCH/DELETE /v1/accounts[/{id}]`, `GET /v1/accounts/{id}/balance`, `GET/POST/PATCH/DELETE /v1/transactions[/{id}]`, `POST /v1/transactions/{id}/void`, `GET /v1/reports/trial-balance`
+- **Accounts + transactions:** `GET/POST/PATCH/DELETE /v1/accounts[/{id}]`, `GET /v1/accounts/{id}/balance`, `GET/POST/PATCH/DELETE /v1/transactions[/{id}]`, `POST /v1/transactions/{id}/void`
 - **Periods:** `GET /v1/periods`, `POST /v1/periods/{id}/{close,reopen}`
 - **Envelopes + sinking funds + pools:** `GET/POST/PATCH/DELETE /v1/envelopes[/{id}]`, `GET/POST/PATCH/DELETE /v1/sinking-funds[/{id}]`, `GET /v1/pools/{id}/balance`, `POST /v1/pools/{id}/{refill,transfer,budget-inflow}`, `POST /v1/pools/balances` (batched), `GET/POST/PATCH/DELETE /v1/refill-schedules[/{id}]`
 - **Importers + reconciliation:** `POST /v1/imports[?force=true]`, `GET /v1/imports/{id}`, `POST /v1/imports/{id}/{apply,lines/{line_id}/promote}`, `GET/POST/PATCH/DELETE /v1/imports/profiles[/{id_or_name}]` (CSV column-mapping profiles, YAML round-trip), `GET/POST/DELETE /v1/reconciliations[/{id}][?cascade=true]`, `POST /v1/reconciliations/{id}/{auto-match,complete,matches,carry-forward}`, `POST /v1/reconciliations/{id}/matches/{id}/reject`, `DELETE /v1/reconciliations/{id}/carry-forward/{tx_id}`
 - **AI (Phase 6, BYOK, admin-only configuration):** `POST/DELETE /v1/ai/keys/{provider}`, `GET /v1/ai/keys`, `GET/PUT /v1/ai/config`, `PUT /v1/ai/config/capabilities/{capability}`, `GET /v1/ai/status`, `POST /v1/ai/preview`, `POST /v1/ai/ask` (two-turn NL query), `GET/POST /v1/ai/proposals[?status=...]`, `GET /v1/ai/proposals/kinds`, `POST /v1/ai/proposals/{id}/{approve,reject}`, `POST /v1/ai/proposals/suggest/budget`
+- **Reports (Phase 7, JSON/HTML/PDF/CSV via `?format=`):** `GET /v1/reports/{trial-balance,balance-sheet,income-statement,cash-flow,envelope-status,sinking-fund-progress,reconciliation-summary,audit-log,custom-query}`
+- **Journal (Phase 7, hledger-format round-trip):** `GET /v1/journal/export[?start=...&end=...]`, `POST /v1/journal/import` (text/plain body → PENDING transactions)
 - **Notifications:** `GET /v1/notifications[?status=...]`, `POST /v1/notifications/{id}/dismiss`
 - **Ops:** `GET /health`, `GET /v1/system/diagnostics` (consumed by `tulip doctor`)
 
@@ -176,7 +178,7 @@ uv run tulip reconcile complete "$RECON_ID"       # strict balance check, denorm
 
 `tulip add --edit` opens `$EDITOR` with a hledger-style template instead of taking flags. `tulip accounts list` renders a Rich tree when nesting exists, a flat table otherwise (`--flat` to force the table for scripting). Tokens persist in the OS keyring; the CLI exit-code map and full RFC 9457 error rendering are documented in [docs/ARCHITECTURE.md §7.8.5](docs/ARCHITECTURE.md).
 
-Other top-level commands: `tulip envelopes`, `tulip sinking-funds`, `tulip refills`, `tulip periods`, `tulip transfer`, `tulip refill`, `tulip budget-inflow`, `tulip transactions {show,edit,void,delete}`, `tulip imports {profiles,apply}`, `tulip notifications {list,dismiss}`, `tulip backup`, `tulip restore`, `tulip doctor`. The `tulip ai` group (Phase 6) covers BYOK + policy editing + the four capabilities: `tulip ai {set-key, forget-key, list-keys, status, preview, config {show,set,clear,set-capability,log-prompts}, ask, propose, proposals, approve, reject, suggest-budget}`. Each takes `--help`; the surface mirrors the API endpoints listed above.
+Other top-level commands: `tulip envelopes`, `tulip sinking-funds`, `tulip refills`, `tulip periods`, `tulip transfer`, `tulip refill`, `tulip budget-inflow`, `tulip transactions {show,edit,void,delete}`, `tulip imports {profiles,apply}`, `tulip notifications {list,dismiss}`, `tulip backup`, `tulip restore`, `tulip doctor`. The `tulip ai` group (Phase 6) covers BYOK + policy editing + the four capabilities: `tulip ai {set-key, forget-key, list-keys, status, preview, config {show,set,clear,set-capability,log-prompts}, ask, propose, proposals, approve, reject, suggest-budget}`. The `tulip reports` group (Phase 7) has one subcommand per report (`trial-balance`, `balance-sheet`, `income-statement`, `cash-flow`, `envelope-status`, `sinking-fund-progress`, `reconciliation-summary`, `audit-log`, `custom-query`); each accepts `--format json|html|pdf|csv` (default json, JSON/HTML default to stdout, PDF/CSV need `--output PATH`). `tulip journal {export,import}` round-trips the household ledger as hledger-format text. Each takes `--help`; the surface mirrors the API endpoints listed above.
 
 ### Development discipline
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Tulip Accounting — Architectural Specification (v1)
 
-**Status:** Phases 0–6 complete (ADR-0005 AI integration shipped end-to-end). Internal-beta ready. Phase 7 (reports + journal export/import) is the next slice.
-**Document version:** 1.1
-**Date:** 2026-04-29 (original) · 2026-05-07 (Phase 5 close + roadmap refresh)
+**Status:** Phases 0–7 complete. Internal-beta ready. The full v1 surface is in place: ADR-0005 AI integration end-to-end, all nine reports rendered in HTML/PDF/CSV, hledger-format journal export + import, and the `tulip reports` / `tulip journal` CLI groups.
+**Document version:** 1.2
+**Date:** 2026-04-29 (original) · 2026-05-07 (Phase 5 close + roadmap refresh) · 2026-05-12 (Phase 7 close)
 
 ---
 
@@ -978,10 +978,13 @@ Per [ADR-0004](adrs/0004-reconciliation.md). Closed 2026-05-07 across nine sub-s
 - ✅ **P6.5.b** — `tulip ai config` editor + `log_prompts` toggle + `tulip ai status` fallback-semantics callout. `GET/PUT /v1/ai/config` + `PUT /v1/ai/config/capabilities/{capability}` admin surface (PR #163).
 - ✅ **P6.5.c** — Sinking-fund forecast extension to the daily-insights handler via a single `ForecastRequest` dataclass (PR #171). Phase 6 closes.
 
-### Phase 7 — Reports + journal export/import
-- All v1 reports rendered as HTML and PDF (weasyprint)
-- Journal export (hledger-compatible)
-- Basic journal import
+### Phase 7 — Reports + journal export/import ✅ complete
+- ✅ **P7.1** — `tulip-reports` package skeleton + all nine reports rendered in HTML via a shared Jinja2 layout (trial-balance, balance-sheet, income-statement, cash-flow, envelope-status, sinking-fund-progress, reconciliation-summary, audit-log, custom-query) (PR #180).
+- ✅ **P7.2** — PDF rendering via weasyprint (pydyf + pango), one engine reused across every report (PR #183).
+- ✅ **P7.3** — CSV output for every report via the Python `csv` stdlib + a per-report row-flattening adapter (PR #184).
+- ✅ **P7.4** — hledger-compatible `GET /v1/journal/export[?start=...&end=...]`; output round-trips through hledger / ledger-cli (PR #186).
+- ✅ **P7.5** — hledger-compatible `POST /v1/journal/import`; account paths resolve by code first then `(type, name)`; imported transactions land in PENDING for review — same convention as the OFX / QIF / CSV importers (PR #188). Phase 7 closes.
+- ✅ **P7.1.b** — CLI surface: `tulip reports <name>` (9 subcommands, `--format json|html|pdf|csv`, `--output PATH`) and `tulip journal {export,import}` over the existing endpoints (PR #190).
 
 ### Phase 8 — Operations + hardening
 - Docker compose for home server

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -242,7 +242,62 @@ red when soft-closed.
 
 ---
 
-## 8. Backup
+## 8. Reports + journal export/import
+
+`tulip reports` covers the nine v1 reports. Every subcommand accepts
+`--format json|html|pdf|csv` (default `json`) and `--output PATH`.
+JSON and HTML default to stdout; PDF and CSV require `--output` since
+piping binary to a terminal isn't useful.
+
+```bash
+# Quick on-screen check.
+uv run tulip reports trial-balance
+
+# Save the same report as HTML, PDF, and CSV side by side.
+uv run tulip reports trial-balance --format html --output trial-balance.html
+uv run tulip reports trial-balance --format pdf  --output trial-balance.pdf
+uv run tulip reports trial-balance --format csv  --output trial-balance.csv
+
+# Period-shaped reports take --start / --end.
+uv run tulip reports income-statement \
+  --start 2026-01-01 --end 2026-05-31 \
+  --format pdf --output income-2026ytd.pdf
+
+# Custom-query gates with the same SQL-safety pass as `tulip ai ask`.
+uv run tulip reports custom-query \
+  --sql 'SELECT account_path, balance FROM ai_balances WHERE balance < 0'
+```
+
+The full list: `trial-balance`, `balance-sheet`, `income-statement`,
+`cash-flow`, `envelope-status`, `sinking-fund-progress`,
+`reconciliation-summary`, `audit-log`, `custom-query`. Each takes
+`--help` for the full option list (point-in-time reports take
+`--as-of`; `audit-log` adds `--actor` / `--entity-type` /
+`--limit` / `--offset`).
+
+For plain-text-accounting workflows (hledger, ledger-cli), Tulip
+exports a hledger-compatible journal and can re-ingest one as PENDING
+transactions for review:
+
+```bash
+# Export the whole ledger as hledger journal text.
+uv run tulip journal export --output ledger.journal
+
+# Or restrict to a date range, write to stdout, pipe into hledger.
+uv run tulip journal export --start 2026-01-01 --end 2026-05-31 | hledger -f - balance
+
+# Re-import a journal file (creates PENDING transactions — review with
+# `tulip transactions list --status pending` then promote).
+uv run tulip journal import ledger.journal
+```
+
+Import errors surface line numbers (`journal.parse_failed` for syntax,
+`journal.import_failed` for unknown accounts, unbalanced postings, or
+currency mismatches) so you can fix the file and retry.
+
+---
+
+## 9. Backup
 
 The stack's SQLite DB and attachments live in Docker volumes inside
 the container. `tulip backup` is bundled into the runtime image so it
@@ -280,7 +335,7 @@ docker compose -f deploy/docker/compose.yml exec -T api \
 
 ---
 
-## 9. Cookbook: rotating the master key
+## 10. Cookbook: rotating the master key
 
 Tulip doesn't ship a `tulip key-rotate` command for internal beta —
 the cost of getting it wrong (un-decryptable TOTP secrets across an
@@ -327,7 +382,7 @@ Doctor should report `master key loaded from file`.
 
 ---
 
-## 10. Cookbook: enabling AI (optional)
+## 11. Cookbook: enabling AI (optional)
 
 Phase 6 added four AI capabilities: transaction categorisation during
 imports, natural-language queries over your ledger, nightly forecast +
@@ -427,7 +482,11 @@ toggle on and off as you experiment.
 ## What's next
 
 - Run `tulip --help` to discover commands not covered here: `envelopes`,
-  `sinking-funds`, `refills`, `transfer`, `budget-inflow`.
+  `sinking-funds`, `refills`, `transfer`, `budget-inflow`,
+  `notifications`.
+- The `tulip reports` and `tulip journal` groups (covered in §8 above)
+  are the easiest way to get printable outputs and hledger-format
+  round-trips.
 - File issues at https://github.com/rmwarriner/tulip-accounting/issues —
   internal beta is the point at which feedback is most actionable.
 - Read [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) if you want to

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -2,9 +2,11 @@
 
 **Status:** lightweight checkpoint, not a deep audit. **Deep audits** are scheduled per the [§10 audit cadence in ARCHITECTURE.md](ARCHITECTURE.md): privacy audit before Phase 6 (AI) ✅ shipped as [ADR-0005](adrs/0005-ai-integration.md); deep security audit at Phase 8 (operations + hardening); pre-cloud re-audit at Phase 9.
 
-**Last updated:** 2026-05-11 · `main` @ Phase 6 complete (AI integration shipped)
+**Last updated:** 2026-05-12 · `main` @ Phase 7 complete (reports + hledger journal export/import shipped)
 
-This document captures what the system protects, what it doesn't, and the constraints Phase 4–6 work must not violate. It exists because the cheap moment to lock in trust boundaries is *before* envelopes / importers / AI add surface area, not after. Tracked as #56.
+This document captures what the system protects, what it doesn't, and the constraints Phase 4–7 work must not violate. It exists because the cheap moment to lock in trust boundaries is *before* envelopes / importers / AI / reports add surface area, not after. Tracked as #56.
+
+**Phase 7 surface check:** the new `/v1/reports/*` endpoints and `/v1/journal/{export,import}` reuse the existing tenant-scoped session + JWT chokepoint — they introduce no new trust boundary, no new external network dependency at runtime (weasyprint is a build-time system lib for PDF), and no new credential store. The `custom-query` report is gated by the same SQL-safety pass that backs the AI NL-query capability (ADR-0005); writes, joins outside the AI-view allowlist, and non-allowlisted table reads are all rejected with `report.unsafe_query`. Journal import lands transactions as PENDING through `TransactionRepository.save_balanced`, the same chokepoint the OFX / QIF / CSV importers use.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -145,6 +145,14 @@ quickstart-smoke:
     uv run tulip reconcile complete "$RECON_ID"
     PERIOD_ID=$(uv run tulip --json periods list | jq -r '.[0].id')
     uv run tulip periods close "$PERIOD_ID"
+    # §8 — Reports + journal export/import (Phase 7 surface).
+    uv run tulip reports trial-balance > "$SCRATCH/tb.json"
+    test -s "$SCRATCH/tb.json"
+    uv run tulip reports trial-balance --format pdf --output "$SCRATCH/tb.pdf"
+    test -s "$SCRATCH/tb.pdf"
+    uv run tulip journal export --output "$SCRATCH/ledger.journal"
+    test -s "$SCRATCH/ledger.journal"
+    uv run tulip journal import "$SCRATCH/ledger.journal"
     docker compose -f deploy/docker/compose.yml exec -T api \
         tulip backup --out - > "$SCRATCH/backup.tar.gz"
     test -s "$SCRATCH/backup.tar.gz"


### PR DESCRIPTION
## Summary

Post-Phase-7 docs sweep. Phase 7 (reports + hledger journal export/import + CLI surface) closed across PRs #180/#183/#184/#186/#188/#190 — README, ARCHITECTURE, QUICKSTART, THREAT_MODEL, and the quickstart-smoke recipe are brought into alignment.

- **README.md** — status line bumped to Phases 0–7 complete; \`/v1/reports/*\` and \`/v1/journal/{export,import}\` added to the endpoint surface; \`tulip reports\` + \`tulip journal\` mentioned in the CLI tour; test count refreshed.
- **docs/ARCHITECTURE.md** — header status + version + date stamped to Phase 7 close (2026-05-12); §10 Phase plan now lists P7.1, P7.2, P7.3, P7.4, P7.5, P7.1.b with PR refs.
- **docs/QUICKSTART.md** — new §8 "Reports + journal export/import" with runnable examples (trial-balance JSON/HTML/PDF/CSV, income-statement w/ \`--start\` / \`--end\`, custom-query, \`journal export\` / \`journal import\`); subsequent sections renumbered. "What's next" surfaces the new groups.
- **docs/THREAT_MODEL.md** — last-updated bumped to Phase 7 close; new Phase-7 surface check (no new trust boundary, \`custom-query\` reuses the AI SQL-safety gate, journal import lands as PENDING via the existing chokepoint).
- **justfile** — \`quickstart-smoke\` now exercises §8 (trial-balance JSON + PDF, journal export + round-trip import) so the recipe stays in lockstep with the docs.

No production code changes; pure docs + the smoke-recipe extension.

## Test plan

- [x] All five files render cleanly (verified locally).
- [x] No anchor links into QUICKSTART exist elsewhere in the repo (\`grep -rn QUICKSTART.md# --include='*.md'\` empty), so renumbering Backup/cookbooks is safe.
- [ ] CI green on this PR (lint + secrets-scan + path-filter; tests should be skipped — no Python touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)