### PR TITLE
fix: thread visibility filter through reports + journal export (closes #229)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/journal.py
+++ b/packages/tulip-api/src/tulip_api/routers/journal.py
@@ -32,6 +32,15 @@ router = APIRouter(prefix="/v1/journal", tags=["journal"])
 _MAX_JOURNAL_BYTES = 5 * 1024 * 1024  # 5 MB — matches the OFX cap (#74).
 
 
+def _filter_for_role(account_visibility: str, created_by: object, claims: Claims) -> bool:
+    """Mirror routers.reports._filter_for_role for journal-export filtering."""
+    if account_visibility == "shared":
+        return True
+    if claims.role == "admin":
+        return True
+    return created_by == claims.user_id
+
+
 class JournalParseFailedError(TulipProblem):
     """The uploaded journal couldn't be parsed (P7.5)."""
 
@@ -107,6 +116,8 @@ def export(
         household_id=claims.household_id,
         start=start,
         end=end,
+        # #229: drop postings on private accounts the caller can't see.
+        visible_account_filter=lambda vis, by: _filter_for_role(vis, by, claims),
     )
     suffix_parts = []
     if start is not None:

--- a/packages/tulip-api/src/tulip_api/routers/reports.py
+++ b/packages/tulip-api/src/tulip_api/routers/reports.py
@@ -29,7 +29,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import HTMLResponse, Response
 
-from tulip_api.auth.deps import get_current_claims
+from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.deps import get_session
 from tulip_api.errors import TulipProblem, problem_response
 from tulip_api.schemas.balance import (
@@ -369,7 +369,12 @@ def envelope_status(
     """Active envelopes with current balance + budget snapshot at ``as_of``."""
     from tulip_reports.reports import envelope_status as report_module
 
-    data = report_module.build(session, household_id=claims.household_id, as_of=as_of)
+    data = report_module.build(
+        session,
+        household_id=claims.household_id,
+        as_of=as_of,
+        visible_pool_filter=lambda vis, by: _filter_for_role(vis, by, claims),
+    )
     return _report_response(
         data,
         report_module.render_html,
@@ -398,7 +403,12 @@ def sinking_fund_progress(
     """Active sinking funds with balance vs target snapshot at ``as_of``."""
     from tulip_reports.reports import sinking_fund_progress as report_module
 
-    data = report_module.build(session, household_id=claims.household_id, as_of=as_of)
+    data = report_module.build(
+        session,
+        household_id=claims.household_id,
+        as_of=as_of,
+        visible_pool_filter=lambda vis, by: _filter_for_role(vis, by, claims),
+    )
     return _report_response(
         data,
         report_module.render_html,
@@ -459,10 +469,16 @@ def audit_log(
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
-    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008 — #229 admin-only
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
-    """Filtered, paginated audit-log report."""
+    """Filtered, paginated audit-log report (**admin-only** per #229).
+
+    Audit rows carry user-typed `description`, `reference`, and `before/after`
+    JSON snapshots — exposing them to non-admin household members would
+    let any member study another member's activity at high fidelity.
+    Gating on admin matches the Phase-7 docs' implicit intent.
+    """
     from tulip_reports.reports import audit_log as report_module
 
     data = report_module.build(

--- a/packages/tulip-reports/src/tulip_reports/journal/export.py
+++ b/packages/tulip-reports/src/tulip_reports/journal/export.py
@@ -31,6 +31,7 @@ exporting both halves would be technically correct but very noisy).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import date as date_type
 from decimal import Decimal
 from typing import TYPE_CHECKING
@@ -71,12 +72,18 @@ def export_journal(
     household_id: UUID,
     start: date_type | None = None,
     end: date_type | None = None,
+    visible_account_filter: Callable[[str, UUID | None], bool] | None = None,
 ) -> bytes:
     """Render the household's posted transactions as a hledger journal.
 
     Filter:
     - ``start`` / ``end`` bound the transaction date range (inclusive).
     - Pending + voided transactions are always excluded.
+    - ``visible_account_filter(visibility, created_by) → bool`` drops
+      postings on accounts the caller can't see, and skips transactions
+      whose every posting becomes invisible. The router supplies a
+      closure over the request's claims; tests can pass ``None``
+      to see every account (#229).
     """
     from sqlalchemy import select
 
@@ -125,12 +132,6 @@ def export_journal(
     lines.append("")
 
     for tx in transactions:
-        # Header line: date + description.
-        description = tx.description.replace("\n", " ").strip() or "(no description)"
-        if tx.reference:
-            description = f"({tx.reference}) {description}"
-        lines.append(f"{tx.date.isoformat()} {description}")
-
         # Postings: stable order by amount sign (debits first, then credits)
         # so the output reads naturally.
         postings = (
@@ -145,6 +146,29 @@ def export_journal(
             .scalars()
             .all()
         )
+
+        # Apply visibility filter at posting level. If every posting on a
+        # transaction is invisible to the caller, skip the whole tx — its
+        # description and amounts would all be derived from invisible
+        # data (#229).
+        if visible_account_filter is not None:
+            visible_postings = []
+            for p in postings:
+                a = accounts.get(p.account_id)
+                if a is None:
+                    # Orphaned posting — treat as invisible defensively.
+                    continue
+                if visible_account_filter(a.visibility, a.created_by_user_id):
+                    visible_postings.append(p)
+            if not visible_postings:
+                continue
+            postings = visible_postings
+
+        # Header line: date + description.
+        description = tx.description.replace("\n", " ").strip() or "(no description)"
+        if tx.reference:
+            description = f"({tx.reference}) {description}"
+        lines.append(f"{tx.date.isoformat()} {description}")
 
         for posting in postings:
             account = accounts.get(posting.account_id)

--- a/packages/tulip-reports/src/tulip_reports/reports/envelope_status.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/envelope_status.py
@@ -7,6 +7,7 @@ period. Reuses the existing shadow-balance query (the same one
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from datetime import date as date_type
@@ -18,6 +19,11 @@ from tulip_reports.engine import get_renderer
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+#: Callable taking (pool_visibility, created_by_user_id) → bool. Same shape
+#: as the account / pool visibility filters in `tulip_api.routers.reports`.
+#: Used to drop private pools the caller can't see (#229).
+VisiblePoolFilter = Callable[[str, "UUID | None"], bool]
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,8 +55,14 @@ def build(
     *,
     household_id: UUID,
     as_of: date_type | None = None,
+    visible_pool_filter: VisiblePoolFilter | None = None,
 ) -> EnvelopeStatusData:
-    """List active envelopes with current balance + budget snapshot."""
+    """List active envelopes with current balance + budget snapshot.
+
+    ``visible_pool_filter`` is a callback used to drop private envelopes
+    the caller can't see (#229). The router supplies a closure over the
+    request's claims; tests can pass ``None`` to see every pool.
+    """
     from sqlalchemy import select
 
     from tulip_storage.models import AllocationPool, Envelope, Household, PoolType
@@ -61,7 +73,7 @@ def build(
     household = session.get(Household, household_id)
     assert household is not None  # noqa: S101
 
-    pools = session.execute(
+    raw_pools = session.execute(
         select(AllocationPool, Envelope)
         .join(
             Envelope,
@@ -74,6 +86,11 @@ def build(
             AllocationPool.is_active.is_(True),
         )
     ).all()
+    pools: list[tuple[AllocationPool, Envelope]] = [(p, e) for p, e in raw_pools]
+    if visible_pool_filter is not None:
+        pools = [
+            (p, e) for p, e in pools if visible_pool_filter(p.visibility, p.created_by_user_id)
+        ]
     pool_ids = [p.id for p, _ in pools]
     balances = shadow_repo.balances_for_pools(pool_ids, as_of=effective_as_of)
 

--- a/packages/tulip-reports/src/tulip_reports/reports/sinking_fund_progress.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/sinking_fund_progress.py
@@ -7,6 +7,7 @@ as a percentage; days-to-target gives a sense of time pressure.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from datetime import date as date_type
@@ -18,6 +19,9 @@ from tulip_reports.engine import get_renderer
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+#: Same shape as `envelope_status.VisiblePoolFilter`. See #229.
+VisiblePoolFilter = Callable[[str, "UUID | None"], bool]
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,8 +54,13 @@ def build(
     *,
     household_id: UUID,
     as_of: date_type | None = None,
+    visible_pool_filter: VisiblePoolFilter | None = None,
 ) -> SinkingFundProgressData:
-    """List active sinking funds with balance + target snapshot."""
+    """List active sinking funds with balance + target snapshot.
+
+    ``visible_pool_filter`` drops private sinking funds the caller can't
+    see (#229). Mirrors `envelope_status.build`.
+    """
     from sqlalchemy import select
 
     from tulip_storage.models import AllocationPool, Household, PoolType, SinkingFund
@@ -62,7 +71,7 @@ def build(
     household = session.get(Household, household_id)
     assert household is not None  # noqa: S101
 
-    pools = session.execute(
+    raw_pools = session.execute(
         select(AllocationPool, SinkingFund)
         .join(
             SinkingFund,
@@ -75,6 +84,11 @@ def build(
             AllocationPool.is_active.is_(True),
         )
     ).all()
+    pools: list[tuple[AllocationPool, SinkingFund]] = [(p, f) for p, f in raw_pools]
+    if visible_pool_filter is not None:
+        pools = [
+            (p, f) for p, f in pools if visible_pool_filter(p.visibility, p.created_by_user_id)
+        ]
     pool_ids = [p.id for p, _ in pools]
     balances = shadow_repo.balances_for_pools(pool_ids, as_of=effective_as_of)
 


### PR DESCRIPTION
## Summary

Closes #229 (M-13 + M-14 from the 2026-05-12 deep security audit). Privacy-side cross-references: privacy audit F-PF-005 (audit-log report admin-only), F-PF-007 (envelope/sinking-fund private-pool leak).

Four reports + journal export now honour caller visibility:

| Surface | Fix |
|---|---|
| `envelope-status` | `build()` accepts `visible_pool_filter`; router passes a closure over `_filter_for_role`. Private envelopes drop out for non-admin / non-creator. |
| `sinking-fund-progress` | Same shape as envelope-status. |
| `audit-log` report | Gated on `require_role("admin")` — simplest fix; audit-row snapshots carry user-typed descriptions + before/after JSON that any member shouldn't be able to study about any other member. |
| `journal export` | `export_journal()` accepts `visible_account_filter`; postings on invisible accounts drop, and transactions whose every posting becomes invisible are skipped. |

`reconciliation-summary` visibility deferred — it's keyed by reconciliation envelope (which carries its account-id), so the cleanest fix is a per-row account-visibility check; this overlaps with privacy-audit F-PF-003 (reconciliation envelope bypass) and is tracked together in the multi-user invite slice.

## Test plan

- [x] Full `test_reports_endpoints.py` + `test_journal_export.py` pass (47/47).
- [x] `just lint` clean.
- [x] `just typecheck` clean.
- [ ] CI green.

Note: dedicated visibility-bypass regression tests (member-can't-see-private-envelope-in-report, member-export-excludes-private-account-postings) belong in the broader multi-user invite slice when that lands, since v1 has no multi-user-within-household surface to exercise them with naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)