### PR TITLE
feat: resolve transaction id by prefix on show/edit/void/delete

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -594,6 +594,15 @@ def list_transactions(
         description="One of 'pending', 'posted', 'reconciled'.",
         pattern="^(pending|posted|reconciled)$",
     ),
+    id_prefix: str | None = Query(
+        default=None,
+        description=(
+            "Restrict to transactions whose UUID begins with this hex prefix "
+            "(case-insensitive). Hyphens are accepted so callers can paste a "
+            "partial UUID like '5df7-822c'. Excludes LIKE wildcards by regex."
+        ),
+        pattern="^[0-9a-fA-F-]{1,36}$",
+    ),
     limit: int | None = Query(
         default=None,
         ge=1,
@@ -617,6 +626,7 @@ def list_transactions(
         from_date=from_date,
         to_date=to_date,
         status=storage_status,
+        id_prefix=id_prefix,
         limit=limit,
     )
     return [_read_response(t.id, claims.household_id, session) for t in rows]

--- a/packages/tulip-api/tests/test_transactions_endpoints.py
+++ b/packages/tulip-api/tests/test_transactions_endpoints.py
@@ -324,3 +324,39 @@ class TestListTransactionsFilters:
             },
         ).json()
         assert {r["description"] for r in rows} == {"lunch-nov"}
+
+    def test_filter_by_id_prefix(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        seeded: tuple[str, str, str],
+    ):
+        all_rows = client.get("/v1/transactions", headers=auth_h).json()
+        target = all_rows[0]
+        prefix = target["id"][:8]
+        rows = client.get("/v1/transactions", headers=auth_h, params={"id_prefix": prefix}).json()
+        assert [r["id"] for r in rows] == [target["id"]]
+
+    def test_filter_by_id_prefix_no_match(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        seeded: tuple[str, str, str],
+    ):
+        # 8 hex chars that almost certainly don't collide with seeded data.
+        rows = client.get(
+            "/v1/transactions", headers=auth_h, params={"id_prefix": "deadbeef"}
+        ).json()
+        assert rows == []
+
+    def test_id_prefix_rejects_wildcards(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        seeded: tuple[str, str, str],
+    ):
+        # LIKE wildcards must not leak through — the regex rejects '%' and '_'.
+        r = client.get("/v1/transactions", headers=auth_h, params={"id_prefix": "%"})
+        assert_problem(r, code="validation.failed", status=422)
+        r = client.get("/v1/transactions", headers=auth_h, params={"id_prefix": "ab_cd"})
+        assert_problem(r, code="validation.failed", status=422)

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -384,6 +384,60 @@ def _resolve_account_id_for_filter(client: TulipClient, identifier: str) -> str:
     return str(resolved["id"])
 
 
+_HEX_PREFIX_CHARS = frozenset("0123456789abcdefABCDEF-")
+
+
+def _resolve_tx_id(client: TulipClient, identifier: str, *, as_json: bool) -> UUID:
+    """Resolve a TXID argument to a full UUID.
+
+    Fast path: a valid UUID string is returned unchanged with no API
+    call. Otherwise the identifier is treated as a hex prefix and
+    looked up via ``GET /v1/transactions?id_prefix=…``. Zero matches
+    raises ``transaction.not_found``; multiple matches raises
+    ``transaction.ambiguous_id_prefix`` with a sample so the user
+    can lengthen the prefix.
+    """
+    try:
+        return UUID(identifier)
+    except ValueError:
+        pass
+    if not identifier or not all(c in _HEX_PREFIX_CHARS for c in identifier):
+        raise typer.BadParameter("TXID must be a UUID or hex prefix (0-9, a-f, -)")
+    response = client.get(
+        "/v1/transactions",
+        authenticated=True,
+        params={"id_prefix": identifier},
+    )
+    rows = response.json()
+    if len(rows) == 0:
+        raise CliError(
+            problem={
+                "type": "/.well-known/errors/transaction.not_found",
+                "title": "No transaction matches that id prefix",
+                "status": 404,
+                "detail": f"No transaction's id begins with {identifier!r}.",
+                "code": "transaction.not_found",
+            },
+            as_json=as_json,
+        )
+    if len(rows) > 1:
+        sample = ", ".join(str(r["id"])[:12] for r in rows[:5])
+        raise CliError(
+            problem={
+                "type": "/.well-known/errors/transaction.ambiguous_id_prefix",
+                "title": "Ambiguous transaction id prefix",
+                "status": 400,
+                "detail": (
+                    f"Prefix {identifier!r} matched {len(rows)} transactions "
+                    f"(e.g. {sample}). Use more characters."
+                ),
+                "code": "transaction.ambiguous_id_prefix",
+            },
+            as_json=as_json,
+        )
+    return UUID(str(rows[0]["id"]))
+
+
 def _render_tx_list_table(rows: list[dict[str, Any]]) -> None:
     table = Table(show_header=True, show_lines=False)
     table.add_column("id")
@@ -526,23 +580,19 @@ def show_transaction(
     tx_id: Annotated[
         str,
         typer.Argument(
-            help="Transaction UUID.",
+            help="Transaction UUID or unambiguous hex prefix.",
             metavar="TXID",
         ),
     ],
 ) -> None:
-    """Show one transaction (header + postings) by UUID."""
+    """Show one transaction (header + postings) by UUID or prefix."""
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
 
     try:
-        UUID(tx_id)
-    except ValueError as exc:
-        raise typer.BadParameter("TXID must be a UUID") from exc
-
-    try:
         with _client(config, as_json=as_json) as client:
-            response = client.get(f"/v1/transactions/{tx_id}", authenticated=True)
+            resolved = _resolve_tx_id(client, tx_id, as_json=as_json)
+            response = client.get(f"/v1/transactions/{resolved}", authenticated=True)
     except CliError as err:
         err.render()
         raise typer.Exit(err.exit_code) from None
@@ -558,7 +608,10 @@ def void_transaction(
     ctx: typer.Context,
     tx_id: Annotated[
         str,
-        typer.Argument(help="Transaction UUID to void.", metavar="TXID"),
+        typer.Argument(
+            help="Transaction UUID or unambiguous hex prefix to void.",
+            metavar="TXID",
+        ),
     ],
     reason: Annotated[
         str,
@@ -591,22 +644,8 @@ def void_transaction(
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
 
-    try:
-        UUID(tx_id)
-    except ValueError as exc:
-        raise typer.BadParameter("TXID must be a UUID") from exc
-
     if reversal_date is not None:
         _validate_iso_date(reversal_date, flag="--date")
-
-    if not yes:
-        confirmed = typer.confirm(
-            f"Void transaction {tx_id}? This posts a reversal sibling.",
-            default=False,
-        )
-        if not confirmed:
-            typer.echo("Aborted; no changes made.")
-            return
 
     body: dict[str, Any] = {"reason": reason}
     if reversal_date is not None:
@@ -614,8 +653,17 @@ def void_transaction(
 
     try:
         with _client(config, as_json=as_json) as client:
+            resolved = _resolve_tx_id(client, tx_id, as_json=as_json)
+            if not yes:
+                confirmed = typer.confirm(
+                    f"Void transaction {resolved}? This posts a reversal sibling.",
+                    default=False,
+                )
+                if not confirmed:
+                    typer.echo("Aborted; no changes made.")
+                    return
             response = client.post(
-                f"/v1/transactions/{tx_id}/void",
+                f"/v1/transactions/{resolved}/void",
                 json=body,
                 authenticated=True,
             )
@@ -637,7 +685,10 @@ def delete_transaction(
     ctx: typer.Context,
     tx_id: Annotated[
         str,
-        typer.Argument(help="Transaction UUID to delete.", metavar="TXID"),
+        typer.Argument(
+            help="Transaction UUID or unambiguous hex prefix to delete.",
+            metavar="TXID",
+        ),
     ],
     yes: Annotated[
         bool,
@@ -653,30 +704,26 @@ def delete_transaction(
     as_json: bool = ctx.obj["json"]
 
     try:
-        UUID(tx_id)
-    except ValueError as exc:
-        raise typer.BadParameter("TXID must be a UUID") from exc
-
-    if not yes:
-        confirmed = typer.confirm(
-            f"Hard-delete transaction {tx_id}? Only PENDING transactions can be deleted.",
-            default=False,
-        )
-        if not confirmed:
-            typer.echo("Aborted; no changes made.")
-            return
-
-    try:
         with _client(config, as_json=as_json) as client:
-            client.delete(f"/v1/transactions/{tx_id}", authenticated=True)
+            resolved = _resolve_tx_id(client, tx_id, as_json=as_json)
+            if not yes:
+                confirmed = typer.confirm(
+                    f"Hard-delete transaction {resolved}? "
+                    "Only PENDING transactions can be deleted.",
+                    default=False,
+                )
+                if not confirmed:
+                    typer.echo("Aborted; no changes made.")
+                    return
+            client.delete(f"/v1/transactions/{resolved}", authenticated=True)
     except CliError as err:
         err.render()
         raise typer.Exit(err.exit_code) from None
 
     if as_json:
-        sys.stdout.write('{"deleted": "' + tx_id + '"}\n')
+        sys.stdout.write('{"deleted": "' + str(resolved) + '"}\n')
         return
-    typer.echo(f"Deleted transaction {tx_id}.")
+    typer.echo(f"Deleted transaction {resolved}.")
 
 
 @transactions_app.command("edit")
@@ -684,7 +731,10 @@ def edit_transaction(
     ctx: typer.Context,
     tx_id: Annotated[
         str,
-        typer.Argument(help="Transaction UUID to edit.", metavar="TXID"),
+        typer.Argument(
+            help="Transaction UUID or unambiguous hex prefix to edit.",
+            metavar="TXID",
+        ),
     ],
 ) -> None:
     """Edit a PENDING transaction in ``$EDITOR`` (hledger format).
@@ -695,16 +745,12 @@ def edit_transaction(
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
 
-    try:
-        UUID(tx_id)
-    except ValueError as exc:
-        raise typer.BadParameter("TXID must be a UUID") from exc
-
     # Pre-flight: load the existing transaction so we can render it into the
     # editor buffer and reject early when it's not PENDING.
     try:
         with _client(config, as_json=as_json) as client:
-            current = client.get(f"/v1/transactions/{tx_id}", authenticated=True).json()
+            resolved = _resolve_tx_id(client, tx_id, as_json=as_json)
+            current = client.get(f"/v1/transactions/{resolved}", authenticated=True).json()
             if current.get("status") != "pending":
                 from tulip_cli.errors import CliError as _CliError
 
@@ -736,17 +782,17 @@ def edit_transaction(
                     buffer = _with_banner(edited, str(exc))
                     continue
                 try:
-                    resolved = _resolve_postings(
+                    resolved_postings = _resolve_postings(
                         client,
                         [ParsedPosting(p.account, p.amount, p.currency) for p in parsed.postings],
                     )
                     body = {
                         "date": parsed.date.isoformat(),
                         "description": parsed.description,
-                        "postings": resolved,
+                        "postings": resolved_postings,
                     }
                     response = client.patch(
-                        f"/v1/transactions/{tx_id}",
+                        f"/v1/transactions/{resolved}",
                         json=body,
                         authenticated=True,
                     )

--- a/packages/tulip-cli/tests/test_p36_read_edit.py
+++ b/packages/tulip-cli/tests/test_p36_read_edit.py
@@ -319,6 +319,31 @@ def test_transactions_show_unknown_uuid_user_error(authed_session: str) -> None:
     assert result.returncode == 1, (result.stdout, result.stderr)
 
 
+@pytest.mark.integration
+def test_transactions_show_by_prefix(seeded_session: tuple[str, str, str, str]) -> None:
+    """An 8-char id prefix resolves to the full UUID via the API resolver."""
+    api_url, _checking, _food, _rent = seeded_session
+    rows = json.loads(_run_cli("--json", "transactions", "list", api_url=api_url).stdout)
+    target = next(r for r in rows if r["description"] == "rent-jun")
+
+    result = _run_cli("transactions", "show", target["id"][:8], api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    assert "rent-jun" in result.stdout
+    assert target["id"] in result.stdout
+
+
+@pytest.mark.integration
+def test_transactions_show_unknown_prefix_user_error(
+    seeded_session: tuple[str, str, str, str],
+) -> None:
+    """A well-formed hex prefix with no matches surfaces a not-found error."""
+    api_url, _checking, _food, _rent = seeded_session
+    # 'deadbeef' is hex-valid but doesn't match any seeded transaction id.
+    result = _run_cli("transactions", "show", "deadbeef", api_url=api_url)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "deadbeef" in result.stderr.lower()
+
+
 # ---------- tulip accounts edit ----------
 
 

--- a/packages/tulip-cli/tests/test_transactions_resolver.py
+++ b/packages/tulip-cli/tests/test_transactions_resolver.py
@@ -1,0 +1,126 @@
+"""Unit tests for ``_resolve_tx_id`` — the prefix-or-UUID resolver shared by
+``transactions show / edit / void / delete``.
+
+The integration coverage in ``test_p36_read_edit.py`` exercises the happy
+path against a real API; here we use ``httpx.MockTransport`` so we can
+drive the ambiguous-prefix and unknown-prefix branches deterministically
+without needing to seed enough transactions to force a collision.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import UUID
+
+import httpx
+import pytest
+import typer
+
+from tulip_cli.auth.tokens import TokenSet, TokenStore
+from tulip_cli.commands.transactions import _resolve_tx_id
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+
+def _config() -> Config:
+    return Config(api_url="https://api.example.com")
+
+
+def _client(tmp_path: Path, handler: httpx.MockTransport) -> TulipClient:
+    store = TokenStore(file_path=tmp_path / "tokens.json")
+    store.save(
+        "https://api.example.com",
+        TokenSet(
+            email="alice@example.com",
+            access_token="access",
+            refresh_token="refresh",
+            access_expires_at=9_999_999_999,
+        ),
+    )
+    return TulipClient(_config(), token_store=store, transport=handler)
+
+
+def test_resolve_tx_id_full_uuid_skips_api(tmp_path: Path) -> None:
+    """A valid UUID is returned without any API round-trip."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(500, json={"unexpected": True})
+
+    client = _client(tmp_path, httpx.MockTransport(handler))
+    full = UUID("12345678-1234-1234-1234-123456789012")
+    assert _resolve_tx_id(client, str(full), as_json=False) == full
+    assert seen == []
+
+
+def test_resolve_tx_id_unambiguous_prefix_resolves(tmp_path: Path) -> None:
+    target = UUID("abcdef01-2345-6789-abcd-ef0123456789")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/transactions"
+        assert request.url.params.get("id_prefix") == "abcdef01"
+        return httpx.Response(
+            200,
+            json=[{"id": str(target), "description": "x"}],
+        )
+
+    client = _client(tmp_path, httpx.MockTransport(handler))
+    assert _resolve_tx_id(client, "abcdef01", as_json=False) == target
+
+
+def test_resolve_tx_id_ambiguous_prefix_raises(tmp_path: Path) -> None:
+    matches = [
+        {"id": "abcdef01-0000-0000-0000-000000000001"},
+        {"id": "abcdef01-0000-0000-0000-000000000002"},
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=matches)
+
+    client = _client(tmp_path, httpx.MockTransport(handler))
+    with pytest.raises(CliError) as excinfo:
+        _resolve_tx_id(client, "abcdef01", as_json=False)
+    assert excinfo.value.problem["code"] == "transaction.ambiguous_id_prefix"
+    # Detail should include the prefix and a hint at the colliding ids.
+    assert "abcdef01" in excinfo.value.problem["detail"]
+
+
+def test_resolve_tx_id_no_match_raises(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    client = _client(tmp_path, httpx.MockTransport(handler))
+    with pytest.raises(CliError) as excinfo:
+        _resolve_tx_id(client, "deadbeef", as_json=False)
+    assert excinfo.value.problem["code"] == "transaction.not_found"
+
+
+def test_resolve_tx_id_rejects_non_hex_input(tmp_path: Path) -> None:
+    """Non-hex characters → typer.BadParameter before any API call."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(500)
+
+    client = _client(tmp_path, httpx.MockTransport(handler))
+    with pytest.raises(typer.BadParameter):
+        _resolve_tx_id(client, "not-a-uuid", as_json=False)
+    assert seen == []
+
+
+def test_resolve_tx_id_as_json_flag_propagates(tmp_path: Path) -> None:
+    """``as_json=True`` makes the resulting CliError render JSON."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    client = _client(tmp_path, httpx.MockTransport(handler))
+    with pytest.raises(CliError) as excinfo:
+        _resolve_tx_id(client, "deadbeef", as_json=True)
+    assert excinfo.value.as_json is True
+    # The body is still valid Problem Details.
+    assert json.dumps(excinfo.value.problem)

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import String, cast, delete, func, select, update
 
 from tulip_storage.models import Posting, Transaction, TransactionStatus
 
@@ -91,13 +91,16 @@ class TransactionRepository:
         from_date: date_type | None = None,
         to_date: date_type | None = None,
         status: TransactionStatus | None = None,
+        id_prefix: str | None = None,
         limit: int | None = None,
     ) -> list[Transaction]:
         """List transaction headers in this household, newest first.
 
         Filters compose with AND. ``account_id`` matches any transaction
         with at least one posting on that account (any currency). Date
-        filters are inclusive on both ends. ``limit`` caps the number of
+        filters are inclusive on both ends. ``id_prefix`` matches
+        transactions whose string-rendered UUID begins with the given
+        hex prefix (case-insensitive). ``limit`` caps the number of
         rows returned; ``None`` means no cap.
         """
         query = select(Transaction).where(Transaction.household_id == self._household_id)
@@ -116,6 +119,12 @@ class TransactionRepository:
             query = query.where(Transaction.date <= to_date)
         if status is not None:
             query = query.where(Transaction.status == status)
+        if id_prefix is not None:
+            # Cast bypasses the GUID type decorator (which would try to
+            # parse the LIKE pattern as a UUID). Stored ids are always
+            # lowercased by ``str(UUID(...))`` in ``GUID.process_bind_param``,
+            # so a lowercased prefix gives case-insensitive matching.
+            query = query.where(cast(Transaction.id, String).like(f"{id_prefix.lower()}%"))
         query = query.order_by(Transaction.date.desc(), Transaction.created_at.desc())
         if limit is not None:
             query = query.limit(limit)

--- a/packages/tulip-storage/tests/test_repositories.py
+++ b/packages/tulip-storage/tests/test_repositories.py
@@ -676,6 +676,41 @@ class TestTransactionRepository:
         assert len(posted) == 1 and posted[0].status is TransactionStatus.POSTED
         assert len(pending) == 1 and pending[0].status is TransactionStatus.PENDING
 
+    def test_list_headers_filters_by_id_prefix(self, session: Session, household: Household):
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        for day in (1, 2, 3):
+            self._post_tx(
+                session,
+                household,
+                tx_date=date(2026, 6, day),
+                debit_account=food,
+                credit_account=cash,
+                amount=Decimal("1.00"),
+            )
+
+        repo = TransactionRepository(session, household.id)
+        all_headers = repo.list_headers()
+        assert len(all_headers) == 3
+        target = all_headers[0]
+        prefix = str(target.id)[:8]
+
+        matched = repo.list_headers(id_prefix=prefix)
+        assert [h.id for h in matched] == [target.id]
+
+        # Case-insensitive: stored ids are lowercase, but a mixed-case prefix
+        # should still resolve.
+        upper = repo.list_headers(id_prefix=prefix.upper())
+        assert [h.id for h in upper] == [target.id]
+
+        # Garbage prefix returns nothing rather than blowing up.
+        assert repo.list_headers(id_prefix="deadbeef") == []
+
     def test_list_headers_respects_limit(self, session: Session, household: Household):
         cash, food = self._seed_accounts(session, household)
         PeriodRepository(session, household.id).create(


### PR DESCRIPTION
## Summary

Closes #211 — and finishes the loop opened by #207 (the 8-char id column is now actionable).

- **Storage**: `TransactionRepository.list_headers` learns `id_prefix`; filters via `CAST(id AS String) LIKE 'prefix%'`. The cast is necessary because the `GUID` TypeDecorator's `process_bind_param` rejects non-UUID values.
- **API**: `GET /v1/transactions?id_prefix=<hex>` accepts 1-36 hex chars (regex pattern `^[0-9a-fA-F-]{1,36}$`), so LIKE wildcards (`%` / `_`) can't leak through.
- **CLI**: new shared `_resolve_tx_id(client, identifier, *, as_json)` used by `transactions show / edit / void / delete`. Full UUIDs take a no-API fast path; shorter inputs round-trip through the prefix endpoint and produce typed errors on 0 matches (`transaction.not_found`) or 2+ matches (`transaction.ambiguous_id_prefix`, with a sample of the colliding ids).

## Test plan

- [x] `uv run pytest packages/tulip-storage/tests/test_repositories.py::TestTransactionRepository::test_list_headers_filters_by_id_prefix` — 1/1 pass (new).
- [x] `uv run pytest packages/tulip-api/tests/test_transactions_endpoints.py::TestListTransactionsFilters` — 10/10 pass (3 new: happy path, no-match, wildcard-rejection).
- [x] `uv run pytest packages/tulip-cli/tests/test_transactions_resolver.py` — 6/6 pass (new file; mocked-transport unit tests covering all four branches of `_resolve_tx_id`).
- [x] `uv run pytest packages/tulip-cli/tests/test_p36_read_edit.py` — 27/27 pass (2 new: show-by-prefix, show-with-unknown-prefix).
- [x] `just test` full suite — 1548 pass, 1 skipped (pre-existing OpenAPI path-collision skip).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green on this PR.

## Manual smoke

```bash
tulip add --date 2026-05-12 --description "smoke" \
  --post assets:checking=-1.00 --post expenses:food=1.00

PREFIX=$(tulip --json transactions list | jq -r '.[0].id[:8]')
tulip transactions show "$PREFIX"
tulip transactions show "$PREFIX" -- and a second tx with the same first hex char if you have one to see the ambiguous-prefix error
tulip transactions show deadbeef                  -- not_found
tulip transactions show not-a-uuid                -- typer.BadParameter (exit 2)
```

Expected: prefix resolves to the full UUID and renders the header + postings. Ambiguous prefix prints `Ambiguous transaction id prefix` with a sample of colliding ids and exits 1. Missing prefix prints `No transaction matches that id prefix` and exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)