### PR TITLE
feat: tulip imports show BATCH_ID

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -185,6 +185,87 @@ def import_csv(
     )
 
 
+@imports_app.command("show")
+def show_import(
+    ctx: typer.Context,
+    batch_id: Annotated[
+        str,
+        typer.Argument(
+            help="Import batch UUID returned by `tulip imports ofx/qif/csv`.",
+            metavar="BATCH_ID",
+        ),
+    ],
+) -> None:
+    """Render an import batch's header + parsed statement lines."""
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get(f"/v1/imports/{batch_id}", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+    _render_batch(response.json())
+
+
+def _render_batch(body: dict[str, Any]) -> None:
+    """Render an ``ImportBatchRead`` body to stdout."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    header_lines = [
+        f"Batch:    {body.get('id', '')}",
+        f"Source:   {body.get('source_filename', '')} ({body.get('source_format', '?').upper()})",
+        f"Account:  {body.get('account_id', '')}",
+        f"Status:   {body.get('status', '?')}",
+        f"Counts:   imported={body.get('imported_count', 0)}  "
+        f"skipped={body.get('skipped_count', 0)}  "
+        f"errors={body.get('error_count', 0)}",
+        f"Created:  {body.get('created_at', '')}",
+    ]
+    applied_at = body.get("applied_at")
+    if applied_at:
+        header_lines.append(f"Applied:  {applied_at}")
+    reverted_at = body.get("reverted_at")
+    if reverted_at:
+        header_lines.append(f"Reverted: {reverted_at}")
+    for line in header_lines:
+        typer.echo(line)
+
+    lines = body.get("lines") or []
+    if not lines:
+        typer.echo("\n(no statement lines)")
+        return
+
+    table = Table(title=f"\nStatement lines ({len(lines)})", show_header=True)
+    table.add_column("#", justify="right")
+    table.add_column("date")
+    table.add_column("amount", justify="right")
+    table.add_column("ccy")
+    table.add_column("description")
+    table.add_column("flag")
+    for line in lines:
+        flag_bits: list[str] = []
+        if line.get("is_excluded"):
+            flag_bits.append("excluded")
+        if line.get("reconciliation_match_id"):
+            flag_bits.append("reconciled")
+        table.add_row(
+            str(line.get("line_number", "")),
+            str(line.get("posted_date", "")),
+            str(line.get("amount", "")),
+            str(line.get("currency", "")),
+            str(line.get("description", "") or ""),
+            ", ".join(flag_bits),
+        )
+    console.print(table)
+
+
 @imports_app.command("apply")
 def apply_import(
     ctx: typer.Context,

--- a/packages/tulip-cli/tests/test_import_command.py
+++ b/packages/tulip-cli/tests/test_import_command.py
@@ -138,6 +138,84 @@ def test_imports_apply_happy_path(authed_session: str) -> None:
 
 
 @pytest.mark.integration
+def test_imports_show_renders_header_and_lines(authed_session: str) -> None:
+    """`tulip imports show BATCH_ID` renders batch header + per-line table."""
+    _seed_checking(authed_session)
+    fixture = _OFX_FIXTURES / "minimal_ofx2.ofx"
+    upload = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            authed_session,
+            "import",
+            "ofx",
+            str(fixture),
+            "--account",
+            "1110",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert upload.returncode == 0, upload.stderr
+    batch_id = json.loads(upload.stdout)["id"]
+
+    show = _run_cli("imports", "show", batch_id, api_url=authed_session)
+    assert show.returncode == 0, show.stderr
+    assert batch_id in show.stdout
+    assert "OFX" in show.stdout
+    assert "Statement lines" in show.stdout
+
+
+@pytest.mark.integration
+def test_imports_show_json_passthrough(authed_session: str) -> None:
+    """`tulip --json imports show BATCH_ID` emits raw ImportBatchRead body."""
+    _seed_checking(authed_session)
+    fixture = _OFX_FIXTURES / "minimal_ofx2.ofx"
+    upload = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            authed_session,
+            "import",
+            "ofx",
+            str(fixture),
+            "--account",
+            "1110",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    batch_id = json.loads(upload.stdout)["id"]
+
+    show = _run_cli("--json", "imports", "show", batch_id, api_url=authed_session)
+    assert show.returncode == 0, show.stderr
+    payload = json.loads(show.stdout)
+    assert payload["id"] == batch_id
+    assert isinstance(payload.get("lines"), list)
+
+
+@pytest.mark.integration
+def test_imports_show_unknown_batch_returns_problem(authed_session: str) -> None:
+    """Unknown batch UUID surfaces the typed import_batch.not_found problem."""
+    from uuid import uuid4
+
+    show = _run_cli("imports", "show", str(uuid4()), api_url=authed_session)
+    assert show.returncode != 0
+    combined = (show.stdout + show.stderr).lower()
+    assert "import_batch.not_found" in combined or "not found" in combined
+
+
+@pytest.mark.integration
 def test_imports_apply_already_applied_returns_409(authed_session: str) -> None:
     """Re-applying renders the typed Problem and exits non-zero."""
     _seed_checking(authed_session)


### PR DESCRIPTION
## Summary

Closes #203. Surfaced during the live Banktivity migration — \`GET /v1/imports/{id}\` exposes the full batch state (header + lines) but the CLI didn't have a way to render it.

- \`tulip imports show BATCH_ID\` fetches the batch and renders a header block (batch id, source format + filename, account, status, imported/skipped/error counts, created_at / applied_at / reverted_at) plus a per-line table (line#, posted_date, amount + currency right-aligned, description, flag column for excluded / reconciled).
- \`--json\` passes through the raw \`ImportBatchRead\` body for scripting.
- Unknown batch UUID surfaces the existing \`import_batch.not_found\` typed problem via the existing CliError renderer — same shape as \`tulip imports apply\`.

No server changes; pure CLI over the existing endpoint.

## Test plan

- [x] \`just lint\` + \`just typecheck\` clean.
- [x] \`just test\` → **1534 passed, 1 skipped** in 4:17 (+3 from this slice).
- [x] +3 integration tests in \`packages/tulip-cli/tests/test_import_command.py\`: header+lines render, \`--json\` passthrough, unknown batch surfaces the typed problem.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)