### PR TITLE
fix: MFA defense-in-depth — 80-bit codes, single-use jti, /v1/auth/* rate limit (closes #219)

### DIFF
--- a/packages/tulip-api/src/tulip_api/auth/rate_limit.py
+++ b/packages/tulip-api/src/tulip_api/auth/rate_limit.py
@@ -1,0 +1,107 @@
+"""Rate limiting for /v1/auth/* — credential-stuffing + MFA brute-force gate.
+
+H-4 (#219): wires a single ``slowapi.Limiter`` into the FastAPI app and
+declares per-route quotas on the auth endpoints most exposed to abuse:
+
+* ``POST /v1/auth/login`` — primary credential-stuffing target.
+* ``POST /v1/auth/login/mfa`` — TOTP brute force (6-digit code).
+* ``POST /v1/auth/login/recover`` — recovery-code brute force.
+* ``POST /v1/auth/refresh`` — token-rotation churn.
+
+Limits are keyed on the client IP via :func:`get_remote_address`. The
+audit (H-4) also called for a per-email key; we defer that — slowapi's
+key function runs before the body is parsed, so layering email keying
+on top of the IP gate requires a custom dependency that re-reads the
+JSON body. The IP gate alone defeats the bulk-credential-stuffing case
+this issue prioritises; per-email keying is tracked separately if the
+threat model later demands it.
+
+Exceedance is rendered as RFC 9457 Problem Details (``auth.rate_limited``)
+so clients dispatch on it the same way as the rest of the API.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi.responses import JSONResponse
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from tulip_api.errors import PROBLEM_CONTENT_TYPE, TulipProblem
+
+if TYPE_CHECKING:
+    from fastapi import Request
+    from slowapi.errors import RateLimitExceeded
+
+
+#: Module-level limiter. Shared across the app. Storage backend defaults
+#: to in-memory which is fine for single-process SQLite; switch to Redis
+#: when we go multi-replica (deferred — see audit roadmap).
+limiter = Limiter(key_func=get_remote_address)
+
+
+#: Quotas applied to the four endpoints listed in the module docstring.
+#: Tight enough to defeat bulk credential stuffing (~600/h per IP), loose
+#: enough that a legitimate user who fat-fingers their password 4 times
+#: still gets through.
+AUTH_LOGIN_LIMIT = "10/minute"
+AUTH_LOGIN_MFA_LIMIT = "10/minute"
+AUTH_LOGIN_RECOVER_LIMIT = "10/minute"
+AUTH_REFRESH_LIMIT = "30/minute"
+
+
+class AuthRateLimitedError(TulipProblem):
+    """The caller exceeded the per-IP auth rate limit (H-4, #219)."""
+
+    def __init__(self, *, retry_after_seconds: int) -> None:
+        """Build the auth.rate_limited problem.
+
+        ``retry_after_seconds`` is also emitted as a ``Retry-After``
+        header per RFC 9110 §10.2.3.
+        """
+        super().__init__(
+            code="auth.rate_limited",
+            title="Too many auth attempts",
+            status=429,
+            detail=(
+                "Too many authentication attempts from this client. "
+                f"Try again in {retry_after_seconds} second(s)."
+            ),
+            extensions={"retry_after_seconds": retry_after_seconds},
+            headers={"Retry-After": str(retry_after_seconds)},
+        )
+
+
+def auth_rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    """Render slowapi's ``RateLimitExceeded`` as Problem Details.
+
+    slowapi's default handler returns a plain ``429`` with a string body,
+    which would break our "every error is application/problem+json"
+    contract. This wrapper extracts the retry window slowapi attaches to
+    the exception (or 60s if unavailable) and emits the canonical
+    ``auth.rate_limited`` body.
+    """
+    retry_after = getattr(exc, "retry_after", None)
+    if not isinstance(retry_after, int) or retry_after <= 0:
+        retry_after = 60
+    problem = AuthRateLimitedError(retry_after_seconds=retry_after)
+    body: dict[str, object] = {
+        "type": problem.type_uri,
+        "title": problem.title,
+        "status": problem.status,
+        "detail": problem.detail,
+        "instance": request.url.path,
+        "code": problem.code,
+    }
+    request_id = request.headers.get("x-request-id")
+    if request_id:
+        body["request_id"] = request_id
+    for key, value in problem.extensions.items():
+        body[key] = value
+    return JSONResponse(
+        status_code=problem.status,
+        content=body,
+        media_type=PROBLEM_CONTENT_TYPE,
+        headers=problem.headers,
+    )

--- a/packages/tulip-api/src/tulip_api/auth/recovery_codes.py
+++ b/packages/tulip-api/src/tulip_api/auth/recovery_codes.py
@@ -6,14 +6,17 @@ stored as argon2id hashes (mfa_recovery_codes.code_hash) so the
 plaintext is only ever visible once, in the response from
 ``/v1/auth/mfa/verify`` (or ``/recovery-codes/regenerate``).
 
-Format: two groups of four base32 characters joined by a dash, e.g.
-``K3M7-QHJR``. Eight codes per user. The base32 alphabet (RFC 4648) is
-A-Z + 2-7 — no 0/1/8/9 to avoid transcription confusion. 8 chars = 40
-bits per code.
+Format: four groups of four base32 characters joined by dashes, e.g.
+``K3M7-QHJR-9PXC-W2VD``. Eight codes per user. The base32 alphabet
+(RFC 4648) is A-Z + 2-7 — no 0/1/8/9 to avoid transcription confusion.
+16 chars = 80 bits per code (H-3 in #219). Codes minted before the
+length bump remain verifiable: ``_normalize`` only strips formatting,
+and ``_HASHER.verify`` works against whatever length the user actually
+transcribes.
 
 Input normalization: case-insensitive, dashes optional. Users transcribe
-these from a printed backup, so accepting ``k3m7qhjr`` and ``K3M7-QHJR``
-identically is the right ergonomic choice.
+these from a printed backup, so accepting ``k3m7qhjr9pxcw2vd`` and
+``K3M7-QHJR-9PXC-W2VD`` identically is the right ergonomic choice.
 """
 
 from __future__ import annotations
@@ -30,9 +33,10 @@ _ALPHABET: Final[str] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
 #: Number of codes minted per call (per user).
 DEFAULT_CODE_COUNT: Final[int] = 8
 
-#: Total characters per code, excluding the dash. Two groups of 4.
+#: Per-group length and group count. 4*4 = 16 chars = 80 bits per code.
 _GROUP_LEN: Final[int] = 4
-_CODE_CHARS: Final[int] = _GROUP_LEN * 2
+_GROUP_COUNT: Final[int] = 4
+_CODE_CHARS: Final[int] = _GROUP_LEN * _GROUP_COUNT
 
 # Reuse argon2-cffi defaults — same parameters used for passwords. The
 # CPU cost during enrollment-verify (8 hashes) is bounded and acceptable.
@@ -72,7 +76,8 @@ def _random_chars(n: int) -> str:
 
 
 def _format(chars: str) -> str:
-    return f"{chars[:_GROUP_LEN]}-{chars[_GROUP_LEN:]}"
+    groups = [chars[i * _GROUP_LEN : (i + 1) * _GROUP_LEN] for i in range(_GROUP_COUNT)]
+    return "-".join(groups)
 
 
 def _normalize(plain: str) -> str:

--- a/packages/tulip-api/src/tulip_api/auth/tokens.py
+++ b/packages/tulip-api/src/tulip_api/auth/tokens.py
@@ -12,7 +12,7 @@ import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Final
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import jwt
 from jwt.exceptions import InvalidTokenError as PyJwtInvalidTokenError
@@ -105,6 +105,7 @@ class MfaChallengeClaims:
 
     user_id: UUID
     household_id: UUID
+    jti: UUID
     issued_at: datetime
     expires_at: datetime
 
@@ -119,7 +120,9 @@ def create_mfa_challenge_token(
     """Mint a short-lived JWT that authorizes a single MFA-step-2 attempt.
 
     Carries ``purpose: "mfa_challenge"`` so an access token cannot be used
-    in its place (and vice versa). Stateless — bound only by TTL.
+    in its place (and vice versa). ``jti`` is a fresh UUIDv4 the caller
+    must persist on first use so that replay attempts (e.g. the second
+    half of a stolen request log) are rejected — see M-7 in #219.
     """
     now = datetime.now(tz=UTC)
     exp = now + ttl
@@ -128,6 +131,7 @@ def create_mfa_challenge_token(
         "sub": str(user_id),
         "household_id": str(household_id),
         "purpose": PURPOSE_MFA_CHALLENGE,
+        "jti": str(uuid4()),
         "iat": int(now.timestamp()),
         "exp": int(exp.timestamp()),
     }
@@ -138,8 +142,10 @@ def verify_mfa_challenge_token(token: str, *, secret: str) -> MfaChallengeClaims
     """Verify an MFA-challenge JWT.
 
     Raises :class:`InvalidTokenError` on signature mismatch, expiry,
-    issuer mismatch, or — critically — wrong ``purpose``. An access
-    token submitted here is rejected.
+    issuer mismatch, malformed ``jti``, or — critically — wrong
+    ``purpose``. An access token submitted here is rejected. Single-use
+    enforcement (rejecting the same ``jti`` twice) is the caller's
+    responsibility; this function only parses + signature-checks.
     """
     try:
         payload = jwt.decode(
@@ -147,15 +153,20 @@ def verify_mfa_challenge_token(token: str, *, secret: str) -> MfaChallengeClaims
             secret,
             algorithms=[JWT_ALGORITHM],
             issuer=ISSUER,
-            options={"require": ["sub", "household_id", "purpose", "iat", "exp"]},
+            options={"require": ["sub", "household_id", "purpose", "jti", "iat", "exp"]},
         )
     except PyJwtInvalidTokenError as exc:
         raise InvalidTokenError(str(exc)) from exc
     if payload.get("purpose") != PURPOSE_MFA_CHALLENGE:
         raise InvalidTokenError("token is not an MFA challenge")
+    try:
+        jti = UUID(payload["jti"])
+    except (TypeError, ValueError) as exc:
+        raise InvalidTokenError("jti is not a valid UUID") from exc
     return MfaChallengeClaims(
         user_id=UUID(payload["sub"]),
         household_id=UUID(payload["household_id"]),
+        jti=jti,
         issued_at=datetime.fromtimestamp(payload["iat"], tz=UTC),
         expires_at=datetime.fromtimestamp(payload["exp"], tz=UTC),
     )

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -18,9 +18,11 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from slowapi.errors import RateLimitExceeded
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
+from tulip_api.auth.rate_limit import auth_rate_limit_handler, limiter
 from tulip_api.config import get_settings
 from tulip_api.errors import install_problem_handlers
 from tulip_api.logging_config import configure_logging
@@ -143,6 +145,15 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
     # Request-id stamping must run before any router-level logging so the
     # request_id is in scope for every log line emitted during handling.
     app.add_middleware(RequestIdMiddleware)
+
+    # H-4 (#219): slowapi limiter for /v1/auth/* — wires the limiter into
+    # the app state and registers a Problem-Details exception handler for
+    # RateLimitExceeded. Per-route quotas are declared on each endpoint.
+    app.state.limiter = limiter
+    # Starlette types the handler arg as Exception; our narrower
+    # RateLimitExceeded signature is correct at runtime (Starlette
+    # dispatches by isinstance) and clearer at the callsite.
+    app.add_exception_handler(RateLimitExceeded, auth_rate_limit_handler)  # type: ignore[arg-type]
 
     install_problem_handlers(app)
 

--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -26,6 +26,13 @@ from tulip_api.auth.mfa import (
     verify_totp_code,
 )
 from tulip_api.auth.passwords import hash_password, needs_rehash, verify_password
+from tulip_api.auth.rate_limit import (
+    AUTH_LOGIN_LIMIT,
+    AUTH_LOGIN_MFA_LIMIT,
+    AUTH_LOGIN_RECOVER_LIMIT,
+    AUTH_REFRESH_LIMIT,
+    limiter,
+)
 from tulip_api.auth.recovery_codes import (
     generate_recovery_codes,
     hash_recovery_code,
@@ -80,6 +87,7 @@ from tulip_storage.models import (
     Household,
     MfaPolicy,
     MfaRecoveryCode,
+    UsedMfaChallenge,
     User,
     UserRole,
 )
@@ -206,8 +214,10 @@ def register(
         403: problem_response("auth.mfa_enrollment_required"),
         400: problem_response("request.body_invalid"),
         422: problem_response("validation.failed"),
+        429: problem_response("auth.rate_limited"),
     },
 )
+@limiter.limit(AUTH_LOGIN_LIMIT)
 def login(
     body: LoginRequest,
     request: Request,
@@ -250,6 +260,26 @@ def login(
         if not candidates:
             # Force the no-such-email path to pay ~argon2 cost too.
             verify_password(body.password, _timing_defense_dummy_hash())
+        else:
+            # We had at least one matching email but the password didn't
+            # match any of them. M-20 (#219): write an audit row anchored
+            # on the first candidate so per-user enumeration / brute-force
+            # patterns are reconstructable. No row for the truly unknown-
+            # email case — there's no household_id to scope the row to,
+            # and structlog already records the attempt below.
+            first = candidates[0]
+            AuditLogWriter(session, first.household_id).write(
+                action="login_failed",
+                actor_kind="user",
+                actor_user_id=first.id,
+                entity_type="user",
+                entity_id=first.id,
+                metadata={"email": body.email},
+                request_id=_request_uuid(request),
+                ip_address=_client_ip(request),
+                user_agent=request.headers.get("user-agent"),
+            )
+            session.commit()
         log.info("login.failed", email=body.email)
         raise InvalidCredentialsError()
 
@@ -288,8 +318,10 @@ def login(
         401: problem_response("auth.invalid_mfa_token", "auth.mfa_invalid_code"),
         400: problem_response("request.body_invalid"),
         422: problem_response("validation.failed"),
+        429: problem_response("auth.rate_limited"),
     },
 )
+@limiter.limit(AUTH_LOGIN_MFA_LIMIT)
 def login_mfa(
     body: MfaLoginRequest,
     request: Request,
@@ -307,17 +339,32 @@ def login_mfa(
     except InvalidTokenError as exc:
         log.info("user.login.mfa_token_rejected", reason=str(exc))
         raise InvalidMfaTokenError() from exc
+    if not _consume_mfa_challenge(session, claims.jti, claims.expires_at):
+        log.info("user.login.mfa_token_replay", jti=str(claims.jti))
+        raise InvalidMfaTokenError()
 
     user = session.get(User, (claims.household_id, claims.user_id))
     if user is None or user.totp_secret_encrypted is None or user.totp_enrolled_at is None:
         # Token was valid but the user is no longer enrolled (or the row
         # vanished). Treat as a token-rejection rather than an MFA-code
         # error — there's nothing to verify against.
+        session.commit()
         raise InvalidMfaTokenError()
 
     secret = decrypt_totp_secret(user.totp_secret_encrypted, master_key=settings.master_key)
     if not verify_totp_code(secret, body.code):
         log.info("user.login.mfa_code_rejected", user_id=str(user.id))
+        AuditLogWriter(session, user.household_id).write(
+            action="mfa.code_rejected",
+            actor_kind="user",
+            actor_user_id=user.id,
+            entity_type="user",
+            entity_id=user.id,
+            request_id=_request_uuid(request),
+            ip_address=_client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+        )
+        session.commit()
         raise MfaInvalidCodeError()
 
     AuditLogWriter(session, user.household_id).write(
@@ -349,8 +396,10 @@ def _enrollment_required(policy: MfaPolicy, role: UserRole) -> bool:
         401: problem_response("auth.invalid_refresh_token"),
         400: problem_response("request.body_invalid"),
         422: problem_response("validation.failed"),
+        429: problem_response("auth.rate_limited"),
     },
 )
+@limiter.limit(AUTH_REFRESH_LIMIT)
 def refresh(
     body: RefreshRequest,
     request: Request,
@@ -531,8 +580,10 @@ def mfa_verify(
         401: problem_response("auth.invalid_mfa_token", "auth.mfa_invalid_recovery_code"),
         400: problem_response("request.body_invalid"),
         422: problem_response("validation.failed"),
+        429: problem_response("auth.rate_limited"),
     },
 )
+@limiter.limit(AUTH_LOGIN_RECOVER_LIMIT)
 def login_recover(
     body: MfaRecoveryLoginRequest,
     request: Request,
@@ -552,14 +603,29 @@ def login_recover(
     except InvalidTokenError as exc:
         log.info("user.login.recover_token_rejected", reason=str(exc))
         raise InvalidMfaTokenError() from exc
+    if not _consume_mfa_challenge(session, claims.jti, claims.expires_at):
+        log.info("user.login.recover_token_replay", jti=str(claims.jti))
+        raise InvalidMfaTokenError()
 
     user = session.get(User, (claims.household_id, claims.user_id))
     if user is None or user.totp_enrolled_at is None:
+        session.commit()
         raise InvalidMfaTokenError()
 
     matched = _consume_recovery_code(session, user, body.recovery_code)
     if matched is None:
         log.info("user.login.recover_rejected", user_id=str(user.id))
+        AuditLogWriter(session, user.household_id).write(
+            action="mfa.recovery_rejected",
+            actor_kind="user",
+            actor_user_id=user.id,
+            entity_type="user",
+            entity_id=user.id,
+            request_id=_request_uuid(request),
+            ip_address=_client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+        )
+        session.commit()
         raise MfaInvalidRecoveryCodeError()
 
     AuditLogWriter(session, user.household_id).write(
@@ -735,6 +801,24 @@ def _is_expired(expires_at: datetime) -> bool:
     if expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=UTC)
     return expires_at <= datetime.now(tz=UTC)
+
+
+def _consume_mfa_challenge(session: Session, jti: UUID, expires_at: datetime) -> bool:
+    """Mark ``jti`` as redeemed; return False if it was already redeemed.
+
+    M-7 (#219): single-use enforcement for the MFA-challenge JWT. The
+    UNIQUE PK turns a replay into an IntegrityError. Committed eagerly
+    so that a second attempt landing 50 ms later is rejected even if
+    the first attempt's downstream verification fails.
+    """
+    session.add(UsedMfaChallenge(jti=jti, expires_at=expires_at))
+    try:
+        session.flush()
+    except IntegrityError:
+        session.rollback()
+        return False
+    session.commit()
+    return True
 
 
 def _mint_recovery_codes(session: Session, user: User) -> list[str]:

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -156,6 +156,7 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
             }
         ],
     },
+    "AuthRateLimitedError": {"retry_after_seconds": 60},
 }
 
 

--- a/packages/tulip-api/tests/conftest.py
+++ b/packages/tulip-api/tests/conftest.py
@@ -85,6 +85,18 @@ def app(session_maker: sessionmaker[Session], settings: Settings) -> Iterator[Fa
     # a separate fixture.
     a = create_app(enable_runner=False)
 
+    # H-4 (#219): the auth rate-limiter is module-scoped, so its
+    # in-memory counters accumulate across tests in the same process.
+    # Reset it per-test so a feature test that incidentally calls
+    # /login many times doesn't trip the 10/min gate. Per-limit reset
+    # methods exercising the gate itself opt back in. ``enabled`` is
+    # re-toggled in case the OpenAPI contract test disabled it first
+    # (it imports the same module-level limiter).
+    from tulip_api.auth.rate_limit import limiter as _auth_limiter
+
+    _auth_limiter.enabled = True
+    _auth_limiter.reset()
+
     def _override_session() -> Iterator[Session]:
         with session_maker() as s:
             yield s

--- a/packages/tulip-api/tests/test_mfa_login_endpoints.py
+++ b/packages/tulip-api/tests/test_mfa_login_endpoints.py
@@ -208,3 +208,137 @@ class TestLoginMfaCompletion:
         code = pyotp.TOTP(secret).now()
         r = client.post("/v1/auth/login/mfa", json={"mfa_token": access, "code": code})
         assert_problem(r, code="auth.invalid_mfa_token", status=401)
+
+
+class TestMfaChallengeJtiSingleUse:
+    """M-7 (#219): a successfully redeemed MFA-challenge JWT cannot be replayed."""
+
+    def _challenge(self, client: TestClient, registered: dict[str, str]) -> tuple[str, str]:
+        access = _login(client, registered["email"]).json()["access_token"]
+        secret = _enroll_and_verify(client, access)
+        challenge = _login(client, registered["email"]).json()
+        return challenge["mfa_token"], secret
+
+    def test_replay_after_success_is_rejected(self, client: TestClient, registered: dict[str, str]):
+        mfa_token, secret = self._challenge(client, registered)
+        code = pyotp.TOTP(secret).now()
+        first = client.post("/v1/auth/login/mfa", json={"mfa_token": mfa_token, "code": code})
+        assert first.status_code == 200, first.text
+        # Same jti → invalid_mfa_token even with a fresh TOTP code.
+        replay_code = pyotp.TOTP(secret).now()
+        replay = client.post(
+            "/v1/auth/login/mfa", json={"mfa_token": mfa_token, "code": replay_code}
+        )
+        assert_problem(replay, code="auth.invalid_mfa_token", status=401)
+
+    def test_replay_after_failure_is_rejected(self, client: TestClient, registered: dict[str, str]):
+        # Even a failed first attempt spends the jti — otherwise a thief
+        # of the mfa_token could brute-force the 6-digit TOTP within the
+        # 5-minute TTL.
+        mfa_token, secret = self._challenge(client, registered)
+        bad = client.post("/v1/auth/login/mfa", json={"mfa_token": mfa_token, "code": "000000"})
+        assert_problem(bad, code="auth.mfa_invalid_code", status=401)
+        good_code = pyotp.TOTP(secret).now()
+        retry = client.post("/v1/auth/login/mfa", json={"mfa_token": mfa_token, "code": good_code})
+        assert_problem(retry, code="auth.invalid_mfa_token", status=401)
+
+
+class TestAuthFailureAuditRows:
+    """M-20 (#219): failed credential / MFA attempts emit audit_log rows."""
+
+    def test_login_failed_writes_audit_row(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        r = client.post(
+            "/v1/auth/login",
+            json={"email": registered["email"], "password": "wrong-password-12345"},
+        )
+        assert_problem(r, code="auth.invalid_credentials", status=401)
+        with session_maker() as s:
+            rows = (
+                s.execute(select(AuditLog).where(AuditLog.action == "login_failed")).scalars().all()
+            )
+        assert len(rows) == 1
+        assert rows[0].metadata_ == {"email": registered["email"]}
+        assert rows[0].actor_kind == "user"
+
+    def test_no_audit_row_for_unknown_email(
+        self,
+        client: TestClient,
+        session_maker: sessionmaker[Session],
+    ):
+        # If we have no household to attribute the row to, the failure
+        # stays in app logs only — no orphan audit rows.
+        r = client.post(
+            "/v1/auth/login",
+            json={"email": "nobody@example.com", "password": "irrelevant-12345"},
+        )
+        assert_problem(r, code="auth.invalid_credentials", status=401)
+        with session_maker() as s:
+            rows = (
+                s.execute(select(AuditLog).where(AuditLog.action == "login_failed")).scalars().all()
+            )
+        assert rows == []
+
+    def test_mfa_code_rejected_writes_audit_row(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        access = _login(client, registered["email"]).json()["access_token"]
+        _enroll_and_verify(client, access)
+        mfa_token = _login(client, registered["email"]).json()["mfa_token"]
+        r = client.post("/v1/auth/login/mfa", json={"mfa_token": mfa_token, "code": "000000"})
+        assert_problem(r, code="auth.mfa_invalid_code", status=401)
+        with session_maker() as s:
+            actions = [
+                row.action
+                for row in s.execute(select(AuditLog).order_by(AuditLog.occurred_at)).scalars()
+            ]
+        assert "mfa.code_rejected" in actions
+
+    def test_mfa_recovery_rejected_writes_audit_row(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        access = _login(client, registered["email"]).json()["access_token"]
+        _enroll_and_verify(client, access)
+        mfa_token = _login(client, registered["email"]).json()["mfa_token"]
+        r = client.post(
+            "/v1/auth/login/recover",
+            json={"mfa_token": mfa_token, "recovery_code": "AAAA-BBBB-CCCC-DDDD"},
+        )
+        assert_problem(r, code="auth.mfa_invalid_recovery_code", status=401)
+        with session_maker() as s:
+            actions = [
+                row.action
+                for row in s.execute(select(AuditLog).order_by(AuditLog.occurred_at)).scalars()
+            ]
+        assert "mfa.recovery_rejected" in actions
+
+
+class TestAuthRateLimit:
+    """H-4 (#219): /v1/auth/login is gated by slowapi at 10/min per IP."""
+
+    def test_login_returns_429_after_burst(self, client: TestClient, registered: dict[str, str]):
+        from tulip_api.auth.rate_limit import limiter as _auth_limiter
+
+        # The conftest resets the limiter per-test; we re-arm an empty
+        # bucket here, then drive 10 wrong-password attempts so the 11th
+        # is gated rather than rejected at credentials check.
+        _auth_limiter.reset()
+        last = None
+        for _ in range(11):
+            last = client.post(
+                "/v1/auth/login",
+                json={"email": registered["email"], "password": "still-wrong-12345"},
+            )
+        assert last is not None
+        assert_problem(last, code="auth.rate_limited", status=429)
+        assert "Retry-After" in last.headers

--- a/packages/tulip-api/tests/test_mfa_recovery_codes.py
+++ b/packages/tulip-api/tests/test_mfa_recovery_codes.py
@@ -55,15 +55,18 @@ def _challenge_token(client: TestClient, email: str = "alice@example.com") -> st
 
 
 class TestVerifyMintsCodes:
-    def test_returns_eight_codes_in_xxxx_dash_xxxx_form(
+    def test_returns_eight_codes_in_four_group_dash_form(
         self, client: TestClient, registered: dict[str, str]
     ):
+        # H-3 (#219): 16 chars + 3 dashes = 19, four 4-char groups.
         access = _login_access_token(client)
         _, codes = _enroll_through_verify(client, access)
         assert len(codes) == 8
         assert len(set(codes)) == 8  # unique within the batch
         for c in codes:
-            assert len(c) == 9 and c[4] == "-"
+            assert len(c) == 19
+            assert c[4] == "-" and c[9] == "-" and c[14] == "-"
+            assert all(len(g) == 4 for g in c.split("-"))
 
     def test_codes_are_stored_hashed_not_plaintext(
         self,

--- a/packages/tulip-api/tests/test_openapi_contract.py
+++ b/packages/tulip-api/tests/test_openapi_contract.py
@@ -128,6 +128,23 @@ _APP = _build_app()
 _SCHEMA = schemathesis.openapi.from_asgi("/openapi.json", _APP)
 
 
+@pytest.fixture(autouse=True)
+def _disable_auth_rate_limit_for_schemathesis():  # type: ignore[no-untyped-def]
+    # H-4 (#219): each parametrized schemathesis case can fire dozens of
+    # requests against the same endpoint within one pytest test, easily
+    # exceeding the 10/min /v1/auth/* limit. The contract test's brief is
+    # schema conformance, not the limiter — so we disable the gate for
+    # the duration of each case.
+    from tulip_api.auth.rate_limit import limiter as _auth_limiter
+
+    previous = _auth_limiter.enabled
+    _auth_limiter.enabled = False
+    try:
+        yield
+    finally:
+        _auth_limiter.enabled = previous
+
+
 @_SCHEMA.parametrize()
 def test_api_conforms_to_schema(case: schemathesis.Case) -> None:
     """Every documented operation: response shape matches the OpenAPI spec.

--- a/packages/tulip-api/tests/test_recovery_codes_service.py
+++ b/packages/tulip-api/tests/test_recovery_codes_service.py
@@ -18,10 +18,16 @@ class TestGenerate:
     def test_default_count_is_eight(self):
         assert len(generate_recovery_codes()) == DEFAULT_CODE_COUNT == 8
 
-    def test_format_is_xxxx_dash_xxxx_base32(self):
+    def test_format_is_four_groups_of_four_base32(self):
         for code in generate_recovery_codes():
-            # Two groups of 4 base32 chars, joined by a dash.
-            assert re.fullmatch(r"[A-Z2-7]{4}-[A-Z2-7]{4}", code), code
+            # H-3 (#219): four groups of 4 base32 chars = 16 chars = 80 bits.
+            assert re.fullmatch(r"[A-Z2-7]{4}-[A-Z2-7]{4}-[A-Z2-7]{4}-[A-Z2-7]{4}", code), code
+
+    def test_entropy_is_at_least_80_bits(self):
+        # H-3 (#219): bumped from 40 bits to 80 bits to make offline brute
+        # force against a stolen argon2id hash infeasible.
+        for code in generate_recovery_codes():
+            assert len(code.replace("-", "")) == 16
 
     def test_codes_are_unique_within_a_batch(self):
         codes = generate_recovery_codes()
@@ -41,24 +47,32 @@ class TestRoundTrip:
     @pytest.mark.parametrize(
         "input_form",
         [
-            "ABCD-EFGH",  # canonical
-            "abcd-efgh",  # lowercase
-            "ABCDEFGH",  # no dash
-            "abcdefgh",  # lowercase, no dash
-            "ABCD EFGH",  # space instead of dash
-            "  ABCD-EFGH  ",  # surrounding whitespace
-            "ABCD--EFGH",  # extra dash
+            "ABCD-EFGH-IJKL-MNOP",  # canonical
+            "abcd-efgh-ijkl-mnop",  # lowercase
+            "ABCDEFGHIJKLMNOP",  # no dashes
+            "abcdefghijklmnop",  # lowercase, no dashes
+            "ABCD EFGH IJKL MNOP",  # spaces instead of dashes
+            "  ABCD-EFGH-IJKL-MNOP  ",  # surrounding whitespace
+            "ABCD--EFGH--IJKL--MNOP",  # extra dashes
         ],
     )
     def test_input_normalization(self, input_form: str):
-        h = hash_recovery_code("ABCD-EFGH")
+        h = hash_recovery_code("ABCD-EFGH-IJKL-MNOP")
         assert verify_recovery_code(input_form, h) is True
 
     def test_empty_input_does_not_verify(self):
-        h = hash_recovery_code("ABCD-EFGH")
+        h = hash_recovery_code("ABCD-EFGH-IJKL-MNOP")
         assert verify_recovery_code("", h) is False
         assert verify_recovery_code("---", h) is False  # all dashes → empty after normalize
 
     def test_garbled_hash_returns_false_not_raises(self):
         # A corrupt row in the DB shouldn't 500 the endpoint.
-        assert verify_recovery_code("ABCD-EFGH", "not-a-real-argon2-hash") is False
+        assert verify_recovery_code("ABCD-EFGH-IJKL-MNOP", "not-a-real-argon2-hash") is False
+
+    def test_legacy_short_codes_still_verify(self):
+        # Pre-H-3 (#219) codes were 8 chars. The on-disk argon2id hashes
+        # are length-agnostic, so existing users who haven't regenerated
+        # can still log in with their original short codes.
+        h = hash_recovery_code("ABCD-EFGH")
+        assert verify_recovery_code("ABCD-EFGH", h) is True
+        assert verify_recovery_code("abcdefgh", h) is True

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260513_1100_d4f7a9e1c8b3_add_used_mfa_challenges.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260513_1100_d4f7a9e1c8b3_add_used_mfa_challenges.py
@@ -1,0 +1,54 @@
+"""Add used_mfa_challenges table.
+
+Tracks redeemed MFA-challenge JWT ``jti`` values so a stolen or replayed
+challenge token cannot be reused. Tiny by design — purged whenever
+``expires_at`` is in the past. See M-7 in #219.
+
+Revision ID: d4f7a9e1c8b3
+Revises: a7d4f1b9e8c2
+Create Date: 2026-05-13 11:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from tulip_storage.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision: str = "d4f7a9e1c8b3"
+down_revision: str | None = "a7d4f1b9e8c2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the used_mfa_challenges table."""
+    op.create_table(
+        "used_mfa_challenges",
+        sa.Column("jti", GUID(length=36), nullable=False),
+        sa.Column(
+            "used_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("jti", name=op.f("pk_used_mfa_challenges")),
+    )
+    with op.batch_alter_table("used_mfa_challenges", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_used_mfa_challenges_expires_at"),
+            ["expires_at"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Drop the used_mfa_challenges table."""
+    with op.batch_alter_table("used_mfa_challenges", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_used_mfa_challenges_expires_at"))
+    op.drop_table("used_mfa_challenges")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -59,6 +59,7 @@ from tulip_storage.models.shadow_transaction import (
 from tulip_storage.models.sinking_fund import ContributionStrategy, SinkingFund
 from tulip_storage.models.statement_line import StatementLine
 from tulip_storage.models.transaction import Transaction, TransactionStatus
+from tulip_storage.models.used_mfa_challenge import UsedMfaChallenge
 from tulip_storage.models.user import User, UserRole
 
 __all__ = [
@@ -109,6 +110,7 @@ __all__ = [
     "StatementLine",
     "Transaction",
     "TransactionStatus",
+    "UsedMfaChallenge",
     "User",
     "UserRole",
 ]

--- a/packages/tulip-storage/src/tulip_storage/models/used_mfa_challenge.py
+++ b/packages/tulip-storage/src/tulip_storage/models/used_mfa_challenge.py
@@ -1,0 +1,43 @@
+"""``used_mfa_challenges`` — single-use ledger for MFA-challenge JWT ``jti``.
+
+The MFA-challenge JWT minted by ``POST /v1/auth/login`` carries a fresh
+``jti`` (UUIDv4). When the caller redeems the challenge at
+``/v1/auth/login/mfa`` or ``/v1/auth/login/recover`` — successfully or
+unsuccessfully — the ``jti`` is inserted here. Subsequent attempts to
+reuse the same token are rejected even if the JWT signature + TTL
+otherwise check out, defeating the replay window left open by the
+stateless 5-minute TTL alone. See M-7 in #219.
+
+The table is intentionally tiny (jti + expires_at + used_at). Rows can
+be purged in bulk once ``expires_at`` is in the past — replaying an
+expired JWT would already be rejected by signature/TTL verification.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class UsedMfaChallenge(Base):
+    """One redeemed MFA-challenge ``jti``.
+
+    No household scoping — ``jti`` is a UUIDv4 with negligible collision
+    probability across the entire deployment, and the JWT already binds
+    ``user_id`` + ``household_id`` cryptographically.
+    """
+
+    __tablename__ = "used_mfa_challenges"
+
+    jti: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    used_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )


### PR DESCRIPTION
## Summary

Closes the four findings bundled into #219:

- **H-3 — Recovery-code entropy ≥80 bits.** Mints 16 base32 chars in `XXXX-XXXX-XXXX-XXXX` form (up from 8 chars / 40 bits). Existing on-disk argon2id hashes still verify, so users keep their original codes until the next regenerate.
- **M-7 — Single-use MFA-challenge JWT.** The challenge token now carries a fresh `jti` (UUIDv4). Redemption stamps a new `used_mfa_challenges` row; a replay within the 5-minute TTL is rejected with `auth.invalid_mfa_token` even when the JWT signature is valid. Failed-code attempts also spend the `jti` so an attacker can't brute-force the 6-digit TOTP within the window.
- **H-4 — slowapi rate limiting on `/v1/auth/*`.** Per-IP gate at 10/min for `/login`, `/login/mfa`, `/login/recover`; 30/min for `/refresh`. Exceedance renders as canonical `auth.rate_limited` Problem Details (429) with `Retry-After`. Per-email keying deferred — needs a post-body-parse key function; IP gate alone defeats the bulk-credential-stuffing threat this finding targets.
- **M-20 — Audit rows on failed auth.** New `login_failed`, `mfa.code_rejected`, and `mfa.recovery_rejected` rows so brute-force / enumeration patterns are reconstructable from the audit log. Failures against unknown emails stay in app logs only (no household to scope an audit row to).

Migration: `d4f7a9e1c8b3 add_used_mfa_challenges` (adds the jti single-use table; tiny, expiry-indexed for future purge job).

## Test plan

- [x] ` uv run pytest packages ` → 1569 passed, 1 skipped, 3 deselected
- [x] ` just lint ` → All checks passed
- [x] ` just typecheck ` → Success
- [x] New focused suites: `TestMfaChallengeJtiSingleUse`, `TestAuthFailureAuditRows`, `TestAuthRateLimit` (replay + failure-replay + per-failure audit rows + 11-burst 429)
- [x] Legacy 8-char recovery codes still verify (covered by `test_legacy_short_codes_still_verify` to confirm the migration path keeps users unlocked)
- [ ] CI green on this PR