### PR TITLE
fix: token store raises TokenStoreError when keyring backend missing (closes #227)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/auth/tokens.py
+++ b/packages/tulip-cli/src/tulip_cli/auth/tokens.py
@@ -25,9 +25,25 @@ from pathlib import Path
 from typing import Final
 
 import keyring
+import keyring.errors
 
 _KEYRING_SERVICE: Final[str] = "tulip-accounting"
 _ENV_TOKEN_STORE: Final[str] = "TULIP_TOKEN_STORE"  # noqa: S105 — env var name, not a credential
+
+
+class TokenStoreError(RuntimeError):
+    """Raised when the token store backend is unusable (e.g. no keyring service).
+
+    The CLI surfaces this with operator guidance rather than the underlying
+    library traceback. See #227.
+    """
+
+
+_KEYRING_GUIDANCE: Final[str] = (
+    "No usable OS keyring service was found. On Linux install "
+    "`libsecret`/`gnome-keyring`; on macOS / Windows the OS provides one. "
+    "For tests only you can set TULIP_TOKEN_STORE to a file path."
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,7 +77,11 @@ class TokenStore:
         return self._file_path is None
 
     def save(self, api_url: str, tokens: TokenSet) -> None:
-        """Persist ``tokens`` for ``api_url``, replacing any existing entry."""
+        """Persist ``tokens`` for ``api_url``, replacing any existing entry.
+
+        Raises ``TokenStoreError`` when the keyring backend is unavailable
+        (e.g. headless Linux without `dbus`/`secret-service`).
+        """
         url = _normalize(api_url)
         payload = json.dumps(asdict(tokens))
         if self._file_path is not None:
@@ -69,15 +89,24 @@ class TokenStore:
             data[url] = payload
             self._write_file(data)
         else:
-            keyring.set_password(_KEYRING_SERVICE, url, payload)
+            try:
+                keyring.set_password(_KEYRING_SERVICE, url, payload)
+            except keyring.errors.NoKeyringError as exc:
+                raise TokenStoreError(_KEYRING_GUIDANCE) from exc
 
     def load(self, api_url: str) -> TokenSet | None:
-        """Return tokens for ``api_url`` if any are stored, else ``None``."""
+        """Return tokens for ``api_url`` if any are stored, else ``None``.
+
+        Raises ``TokenStoreError`` when the keyring backend is unavailable.
+        """
         url = _normalize(api_url)
         if self._file_path is not None:
             payload = self._read_file().get(url)
         else:
-            payload = keyring.get_password(_KEYRING_SERVICE, url)
+            try:
+                payload = keyring.get_password(_KEYRING_SERVICE, url)
+            except keyring.errors.NoKeyringError as exc:
+                raise TokenStoreError(_KEYRING_GUIDANCE) from exc
         if not payload:
             return None
         try:
@@ -92,7 +121,10 @@ class TokenStore:
             return None
 
     def clear(self, api_url: str) -> None:
-        """Remove any stored tokens for ``api_url``. Idempotent — no error if absent."""
+        """Remove any stored tokens for ``api_url``. Idempotent — no error if absent.
+
+        Raises ``TokenStoreError`` when the keyring backend is unavailable.
+        """
         url = _normalize(api_url)
         if self._file_path is not None:
             data = self._read_file()
@@ -103,6 +135,8 @@ class TokenStore:
                 keyring.delete_password(_KEYRING_SERVICE, url)
             except keyring.errors.PasswordDeleteError:
                 pass
+            except keyring.errors.NoKeyringError as exc:
+                raise TokenStoreError(_KEYRING_GUIDANCE) from exc
 
     def _read_file(self) -> dict[str, str]:
         if self._file_path is None or not self._file_path.is_file():

--- a/packages/tulip-cli/tests/test_token_store.py
+++ b/packages/tulip-cli/tests/test_token_store.py
@@ -99,3 +99,51 @@ def test_default_token_store_uses_keyring_when_env_var_unset(
     # Don't actually write to the user's keyring during tests; just check
     # that the store reports keyring mode.
     assert store.is_keyring_backed
+
+
+class TestKeyringUnavailable:
+    """When the OS keyring backend is missing, raise TokenStoreError (#227)."""
+
+    def test_save_raises_token_store_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import keyring
+        import keyring.errors
+
+        from tulip_cli.auth.tokens import TokenStoreError
+
+        def _no_keyring(*_a: object, **_kw: object) -> None:
+            raise keyring.errors.NoKeyringError("no usable backend")
+
+        monkeypatch.setattr(keyring, "set_password", _no_keyring)
+        store = TokenStore()  # keyring-backed
+        with pytest.raises(TokenStoreError) as excinfo:
+            store.save("https://api.example.com", _tokens())
+        # Operator guidance must mention how to recover.
+        assert "keyring" in str(excinfo.value).lower()
+
+    def test_load_raises_token_store_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import keyring
+        import keyring.errors
+
+        from tulip_cli.auth.tokens import TokenStoreError
+
+        def _no_keyring(*_a: object, **_kw: object) -> None:
+            raise keyring.errors.NoKeyringError("no usable backend")
+
+        monkeypatch.setattr(keyring, "get_password", _no_keyring)
+        store = TokenStore()
+        with pytest.raises(TokenStoreError):
+            store.load("https://api.example.com")
+
+    def test_clear_raises_token_store_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import keyring
+        import keyring.errors
+
+        from tulip_cli.auth.tokens import TokenStoreError
+
+        def _no_keyring(*_a: object, **_kw: object) -> None:
+            raise keyring.errors.NoKeyringError("no usable backend")
+
+        monkeypatch.setattr(keyring, "delete_password", _no_keyring)
+        store = TokenStore()
+        with pytest.raises(TokenStoreError):
+            store.clear("https://api.example.com")


### PR DESCRIPTION
## Summary

Closes #227 (M-10 from the 2026-05-12 deep security audit).

CLI token store called `keyring.set_password` / `get_password` / `delete_password` without exception handling. On headless Linux without `dbus`/`secret-service`, `keyring.errors.NoKeyringError` propagates as an unhelpful traceback. The audit recommended a typed error with operator guidance.

Catch `NoKeyringError` on save / load / clear; raise `TokenStoreError` with the recovery hint (install `libsecret`/`gnome-keyring`, or set `TULIP_TOKEN_STORE` for testing).

## Test plan

- [x] Three new tests (`TestKeyringUnavailable`) monkeypatch each keyring function to raise `NoKeyringError`; assert our wrapper raises `TokenStoreError`.
- [x] Full `test_token_store.py` passes (11/11).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)