### PR TITLE
feat: tulip reconcile interactive (guided wizard, closes #205)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
@@ -571,6 +571,162 @@ def complete_command(
     )
 
 
+# ---- interactive (guided wizard) ------------------------------------------
+
+
+def _read_wizard_choice() -> str:
+    """Read one line from stdin and return the first character, lowercased.
+
+    Empty input (just Enter) returns ``""`` so the caller can supply its own
+    default. EOF returns ``"q"`` so a piped script with too few inputs cleanly
+    quits instead of hanging.
+    """
+    try:
+        line = input("[A]ccept  [R]eject  [S]kip  [Q]uit > ").strip().lower()
+    except EOFError:
+        return "q"
+    return line[:1]
+
+
+@reconcile_app.command("interactive")
+def interactive_command(
+    ctx: typer.Context,
+    reconciliation_id: Annotated[
+        UUID,
+        typer.Argument(help="Reconciliation UUID.", metavar="RECONCILIATION_ID"),
+    ],
+) -> None:
+    """Walk through auto-matched proposals one at a time (accept / reject / skip / quit).
+
+    Designed for the migration / monthly-review flow: rather than copying UUIDs
+    out of ``reconcile show`` and pasting them into ``match``, this loop renders
+    each auto-matched proposal with its statement-line and ledger-transaction
+    context side by side and accepts one-keystroke decisions. Manual-only
+    matches (no ``matcher_version``) are skipped — they're already user-decided.
+
+    On ``Q``, the reconciliation envelope is left in its current state with all
+    accepted matches intact; run ``tulip reconcile complete`` separately when
+    you're ready to finalise.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    if as_json:
+        raise typer.BadParameter("--json is incompatible with the interactive wizard")
+
+    console = Console()
+    try:
+        with _client(config, as_json=as_json) as client:
+            inbox = client.get(
+                f"/v1/reconciliations/{reconciliation_id}",
+                authenticated=True,
+            ).json()
+            auto_matches = [m for m in inbox["matches"] if m.get("matcher_version")]
+            if not auto_matches:
+                if inbox["matches"]:
+                    typer.echo("All matches in this reconciliation are manual; nothing to review.")
+                else:
+                    typer.echo(
+                        f"No matches to review yet. Run `tulip reconcile auto-match "
+                        f"{reconciliation_id}` first."
+                    )
+                return
+
+            recon = inbox["reconciliation"]
+            lines_by_id, txs_by_id = _build_match_context_lookups(client, recon)
+            accepted, rejected, skipped = _run_wizard_loop(
+                client,
+                console,
+                reconciliation_id,
+                auto_matches,
+                lines_by_id,
+                txs_by_id,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    typer.echo(f"\nReviewed: {accepted} accepted, {rejected} rejected, {skipped} skipped.")
+    typer.echo(f"Run `tulip reconcile complete {reconciliation_id}` when ready to finalise.")
+
+
+def _build_match_context_lookups(
+    client: TulipClient,
+    recon: dict[str, Any],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Two GETs to populate (line_id → line) and (tx_id → tx) lookups.
+
+    Matched items have been removed from the inbox's ``unmatched_*`` arrays,
+    so to render their detail we re-fetch from the source batch and the
+    transactions endpoint scoped to the recon's account + period.
+    """
+    lines_by_id: dict[str, dict[str, Any]] = {}
+    batch_id = recon.get("source_import_batch_id")
+    if batch_id:
+        batch = client.get(f"/v1/imports/{batch_id}", authenticated=True).json()
+        lines_by_id = {ln["id"]: ln for ln in batch.get("lines", [])}
+
+    txs = client.get(
+        "/v1/transactions",
+        authenticated=True,
+        params={
+            "account_id": recon["account_id"],
+            "from": recon["statement_period_start"],
+            "to": recon["statement_period_end"],
+        },
+    ).json()
+    txs_by_id = {tx["id"]: tx for tx in txs}
+    return lines_by_id, txs_by_id
+
+
+def _run_wizard_loop(
+    client: TulipClient,
+    console: Console,
+    reconciliation_id: UUID,
+    auto_matches: list[dict[str, Any]],
+    lines_by_id: dict[str, dict[str, Any]],
+    txs_by_id: dict[str, dict[str, Any]],
+) -> tuple[int, int, int]:
+    """Iterate auto-matches; return ``(accepted, rejected, skipped)``."""
+    accepted = rejected = skipped = 0
+    total = len(auto_matches)
+    for idx, match in enumerate(auto_matches, start=1):
+        line = lines_by_id.get(match["statement_line_id"], {})
+        tx = txs_by_id.get(match["ledger_transaction_id"], {})
+        confidence = str(match.get("confidence") or "?").upper()
+        console.print(f"\n[bold][{idx}/{total}] {confidence} confidence[/bold]")
+        console.print(
+            f"  statement: {line.get('posted_date', '?')}  "
+            f"{(line.get('description') or '')[:50]}  "
+            f"{line.get('amount', '?')} {line.get('currency', '')}"
+        )
+        console.print(
+            f"  ledger tx: {str(tx.get('id', ''))[:8]}  {tx.get('date', '?')}  "
+            f"{(tx.get('description') or '')[:50]}  status={tx.get('status', '?')}"
+        )
+
+        choice = _read_wizard_choice()
+        if choice == "" or choice == "a":
+            accepted += 1
+            console.print("  [green]✓ accepted[/green]")
+        elif choice == "r":
+            client.post(
+                f"/v1/reconciliations/{reconciliation_id}/matches/{match['id']}/reject",
+                authenticated=True,
+            )
+            rejected += 1
+            console.print("  [yellow]✗ rejected[/yellow]")
+        elif choice == "s":
+            skipped += 1
+            console.print("  skipped")
+        elif choice == "q":
+            console.print("  quit")
+            break
+        else:
+            console.print(f"  unknown choice {choice!r}; skipping")
+            skipped += 1
+    return accepted, rejected, skipped
+
+
 # ---- delete ---------------------------------------------------------------
 
 

--- a/packages/tulip-cli/tests/test_reconcile_command.py
+++ b/packages/tulip-cli/tests/test_reconcile_command.py
@@ -308,6 +308,140 @@ def test_reconcile_show_renders_four_sections(session_setup: dict[str, str]) -> 
 # ---- auto-match / match / reject ----------------------------------------
 
 
+# ---- interactive wizard --------------------------------------------------
+
+
+def _create_recon(session_setup: dict[str, str]) -> str:
+    """Create a recon envelope and return its UUID."""
+    create = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            session_setup["api_url"],
+            "reconcile",
+            "create",
+            "--account",
+            "1110",
+            "--batch",
+            session_setup["batch_id"],
+            "--period",
+            "2026-05-01..2026-05-31",
+            "--starting",
+            "0.00",
+            "--ending",
+            "1457.83",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert create.returncode == 0, create.stderr
+    return str(json.loads(create.stdout)["id"])
+
+
+@pytest.mark.integration
+def test_reconcile_interactive_no_matches_hints_auto_match(
+    session_setup: dict[str, str],
+) -> None:
+    """If no auto-matches exist yet, the wizard tells the user to run auto-match."""
+    recon_id = _create_recon(session_setup)
+    result = _run_cli(
+        "reconcile",
+        "interactive",
+        recon_id,
+        api_url=session_setup["api_url"],
+    )
+    assert result.returncode == 0, result.stderr
+    assert "auto-match" in result.stdout.lower()
+
+
+@pytest.mark.integration
+def test_reconcile_interactive_accept_all(session_setup: dict[str, str]) -> None:
+    """Pipe 'a\\na\\n' to accept both auto-matched candidates; summary should report 2 accepted."""
+    recon_id = _create_recon(session_setup)
+    # Pre-run auto-match so there are candidates to walk through.
+    auto = _run_cli("reconcile", "auto-match", recon_id, api_url=session_setup["api_url"])
+    assert auto.returncode == 0, auto.stderr
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--api-url",
+            session_setup["api_url"],
+            "reconcile",
+            "interactive",
+            recon_id,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        input="a\na\n",
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "2 accepted" in result.stdout
+    assert "0 rejected" in result.stdout
+
+    # And complete should still work since accepted matches are preserved.
+    complete = _run_cli("reconcile", "complete", recon_id, api_url=session_setup["api_url"])
+    assert complete.returncode == 0, complete.stderr
+
+
+@pytest.mark.integration
+def test_reconcile_interactive_reject_then_quit(session_setup: dict[str, str]) -> None:
+    """Reject one, quit; the rejected match should be gone from the inbox."""
+    recon_id = _create_recon(session_setup)
+    auto = _run_cli("reconcile", "auto-match", recon_id, api_url=session_setup["api_url"])
+    assert auto.returncode == 0, auto.stderr
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--api-url",
+            session_setup["api_url"],
+            "reconcile",
+            "interactive",
+            recon_id,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        input="r\nq\n",
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "1 rejected" in result.stdout
+
+    # And the inbox should now show one fewer match.
+    show = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            session_setup["api_url"],
+            "reconcile",
+            "show",
+            recon_id,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    body = json.loads(show.stdout)
+    assert len(body["matches"]) == 1  # one remained (the one we quit on)
+
+
 @pytest.mark.integration
 def test_reconcile_auto_match_and_complete(session_setup: dict[str, str]) -> None:
     create = subprocess.run(


### PR DESCRIPTION
## Summary

New `tulip reconcile interactive RECON_ID` subcommand that walks the auto-matcher's persisted proposals one at a time, with one-keystroke decisions: `[A]ccept  [R]eject  [S]kip  [Q]uit`.

- Reject calls `POST /v1/reconciliations/{id}/matches/{match_id}/reject` (existing endpoint) — match is deleted and both items return to the unmatched piles.
- Accept / skip leave the match in place; a separate `tulip reconcile complete` still finalises.
- Quit exits without forcing complete — envelope stays IN_PROGRESS so the user can resume.
- Manual matches (no `matcher_version`) are filtered out — already user-decided.
- Empty / no-auto-matches state surfaces a hint to run `auto-match` first.

Pure stdlib UX (no Textual dependency). The TUI option called out on #205 is deliberately deferred — revisit if end-to-end fatigue still surfaces after this wizard ships.

## Test plan

- [x] `uv run pytest packages/tulip-cli/tests/test_reconcile_command.py` — 11/11 pass (3 new: no-matches-hint, accept-all happy path, reject-then-quit).
- [x] `just test` full suite — 1551 pass, 1 skipped (pre-existing OpenAPI path-collision skip).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green on this PR.

## Manual smoke

```bash
# Spin up the API on localhost (separate terminal):
uv run uvicorn tulip_api.main:app --port 8000

# Register + login:
tulip register --email you@example.com --household "Smoke" --display-name "You"
tulip auth login --email you@example.com

# Seed an account, import a statement, create the recon:
tulip accounts add --name Checking --type asset --currency USD --code 1110
BATCH=$(tulip --json imports ofx packages/tulip-importers/tests/fixtures/ofx/minimal_ofx2.ofx --account 1110 | jq -r '.id')

# Create a couple of matching ledger transactions so auto-match has something to do:
tulip accounts add --name Misc --type expense --currency USD --code 5100
tulip add --date 2026-05-12 --description PAYPAL --post 1110=-42.17 --post 5100=42.17
tulip add --date 2026-05-15 --description PAYROLL --post 1110=1500.00 --post 5100=-1500.00

RECON=$(tulip --json reconcile create --account 1110 --batch "$BATCH" --period 2026-05-01..2026-05-31 --starting 0.00 --ending 1457.83 | jq -r '.id')
tulip reconcile auto-match "$RECON"

# Walk the wizard:
tulip reconcile interactive "$RECON"
```

Expected: two HIGH-confidence proposals render side by side with their statement-line + ledger-tx detail, prompt `[A]ccept  [R]eject  [S]kip  [Q]uit > ` accepts one char. Closing summary: `Reviewed: 2 accepted, 0 rejected, 0 skipped.` followed by the `reconcile complete` reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)