### PR TITLE
fix: refuse boot with ephemeral keys in TULIP_ENV=prod (closes #223)

### DIFF
--- a/packages/tulip-api/src/tulip_api/config.py
+++ b/packages/tulip-api/src/tulip_api/config.py
@@ -16,10 +16,44 @@ log = logging.getLogger("tulip_api.config")
 #: Where the master key came from. Surfaced in ``GET /v1/system/diagnostics``
 #: so the doctor CLI can flag ephemeral fallback as a hard failure (#135).
 MasterKeySource = Literal["env", "file", "ephemeral"]
+#: Where the JWT secret came from. Parallels ``MasterKeySource`` (#223).
+JwtSecretSource = Literal["env", "ephemeral"]
+#: Deployment mode. ``prod`` refuses to boot with any ephemeral secret;
+#: ``dev`` warns but allows. Default ``dev`` so existing test + local
+#: workflows are unchanged (#223).
+DeploymentMode = Literal["dev", "prod"]
 
 
 def _default_jwt_secret() -> str:
-    return os.environ.get("TULIP_JWT_SECRET") or secrets.token_urlsafe(48)
+    raw = os.environ.get("TULIP_JWT_SECRET")
+    if raw is not None:
+        return raw
+    # Mirror the master-key warning shape — silent fallback was the #223
+    # M-3 finding: operators forgot to set the env var and lost every
+    # outstanding access token on the next restart with no signal.
+    log.warning(
+        "TULIP_JWT_SECRET not set; generating an ephemeral 48-byte secret. "
+        "Every restart invalidates all outstanding access tokens.",
+    )
+    return secrets.token_urlsafe(48)
+
+
+def _default_jwt_secret_source() -> JwtSecretSource:
+    """Pure inspection of which env path produced the JWT secret."""
+    if os.environ.get("TULIP_JWT_SECRET") is not None:
+        return "env"
+    return "ephemeral"
+
+
+def _default_deployment_mode() -> DeploymentMode:
+    """Read ``TULIP_ENV`` (``dev`` | ``prod``). Default ``dev``.
+
+    Used by :class:`Settings` to gate on ephemeral-secret refusal.
+    """
+    raw = os.environ.get("TULIP_ENV", "dev").strip().lower()
+    if raw in ("prod", "production"):
+        return "prod"
+    return "dev"
 
 
 def _default_db_url() -> str:
@@ -121,13 +155,36 @@ def _default_master_key_source() -> MasterKeySource:
 
 @dataclass(frozen=True, slots=True)
 class Settings:
-    """Read-only runtime settings."""
+    """Read-only runtime settings.
+
+    Boots silently in ``dev`` mode (the default) even when secrets fall
+    back to ephemeral values. In ``prod`` mode (``TULIP_ENV=prod``) the
+    constructor refuses to materialise a Settings instance if either the
+    master key or the JWT secret is ephemeral — see #223 (M-2 + M-3).
+    """
 
     database_url: str = field(default_factory=_default_db_url)
     jwt_secret: str = field(default_factory=_default_jwt_secret)
+    jwt_secret_source: JwtSecretSource = field(default_factory=_default_jwt_secret_source)
     master_key: bytes = field(default_factory=_default_master_key)
     master_key_source: MasterKeySource = field(default_factory=_default_master_key_source)
     attachment_root: Path = field(default_factory=_default_attachment_root)
+    deployment_mode: DeploymentMode = field(default_factory=_default_deployment_mode)
+
+    def __post_init__(self) -> None:
+        """Refuse boot in prod mode when any secret is ephemeral (#223)."""
+        if self.deployment_mode != "prod":
+            return
+        if self.master_key_source == "ephemeral":
+            raise RuntimeError(
+                "TULIP_ENV=prod: refusing to boot with an ephemeral master key. "
+                "Set TULIP_MASTER_KEY or TULIP_KEY_FILE before starting the API.",
+            )
+        if self.jwt_secret_source == "ephemeral":  # noqa: S105 — enum-value compare, not a credential
+            raise RuntimeError(
+                "TULIP_ENV=prod: refusing to boot with an ephemeral JWT secret. "
+                "Set TULIP_JWT_SECRET before starting the API.",
+            )
 
 
 _SINGLETON: Settings | None = None

--- a/packages/tulip-api/src/tulip_api/routers/system.py
+++ b/packages/tulip-api/src/tulip_api/routers/system.py
@@ -73,5 +73,7 @@ def get_system_diagnostics(
         alembic_head_match=head_in_db == head_expected,
         master_key_source=settings.master_key_source,
         master_key_loaded=settings.master_key_source != "ephemeral",
+        jwt_secret_source=settings.jwt_secret_source,
+        deployment_mode=settings.deployment_mode,
         attachment_root_writable=_probe_attachment_root_writable(settings),
     )

--- a/packages/tulip-api/src/tulip_api/schemas/diagnostics.py
+++ b/packages/tulip-api/src/tulip_api/schemas/diagnostics.py
@@ -43,6 +43,19 @@ class SystemDiagnosticsRead(BaseModel):
             "failure on the CLI side."
         )
     )
+    jwt_secret_source: Literal["env", "ephemeral"] = Field(
+        description=(
+            "Which env path produced the JWT signing secret. ``ephemeral`` "
+            "means TULIP_JWT_SECRET was unset — every restart invalidates "
+            "all outstanding access tokens. Added in #223."
+        )
+    )
+    deployment_mode: Literal["dev", "prod"] = Field(
+        description=(
+            "Value of ``TULIP_ENV``. ``prod`` refuses to boot with any "
+            "ephemeral secret; ``dev`` warns but allows. Added in #223."
+        )
+    )
     attachment_root_writable: bool = Field(
         description=(
             "True iff the configured ``attachment_root`` accepted a probe "

--- a/packages/tulip-api/tests/test_config.py
+++ b/packages/tulip-api/tests/test_config.py
@@ -37,9 +37,13 @@ class TestMasterKey:
         with patch("tulip_api.config.log") as mock_log:
             s = Settings()
         assert len(s.master_key) == 32
-        mock_log.warning.assert_called_once()
-        msg = mock_log.warning.call_args.args[0].lower()
-        assert "ephemeral" in msg and "master" in msg
+        # The master-key warning fires; JWT may also warn if env-unset.
+        master_warnings = [
+            call
+            for call in mock_log.warning.call_args_list
+            if "master" in call.args[0].lower() and "ephemeral" in call.args[0].lower()
+        ]
+        assert len(master_warnings) == 1
 
     def test_ephemeral_keys_differ_per_construction(self, monkeypatch: pytest.MonkeyPatch):
         # Each construction generates a fresh key — that's what makes it
@@ -129,7 +133,9 @@ class TestMasterKeyFile:
         with patch("tulip_api.config.log") as mock_log:
             s = Settings()
         assert len(s.master_key) == 32
-        mock_log.warning.assert_called_once()
+        # At least one warning fires for the master key. JWT may also warn
+        # if its env var is unset; we don't pin the count.
+        assert mock_log.warning.called
 
 
 class TestMasterKeySource:
@@ -170,3 +176,75 @@ class TestMasterKeySource:
         # Mirrors the resolution order: env wins over file for both
         # the bytes and the source label.
         assert Settings().master_key_source == "env"
+
+
+class TestJwtSecretSource:
+    """#223 M-3: JWT secret source tracking + ephemeral-fallback warning."""
+
+    def test_env_source_when_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("TULIP_JWT_SECRET", "configured-jwt-secret-value")
+        s = Settings()
+        assert s.jwt_secret_source == "env"
+        assert s.jwt_secret == "configured-jwt-secret-value"
+
+    def test_ephemeral_source_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("TULIP_JWT_SECRET", raising=False)
+        with patch("tulip_api.config.log") as mock_log:
+            s = Settings()
+        assert s.jwt_secret_source == "ephemeral"
+        # Mirrors the master-key fallback: log.warning fires.
+        mock_log.warning.assert_called()
+        # The first call should mention JWT_SECRET in the message.
+        first_warning = mock_log.warning.call_args_list[0].args[0].lower()
+        assert "tulip_jwt_secret" in first_warning
+
+
+class TestDeploymentModeProdRefusal:
+    """#223 M-2 + M-3: TULIP_ENV=prod refuses ephemeral secrets."""
+
+    def test_prod_refuses_ephemeral_master_key(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        monkeypatch.delenv("TULIP_KEY_FILE", raising=False)
+        monkeypatch.setenv("TULIP_JWT_SECRET", "real")
+        monkeypatch.setenv("TULIP_ENV", "prod")
+        with pytest.raises(RuntimeError, match="ephemeral master key"):
+            Settings()
+
+    def test_prod_refuses_ephemeral_jwt_secret(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("TULIP_MASTER_KEY", base64.b64encode(b"\x08" * 32).decode("ascii"))
+        monkeypatch.delenv("TULIP_JWT_SECRET", raising=False)
+        monkeypatch.setenv("TULIP_ENV", "prod")
+        with pytest.raises(RuntimeError, match="ephemeral JWT secret"):
+            Settings()
+
+    def test_prod_with_both_secrets_set_boots(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("TULIP_MASTER_KEY", base64.b64encode(b"\x09" * 32).decode("ascii"))
+        monkeypatch.setenv("TULIP_JWT_SECRET", "real")
+        monkeypatch.setenv("TULIP_ENV", "prod")
+        s = Settings()  # no raise
+        assert s.deployment_mode == "prod"
+
+    def test_dev_mode_allows_ephemeral(self, monkeypatch: pytest.MonkeyPatch):
+        """Dev mode (default) tolerates ephemeral secrets — tests + local dev."""
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        monkeypatch.delenv("TULIP_KEY_FILE", raising=False)
+        monkeypatch.delenv("TULIP_JWT_SECRET", raising=False)
+        monkeypatch.delenv("TULIP_ENV", raising=False)  # defaults to "dev"
+        with patch("tulip_api.config.log"):  # silence the warnings
+            s = Settings()
+        assert s.deployment_mode == "dev"
+
+    def test_unknown_env_value_defaults_to_dev(self, monkeypatch: pytest.MonkeyPatch):
+        """Unrecognised TULIP_ENV values default to dev, not prod (fail-open).
+
+        This is intentional: a typo'd `TULIP_ENV=produciton` shouldn't lock
+        operators out of their own dev environment. The doctor CLI surfaces
+        deployment_mode so any drift is visible.
+        """
+        monkeypatch.setenv("TULIP_ENV", "production-typo")
+        monkeypatch.delenv("TULIP_MASTER_KEY", raising=False)
+        monkeypatch.delenv("TULIP_KEY_FILE", raising=False)
+        monkeypatch.delenv("TULIP_JWT_SECRET", raising=False)
+        with patch("tulip_api.config.log"):
+            s = Settings()
+        assert s.deployment_mode == "dev"


### PR DESCRIPTION
## Summary

Closes #223 (M-2 + M-3 from the 2026-05-12 deep security audit).

Two related fallback gaps. **M-2**: master-key fallback warned but didn't refuse boot — a misconfigured prod deploy booted silently with `secrets.token_bytes(32)`; on next restart every field-encrypted column became permanently undecryptable. **M-3**: jwt-secret fallback was silent (no warning at all) and silently rotated on every restart, invalidating all outstanding access tokens.

**Three changes:**

1. **`TULIP_ENV` setting** (default `dev`). In `prod`, `Settings.__post_init__` raises `RuntimeError` if `master_key_source` or `jwt_secret_source` is `ephemeral`. Dev default keeps existing local + test workflows unchanged.
2. **JWT-secret ephemeral fallback emits `log.warning`** parallel to the master-key fallback. Operators see the rotation-on-restart problem in the log.
3. **`jwt_secret_source` + `deployment_mode` on `Settings`** + surfaced via `GET /v1/system/diagnostics` so `tulip doctor` can flag either ephemeral as a hard failure when env is prod.

## Test plan

- [x] New tests in `TestJwtSecretSource` for env / ephemeral sourcing.
- [x] New tests in `TestDeploymentModeProdRefusal` for both refusal paths, both happy paths, and the unknown-env-value fail-open default (`TULIP_ENV=production-typo` → defaults to dev rather than locking the operator out).
- [x] Existing tests adjusted to allow the additional JWT warning when both env vars are unset.
- [x] Full `test_config.py` + `test_system_diagnostics_endpoint.py` pass.
- [x] Full `tulip-api` test suite passes (624 passed).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)