### PR TITLE
fix: wire needs_rehash() into login (closes #224)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -25,7 +25,7 @@ from tulip_api.auth.mfa import (
     generate_totp_secret,
     verify_totp_code,
 )
-from tulip_api.auth.passwords import hash_password, verify_password
+from tulip_api.auth.passwords import hash_password, needs_rehash, verify_password
 from tulip_api.auth.recovery_codes import (
     generate_recovery_codes,
     hash_recovery_code,
@@ -222,6 +222,13 @@ def login(
     if user is None:
         log.info("login.failed", email=body.email)
         raise InvalidCredentialsError()
+
+    # Argon2 parameter upgrades: re-hash on next successful password verify.
+    # Must commit here — /login/mfa + /login/recover don't see the plaintext.
+    if needs_rehash(user.password_hash):
+        user.password_hash = hash_password(body.password)
+        session.commit()
+        log.info("user.password_rehashed", user_id=str(user.id))
 
     if user.totp_enrolled_at is not None:
         token = create_mfa_challenge_token(

--- a/packages/tulip-api/tests/test_auth_endpoints.py
+++ b/packages/tulip-api/tests/test_auth_endpoints.py
@@ -167,6 +167,78 @@ class TestLogin:
         assert_problem(r, code="auth.invalid_credentials", status=401)
         assert r.headers["www-authenticate"] == "Bearer"
 
+    def test_login_rehashes_password_when_params_changed(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """When argon2 params are tuned, the next successful login re-hashes (issue #224)."""
+        from sqlalchemy import select
+
+        import tulip_api.routers.auth as auth_router
+        from tulip_api.auth.passwords import verify_password
+        from tulip_storage.models import User
+
+        with session_maker() as s:
+            original_hash = (
+                s.execute(select(User).where(User.email == registered["email"]))
+                .scalar_one()
+                .password_hash
+            )
+
+        # Simulate "argon2 params bumped": force needs_rehash to fire.
+        monkeypatch.setattr(auth_router, "needs_rehash", lambda _h: True)
+
+        r = client.post(
+            "/v1/auth/login",
+            json={"email": registered["email"], "password": registered["password"]},
+        )
+        assert r.status_code == 200
+
+        with session_maker() as s:
+            new_hash = (
+                s.execute(select(User).where(User.email == registered["email"]))
+                .scalar_one()
+                .password_hash
+            )
+        assert new_hash != original_hash
+        # The new hash must still verify the same password.
+        assert verify_password(registered["password"], new_hash)
+
+    def test_login_does_not_rehash_when_params_unchanged(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker,
+    ):
+        """Default case: argon2 params match, hash is untouched on login."""
+        from sqlalchemy import select
+
+        from tulip_storage.models import User
+
+        with session_maker() as s:
+            original_hash = (
+                s.execute(select(User).where(User.email == registered["email"]))
+                .scalar_one()
+                .password_hash
+            )
+
+        r = client.post(
+            "/v1/auth/login",
+            json={"email": registered["email"], "password": registered["password"]},
+        )
+        assert r.status_code == 200
+
+        with session_maker() as s:
+            new_hash = (
+                s.execute(select(User).where(User.email == registered["email"]))
+                .scalar_one()
+                .password_hash
+            )
+        assert new_hash == original_hash
+
 
 class TestRefresh:
     def test_rotates_refresh_token(self, client: TestClient, registered: dict[str, str]):


### PR DESCRIPTION
## Summary

Closes #224 (M-4 from the 2026-05-12 deep security audit).

After a successful password verify in `routers/auth.py:login`, check `needs_rehash(user.password_hash)` and rotate the stored hash with current argon2 params. Commit before any MFA-branch exception so the upgrade lands even when the request continues to `/login/mfa` (which never sees the plaintext password).

The fix realises the threat-model claim at `THREAT_MODEL.md:20` — "PHC-formatted hashes are self-describing, so re-tuning later is a no-op for old hashes" — which was previously only true if `needs_rehash` was actually called somewhere. Now the upgrade path fires.

## Test plan

- [x] New test asserts that with `monkeypatch.setattr(auth_router, "needs_rehash", lambda _h: True)`, the password hash rotates on next login and the new hash still verifies the same password.
- [x] New test asserts default case (params unchanged) does not rotate the hash.
- [x] Full `test_auth_endpoints.py` suite passes (13/13).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)