### PR TITLE
fix: AICategorizer accepts caller's session to fix SQLite deadlock

### DIFF
--- a/packages/tulip-ai/src/tulip_ai/_sessions.py
+++ b/packages/tulip-ai/src/tulip_ai/_sessions.py
@@ -1,0 +1,55 @@
+"""Session-sharing helper for AI capabilities (#199, #200).
+
+Every AI capability used to open its own SQLAlchemy session via
+``self._session_maker()`` for its DB work + audit write. That works fine
+for standalone callers (the ``/v1/ai/*`` endpoints, one short transaction
+per request), but breaks when the capability is invoked from inside a
+caller's already-open write transaction: SQLite serialises writers, so
+the capability's *separate* connection deadlocks on the caller's write
+lock and fails with ``database is locked``.
+
+This module gives capabilities an opt-in path to share the caller's
+session. Callers that are mid-transaction (the import-apply path is the
+motivating case) pass their session; the capability uses it for both the
+domain reads and the ``ai_invocations`` write. The audit row then shares
+the caller's commit/rollback fate — acceptable because the caller is the
+one choosing to share.
+
+Standalone callers continue to pass nothing; the capability opens its
+own session as before.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+@contextmanager
+def use_session_or_make_one(
+    session: Session | None,
+    session_maker: sessionmaker[Session],
+) -> Iterator[tuple[Session, bool]]:
+    """Yield ``(session, should_commit)``.
+
+    If ``session`` is given, ``should_commit`` is ``False`` — the caller
+    owns transaction boundaries and the capability must not commit. The
+    session is not closed on exit.
+
+    Otherwise the helper opens a fresh session via ``session_maker``,
+    yields ``(session, True)``, and closes the session on exit. The
+    capability is expected to commit when ``should_commit`` is ``True``.
+    """
+    if session is not None:
+        yield session, False
+        return
+    with session_maker() as own:
+        yield own, True
+
+
+__all__ = ["use_session_or_make_one"]

--- a/packages/tulip-ai/src/tulip_ai/categorize.py
+++ b/packages/tulip-ai/src/tulip_ai/categorize.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 
+from tulip_ai._sessions import use_session_or_make_one
 from tulip_ai.adapters import ProviderAdapter, ProviderResponse
 from tulip_ai.audit import AIInvocationRecord, AIInvocationWriter, hash_prompt_payload
 from tulip_ai.cost import PreCallApproval, enforce_pre_call
@@ -104,20 +105,30 @@ class AICategorizer:
         self._adapter = adapter
 
     async def categorize(
-        self, line: StatementLine, household_context: HouseholdContext
+        self,
+        line: StatementLine,
+        household_context: HouseholdContext,
+        *,
+        session: Session | None = None,
     ) -> CategorizationResult:
         """Suggest a category for one statement line.
+
+        ``session`` is the opt-in session-sharing path (#199, #200): callers
+        that are mid-transaction (the import-apply flow is the motivating
+        case) pass their session so the audit-row write doesn't deadlock
+        against the caller's own write lock. Standalone callers pass
+        nothing and the capability opens its own session.
 
         Wide ``except`` is intentional at the outer boundary: importer
         failures from a flaky AI provider — or from any AI-stack bug —
         must not block the whole apply batch. The provider-error branch
         produces an explicit ``ai_invocations`` row; deeper failures
-        (DB lock, decryption, unexpected exception) fall through to a
-        silent ``Imbalance:Unknown`` so the apply succeeds and the
-        operator gets the signal via structlog.
+        (decryption, unexpected exception) fall through to a silent
+        ``Imbalance:Unknown`` so the apply succeeds and the operator
+        gets the signal via structlog.
         """
         try:
-            return await self._categorize_inner(line, household_context)
+            return await self._categorize_inner(line, household_context, session=session)
         except Exception:
             log.exception(
                 "ai.categorize.failed",
@@ -126,10 +137,14 @@ class AICategorizer:
             return _FALLBACK_RESULT
 
     async def _categorize_inner(
-        self, line: StatementLine, household_context: HouseholdContext
+        self,
+        line: StatementLine,
+        household_context: HouseholdContext,
+        *,
+        session: Session | None,
     ) -> CategorizationResult:
         """Inner categorize body — caller wraps in a broad exception guard."""
-        with self._session_maker() as session:
+        with use_session_or_make_one(session, self._session_maker) as (session, should_commit):
             inputs = self._load_inputs(session, household_context.household_id)
             if inputs is None:
                 # Household vanished mid-call (shouldn't happen) — fall back silently.
@@ -150,7 +165,8 @@ class AICategorizer:
                         prompt_hash=hash_prompt_payload(payload.to_dict()),
                     )
                 )
-                session.commit()
+                if should_commit:
+                    session.commit()
                 return _FALLBACK_RESULT
 
             if inputs.api_key is None and policy.provider != "ollama":
@@ -168,7 +184,8 @@ class AICategorizer:
                         response_text="no api key configured for provider",
                     )
                 )
-                session.commit()
+                if should_commit:
+                    session.commit()
                 return _FALLBACK_RESULT
 
             payload = build_categorize_prompt(line, inputs.chart)
@@ -212,7 +229,8 @@ class AICategorizer:
                         response_text=gate.reason[:500],
                     )
                 )
-                session.commit()
+                if should_commit:
+                    session.commit()
                 return _FALLBACK_RESULT
 
             call_provider = gate.provider or ""
@@ -239,7 +257,8 @@ class AICategorizer:
                         response_text=str(exc)[:500],
                     )
                 )
-                session.commit()
+                if should_commit:
+                    session.commit()
                 return _FALLBACK_RESULT
 
             result = _parse_response(response, fallback_chart=inputs.chart)
@@ -264,7 +283,8 @@ class AICategorizer:
                     response_text=response.text if policy.log_prompts else None,
                 )
             )
-            session.commit()
+            if should_commit:
+                session.commit()
             return result
 
     def _load_inputs(self, session: Session, household_id: UUID) -> _PromptInputs | None:

--- a/packages/tulip-ai/tests/test_categorize.py
+++ b/packages/tulip-ai/tests/test_categorize.py
@@ -153,6 +153,74 @@ async def test_categorize_falls_back_when_policy_disabled(
 
 
 @pytest.mark.asyncio
+async def test_categorize_inside_open_write_transaction_does_not_deadlock(
+    session_maker: sessionmaker[Session], household_and_user, master_key: bytes
+) -> None:
+    """Regression for #199 + #200: categorize must accept the caller's session.
+
+    Before the fix, the import-apply path held a write lock on connection
+    A while calling categorize; categorize opened connection B for its
+    audit row write, which failed with ``database is locked``. The fix
+    threads the caller's session into categorize so the audit lands in
+    the same transaction (and the same connection).
+    """
+    household, _ = household_and_user
+    _seed_chart(
+        session_maker,
+        household.id,
+        codes=[("5100", "Groceries", AccountType.EXPENSE)],
+    )
+    with session_maker() as s:
+        h = s.get(Household, household.id)
+        assert h is not None
+        h.ai_policy = {"capabilities": {"categorize": {"policy": "disabled"}}}
+        s.commit()
+
+    adapter = RecordingAdapter(canned_reply='{"account_code": "5100"}')
+    categorizer = AICategorizer(session_maker=session_maker, master_key=master_key, adapter=adapter)
+
+    with session_maker() as shared:
+        # Simulate the import-apply path: hold a write lock by inserting
+        # an account without committing, then call categorize within the
+        # same session. The audit row must land in this session's
+        # transaction rather than via a second connection.
+        shared.add(
+            Account(
+                household_id=household.id,
+                id=uuid4(),
+                name="Cash",
+                type=AccountType.ASSET,
+                currency="USD",
+                code="1110",
+                visibility="shared",
+                created_by_user_id=None,
+            )
+        )
+        shared.flush()  # write lock acquired here
+
+        result = await categorizer.categorize(
+            _make_statement_line(description="WHOLE FOODS", amount="-12.00"),
+            HouseholdContext(household_id=household.id, account_whitelist=frozenset()),
+            session=shared,
+        )
+        # No deadlock; categorize returned the fallback (policy_disabled).
+        assert result.account_code == "Imbalance:Unknown"
+
+        # Audit row is pending in the shared session — not committed yet
+        # (caller owns commit when sharing).
+        pending_rows = shared.execute(select(AIInvocation)).scalars().all()
+        assert len(pending_rows) == 1
+        assert pending_rows[0].outcome == "policy_disabled"
+
+        shared.commit()
+
+    # After commit, the audit row + the seeded Account are both visible.
+    with session_maker() as s:
+        rows = s.execute(select(AIInvocation)).scalars().all()
+        assert len(rows) == 1
+
+
+@pytest.mark.asyncio
 async def test_categorize_falls_back_when_no_api_key(
     session_maker: sessionmaker[Session], household_and_user, master_key: bytes
 ) -> None:

--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -147,6 +147,7 @@ async def promote_statement_line(
     suggestion = await categorizer.categorize(
         domain_line,
         HouseholdContext(household_id=household_id, account_whitelist=frozenset()),
+        session=session,
     )
     other_account = accounts.get_by_code(suggestion.account_code)
     if other_account is None:

--- a/packages/tulip-api/tests/services/test_import_apply.py
+++ b/packages/tulip-api/tests/services/test_import_apply.py
@@ -264,7 +264,9 @@ class TestPromoteStatementLine:
     @pytest.mark.asyncio
     async def test_unknown_categorizer_account_raises(self, session_maker, setup):
         class _BadCategorizer:
-            async def categorize(self, line, household_context) -> CategorizationResult:
+            async def categorize(
+                self, line, household_context, *, session=None
+            ) -> CategorizationResult:
                 return CategorizationResult(account_code="DoesNotExist", confidence=0.5)
 
         with session_maker() as s:

--- a/packages/tulip-core/src/tulip_core/reconciliation/categorizer.py
+++ b/packages/tulip-core/src/tulip_core/reconciliation/categorizer.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import inspect
 import warnings
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 from uuid import UUID
 
 from tulip_core.reconciliation.statement_line import StatementLine
@@ -66,10 +66,21 @@ class Categorizer(Protocol):
     Phase 6's ``AICategorizer`` plugs in here via :func:`register_categorizer`.
     The matcher and P5.4's reconciliation flow call :func:`get_categorizer`
     to obtain the active implementation.
+
+    ``session`` is the opt-in session-sharing hook (#199, #200): callers
+    that are inside an open DB transaction pass theirs, and the concrete
+    implementer (e.g. ``AICategorizer``) uses it so the audit row write
+    can't deadlock against the caller's write lock. The Protocol stays
+    DB-agnostic by typing it as ``object | None``; the concrete impl
+    narrows to its own session type.
     """
 
     async def categorize(
-        self, line: StatementLine, household_context: HouseholdContext
+        self,
+        line: StatementLine,
+        household_context: HouseholdContext,
+        *,
+        session: Any = None,  # noqa: ANN401 — tulip-core can't import sqlalchemy
     ) -> CategorizationResult:
         """Suggest a category for an unmatched statement line."""
         ...
@@ -84,10 +95,14 @@ class NullCategorizer:
     """
 
     async def categorize(
-        self, line: StatementLine, household_context: HouseholdContext
+        self,
+        line: StatementLine,
+        household_context: HouseholdContext,
+        *,
+        session: Any = None,  # noqa: ANN401 — tulip-core can't import sqlalchemy
     ) -> CategorizationResult:
         """Return ``Imbalance:Unknown`` regardless of ``line``."""
-        del line, household_context  # unused — placeholder-by-design
+        del line, household_context, session  # unused — placeholder-by-design
         return CategorizationResult(account_code="Imbalance:Unknown", confidence=1.0)
 
 

--- a/packages/tulip-core/tests/reconciliation/test_categorizer.py
+++ b/packages/tulip-core/tests/reconciliation/test_categorizer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 from types import MappingProxyType
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -137,7 +138,11 @@ class TestRegistry:
     def test_register_replaces_default(self):
         class CustomCategorizer:
             async def categorize(
-                self, line: StatementLine, household_context: HouseholdContext
+                self,
+                line: StatementLine,
+                household_context: HouseholdContext,
+                *,
+                session: Any = None,
             ) -> CategorizationResult:
                 return CategorizationResult(account_code="Custom:Account", confidence=0.5)
 
@@ -155,13 +160,21 @@ class TestRegistry:
     def test_re_registration_warns(self):
         class CustomA:
             async def categorize(
-                self, line: StatementLine, household_context: HouseholdContext
+                self,
+                line: StatementLine,
+                household_context: HouseholdContext,
+                *,
+                session: Any = None,
             ) -> CategorizationResult:
                 return CategorizationResult("A", 1.0)
 
         class CustomB:
             async def categorize(
-                self, line: StatementLine, household_context: HouseholdContext
+                self,
+                line: StatementLine,
+                household_context: HouseholdContext,
+                *,
+                session: Any = None,
             ) -> CategorizationResult:
                 return CategorizationResult("B", 1.0)
 


### PR DESCRIPTION
## Summary

Closes #199 and #200. Slice A of the two-PR Banktivity-migration unblock.

Root cause for both: the import-apply flow opened a write transaction on connection A, then called \`AICategorizer.categorize\` for each line. \`categorize\` used \`self._session_maker()\` to open a *separate* connection B for its \`ai_invocations\` audit row. SQLite serializes writers — B blocked waiting for A's lock and failed with "database is locked". Every line repeated the failure; the resulting \`Imbalance:Unknown\` fallback didn't resolve to a real account, so the whole apply rolled back. Net effect: 128-line import produced zero PENDING transactions, even with \`policy=disabled\`.

- New helper \`tulip_ai._sessions.use_session_or_make_one\` — context manager yielding \`(session, should_commit)\`. If the caller passes a session, the capability uses it with \`should_commit=False\` (caller owns commit/rollback). Otherwise opens a fresh session via the session_maker.
- \`AICategorizer.categorize\` / \`_categorize_inner\` now accept an optional \`session=\` kwarg. All five exit paths (policy_disabled, no_api_key, gate_blocked, provider_error, success) gate their \`session.commit()\` on \`should_commit\`.
- \`import_apply.promote_statement_line\` passes its session to categorize so the audit row writes into the apply transaction. No second connection, no deadlock.
- \`Categorizer\` Protocol (tulip-core) widened to include \`session: Any = None\` so concrete impls can narrow to their session type. tulip-core can't import sqlalchemy (architecture rule); hence \`Any\` with a focused \`# noqa: ANN401\`.
- New regression test: holds a write lock on a shared session, calls \`categorize(..., session=shared)\` with \`policy=disabled\`, asserts the audit row lands in the same transaction.

**Scope intentionally tight**: \`nl_query\` / \`forecast\` / \`proposals\` follow the same \`self._session_maker()\` pattern but aren't called from inside an open write transaction today, so they aren't refactored. The same fix transfers cleanly when a similar caller appears.

**Slice B** (next): apply path is graceful when categorize returns \`Imbalance:Unknown\` — currently raises \`CategorizeUnknownAccountError\` because that account doesn't exist. B will either auto-create it (hledger convention) or add \`--no-categorize\` to skip the call entirely.

## Test plan

- [x] \`just lint\` clean.
- [x] \`just typecheck\` clean.
- [x] \`just test\` → **1528 passed, 1 skipped** in 4:09 (same as baseline + the new regression). The lone failure is pre-existing #194 schemathesis flake on a different endpoint.
- [x] New regression test: \`test_categorize_inside_open_write_transaction_does_not_deadlock\` in \`packages/tulip-ai/tests/test_categorize.py\`.
- [ ] CI green on this PR.

### Manual smoke (after Slice B lands or with AI policy set to allow categorize)

\`\`\`bash
docker compose -f deploy/docker/compose.yml up --build --wait
# ... seed accounts, upload OFX/QIF/CSV ...
uv run tulip ai config set-capability categorize policy disabled
uv run tulip imports apply <BATCH_ID>
# Expected before fix: "database is locked" then CategorizeUnknownAccountError.
# Expected after fix: still CategorizeUnknownAccountError (slice B fixes that),
# but the underlying lock contention is gone — visible in docker logs as
# zero "database is locked" tracebacks during apply.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)