### PR TITLE
fix: privacy(H-1) — gate AI error-path response_text on log_prompts (closes #234)

### DIFF
--- a/packages/tulip-ai/src/tulip_ai/categorize.py
+++ b/packages/tulip-ai/src/tulip_ai/categorize.py
@@ -181,7 +181,10 @@ class AICategorizer:
                         model=policy.model,
                         outcome="provider_error",
                         prompt_hash=hash_prompt_payload(payload.to_dict()),
-                        response_text="no api key configured for provider",
+                        # H-1 (#234): gate error-path response_text on log_prompts.
+                        response_text=(
+                            "no api key configured for provider" if policy.log_prompts else None
+                        ),
                     )
                 )
                 if should_commit:
@@ -226,7 +229,7 @@ class AICategorizer:
                         model=policy.model,
                         outcome=gate.outcome,
                         prompt_hash=hash_prompt_payload(body),
-                        response_text=gate.reason[:500],
+                        response_text=gate.reason[:500] if policy.log_prompts else None,
                     )
                 )
                 if should_commit:
@@ -254,7 +257,7 @@ class AICategorizer:
                         model=call_model,
                         outcome="provider_error",
                         prompt_hash=hash_prompt_payload(body),
-                        response_text=str(exc)[:500],
+                        response_text=str(exc)[:500] if policy.log_prompts else None,
                     )
                 )
                 if should_commit:

--- a/packages/tulip-ai/src/tulip_ai/forecast.py
+++ b/packages/tulip-ai/src/tulip_ai/forecast.py
@@ -260,7 +260,10 @@ class AIForecastCapability:
                     prompt_hash=hash_prompt_payload(
                         {"task": "forecast", "envelope_id": str(envelope_id)}
                     ),
-                    response_text="no api key configured for provider",
+                    # H-1 (#234): gate error-path response_text on log_prompts.
+                    response_text=(
+                        "no api key configured for provider" if policy.log_prompts else None
+                    ),
                 )
                 return ForecastResult(text="", error="no api key")
 
@@ -288,7 +291,7 @@ class AIForecastCapability:
                     prompt_hash=hash_prompt_payload(
                         {"task": "forecast", "envelope_id": str(envelope_id)}
                     ),
-                    response_text=gate.reason[:500],
+                    response_text=gate.reason[:500] if policy.log_prompts else None,
                 )
                 return ForecastResult(text="", error=gate.outcome)
 
@@ -325,7 +328,7 @@ class AIForecastCapability:
                 model=call_model,
                 outcome="provider_error",
                 prompt_hash=hash_prompt_payload(payload.to_dict()),
-                response_text=str(exc)[:500],
+                response_text=str(exc)[:500] if policy.log_prompts else None,
             )
             return ForecastResult(text="", error=f"provider error: {exc}")
 

--- a/packages/tulip-ai/src/tulip_ai/nl_query.py
+++ b/packages/tulip-ai/src/tulip_ai/nl_query.py
@@ -266,7 +266,10 @@ class AINLQueryCapability:
                         outcome="provider_error",
                         prompt_hash=hash_prompt_payload({"question": question}),
                         actor_user_id=actor_user_id,
-                        response_text="no api key configured for provider",
+                        # H-1 (#234): gate error-path response_text on log_prompts.
+                        response_text=(
+                            "no api key configured for provider" if policy.log_prompts else None
+                        ),
                     )
                 )
                 session.commit()
@@ -301,7 +304,7 @@ class AINLQueryCapability:
                         outcome=gate.outcome,
                         prompt_hash=hash_prompt_payload({"question": question}),
                         actor_user_id=actor_user_id,
-                        response_text=gate.reason[:500],
+                        response_text=gate.reason[:500] if policy.log_prompts else None,
                     )
                 )
                 session.commit()
@@ -336,7 +339,7 @@ class AINLQueryCapability:
                 model=call_model,
                 outcome="provider_error",
                 prompt_hash=hash_prompt_payload({"turn": 1, "question": question}),
-                response_text=str(exc)[:500],
+                response_text=str(exc)[:500] if policy.log_prompts else None,
             )
             return NLAnswer(
                 summary="", rows=[], sql=None, error=f"Provider error on SQL turn: {exc}"
@@ -361,7 +364,7 @@ class AINLQueryCapability:
                 prompt_hash=hash_prompt_payload(
                     {"turn": 1, "question": question, "sql": emitted_sql}
                 ),
-                response_text=f"unsafe_sql: {exc}",
+                response_text=f"unsafe_sql: {exc}" if policy.log_prompts else None,
             )
             return NLAnswer(
                 summary="",
@@ -416,7 +419,7 @@ class AINLQueryCapability:
                 model=call_model,
                 outcome="provider_error",
                 prompt_hash=hash_prompt_payload({"turn": 2, "rows_count": len(redacted)}),
-                response_text=str(exc)[:500],
+                response_text=str(exc)[:500] if policy.log_prompts else None,
             )
             return NLAnswer(
                 summary="",

--- a/packages/tulip-ai/src/tulip_ai/proposals.py
+++ b/packages/tulip-ai/src/tulip_ai/proposals.py
@@ -157,7 +157,10 @@ class AIProposalCapability:
                     prompt_hash=hash_prompt_payload(
                         {"task": "suggest_envelope_budget", "envelope_id": str(envelope_id)}
                     ),
-                    response_text="no api key configured for provider",
+                    # H-1 (#234): gate error-path response_text on log_prompts.
+                    response_text=(
+                        "no api key configured for provider" if policy.log_prompts else None
+                    ),
                 )
                 return SuggestionResult(proposal=None, error="no api key")
 
@@ -185,7 +188,7 @@ class AIProposalCapability:
                     prompt_hash=hash_prompt_payload(
                         {"task": "suggest_envelope_budget", "envelope_id": str(envelope_id)}
                     ),
-                    response_text=gate.reason[:500],
+                    response_text=gate.reason[:500] if policy.log_prompts else None,
                 )
                 return SuggestionResult(proposal=None, error=gate.outcome)
 
@@ -236,7 +239,7 @@ class AIProposalCapability:
                 model=call_model,
                 outcome="provider_error",
                 prompt_hash=hash_prompt_payload(prompt_body),
-                response_text=str(exc)[:500],
+                response_text=str(exc)[:500] if policy.log_prompts else None,
             )
             return SuggestionResult(proposal=None, error=f"provider error: {exc}")
 
@@ -251,7 +254,9 @@ class AIProposalCapability:
                 model=call_model,
                 outcome="provider_error",
                 prompt_hash=hash_prompt_payload(prompt_body),
-                response_text=f"unparseable suggestion: {response.text[:300]}",
+                response_text=(
+                    f"unparseable suggestion: {response.text[:300]}" if policy.log_prompts else None
+                ),
                 tokens_in=response.tokens_in,
                 tokens_out=response.tokens_out,
                 cost_estimate_usd=response.cost_estimate_usd,

--- a/packages/tulip-ai/tests/test_categorize.py
+++ b/packages/tulip-ai/tests/test_categorize.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from tulip_ai.adapters import RecordingAdapter
 from tulip_ai.categorize import AICategorizer, build_categorize_prompt
+from tulip_ai.errors import AIProviderError
 from tulip_ai.redaction import ChartEntry
 from tulip_core.money import Money
 from tulip_core.reconciliation.categorizer import HouseholdContext
@@ -248,6 +249,40 @@ async def test_categorize_falls_back_when_no_api_key(
     with session_maker() as s:
         rows = s.execute(select(AIInvocation)).scalars().all()
         assert rows[0].outcome == "provider_error"
+        # H-1 (#234): response_text is gated on log_prompts; default is
+        # False, so the structured ``outcome`` is the assertion target.
+        assert rows[0].response_text is None
+
+
+@pytest.mark.asyncio
+async def test_categorize_no_api_key_response_text_opt_in_when_log_prompts(
+    session_maker: sessionmaker[Session], household_and_user, master_key: bytes
+) -> None:
+    """H-1 (#234): log_prompts=True restores the diagnostic response_text."""
+    household, _ = household_and_user
+    _seed_chart(session_maker, household.id, codes=[("5100", "Groceries", AccountType.EXPENSE)])
+    with session_maker() as s:
+        h = s.get(Household, household.id)
+        assert h is not None
+        h.ai_policy = {
+            "default_provider": "anthropic",
+            "default_model": "claude-opus-4-7",
+            "log_prompts": True,
+        }
+        s.commit()
+
+    categorizer = AICategorizer(
+        session_maker=session_maker,
+        master_key=master_key,
+        adapter=RecordingAdapter(canned_reply=""),
+    )
+    await categorizer.categorize(
+        _make_statement_line(description="WHOLE FOODS", amount="-12.00"),
+        HouseholdContext(household_id=household.id, account_whitelist=frozenset()),
+    )
+    with session_maker() as s:
+        rows = s.execute(select(AIInvocation)).scalars().all()
+        assert rows[0].outcome == "provider_error"
         assert rows[0].response_text == "no api key configured for provider"
 
 
@@ -420,7 +455,9 @@ async def test_categorize_cost_cap_hard_fail_blocks_with_audit(
             .all()
         )
         assert len(rows) == 1
-        assert "cap" in (rows[0].response_text or "").lower()
+        # H-1 (#234): outcome is the structured field; response_text is
+        # gated on log_prompts (False by default).
+        assert rows[0].outcome == "cost_capped"
 
 
 @pytest.mark.asyncio
@@ -466,3 +503,65 @@ async def test_categorize_rate_limited_blocks_with_audit(
             .all()
         )
         assert len(rows) == 1
+
+
+class _RaisingAdapter:
+    """Adapter that always raises AIProviderError — proves the gate on the
+    provider-error branch of every capability."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def chat(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        raise AIProviderError("provider blew up: prompt fragment was 'WHOLE FOODS 12.00'")
+
+
+@pytest.mark.asyncio
+async def test_provider_error_response_text_gated_off_by_default(
+    session_maker: sessionmaker[Session], household_and_user, master_key: bytes
+) -> None:
+    """H-1 (#234): provider-error response_text is NULL when log_prompts=False."""
+    household, _ = household_and_user
+    _seed_chart(session_maker, household.id, codes=[("5100", "Groceries", AccountType.EXPENSE)])
+    _set_ai_keys(session_maker, household.id, keys={"anthropic": "sk-real"}, master_key=master_key)
+
+    categorizer = AICategorizer(
+        session_maker=session_maker, master_key=master_key, adapter=_RaisingAdapter()
+    )
+    await categorizer.categorize(
+        _make_statement_line(description="WHOLE FOODS", amount="-12.00"),
+        HouseholdContext(household_id=household.id, account_whitelist=frozenset()),
+    )
+    with session_maker() as s:
+        rows = s.execute(select(AIInvocation)).scalars().all()
+        assert rows[0].outcome == "provider_error"
+        assert rows[0].response_text is None
+
+
+@pytest.mark.asyncio
+async def test_provider_error_response_text_persisted_when_log_prompts_on(
+    session_maker: sessionmaker[Session], household_and_user, master_key: bytes
+) -> None:
+    """H-1 (#234): log_prompts=True preserves diagnostic content."""
+    household, _ = household_and_user
+    _seed_chart(session_maker, household.id, codes=[("5100", "Groceries", AccountType.EXPENSE)])
+    _set_ai_keys(session_maker, household.id, keys={"anthropic": "sk-real"}, master_key=master_key)
+    with session_maker() as s:
+        h = s.get(Household, household.id)
+        assert h is not None
+        h.ai_policy = {**dict(h.ai_policy or {}), "log_prompts": True}
+        s.commit()
+
+    categorizer = AICategorizer(
+        session_maker=session_maker, master_key=master_key, adapter=_RaisingAdapter()
+    )
+    await categorizer.categorize(
+        _make_statement_line(description="WHOLE FOODS", amount="-12.00"),
+        HouseholdContext(household_id=household.id, account_whitelist=frozenset()),
+    )
+    with session_maker() as s:
+        rows = s.execute(select(AIInvocation)).scalars().all()
+        assert rows[0].outcome == "provider_error"
+        assert rows[0].response_text is not None
+        assert "provider blew up" in rows[0].response_text

--- a/packages/tulip-ai/tests/test_nl_query.py
+++ b/packages/tulip-ai/tests/test_nl_query.py
@@ -215,9 +215,9 @@ async def test_ask_rejects_unsafe_emitted_sql(
             .scalars()
             .all()
         )
-        assert any(
-            r.outcome == "provider_error" and "unsafe_sql" in (r.response_text or "") for r in rows
-        )
+        # H-1 (#234): response_text is gated on log_prompts; rely on the
+        # structured ``outcome`` to identify the unsafe-SQL rejection.
+        assert any(r.outcome == "provider_error" for r in rows)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes the High-severity privacy contract breach: the success path correctly gates prompt content on ``policy.log_prompts``, but every error path was persisting ``str(exc)[:500]``, ``gate.reason[:500]``, ``f\"unsafe_sql: {exc}\"``, or ``f\"unparseable suggestion: {response.text[:300]}\"`` unconditionally. LiteLLM error strings frequently echo the request body's first N chars; unsafe-SQL strings derive directly from user prompts; cost-gate reasons include cost detail. A household with ``log_prompts=false`` (the default) was still accumulating prompt-derived content in ``ai_invocations.response_text`` on every error.

Gates the same way the success path does — when ``log_prompts`` is False, ``response_text`` is NULL on every error-path AI invocation row. The structured ``outcome`` enum (``provider_error`` / ``cost_capped`` / ``unsafe_sql`` / ``rate_limited`` / ``policy_disabled``) remains the load-bearing field downstream cares about.

Sites updated:

| File | Sites |
| --- | --- |
| ``packages/tulip-ai/src/tulip_ai/forecast.py`` | 3 |
| ``packages/tulip-ai/src/tulip_ai/nl_query.py`` | 5 |
| ``packages/tulip-ai/src/tulip_ai/categorize.py`` | 3 |
| ``packages/tulip-ai/src/tulip_ai/proposals.py`` | 4 |

## Test plan

- [x] ` uv run pytest packages ` → 1577 passed, 1 skipped, 3 deselected
- [x] ` just lint ` → All checks passed
- [x] ` just typecheck ` → Success
- [x] Existing test expectations that checked literal ``response_text`` content updated to check structured ``outcome`` (audit's load-bearing field) instead
- [x] New ``test_categorize_no_api_key_response_text_opt_in_when_log_prompts`` proves the diagnostic returns under ``log_prompts=true``
- [x] New ``test_provider_error_response_text_gated_off_by_default`` proves the gate on the ``AIProviderError`` branch with a raising adapter
- [x] New ``test_provider_error_response_text_persisted_when_log_prompts_on`` proves diagnostic content survives under ``log_prompts=true``
- [ ] CI green on this PR