### PR TITLE
fix: drop ai_invocation_id from ProposalCreate body (closes #218)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/proposals.py
+++ b/packages/tulip-api/src/tulip_api/routers/proposals.py
@@ -95,33 +95,30 @@ def create_proposal(
     claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> ProposalRead:
-    """Create a new pending proposal.
+    """Create a new user-originated pending proposal.
 
-    AI-generated proposals (P6.4.b) supply ``ai_invocation_id`` and set
-    ``created_by_kind=ai_agent`` server-side based on its presence.
-    Direct user-created proposals omit it and stamp ``created_by_kind=user``.
+    Always stamps ``created_by_kind=user``. AI-originated proposals are
+    written via ``PendingProposalRepository.create`` from inside the
+    capability layer (e.g. ``/v1/ai/proposals/suggest/budget``) — that
+    path stamps ``ai_agent`` server-side with a verified ``ai_invocation_id``.
+    See #218 for why we don't accept the field on this HTTP body.
     """
-    creator_kind = (
-        ProposalCreatorKind.AI_AGENT.value
-        if body.ai_invocation_id is not None
-        else ProposalCreatorKind.USER.value
-    )
     repo = PendingProposalRepository(session, claims.household_id)
     row = repo.create(
         kind=body.kind,
         title=body.title,
         payload=body.payload,
         rationale=body.rationale,
-        created_by_kind=creator_kind,
+        created_by_kind=ProposalCreatorKind.USER.value,
         created_by_user_id=claims.user_id,
-        ai_invocation_id=body.ai_invocation_id,
+        ai_invocation_id=None,
     )
     session.commit()
     log.info(
         "proposal.created",
         proposal_id=str(row.id),
         kind=row.kind,
-        created_by_kind=creator_kind,
+        created_by_kind=ProposalCreatorKind.USER.value,
     )
     return _to_read(row)
 

--- a/packages/tulip-api/src/tulip_api/schemas/proposal.py
+++ b/packages/tulip-api/src/tulip_api/schemas/proposal.py
@@ -6,16 +6,26 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ProposalCreate(BaseModel):
     """Body for ``POST /v1/ai/proposals``.
 
-    Used by both the AI flow (P6.4.b — sets ``ai_invocation_id``) and a
-    human-driven manual-propose path (CLI / direct API call). The kind
-    must be supported by an executor; the payload is kind-specific JSON.
+    User-driven manual-propose path only — AI-originated proposals are
+    written via ``PendingProposalRepository.create`` from inside the
+    capability (e.g. ``/v1/ai/proposals/suggest/budget``), never through
+    this HTTP body.
+
+    ``ai_invocation_id`` is deliberately not accepted here: it's a
+    server-side link from a proposal to the audit row that produced it,
+    and accepting it from the client lets a user spoof
+    ``created_by_kind=ai_agent`` on a proposal of their own making (#218).
+    ``extra="forbid"`` rejects unknown fields loudly so older clients
+    that send ``ai_invocation_id`` get a 422 rather than silent drop.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     kind: str = Field(
         min_length=1,
@@ -25,7 +35,6 @@ class ProposalCreate(BaseModel):
     title: str = Field(min_length=1, max_length=200)
     payload: dict[str, Any]
     rationale: str = ""
-    ai_invocation_id: UUID | None = None
 
 
 class ProposalRead(BaseModel):

--- a/packages/tulip-api/tests/test_proposals_endpoints.py
+++ b/packages/tulip-api/tests/test_proposals_endpoints.py
@@ -89,11 +89,13 @@ class TestCreateAndList:
         assert body["status"] == "pending"
         assert body["ai_invocation_id"] is None
 
-    def test_create_ai_proposal_sets_creator_kind_ai_agent(
+    def test_create_rejects_ai_invocation_id_field(
         self, client: TestClient, auth_h: dict[str, str]
     ) -> None:
+        """#218: clients cannot spoof `created_by_kind=ai_agent` by supplying
+        `ai_invocation_id` in the create body. The field is now schema-rejected.
+        """
         env_id = _make_envelope(client, auth_h)
-        # Passing ai_invocation_id flips creator_kind to ai_agent.
         r = client.post(
             "/v1/ai/proposals",
             headers=auth_h,
@@ -104,8 +106,19 @@ class TestCreateAndList:
                 "ai_invocation_id": str(uuid4()),
             },
         )
-        assert r.status_code == 201
-        assert r.json()["created_by_kind"] == "ai_agent"
+        # extra="forbid" on ProposalCreate → 422 validation.failed.
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_create_always_sets_creator_kind_user(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """The HTTP create body is user-only; the AI flow writes via the repo directly."""
+        env_id = _make_envelope(client, auth_h)
+        body = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="200.00"
+        )
+        assert body["created_by_kind"] == "user"
+        assert body["ai_invocation_id"] is None
 
     def test_list_filters_to_pending_by_default(
         self, client: TestClient, auth_h: dict[str, str]
@@ -170,20 +183,33 @@ class TestApprove:
         auth_h: dict[str, str],
         household_id: UUID,
     ) -> None:
-        """The locked rule from ARCHITECTURE.md §6.2 / THREAT_MODEL §5.3."""
+        """The locked rule from ARCHITECTURE.md §6.2 / THREAT_MODEL §5.3.
+
+        Per #218, AI-originated proposals can no longer be seeded via the
+        HTTP create endpoint (clients can't spoof ai_agent). Seed via the
+        repository directly — same path the SuggestBudget endpoint uses
+        in production.
+        """
+        from tulip_api.deps import get_session
+        from tulip_storage.models import ProposalCreatorKind
+        from tulip_storage.repositories import PendingProposalRepository
+
         env_id = _make_envelope(client, auth_h, budget_amount="100.00")
-        # Create AI-flavoured proposal.
-        r = client.post(
-            "/v1/ai/proposals",
-            headers=auth_h,
-            json={
-                "kind": "envelope_budget_update",
-                "title": "AI-suggested",
-                "payload": {"envelope_id": env_id, "new_budget_amount": "175.00"},
-                "ai_invocation_id": str(uuid4()),
-            },
-        )
-        proposal_id = r.json()["id"]
+        overrides = client.app.dependency_overrides
+        session_factory = overrides[get_session]
+        with next(session_factory()) as seed_session:
+            row = PendingProposalRepository(seed_session, household_id).create(
+                kind="envelope_budget_update",
+                title="AI-suggested",
+                payload={"envelope_id": env_id, "new_budget_amount": "175.00"},
+                rationale="",
+                created_by_kind=ProposalCreatorKind.AI_AGENT.value,
+                created_by_user_id=None,
+                ai_invocation_id=uuid4(),
+            )
+            seed_session.commit()
+            proposal_id = str(row.id)
+
         client.post(f"/v1/ai/proposals/{proposal_id}/approve", headers=auth_h).raise_for_status()
 
         # Inspect audit_log via the test session.


### PR DESCRIPTION
## Summary

Closes #218 (H-2 from the 2026-05-12 deep security audit).

`ProposalCreate.ai_invocation_id` was a client-supplied UUID that the router used to flip `created_by_kind` to `AI_AGENT`. A `member` could pass any UUID and land a `pending_proposals` row that the executor's audit chain falsely attributes to the AI — breaking the `THREAT_MODEL.md:132` guarantee that `actor_kind=ai_agent` reliably distinguishes AI authorship.

The production AI flow already writes proposals via `PendingProposalRepository.create()` from inside the capability layer (`routers/proposals.py:349-358`, the `SuggestBudget` endpoint), so removing the HTTP field doesn't break the AI path. The HTTP `POST /v1/ai/proposals` is now user-only:
- `created_by_kind=USER` always.
- `ai_invocation_id=None` always.
- `extra="forbid"` rejects older clients that send the dropped field with 422 validation.failed (rather than silently ignoring it).

## Test plan

- [x] New test: POST with `ai_invocation_id` returns 422 validation.failed.
- [x] Existing test that seeded an AI-flavoured proposal via HTTP rewritten to seed via the repository directly (same path SuggestBudget uses in production).
- [x] Full `test_proposals_endpoints.py` passes (21/21).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)