### PR TITLE
fix: tulip imports apply --no-categorize for bulk migrations

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -375,6 +375,16 @@ async def upload_import(
 async def apply_import(
     batch_id: UUID,
     request: Request,
+    no_categorize: bool = Query(
+        default=False,
+        description=(
+            "If true, skip the categorizer entirely. Each line lands "
+            "balanced against the household's Imbalance:Unknown account "
+            "(auto-created per currency on first use) so the user can "
+            "review + assign categories manually. Useful for bulk "
+            "migrations from another accounting tool."
+        ),
+    ),
     claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> ImportBatchApplyResponse:
@@ -397,6 +407,7 @@ async def apply_import(
             batch=batch,
             categorizer=get_categorizer(),
             actor_user_id=claims.user_id,
+            no_categorize=no_categorize,
         )
     except BatchAlreadyAppliedError as exc:
         raise ImportAlreadyAppliedError(batch_id=str(batch_id)) from exc

--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -43,7 +43,7 @@ from tulip_core.transactions import (
 from tulip_core.transactions import (
     TransactionStatus as DomainTxStatus,
 )
-from tulip_storage.models import ImportBatchStatus
+from tulip_storage.models import AccountType, ImportBatchStatus
 from tulip_storage.repositories import (
     AccountRepository,
     ImportBatchRepository,
@@ -55,7 +55,43 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from tulip_core.reconciliation.categorizer import Categorizer
-    from tulip_storage.models import ImportBatch, StatementLine, Transaction
+    from tulip_storage.models import Account, ImportBatch, StatementLine, Transaction
+
+
+# Stable name + code used for the auto-created Imbalance account
+# (one per currency). hledger / ledger-cli use the same name convention,
+# so journal export → external tool → re-import round-trips cleanly.
+_IMBALANCE_NAME = "Imbalance:Unknown"
+_IMBALANCE_CODE_PREFIX = "9999"  # 9999.<CURRENCY>, e.g. 9999.USD
+
+
+def _get_or_create_imbalance_account(
+    *,
+    session: Session,
+    household_id: UUID,
+    currency: str,
+    actor_user_id: UUID | None,
+) -> Account:
+    """Return the household's Imbalance:Unknown account for ``currency``.
+
+    Looks up by code ``9999.<CURRENCY>`` first; creates it as an EQUITY
+    account if missing. Used by the ``no_categorize`` apply path (#199
+    slice B) so users migrating data from another system can land
+    everything as PENDING and assign categories manually later.
+    """
+    accounts = AccountRepository(session, household_id)
+    code = f"{_IMBALANCE_CODE_PREFIX}.{currency}"
+    existing = accounts.get_by_code(code)
+    if existing is not None:
+        return existing
+    return accounts.create(
+        name=_IMBALANCE_NAME,
+        type=AccountType.EQUITY,
+        currency=currency,
+        code=code,
+        visibility="shared",
+        created_by_user_id=actor_user_id,
+    )
 
 
 class BatchAlreadyAppliedError(ValueError):
@@ -117,8 +153,15 @@ async def promote_statement_line(
     line: StatementLine,
     categorizer: Categorizer,
     actor_user_id: UUID | None,
+    no_categorize: bool = False,
 ) -> Transaction:
     """Promote one statement line into a PENDING ledger Transaction.
+
+    ``no_categorize=True`` skips the categorizer entirely and routes the
+    other-side posting to the household's ``Imbalance:Unknown`` account
+    for the bank account's currency (auto-created on first use). Used
+    for bulk migrations from other accounting tools where the user
+    wants to assign categories manually after import.
 
     Raises:
         LineExcludedError: ``line.is_excluded`` is True (caller should
@@ -126,6 +169,7 @@ async def promote_statement_line(
         LineAlreadyPromotedError: ``line.promoted_transaction_id`` is set.
         CategorizeUnknownAccountError: the categorizer returned an
             account_code that doesn't exist in this household's chart.
+            Not raised when ``no_categorize=True``.
 
     """
     if line.is_excluded:
@@ -143,15 +187,24 @@ async def promote_statement_line(
     if bank_account is None:  # pragma: no cover - bank account is FK-enforced
         raise LookupError(f"batch.account_id {batch.account_id} not found")
 
-    domain_line = _to_domain_line(line)
-    suggestion = await categorizer.categorize(
-        domain_line,
-        HouseholdContext(household_id=household_id, account_whitelist=frozenset()),
-        session=session,
-    )
-    other_account = accounts.get_by_code(suggestion.account_code)
-    if other_account is None:
-        raise CategorizeUnknownAccountError(suggestion.account_code, household_id)
+    if no_categorize:
+        other_account = _get_or_create_imbalance_account(
+            session=session,
+            household_id=household_id,
+            currency=line.currency,
+            actor_user_id=actor_user_id,
+        )
+    else:
+        domain_line = _to_domain_line(line)
+        suggestion = await categorizer.categorize(
+            domain_line,
+            HouseholdContext(household_id=household_id, account_whitelist=frozenset()),
+            session=session,
+        )
+        resolved = accounts.get_by_code(suggestion.account_code)
+        if resolved is None:
+            raise CategorizeUnknownAccountError(suggestion.account_code, household_id)
+        other_account = resolved
 
     bank_amount = Money(line.amount, line.currency)
     other_amount = Money(-line.amount, line.currency)
@@ -181,6 +234,7 @@ async def apply_batch(
     batch: ImportBatch,
     categorizer: Categorizer,
     actor_user_id: UUID | None,
+    no_categorize: bool = False,
 ) -> ApplyResult:
     """Promote every applicable line in ``batch``, then mark batch APPLIED.
 
@@ -219,6 +273,7 @@ async def apply_batch(
             line=line,
             categorizer=categorizer,
             actor_user_id=actor_user_id,
+            no_categorize=no_categorize,
         )
         transaction_ids.append(tx.id)
 

--- a/packages/tulip-api/tests/services/test_import_apply.py
+++ b/packages/tulip-api/tests/services/test_import_apply.py
@@ -282,6 +282,49 @@ class TestPromoteStatementLine:
                     actor_user_id=None,
                 )
 
+    @pytest.mark.asyncio
+    async def test_no_categorize_skips_categorizer_and_auto_creates_imbalance(
+        self, session_maker, setup
+    ):
+        """Slice B: ``no_categorize=True`` bypasses the categorizer entirely
+        and routes every line to an auto-created ``Imbalance:Unknown``
+        account (code ``9999.<currency>``) for the bank account's currency.
+
+        The categorizer used here would raise if called; the test asserts
+        ``no_categorize=True`` short-circuits before invocation.
+        """
+
+        class _ExplodingCategorizer:
+            async def categorize(
+                self, line, household_context, *, session=None
+            ) -> CategorizationResult:
+                raise AssertionError("categorizer must not be invoked when no_categorize=True")
+
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=_ExplodingCategorizer(),
+                actor_user_id=None,
+                no_categorize=True,
+            )
+            s.commit()
+
+            # Auto-created Imbalance:Unknown for USD is the other-side account.
+            other_account = AccountRepository(s, setup["household_id"]).get_by_code("9999.USD")
+            assert other_account is not None
+            assert other_account.name == "Imbalance:Unknown"
+            assert other_account.type == AccountType.EQUITY
+            assert other_account.currency == "USD"
+
+            postings = s.query(Posting).filter_by(transaction_id=tx.id).all()
+            other_ids = {p.account_id for p in postings} - {setup["cash_id"]}
+            assert other_ids == {other_account.id}
+
 
 # ---- apply_batch ----------------------------------------------------------
 

--- a/packages/tulip-api/tests/test_apply_promote_endpoints.py
+++ b/packages/tulip-api/tests/test_apply_promote_endpoints.py
@@ -89,6 +89,26 @@ class TestApplyImportHappyPath:
         assert r.json()["status"] == "applied"
         assert r.json()["applied_at"] is not None
 
+    def test_apply_no_categorize_succeeds_without_categorizer_account(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        """Slice B: ?no_categorize=true short-circuits the categorizer and
+        auto-creates the Imbalance:Unknown account on demand. The endpoint
+        must succeed even on a household with no chart-of-accounts entry
+        for the categorizer's usual return value.
+        """
+        r = client.post(
+            f"/v1/imports/{parsed_batch}/apply?no_categorize=true",
+            headers=auth_h,
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["created_count"] == 2
+        # And the auto-created Imbalance:Unknown account exists.
+        accounts = client.get("/v1/accounts", headers=auth_h).json()
+        codes = {a.get("code") for a in accounts}
+        assert "9999.USD" in codes
+
 
 class TestApplyImportErrors:
     def test_unknown_batch_returns_404(self, client: TestClient, auth_h: dict[str, str]):

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -195,16 +195,28 @@ def apply_import(
             metavar="BATCH_ID",
         ),
     ],
+    no_categorize: Annotated[
+        bool,
+        typer.Option(
+            "--no-categorize",
+            help=(
+                "Skip the AI categorizer; route every line to the "
+                "household's Imbalance:Unknown account (auto-created per "
+                "currency on first use). Useful for bulk migrations from "
+                "another tool where you'll assign categories manually."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Apply a parsed batch: every non-excluded line becomes a PENDING ledger transaction."""
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
+    path = f"/v1/imports/{batch_id}/apply"
+    if no_categorize:
+        path += "?no_categorize=true"
     try:
         with _client(config, as_json=as_json) as client:
-            response = client.post(
-                f"/v1/imports/{batch_id}/apply",
-                authenticated=True,
-            )
+            response = client.post(path, authenticated=True)
     except CliError as err:
         err.render()
         raise typer.Exit(err.exit_code) from None


### PR DESCRIPTION
## Summary

Slice B of the two-PR Banktivity-migration unblock. Slice A (#201) fixed the SQLite write-lock deadlock; this slice adds a way to bypass the categorizer entirely so users migrating data from another tool can land everything as PENDING for manual review.

- **Service**: \`promote_statement_line\` / \`apply_batch\` accept \`no_categorize=False\` (default). When \`True\`, the categorizer is skipped entirely and the other-side posting routes to an auto-created \`Imbalance:Unknown\` account for the bank account's **currency**. Auto-creation is per-currency (code \`9999.<CURRENCY>\`) so a household with USD + EUR statements ends up with one Imbalance account per currency. EQUITY type, matching hledger / ledger-cli convention.
- **Router**: \`POST /v1/imports/{id}/apply?no_categorize=true\` plumbs the flag through. Default behavior unchanged.
- **CLI**: \`tulip imports apply <BATCH_ID> --no-categorize\` for the human-friendly path.
- **Helper** \`_get_or_create_imbalance_account\` is the single source of truth for the account lookup/creation. Idempotent — re-applying the same household twice doesn't create duplicates.

After merging both slices, the migration flow from Banktivity-shaped data is unblocked:

\`\`\`bash
# Strip Banktivity's preamble (until #198 lands).
awk '/^!Type:Bank/{f=1} f{print} /^!Type:Security/{exit}' \\
  banktivity-checking.qif > checking.bank.qif
uv run tulip imports qif checking.bank.qif --account 1010
uv run tulip imports apply <BATCH_ID> --no-categorize
uv run tulip transactions list --status pending     # review + reassign
\`\`\`

## Test plan

- [x] \`just lint\` + \`just typecheck\` clean.
- [x] \`just test\` → **1531 passed, 1 skipped** in 4:06 (+2 from this slice on top of slice A's +1).
- [x] New service test: \`test_no_categorize_skips_categorizer_and_auto_creates_imbalance\` — exploding categorizer asserts short-circuit + asserts auto-create.
- [x] New router test: \`test_apply_no_categorize_succeeds_without_categorizer_account\` — endpoint with \`?no_categorize=true\` succeeds + Imbalance:Unknown:9999.USD materialises.
- [ ] CI green on this PR.

### Manual smoke (against the compose stack with this branch's image)

\`\`\`bash
uv run tulip imports qif checking.bank.qif --account 1010
uv run tulip imports apply <BATCH_ID> --no-categorize
uv run tulip accounts list   # should show "Imbalance:Unknown" with code 9999.USD
uv run tulip transactions list --status pending   # should show all 128 lines
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)