### PR TITLE
fix: backup restore rejects path traversal in attachment members (closes #217)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/backup.py
+++ b/packages/tulip-cli/src/tulip_cli/backup.py
@@ -307,6 +307,7 @@ def restore_backup(
                 f"{attachment_root}. Pass --force to overwrite."
             )
 
+    safe_attachment_root = attachment_root.resolve()
     with tarfile.open(in_path, mode="r:gz") as tar:
         for member in tar.getmembers():
             name = member.name
@@ -322,6 +323,19 @@ def restore_backup(
                     continue  # the directory entry itself
                 attachment_root.mkdir(parents=True, exist_ok=True)
                 target = attachment_root / stripped
+                # Reject any member whose resolved path escapes
+                # attachment_root (`..` segments, absolute paths, etc.).
+                # The DB branch uses `tar.extract(..., filter="data")`
+                # which has Python 3.12+'s built-in safe filter; the
+                # attachment branch writes manually so it needs its own
+                # guard. See #217.
+                resolved = target.resolve()
+                if not resolved.is_relative_to(safe_attachment_root):
+                    raise RestoreError(
+                        f"backup contains path traversal in attachment "
+                        f"member {name!r}: resolves to {resolved} which "
+                        f"escapes attachment_root {safe_attachment_root}"
+                    )
                 target.parent.mkdir(parents=True, exist_ok=True)
                 if member.isdir():
                     target.mkdir(parents=True, exist_ok=True)

--- a/packages/tulip-cli/tests/test_backup_restore.py
+++ b/packages/tulip-cli/tests/test_backup_restore.py
@@ -277,6 +277,97 @@ class TestRoundTrip:
         assert manifest.alembic_head == "aaaa1111"
         assert manifest.tulip_version == "0.1.0"
 
+
+class TestPathTraversalDefence:
+    """#217: malicious attachment members must not escape attachment_root."""
+
+    def _build_malicious_backup(
+        self,
+        tmp_path: Path,
+        seeded_db: Path,
+        attachment_root: Path,
+        master_key: bytes,
+        bad_member_name: str,
+    ) -> Path:
+        """Build a backup tarball with one rogue attachment member name."""
+        # Start with a legitimate backup, then re-pack the tarball injecting
+        # a traversal-shaped attachment member.
+        clean_path = tmp_path / "clean.tar.gz"
+        with clean_path.open("wb") as f:
+            write_backup(
+                db_path=seeded_db,
+                attachment_root=attachment_root,
+                master_key=master_key,
+                tulip_version="0.1.0",
+                out=f,
+            )
+
+        evil_path = tmp_path / "evil.tar.gz"
+        with (
+            tarfile.open(clean_path, "r:gz") as src,
+            tarfile.open(evil_path, "w:gz") as dst,
+        ):
+            for m in src.getmembers():
+                f_in = src.extractfile(m)
+                dst.addfile(m, fileobj=f_in)
+            # Append the rogue file.
+            escape_info = tarfile.TarInfo(name=bad_member_name)
+            escape_info.size = 5
+            import io as _io
+
+            dst.addfile(escape_info, fileobj=_io.BytesIO(b"pwned"))
+        return evil_path
+
+    def test_restore_rejects_dotdot_traversal_in_attachment_member(
+        self, tmp_path: Path, seeded_db: Path, attachment_root: Path
+    ):
+        master_key = b"\x0c" * 32
+        evil = self._build_malicious_backup(
+            tmp_path,
+            seeded_db,
+            attachment_root,
+            master_key,
+            bad_member_name="attachments/../../escape.bin",
+        )
+        # Sentinel file that must NOT be overwritten by the restore.
+        canary = tmp_path / "escape.bin"
+        assert not canary.exists()
+
+        with pytest.raises(RestoreError, match="path traversal"):
+            restore_backup(
+                in_path=evil,
+                db_path=tmp_path / "restored.db",
+                attachment_root=tmp_path / "restored-attachments",
+                master_key=master_key,
+                current_alembic_head="aaaa1111",
+                force=False,
+            )
+        # Confirm nothing wrote outside the attachment root.
+        assert not canary.exists()
+
+    def test_restore_rejects_absolute_path_in_attachment_member(
+        self, tmp_path: Path, seeded_db: Path, attachment_root: Path
+    ):
+        master_key = b"\x0d" * 32
+        evil = self._build_malicious_backup(
+            tmp_path,
+            seeded_db,
+            attachment_root,
+            master_key,
+            # An absolute path inside the attachments/ prefix gives stripped
+            # ='/tmp/...' after lstrip-prefix.
+            bad_member_name="attachments//etc/cron.d/evil",
+        )
+        with pytest.raises(RestoreError, match="path traversal"):
+            restore_backup(
+                in_path=evil,
+                db_path=tmp_path / "restored.db",
+                attachment_root=tmp_path / "restored-attachments",
+                master_key=master_key,
+                current_alembic_head="aaaa1111",
+                force=False,
+            )
+
     def test_format_version_too_new_refused(self, tmp_path: Path):
         # Build a tarball with a manifest whose format_version is FORMAT_VERSION+1.
         backup_path = tmp_path / "future.tar.gz"


### PR DESCRIPTION
## Summary

Closes #217 (H-1 from the 2026-05-12 deep security audit).

`tulip restore`'s DB-extract branch used `tar.extract(..., filter="data")` (Python 3.12+ safe filter). The attachment branch wrote members manually via `target.write_bytes` with **no `resolve()` + `is_relative_to(attachment_root)` check**. A crafted tarball member named `attachments/../../../tmp/cron.d/evil` landed outside the configured root — arbitrary file write under the CLI process's permissions on restore (attacker still needs the master key to forge the HMAC envelope).

After computing the target path, resolve it and refuse the entire archive when the resolved path escapes `attachment_root`. Symlink members were already skipped (`tar.extractfile` returns None); the remaining gap was plain `..` and absolute-path traversal.

## Test plan

- [x] New test: `attachments/../../escape.bin` triggers `RestoreError("path traversal")`; sentinel file outside the root is not written.
- [x] New test: `attachments//etc/cron.d/evil` (absolute-path-shaped) triggers `RestoreError`.
- [x] Full `test_backup_restore.py` passes (26/26).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)