### PR TITLE
feat: show transaction id prefix in tulip transactions list

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -386,6 +386,7 @@ def _resolve_account_id_for_filter(client: TulipClient, identifier: str) -> str:
 
 def _render_tx_list_table(rows: list[dict[str, Any]]) -> None:
     table = Table(show_header=True, show_lines=False)
+    table.add_column("id")
     table.add_column("date")
     table.add_column("description")
     table.add_column("reference")
@@ -401,7 +402,9 @@ def _render_tx_list_table(rows: list[dict[str, Any]]) -> None:
             short = str(account)[:8] if account else "—"
             summary_parts.append(f"{short} {amount} {currency}")
         summary = "\n".join(summary_parts)
+        tx_id = row.get("id") or ""
         table.add_row(
+            str(tx_id)[:8] if tx_id else "—",
             str(row.get("date") or ""),
             row.get("description") or "",
             row.get("reference") or "—",

--- a/packages/tulip-cli/tests/test_p36_read_edit.py
+++ b/packages/tulip-cli/tests/test_p36_read_edit.py
@@ -150,6 +150,35 @@ def test_transactions_list_renders_all(seeded_session: tuple[str, str, str, str]
 
 
 @pytest.mark.integration
+def test_transactions_list_shows_id_prefix(seeded_session: tuple[str, str, str, str]) -> None:
+    """Default table prints the first 8 chars of each transaction id (#207)."""
+    api_url, _checking, _food, _rent = seeded_session
+    json_result = _run_cli("--json", "transactions", "list", api_url=api_url)
+    rows = json.loads(json_result.stdout)
+    assert len(rows) == 3
+
+    table_result = _run_cli("transactions", "list", api_url=api_url)
+    assert table_result.returncode == 0, table_result.stderr
+    for row in rows:
+        prefix = row["id"][:8]
+        assert prefix in table_result.stdout, (prefix, table_result.stdout)
+
+
+@pytest.mark.integration
+def test_transactions_list_json_payload_unchanged(
+    seeded_session: tuple[str, str, str, str],
+) -> None:
+    """--json passthrough still emits full UUIDs (not truncated)."""
+    api_url, _checking, _food, _rent = seeded_session
+    result = _run_cli("--json", "transactions", "list", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    rows = json.loads(result.stdout)
+    for row in rows:
+        # Full UUIDs are 36 characters with hyphens.
+        assert len(row["id"]) == 36
+
+
+@pytest.mark.integration
 def test_transactions_list_filters_by_account_code(
     seeded_session: tuple[str, str, str, str],
 ) -> None:


### PR DESCRIPTION
## Summary

- Adds an `id` column to `_render_tx_list_table`, leading with the first 8 chars of the UUID. Same prefix convention already used inline for `account_id` in the same table.
- `--json` passthrough is untouched; full UUIDs remain available there for scripting.
- Closes #207.

## Test plan

- [x] `uv run pytest packages/tulip-cli/tests/test_p36_read_edit.py` — 25/25 pass locally (includes one new test asserting the rendered table contains each id prefix and one asserting the `--json` payload's `id` is still a full 36-char UUID).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green on this PR.

## Manual smoke

```bash
tulip add --date 2026-05-12 --description "smoke" \
  --post assets:checking=-1.00 --post expenses:food=1.00
tulip transactions list
```

Expected: the rendered table now has an `id` column showing the first 8 chars of each transaction UUID. The full UUID is still available via `tulip --json transactions list | jq '.[].id'` and is what `tulip transactions show TXID` requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)