### PR TITLE
fix: token-file backend writes 0600 atomically + refuses loose modes (closes #226)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/auth/tokens.py
+++ b/packages/tulip-cli/src/tulip_cli/auth/tokens.py
@@ -18,6 +18,7 @@ separately in #28.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 from dataclasses import asdict, dataclass
@@ -141,6 +142,17 @@ class TokenStore:
     def _read_file(self) -> dict[str, str]:
         if self._file_path is None or not self._file_path.is_file():
             return {}
+        # #226: refuse to load if mode is loose. Mirrors the master-key-file
+        # gate in tulip_api.config — operators should keep tokens off shared
+        # filesystems. The JSON backend is documented as CI/tests only.
+        mode = self._file_path.stat().st_mode & 0o777
+        if mode & 0o077:
+            raise TokenStoreError(
+                f"token store {self._file_path} has mode {mode:#o}; "
+                f"group/other access is forbidden. Run `chmod 0600 "
+                f"{self._file_path}` and retry, or migrate to the keyring "
+                "backend (unset TULIP_TOKEN_STORE).",
+            )
         try:
             data = json.loads(self._file_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
@@ -151,7 +163,24 @@ class TokenStore:
         if self._file_path is None:
             return
         self._file_path.parent.mkdir(parents=True, exist_ok=True)
-        self._file_path.write_text(json.dumps(data), encoding="utf-8")
+        # #226: atomic write + 0600 mode.
+        #   * `os.open(..., O_CREAT|O_EXCL, 0o600)` would race with concurrent
+        #     writers; use the tempfile-in-same-dir + os.replace pattern which
+        #     is atomic on POSIX and tolerates concurrent overwrites.
+        #   * 0o600 enforced via the open() mode + an explicit chmod (umask
+        #     subtraction means open() alone is not sufficient on every host).
+        tmp = self._file_path.with_suffix(self._file_path.suffix + ".tmp")
+        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(json.dumps(data))
+            os.chmod(tmp, 0o600)  # defensive against permissive umask
+            os.replace(tmp, self._file_path)
+        except Exception:
+            # Best-effort cleanup of the half-written temp file.
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(tmp)
+            raise
 
 
 def default_token_store() -> TokenStore:

--- a/packages/tulip-cli/tests/test_token_store.py
+++ b/packages/tulip-cli/tests/test_token_store.py
@@ -101,6 +101,54 @@ def test_default_token_store_uses_keyring_when_env_var_unset(
     assert store.is_keyring_backed
 
 
+class TestFileBackendMode:
+    """#226: file backend writes 0600, refuses to load looser-mode files."""
+
+    def test_save_writes_mode_0600(self, tmp_path: Path) -> None:
+        path = tmp_path / "tokens.json"
+        store = TokenStore(file_path=path)
+        store.save("https://api.example.com", _tokens())
+        assert path.exists()
+        mode = path.stat().st_mode & 0o777
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+    def test_load_refuses_world_readable_file(self, tmp_path: Path) -> None:
+        from tulip_cli.auth.tokens import TokenStoreError
+
+        path = tmp_path / "tokens.json"
+        store = TokenStore(file_path=path)
+        store.save("https://api.example.com", _tokens())
+        path.chmod(0o644)
+        with pytest.raises(TokenStoreError, match=r"chmod 0600"):
+            store.load("https://api.example.com")
+
+    def test_load_refuses_group_readable_file(self, tmp_path: Path) -> None:
+        from tulip_cli.auth.tokens import TokenStoreError
+
+        path = tmp_path / "tokens.json"
+        store = TokenStore(file_path=path)
+        store.save("https://api.example.com", _tokens())
+        path.chmod(0o640)
+        with pytest.raises(TokenStoreError, match=r"chmod 0600"):
+            store.load("https://api.example.com")
+
+    def test_save_overwrite_preserves_mode_0600(self, tmp_path: Path) -> None:
+        """A second save (atomic replace) must not regress to umask mode."""
+        path = tmp_path / "tokens.json"
+        store = TokenStore(file_path=path)
+        store.save("https://api.example.com", _tokens(access_token="first"))
+        store.save("https://api.example.com", _tokens(access_token="second"))
+        assert (path.stat().st_mode & 0o777) == 0o600
+
+    def test_save_does_not_leave_tmp_files(self, tmp_path: Path) -> None:
+        """Successful atomic-write path cleans up after itself."""
+        path = tmp_path / "tokens.json"
+        store = TokenStore(file_path=path)
+        store.save("https://api.example.com", _tokens())
+        tmps = list(tmp_path.glob("*.tmp"))
+        assert not tmps, f"unexpected tmp files: {tmps}"
+
+
 class TestKeyringUnavailable:
     """When the OS keyring backend is missing, raise TokenStoreError (#227)."""
 


### PR DESCRIPTION
## Summary

Closes #226 (M-9 from the 2026-05-12 deep security audit).

CLI token-file backend (TULIP_TOKEN_STORE) had three related gaps:

- `write_text()` inherited the user's umask, typically landing tokens at `0644` on macOS/Linux defaults.
- No atomic write — a process crash mid-write left a truncated file.
- No load-time mode check — once the file existed at any mode, `load()` returned the tokens.

Three fixes mirroring the master-key-file gate in `tulip_api.config`:

1. `_write_file` now writes via `os.open(O_WRONLY|O_CREAT|O_TRUNC, 0o600)` to a sibling `.tmp` file, then `os.replace()` atomically into place. Explicit `os.chmod(0o600)` is defensive against permissive umask.
2. `_read_file` refuses to load when mode has any group/other bits set; raises `TokenStoreError` with `chmod 0600` guidance.
3. Cleanup on write exception via `contextlib.suppress(FileNotFoundError) + os.unlink` so a crashed save doesn't pollute the parent directory.

## Test plan

- [x] New tests in `TestFileBackendMode`: mode-0600 on first save, mode-preserved on overwrite, world-readable refusal on load, group-readable refusal on load, and "successful save leaves no stray .tmp files."
- [x] Full `test_token_store.py` passes (16/16).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)