### PR TITLE
ci: skip CodeQL on docs-only PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,16 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Skip docs-only / tooling-only PRs — CodeQL has no Python to analyze
+    # there, and the analyze step is ~1–2 min per run. The `push` trigger
+    # above still runs CodeQL unconditionally on every merge to main, so
+    # nothing slips through if a future docs PR accidentally touches code.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'justfile'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/labeler.yml'
   schedule:
     # Weekly Monday 06:30 UTC. Cron must exist on the default branch to fire.
     - cron: "30 6 * * 1"


### PR DESCRIPTION
## Summary

Closes #192. \`codeql.yml\` had no \`paths\` / \`paths-ignore\` filter on its \`pull_request\` trigger, so docs-only PRs ate a ~1-2 min CodeQL analyze step against the full Python tree even when zero \`.py\` files changed. (Concrete example: PR #191 — a pure docs sweep — was held on CodeQL for >5 min while the rest of CI finished in seconds.)

- Adds a \`paths-ignore\` block on \`pull_request\` covering markdown, docs, the \`justfile\`, issue templates, and the labeler config.
- Does **not** ignore \`codeql.yml\` itself, dependency files (\`pyproject.toml\` / \`uv.lock\`), or other workflow files — those can change what CodeQL flags.
- \`push: branches: [main]\` is unchanged, so the post-merge gate still runs CodeQL unconditionally. Nothing slips through if a future docs PR accidentally touches code.
- Weekly \`schedule\` cron unchanged.

Mirrors the path-conditional pattern \`ci.yml\` already uses via its \`changes\` job (#92).

## Test plan

- [x] Local lint clean (no Python touched; secrets-scan pre-commit passed).
- [ ] On this PR, the CodeQL \`Analyze (python)\` check should be **skipped** (since this PR touches only \`.github/workflows/codeql.yml\`, but that path is *not* in \`paths-ignore\`, so CodeQL **will still run**) — this is the intended behavior. The acceptance verification happens on the next docs-only PR (or a follow-up README typo).
- [ ] After merge, a follow-up docs-only PR (or amending PR #191's pattern) should see CodeQL listed as \`skipping\`.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)