### PR TITLE
fix: privacy(C-1) — local_only profile can no longer resolve to a cloud provider (closes #233)

### DIFF
--- a/packages/tulip-ai/src/tulip_ai/policy.py
+++ b/packages/tulip-ai/src/tulip_ai/policy.py
@@ -22,6 +22,16 @@ PolicyLevel = Literal["permissive", "requires_approval", "disabled"]
 Capability = Literal["categorize", "nl_query", "forecast", "agentic"]
 CostCapBehaviour = Literal["degrade", "hard_fail"]
 
+#: Providers that run entirely on the household's machine. ADR-0005 §Q4
+#: locks ``profile=local_only`` to one of these regardless of any other
+#: provider config — see C-1 in the deep privacy audit (#233). Extending
+#: this set is a deliberate one-time decision per engine.
+_LOCAL_PROVIDERS: frozenset[str] = frozenset({"ollama"})
+
+#: Default local provider when ``profile=local_only`` and the household
+#: hasn't configured a specific one.
+_DEFAULT_LOCAL_PROVIDER: str = "ollama"
+
 _SEVERITY: dict[PolicyLevel, int] = {
     "permissive": 0,
     "requires_approval": 1,
@@ -135,7 +145,13 @@ def resolve_policy(
     model = cap_settings.get("model") or household_policy.get("default_model")
 
     if profile == "local_only":
-        provider = household_policy.get("fallback_provider") or "ollama"
+        # C-1 (#233): ADR-0005 §Q4 — local_only must never resolve to a
+        # cloud provider. Honour an explicit local fallback_provider so
+        # operators can name a self-hosted alternative; otherwise pin to
+        # the default local engine. fallback_model still acts as the
+        # "local model" hint so existing configs keep working.
+        candidate = household_policy.get("fallback_provider")
+        provider = candidate if candidate in _LOCAL_PROVIDERS else _DEFAULT_LOCAL_PROVIDER
         model = household_policy.get("fallback_model") or model
 
     from tulip_ai.cost import DEFAULT_RATE_LIMIT_PER_HOUR

--- a/packages/tulip-ai/tests/test_policy.py
+++ b/packages/tulip-ai/tests/test_policy.py
@@ -84,6 +84,80 @@ class TestProviderInheritance:
         assert r.model == "llama3:70b"
 
 
+class TestLocalOnlyLock:
+    """C-1 (#233): profile=local_only must never resolve to a cloud provider.
+
+    ADR-0005 §Q4 locks this; the previous resolver inherited ``provider``
+    from ``fallback_provider`` unconditionally, which silently routed a
+    privacy-conscious household to whatever cloud they had configured as
+    their cost-cap degrade target.
+    """
+
+    def test_cloud_fallback_provider_is_overridden(self) -> None:
+        # Regression test for the bug fixed in #233.
+        h = {
+            "default_provider": "anthropic",
+            "fallback_provider": "openai",
+            "fallback_model": "gpt-5",
+            "profile": "local_only",
+        }
+        r = resolve_policy(h, None, "categorize")
+        assert r.provider == "ollama"
+
+    def test_unset_fallback_resolves_to_ollama(self) -> None:
+        h = {"default_provider": "anthropic", "profile": "local_only"}
+        r = resolve_policy(h, None, "categorize")
+        assert r.provider == "ollama"
+
+    def test_capability_provider_override_does_not_escape_lock(self) -> None:
+        # Per-capability provider override is also subject to the lock.
+        h = {
+            "profile": "local_only",
+            "capabilities": {"categorize": {"provider": "openai", "model": "gpt-5"}},
+        }
+        r = resolve_policy(h, None, "categorize")
+        assert r.provider == "ollama"
+
+    def test_fallback_model_preserved_for_local_use(self) -> None:
+        # fallback_model continues to act as the "local model" hint
+        # (matches existing test_local_only_profile_forces_ollama).
+        h = {
+            "profile": "local_only",
+            "fallback_provider": "openai",  # cloud — ignored
+            "fallback_model": "llama3:70b",
+        }
+        r = resolve_policy(h, None, "categorize")
+        assert r.provider == "ollama"
+        assert r.model == "llama3:70b"
+
+
+class TestLocalOnlyLockProperty:
+    """Property: profile=local_only ⇒ resolved provider is in the local allowlist."""
+
+    def test_local_only_resolves_to_local_for_any_provider_config(self) -> None:
+        from tulip_ai.policy import _LOCAL_PROVIDERS
+
+        # Hand-rolled instead of hypothesis to keep the suite snappy; we
+        # cover the full cartesian product of the inputs that mattered
+        # for the bug.
+        candidates = [None, "anthropic", "openai", "ollama", "google", ""]
+        for default in candidates:
+            for fallback in candidates:
+                for cap in candidates:
+                    h: dict[str, object] = {"profile": "local_only"}
+                    if default is not None:
+                        h["default_provider"] = default
+                    if fallback is not None:
+                        h["fallback_provider"] = fallback
+                    if cap is not None:
+                        h["capabilities"] = {"categorize": {"provider": cap}}
+                    r = resolve_policy(h, None, "categorize")
+                    assert r.provider in _LOCAL_PROVIDERS, (
+                        f"local_only lock broken: default={default!r} "
+                        f"fallback={fallback!r} cap={cap!r} → {r.provider!r}"
+                    )
+
+
 class TestCostCap:
     def test_cap_parsed_as_decimal(self) -> None:
         h = {"monthly_cost_cap_usd": "10.00"}


### PR DESCRIPTION
## Summary

Fixes the ADR-0005 §Q4 violation flagged as Critical in the deep privacy audit. Before this PR, ``resolve_policy`` populated ``provider = household_policy['fallback_provider'] or 'ollama'`` whenever ``profile == 'local_only'``. A household that had configured ``fallback_provider=openai`` for cost-cap-degrade purposes — typically months earlier — was silently shipping every AI prompt to the cloud once any operator set the privacy profile to ``local_only``.

The resolver now keeps ``fallback_provider`` only when it names a member of a small ``_LOCAL_PROVIDERS`` allowlist (currently just ``ollama``). Cloud values are ignored in this branch; the resolver falls back to the default local engine. ``fallback_model`` keeps its role as the local-model hint so existing valid configs are unchanged.

## Test plan

- [x] ` uv run --package tulip-ai pytest packages/tulip-ai/tests ` → 103 passed
- [x] ` just lint ` → All checks passed
- [x] ` just typecheck ` → Success
- [x] New ``TestLocalOnlyLock`` covers the regression (cloud fallback → ollama), the unset case, the per-capability override, and ``fallback_model`` preservation
- [x] ``TestLocalOnlyLockProperty`` runs the full cartesian product of ``default_provider`` × ``fallback_provider`` × per-capability ``provider`` and asserts the resolved provider is always in ``_LOCAL_PROVIDERS``
- [ ] CI green on this PR