### PR TITLE
fix: login timing oracle — dummy verify + no short-circuit (closes #221)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -100,6 +100,21 @@ if TYPE_CHECKING:
 router = APIRouter(prefix="/v1/auth", tags=["auth"])
 log = structlog.get_logger("tulip_api.auth")
 
+# A precomputed argon2 hash used only to make the no-such-email login path
+# pay roughly the same wall-clock as a single-match path (#221). Lazily
+# initialised so import-time stays cheap.
+_TIMING_DEFENSE_DUMMY_HASH: str | None = None
+
+
+def _timing_defense_dummy_hash() -> str:
+    """Return a stable argon2 hash for the timing-defense dummy verify."""
+    global _TIMING_DEFENSE_DUMMY_HASH
+    if _TIMING_DEFENSE_DUMMY_HASH is None:
+        # Hash of a constant string. The plaintext is never sent; this is
+        # consumed only by verify_password() to spend argon2 cost.
+        _TIMING_DEFENSE_DUMMY_HASH = hash_password("tulip-timing-defense-dummy")
+    return _TIMING_DEFENSE_DUMMY_HASH
+
 
 @router.post(
     "/register",
@@ -217,9 +232,24 @@ def login(
     # email and pick the one whose password matches. Collisions across
     # households + matching passwords are extremely unlikely; if it ever
     # happens, we just sign in as the first match.
+    #
+    # #221 timing-oracle defense: iterate ALL candidates without short-
+    # circuit so wall-clock doesn't distinguish "matched first" from
+    # "matched last." When there are zero candidates, run one dummy
+    # argon2 verify so the no-such-email response takes ~argon2 time too.
+    # This still leaks multi-household-count (N candidates ⇒ N verifies),
+    # but eliminates the existence + position oracles. Full defense would
+    # require padding to a fixed verify-count or making emails globally
+    # unique — both deferred decisions.
     candidates = session.execute(select(User).where(User.email == body.email)).scalars().all()
-    user = next((u for u in candidates if verify_password(body.password, u.password_hash)), None)
+    user: User | None = None
+    for candidate in candidates:
+        if verify_password(body.password, candidate.password_hash) and user is None:
+            user = candidate
     if user is None:
+        if not candidates:
+            # Force the no-such-email path to pay ~argon2 cost too.
+            verify_password(body.password, _timing_defense_dummy_hash())
         log.info("login.failed", email=body.email)
         raise InvalidCredentialsError()
 

--- a/packages/tulip-api/tests/test_auth_endpoints.py
+++ b/packages/tulip-api/tests/test_auth_endpoints.py
@@ -207,6 +207,73 @@ class TestLogin:
         # The new hash must still verify the same password.
         assert verify_password(registered["password"], new_hash)
 
+    def test_login_unknown_email_still_calls_verify_password(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """#221: no-such-email path runs the dummy verify so wall-clock matches single-match."""
+        import tulip_api.routers.auth as auth_router
+
+        calls: list[str] = []
+        original = auth_router.verify_password
+
+        def _counting(plain: str, hashed: str) -> bool:
+            calls.append(hashed)
+            return original(plain, hashed)
+
+        monkeypatch.setattr(auth_router, "verify_password", _counting)
+
+        r = client.post(
+            "/v1/auth/login",
+            json={"email": "no-such-user@example.com", "password": "whatever"},
+        )
+        assert r.status_code == 401
+        assert len(calls) == 1
+        assert calls[0].startswith("$argon2id$")
+
+    def test_login_no_short_circuit_on_duplicate_email(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """#221: with N candidates, all N get verified (no short-circuit).
+
+        Constant-time within "N candidates" — eliminates the matched-first
+        vs matched-last position oracle. The multi-household-count oracle
+        (1 vs 2 verifies) is documented as residual.
+        """
+        r = client.post(
+            "/v1/auth/register",
+            json={
+                "email": registered["email"],
+                "password": "different-password-67890",
+                "display_name": "Other",
+                "household_name": "Other Family",
+            },
+        )
+        assert r.status_code == 201
+
+        import tulip_api.routers.auth as auth_router
+
+        calls: list[str] = []
+        original = auth_router.verify_password
+
+        def _counting(plain: str, hashed: str) -> bool:
+            calls.append(hashed)
+            return original(plain, hashed)
+
+        monkeypatch.setattr(auth_router, "verify_password", _counting)
+
+        r = client.post(
+            "/v1/auth/login",
+            json={"email": registered["email"], "password": registered["password"]},
+        )
+        assert r.status_code == 200
+        # Both candidates verified, despite the first one matching.
+        assert len(calls) == 2
+
     def test_login_does_not_rehash_when_params_unchanged(
         self,
         client: TestClient,


### PR DESCRIPTION
## Summary

Closes #221 (H-7 from the 2026-05-12 deep security audit).

Email is per-household-unique. Old `login()` iterated all candidate users for an email and short-circuited on the first whose password matched. The number of argon2 verifies leaked:

- 0 candidates → 0 verifies (fast: no-such-email response)
- 1 candidate → 1 verify
- N candidates matched at position k → k verifies

The 0-vs-1+ delta is order-of-magnitude (argon2id at OWASP params runs ~50-200 ms), giving an attacker a reliable email-existence oracle.

**Two changes:**

1. **No short-circuit.** Iterate all candidates and run a verify on each, keeping the first match. Wall-clock now depends only on candidate count, not match position.
2. **Dummy verify on zero candidates.** Pre-computed argon2 hash consumed by `verify_password` when the email has no matches, so the no-such-email branch pays ~argon2 cost too.

**Residual gap (documented):** multi-household-count is still distinguishable (1 verify vs N verifies). Full defense would require padding to a fixed count or making email globally unique. Both deferred decisions — see the audit doc.

## Test plan

- [x] New test: `login(no-such-user@example.com)` calls `verify_password` exactly once (the dummy hash).
- [x] New test: multi-household duplicate-email scenario — login as user 1 still verifies both candidates (no short-circuit).
- [x] Full `test_auth_endpoints.py` passes (15/15).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)