### PR TITLE
fix: composite FK on ai_invocation_id (closes #231)

### DIFF
--- a/packages/tulip-api/tests/test_proposals_endpoints.py
+++ b/packages/tulip-api/tests/test_proposals_endpoints.py
@@ -232,13 +232,29 @@ class TestApprove:
         in production.
         """
         from tulip_api.deps import get_session
-        from tulip_storage.models import ProposalCreatorKind
+        from tulip_storage.models import AIInvocation, ProposalCreatorKind
         from tulip_storage.repositories import PendingProposalRepository
 
         env_id = _make_envelope(client, auth_h, budget_amount="100.00")
         overrides = client.app.dependency_overrides
         session_factory = overrides[get_session]
         with next(session_factory()) as seed_session:
+            # The composite FK (#231 / M-21) requires ai_invocation_id to
+            # reference a real ai_invocations row in the same household,
+            # so seed one alongside the proposal.
+            invocation_id = uuid4()
+            seed_session.add(
+                AIInvocation(
+                    household_id=household_id,
+                    id=invocation_id,
+                    capability="agentic",
+                    policy_resolved="permissive",
+                    profile="default",
+                    outcome="success",
+                    prompt_hash=b"\x00" * 32,
+                )
+            )
+            seed_session.flush()
             row = PendingProposalRepository(seed_session, household_id).create(
                 kind="envelope_budget_update",
                 title="AI-suggested",
@@ -246,7 +262,7 @@ class TestApprove:
                 rationale="",
                 created_by_kind=ProposalCreatorKind.AI_AGENT.value,
                 created_by_user_id=None,
-                ai_invocation_id=uuid4(),
+                ai_invocation_id=invocation_id,
             )
             seed_session.commit()
             proposal_id = str(row.id)

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260513_0630_b1c2d3e4f5a6_composite_fk_ai_invocation_id.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260513_0630_b1c2d3e4f5a6_composite_fk_ai_invocation_id.py
@@ -12,7 +12,7 @@ if the underlying invocation is purged; the audit chain weakens but the
 business object survives.
 
 Revision ID: b1c2d3e4f5a6
-Revises: a7d4f1b9e8c2
+Revises: e8b5c2a9d1f4
 Create Date: 2026-05-13 06:30:00.000000+00:00
 """
 
@@ -23,7 +23,7 @@ from collections.abc import Sequence
 from alembic import op
 
 revision: str = "b1c2d3e4f5a6"
-down_revision: str | None = "a7d4f1b9e8c2"
+down_revision: str | None = "e8b5c2a9d1f4"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260513_0630_b1c2d3e4f5a6_composite_fk_ai_invocation_id.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260513_0630_b1c2d3e4f5a6_composite_fk_ai_invocation_id.py
@@ -1,0 +1,62 @@
+"""Add composite FK on pending_proposals.ai_invocation_id and notifications.ai_invocation_id.
+
+Per #231 / privacy audit M-21. Previously the column was `CHAR(32)` with no
+FK constraint, so a row in household A could in principle carry an
+`ai_invocation_id` pointing at a row in household B. The schema-level
+guarantee that composite FKs make cross-tenant references impossible
+(ARCHITECTURE §3.3) didn't hold for these two columns.
+
+Adds `(household_id, ai_invocation_id) → ai_invocations(household_id, id)`
+ON DELETE SET NULL. SET-NULL preserves the proposal/notification row even
+if the underlying invocation is purged; the audit chain weakens but the
+business object survives.
+
+Revision ID: b1c2d3e4f5a6
+Revises: a7d4f1b9e8c2
+Create Date: 2026-05-13 06:30:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: str | None = "a7d4f1b9e8c2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add composite FKs on ai_invocation_id columns."""
+    with op.batch_alter_table("pending_proposals") as batch:
+        batch.create_foreign_key(
+            "fk_pending_proposals_ai_invocation_id_ai_invocations",
+            "ai_invocations",
+            ["household_id", "ai_invocation_id"],
+            ["household_id", "id"],
+            ondelete="SET NULL",
+        )
+    with op.batch_alter_table("notifications") as batch:
+        batch.create_foreign_key(
+            "fk_notifications_ai_invocation_id_ai_invocations",
+            "ai_invocations",
+            ["household_id", "ai_invocation_id"],
+            ["household_id", "id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    """Drop the composite FKs."""
+    with op.batch_alter_table("notifications") as batch:
+        batch.drop_constraint(
+            "fk_notifications_ai_invocation_id_ai_invocations",
+            type_="foreignkey",
+        )
+    with op.batch_alter_table("pending_proposals") as batch:
+        batch.drop_constraint(
+            "fk_pending_proposals_ai_invocation_id_ai_invocations",
+            type_="foreignkey",
+        )

--- a/packages/tulip-storage/src/tulip_storage/models/notification.py
+++ b/packages/tulip-storage/src/tulip_storage/models/notification.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum
 from uuid import UUID
 
-from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, ForeignKeyConstraint, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from tulip_storage.models.base import GUID, Base
@@ -38,6 +38,15 @@ class Notification(Base):
     """
 
     __tablename__ = "notifications"
+    __table_args__ = (
+        # Composite FK so `ai_invocation_id` cannot cross households (#231).
+        ForeignKeyConstraint(
+            ["household_id", "ai_invocation_id"],
+            ["ai_invocations.household_id", "ai_invocations.id"],
+            ondelete="SET NULL",
+            name="fk_notifications_ai_invocation_id_ai_invocations",
+        ),
+    )
 
     household_id: Mapped[UUID] = mapped_column(
         GUID(), ForeignKey("households.id", ondelete="CASCADE"), primary_key=True

--- a/packages/tulip-storage/src/tulip_storage/models/pending_proposal.py
+++ b/packages/tulip-storage/src/tulip_storage/models/pending_proposal.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, func
+from sqlalchemy import JSON, DateTime, ForeignKey, ForeignKeyConstraint, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from tulip_storage.models.base import GUID, Base
@@ -38,6 +38,15 @@ class PendingProposal(Base):
     """
 
     __tablename__ = "pending_proposals"
+    __table_args__ = (
+        # Composite FK so `ai_invocation_id` cannot cross households (#231).
+        ForeignKeyConstraint(
+            ["household_id", "ai_invocation_id"],
+            ["ai_invocations.household_id", "ai_invocations.id"],
+            ondelete="SET NULL",
+            name="fk_pending_proposals_ai_invocation_id_ai_invocations",
+        ),
+    )
 
     household_id: Mapped[UUID] = mapped_column(
         GUID(), ForeignKey("households.id", ondelete="CASCADE"), primary_key=True

--- a/packages/tulip-storage/tests/test_migrations.py
+++ b/packages/tulip-storage/tests/test_migrations.py
@@ -58,6 +58,64 @@ def migrated_db(tmp_path):
     eng.dispose()
 
 
+class TestCompositeFkAiInvocationId:
+    """#231: pending_proposals + notifications carry a composite FK to ai_invocations.
+
+    Prevents cross-household references (a row in household A pointing at
+    an invocation in household B) at the schema level.
+    """
+
+    def test_cross_household_ai_invocation_id_rejected_on_pending_proposals(self, migrated_db):
+        from datetime import UTC, datetime
+
+        from tulip_storage.models import AIInvocation, PendingProposal
+
+        _, maker = migrated_db
+        with maker() as s:
+            household_a = Household(id=uuid4(), name="A", base_currency="USD")
+            household_b = Household(id=uuid4(), name="B", base_currency="USD")
+            s.add(household_a)
+            s.add(household_b)
+            s.flush()
+
+            inv_b = AIInvocation(
+                household_id=household_b.id,
+                id=uuid4(),
+                created_at=datetime.now(tz=UTC),
+                capability="categorize",
+                policy_resolved="default",
+                profile="default",
+                provider="ollama",
+                model="llama3",
+                tokens_in=0,
+                tokens_out=0,
+                latency_ms=0,
+                outcome="success",
+                cost_estimate_usd=Decimal("0"),
+                prompt_hash=b"\x00" * 32,
+                actor_user_id=None,
+                request_id=None,
+                provider_response_id=None,
+            )
+            s.add(inv_b)
+            s.flush()
+
+            # Now try to land a proposal in household_a referencing inv_b.
+            bad_proposal = PendingProposal(
+                household_id=household_a.id,
+                id=uuid4(),
+                kind="envelope_budget_update",
+                title="spoof",
+                payload={"x": 1},
+                created_by_kind="ai_agent",
+                ai_invocation_id=inv_b.id,
+            )
+            s.add(bad_proposal)
+            with pytest.raises(IntegrityError):
+                s.flush()
+            s.rollback()
+
+
 class TestMigrationsRoundTrip:
     def test_upgrade_then_downgrade_is_clean(self, tmp_path):
         db_path = tmp_path / "tulip.db"


### PR DESCRIPTION
## Summary

Closes #231 (M-21 from the 2026-05-12 deep security audit).

`pending_proposals.ai_invocation_id` and `notifications.ai_invocation_id` were `CHAR(32)` with no FK — schema didn't prevent cross-household references. New migration adds composite FK `(household_id, ai_invocation_id) → ai_invocations(household_id, id)` with `ON DELETE SET NULL`. Model `__table_args__` mirrors the constraint at the ORM layer.

Pairs with #218 (H-2): #218 closed the input-validation side (members can't supply `ai_invocation_id` at all); this closes the schema side.

## Test plan

- [x] New test seeds 2 households + AIInvocation in B, asserts cross-tenant insert raises `IntegrityError`.
- [x] Full migration test suite passes (5/5).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)