### PR TITLE
fix: audit-log rows for logout/refresh/proposal/refill_schedule (closes #222)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -371,6 +371,16 @@ def refresh(
 
     # Rotate: revoke this row, then issue a fresh pair.
     row.revoked_at = datetime.now(tz=UTC)
+    AuditLogWriter(session, user.household_id).write(
+        action="auth.refresh",
+        actor_kind="user",
+        actor_user_id=user.id,
+        entity_type="session",
+        entity_id=row.id,
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
     session.flush()
     return _issue_tokens(session, user, settings, request)
 
@@ -385,6 +395,7 @@ def refresh(
 )
 def logout(
     body: LogoutRequest,
+    request: Request,
     session: Session = Depends(get_session),  # noqa: B008
 ) -> None:
     """Revoke a refresh token. Subsequent uses are rejected."""
@@ -394,6 +405,16 @@ def logout(
     ).scalar_one_or_none()
     if row is not None and row.revoked_at is None:
         row.revoked_at = datetime.now(tz=UTC)
+        AuditLogWriter(session, row.household_id).write(
+            action="auth.logout",
+            actor_kind="user",
+            actor_user_id=row.user_id,
+            entity_type="session",
+            entity_id=row.id,
+            request_id=_request_uuid(request),
+            ip_address=_client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+        )
         session.commit()
 
 

--- a/packages/tulip-api/src/tulip_api/routers/proposals.py
+++ b/packages/tulip-api/src/tulip_api/routers/proposals.py
@@ -23,7 +23,7 @@ from tulip_api.services.proposal_executor import (
     supported_proposal_kinds,
 )
 from tulip_storage.models import PendingProposal, ProposalCreatorKind, ProposalStatus
-from tulip_storage.repositories import PendingProposalRepository
+from tulip_storage.repositories import AuditLogWriter, PendingProposalRepository
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -92,6 +92,7 @@ def _to_read(row: PendingProposal) -> ProposalRead:
 )
 def create_proposal(
     body: ProposalCreate,
+    request: Request,
     claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> ProposalRead:
@@ -112,6 +113,15 @@ def create_proposal(
         created_by_kind=ProposalCreatorKind.USER.value,
         created_by_user_id=claims.user_id,
         ai_invocation_id=None,
+    )
+    AuditLogWriter(session, claims.household_id).write(
+        action="proposal.create",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="proposal",
+        entity_id=row.id,
+        after={"kind": row.kind, "title": row.title},
+        request_id=_request_uuid(request),
     )
     session.commit()
     log.info(
@@ -198,6 +208,16 @@ async def approve_proposal(
         note=note,
     )
     assert updated is not None  # noqa: S101 — we just got it from the repo
+    AuditLogWriter(session, claims.household_id).write(
+        action="proposal.approve",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="proposal",
+        entity_id=proposal_id,
+        before={"status": ProposalStatus.PENDING.value},
+        after={"status": ProposalStatus.APPROVED.value, "decision_note": note},
+        request_id=_request_uuid(request),
+    )
     session.commit()
     log.info("proposal.approved", proposal_id=str(proposal_id), kind=proposal.kind)
     return _to_read(updated)
@@ -216,6 +236,7 @@ async def approve_proposal(
 )
 def reject_proposal(
     proposal_id: UUID,
+    request: Request,
     body: ProposalDecisionBody | None = None,
     claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
@@ -231,6 +252,7 @@ def reject_proposal(
     ):
         raise ProposalAlreadyDecidedError(proposal.status)
     note = body.note if body is not None else None
+    before_status = proposal.status
     updated = repo.mark_decided(
         proposal_id,
         status=ProposalStatus.REJECTED.value,
@@ -238,6 +260,16 @@ def reject_proposal(
         note=note,
     )
     assert updated is not None  # noqa: S101
+    AuditLogWriter(session, claims.household_id).write(
+        action="proposal.reject",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="proposal",
+        entity_id=proposal_id,
+        before={"status": before_status},
+        after={"status": ProposalStatus.REJECTED.value, "decision_note": note},
+        request_id=_request_uuid(request),
+    )
     session.commit()
     log.info("proposal.rejected", proposal_id=str(proposal_id), kind=proposal.kind)
     return _to_read(updated)

--- a/packages/tulip-api/src/tulip_api/routers/refill_schedules.py
+++ b/packages/tulip-api/src/tulip_api/routers/refill_schedules.py
@@ -44,6 +44,7 @@ from tulip_api.schemas.refill_schedule import (
     ScheduledJobRead,
 )
 from tulip_storage.repositories import (
+    AuditLogWriter,
     EnvelopeRepository,
     ScheduledJobRepository,
 )
@@ -61,6 +62,17 @@ REFILL_KIND = "envelope_refill"
 
 router = APIRouter(tags=["refill-schedules"])
 log = structlog.get_logger("tulip_api.refill_schedules")
+
+
+def _request_uuid(request: Request) -> UUID | None:
+    """Same shape as the helper in other routers; #222 audit-row request_id."""
+    rid = request.headers.get("x-request-id")
+    if rid:
+        try:
+            return UUID(rid)
+        except ValueError:
+            return None
+    return None
 
 
 def get_runner(request: Request) -> Runner:
@@ -192,13 +204,23 @@ def create_refill_schedule(
         # ``start_at`` (e.g. UNTIL already past).
         raise RefillScheduleInvalidRRuleError(reason=str(exc)) from exc
 
+    # Runner committed in its own session; record an audit row in ours.
+    AuditLogWriter(session, claims.household_id).write(
+        action="refill_schedule.create",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="scheduled_job",
+        entity_id=job_id,
+        after={"envelope_id": str(envelope_id), "rrule": body.rrule},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
     log.info(
         "refill_schedule.created",
         envelope_id=str(envelope_id),
         scheduled_job_id=str(job_id),
     )
 
-    # The runner committed in its own session; refresh ours and return.
     repo = ScheduledJobRepository(session, claims.household_id)
     job = repo.get(job_id)
     if job is None:
@@ -248,6 +270,7 @@ def get_refill_schedule(
 )
 def cancel_refill_schedule(
     envelope_id: UUID,
+    request: Request,
     claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
     runner: Runner = Depends(get_runner),  # noqa: B008
@@ -274,6 +297,17 @@ def cancel_refill_schedule(
         raise RefillScheduleNotFoundError()
 
     runner.cancel(claims.household_id, job.id)
+    AuditLogWriter(session, claims.household_id).write(
+        action="refill_schedule.cancel",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="scheduled_job",
+        entity_id=job.id,
+        before={"envelope_id": str(envelope_id), "is_active": True},
+        after={"is_active": False},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
     log.info(
         "refill_schedule.cancelled",
         envelope_id=str(envelope_id),

--- a/packages/tulip-api/tests/test_auth_endpoints.py
+++ b/packages/tulip-api/tests/test_auth_endpoints.py
@@ -331,6 +331,54 @@ class TestRefresh:
         assert_problem(r, code="auth.invalid_refresh_token", status=401)
 
 
+class TestAuditCoverage:
+    """#222: logout + refresh must write an audit_log row."""
+
+    def test_refresh_writes_audit_row(
+        self, client: TestClient, registered: dict[str, str], session_maker
+    ):
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": registered["email"], "password": registered["password"]},
+        ).json()
+        rt = login["refresh_token"]
+        r = client.post("/v1/auth/refresh", json={"refresh_token": rt})
+        assert r.status_code == 200
+
+        with session_maker() as s:
+            rows = list(
+                s.execute(select(AuditLog).where(AuditLog.action == "auth.refresh")).scalars().all()
+            )
+        assert len(rows) >= 1
+        assert rows[-1].entity_type == "session"
+
+    def test_logout_writes_audit_row(
+        self, client: TestClient, registered: dict[str, str], session_maker
+    ):
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": registered["email"], "password": registered["password"]},
+        ).json()
+        rt = login["refresh_token"]
+        r = client.post("/v1/auth/logout", json={"refresh_token": rt})
+        assert r.status_code == 204
+
+        with session_maker() as s:
+            rows = list(
+                s.execute(select(AuditLog).where(AuditLog.action == "auth.logout")).scalars().all()
+            )
+        assert len(rows) == 1
+        assert rows[0].entity_type == "session"
+
+
 class TestLogout:
     def test_revokes_refresh_token(self, client: TestClient, registered: dict[str, str]):
         login = client.post(

--- a/packages/tulip-api/tests/test_proposals_endpoints.py
+++ b/packages/tulip-api/tests/test_proposals_endpoints.py
@@ -151,6 +151,47 @@ class TestCreateAndList:
         assert r.status_code == 200
         assert "envelope_budget_update" in r.json()
 
+    def test_create_writes_audit_row(
+        self, client: TestClient, auth_h: dict[str, str], session_maker
+    ) -> None:
+        """#222: proposal.create lands its own audit_log row."""
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        env_id = _make_envelope(client, auth_h)
+        _propose_envelope_budget_update(client, auth_h, envelope_id=env_id, new_amount="250.00")
+        with session_maker() as s:
+            rows = list(
+                s.execute(select(AuditLog).where(AuditLog.action == "proposal.create"))
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+        assert rows[0].entity_type == "proposal"
+
+    def test_reject_writes_audit_row(
+        self, client: TestClient, auth_h: dict[str, str], session_maker
+    ) -> None:
+        """#222: proposal.reject lands an audit_log row."""
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        env_id = _make_envelope(client, auth_h)
+        proposal = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="250.00"
+        )
+        r = client.post(f"/v1/ai/proposals/{proposal['id']}/reject", headers=auth_h)
+        assert r.status_code == 200
+        with session_maker() as s:
+            rows = list(
+                s.execute(select(AuditLog).where(AuditLog.action == "proposal.reject"))
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+
 
 class TestApprove:
     def test_approve_envelope_budget_update_changes_envelope(


### PR DESCRIPTION
## Summary

Closes #222 (H-8 + M-19 from the 2026-05-12 deep security audit).

Six new audit-log writes:
- auth.refresh, auth.logout (session entity)
- proposal.create, proposal.approve, proposal.reject (proposal entity)
- refill_schedule.create, refill_schedule.cancel (scheduled_job entity)

The `logout` endpoint gained `request: Request` so the audit row carries request_id + ip + user_agent.

## Test plan

- [x] New TestAuditCoverage in test_auth_endpoints.py (refresh + logout).
- [x] Two new tests in test_proposals_endpoints.py (create + reject).
- [x] Existing approve audit-row test still passes.
- [x] 57/57 across auth + proposals + refill schedules.
- [x] `just lint` + `just typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)