### PR TITLE
fix: privacy(H-2+H-3) — household + user right-to-erasure (closes #235)

### DIFF
--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -169,6 +169,69 @@ class InvalidCredentialsError(TulipProblem):
         )
 
 
+class UserNotFoundError(TulipProblem):
+    """The targeted user does not exist within the caller's household."""
+
+    def __init__(self) -> None:
+        """Build the user.not_found problem."""
+        super().__init__(
+            code="user.not_found",
+            title="User not found",
+            status=404,
+            detail="No user with the given id exists in your household.",
+        )
+
+
+class LastAdminDeletionError(TulipProblem):
+    """Refused: deleting this user would leave the household with no admin."""
+
+    def __init__(self) -> None:
+        """Build the user.last_admin problem."""
+        super().__init__(
+            code="user.last_admin",
+            title="Cannot delete the last admin",
+            status=409,
+            detail=(
+                "This user is the only admin in the household; "
+                "promote another member to admin first."
+            ),
+        )
+
+
+class HouseholdErasureNotRequestedError(TulipProblem):
+    """``DELETE /v1/households/me`` requires a fresh confirmation token."""
+
+    def __init__(self) -> None:
+        """Build the household.erasure_not_requested problem."""
+        super().__init__(
+            code="household.erasure_not_requested",
+            title="Erasure not requested",
+            status=409,
+            detail=(
+                "Issue a confirmation token first via "
+                "POST /v1/households/me/erase-request, then resubmit with "
+                "the token in the X-Erasure-Token header."
+            ),
+        )
+
+
+class HouseholdErasureTokenInvalidError(TulipProblem):
+    """The X-Erasure-Token header is missing, malformed, or doesn't match."""
+
+    def __init__(self) -> None:
+        """Build the household.erasure_token_invalid problem."""
+        super().__init__(
+            code="household.erasure_token_invalid",
+            title="Invalid erasure token",
+            status=401,
+            detail=(
+                "The X-Erasure-Token header is missing, expired, or does "
+                "not match the most recent erasure request. Request a "
+                "fresh token via POST /v1/households/me/erase-request."
+            ),
+        )
+
+
 class DuplicateEmailError(TulipProblem):
     """Registration was attempted with an email that already exists in the household."""
 

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -34,6 +34,7 @@ from tulip_api.routers import (
     csv_profiles,
     envelopes,
     health,
+    households,
     imports,
     journal,
     notifications,
@@ -46,6 +47,7 @@ from tulip_api.routers import (
     sinking_funds,
     system,
     transactions,
+    users,
     well_known_errors,
 )
 from tulip_core.reconciliation.categorizer import register_categorizer
@@ -122,6 +124,16 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
             settings = get_settings()
             session_maker = _build_session_maker(settings.database_url)
             runner = Runner(session_maker)
+            # H-3 (#235): register the attachment GC handler so orphaned
+            # ciphertext files get swept periodically. The runner reads
+            # ``scheduled_jobs`` for the actual fire cadence; an installer
+            # is expected to seed a daily rrule for ``attachment_gc``.
+            from tulip_storage.runner.handlers import make_attachment_gc_handler
+
+            runner.register_handler(
+                "attachment_gc",
+                make_attachment_gc_handler(session_maker, settings.attachment_root),
+            )
             app.state.runner = runner
             _register_ai_categorizer(session_maker)
             await runner.start()
@@ -164,6 +176,8 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
     app.include_router(ai.router)
     app.include_router(well_known_errors.router)
     app.include_router(auth.router)
+    app.include_router(users.router)
+    app.include_router(households.router)
     app.include_router(accounts.router)
     app.include_router(transactions.router)
     app.include_router(periods.router)

--- a/packages/tulip-api/src/tulip_api/routers/households.py
+++ b/packages/tulip-api/src/tulip_api/routers/households.py
@@ -1,0 +1,217 @@
+"""Household administration — right-to-erasure flow (H-2/H-3, #235).
+
+Two endpoints implement GDPR Art. 17 / CCPA §1798.105 for an entire
+household:
+
+* ``POST /v1/households/me/erase-request`` — admin issues a fresh
+  confirmation token (returned exactly once). The plaintext is required
+  on the matching ``DELETE`` call; the server stores only its SHA-256.
+* ``DELETE /v1/households/me`` — admin submits the token in
+  ``X-Erasure-Token``; on match, the household row is deleted, schema
+  ``ondelete="CASCADE"`` clears every child table, and the household's
+  attachment ciphertext files are unlinked from disk (after first
+  checking that no other household still references the same content
+  hash — within-household dedup means a given blob can in principle
+  back rows in other tenants too).
+
+The token TTL is short (15 minutes) so a leaked request from an old
+browser tab can't be replayed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, Request, status
+from pydantic import BaseModel
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
+
+from tulip_api.auth.deps import require_role
+from tulip_api.config import Settings, get_settings
+from tulip_api.deps import get_session
+from tulip_api.errors import (
+    HouseholdErasureNotRequestedError,
+    HouseholdErasureTokenInvalidError,
+    problem_response,
+)
+from tulip_storage.models import Attachment, Household, PendingHouseholdErasure
+from tulip_storage.repositories import AuditLogWriter
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_api.auth.tokens import Claims
+
+
+router = APIRouter(prefix="/v1/households", tags=["households"])
+
+#: How long the erasure confirmation token stays valid.
+_ERASURE_TOKEN_TTL: timedelta = timedelta(minutes=15)
+
+
+class EraseRequestResponse(BaseModel):
+    """Body returned from ``POST /v1/households/me/erase-request``."""
+
+    token: str
+    expires_at: datetime
+
+
+def _hash_token(plain: str) -> str:
+    return hashlib.sha256(plain.encode("utf-8")).hexdigest()
+
+
+@router.post(
+    "/me/erase-request",
+    response_model=EraseRequestResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+    },
+)
+def request_erasure(
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> EraseRequestResponse:
+    """Step 1 — issue a confirmation token for household erasure.
+
+    Overwrites any prior outstanding request (one slot per household);
+    only the most recent token is valid. Plaintext is returned exactly
+    once and stored hashed.
+    """
+    token_plain = secrets.token_urlsafe(32)
+    now = datetime.now(tz=UTC)
+    expires = now + _ERASURE_TOKEN_TTL
+
+    existing = session.get(PendingHouseholdErasure, claims.household_id)
+    if existing is None:
+        session.add(
+            PendingHouseholdErasure(
+                household_id=claims.household_id,
+                token_hash=_hash_token(token_plain),
+                requested_at=now,
+                expires_at=expires,
+                requested_by_user_id=claims.user_id,
+            )
+        )
+    else:
+        existing.token_hash = _hash_token(token_plain)
+        existing.requested_at = now
+        existing.expires_at = expires
+        existing.requested_by_user_id = claims.user_id
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="household.erase_requested",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="household",
+        entity_id=claims.household_id,
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    return EraseRequestResponse(token=token_plain, expires_at=expires)
+
+
+@router.delete(
+    "/me",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: problem_response("auth.unauthorized", "household.erasure_token_invalid"),
+        403: problem_response("auth.forbidden"),
+        409: problem_response("household.erasure_not_requested"),
+    },
+)
+def erase_household(
+    request: Request,
+    x_erasure_token: str | None = Header(default=None, alias="X-Erasure-Token"),
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> None:
+    """Step 2 — erase the entire household, attachments and all.
+
+    Validates the confirmation token from step 1, captures the set of
+    attachment content hashes referenced by this household (so we can
+    unlink the ciphertext after the schema cascade clears the rows),
+    deletes the ``households`` row (CASCADE handles every child table),
+    then unlinks orphaned attachment blobs from disk.
+    """
+    pending = session.get(PendingHouseholdErasure, claims.household_id)
+    if pending is None:
+        raise HouseholdErasureNotRequestedError()
+
+    if x_erasure_token is None or _hash_token(x_erasure_token) != pending.token_hash:
+        raise HouseholdErasureTokenInvalidError()
+
+    now = datetime.now(tz=UTC)
+    expires_at = pending.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    if expires_at <= now:
+        raise HouseholdErasureTokenInvalidError()
+
+    # Snapshot the content hashes before the cascade clears the rows.
+    content_hashes = {
+        row[0]
+        for row in session.execute(
+            select(Attachment.content_hash).where(Attachment.household_id == claims.household_id)
+        ).all()
+    }
+
+    # Tombstone (no PII; just the structural fact that this household existed).
+    AuditLogWriter(session, claims.household_id).write(
+        action="household.deleted",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="household",
+        entity_id=claims.household_id,
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.flush()
+
+    # Drop the household row → CASCADE removes audit_log, users, sessions,
+    # mfa_recovery_codes, accounts, transactions, postings, periods,
+    # allocation_pools, envelopes, sinking_funds, shadow_transactions,
+    # shadow_postings, csv_profiles, import_batches, reconciliations,
+    # attachments, ai_invocations, notifications, pending_proposals,
+    # scheduled_jobs, pending_household_erasures.
+    session.execute(sa_delete(Household).where(Household.id == claims.household_id))
+    session.commit()
+
+    # Unlink orphaned attachment ciphertext. A blob is orphaned iff no
+    # other household still references its content_hash (within-household
+    # dedup means cross-household sharing is theoretically possible).
+    for h in content_hashes:
+        still_used = session.execute(
+            select(Attachment.id).where(Attachment.content_hash == h).limit(1)
+        ).first()
+        if still_used is None:
+            blob = settings.attachment_root / h
+            try:
+                blob.unlink()
+            except FileNotFoundError:
+                continue
+
+
+def _request_uuid(request: Request) -> UUID | None:
+    rid = request.headers.get("x-request-id")
+    if rid:
+        try:
+            return UUID(rid)
+        except ValueError:
+            return None
+    return None
+
+
+def _client_ip(request: Request) -> str | None:
+    return request.client.host if request.client else None

--- a/packages/tulip-api/src/tulip_api/routers/users.py
+++ b/packages/tulip-api/src/tulip_api/routers/users.py
@@ -1,0 +1,124 @@
+"""DELETE /v1/users/{user_id} — right-to-erasure for one user (H-2, #235).
+
+GDPR Art. 17 + CCPA §1798.105 give an end-user the right to have their
+account erased. The endpoint cascades sessions + MFA codes via the
+existing schema ``ondelete="CASCADE"`` (no manual deletes needed), then
+nulls out the deleted user's PII from historic ``audit_log`` JSON blobs.
+
+The user's ``id`` is retained as a pseudonym across ``actor_user_id`` /
+``entity_id`` columns — Art. 17(3)(e) permits this for audit-trail
+integrity, and the schema doesn't carry FK from those columns back to
+``users.id`` so nothing breaks when the row vanishes.
+
+Admin-only; refuses when the target is the last admin in the household.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Request, status
+from sqlalchemy import func, or_, select, update
+
+from tulip_api.auth.deps import require_role
+from tulip_api.deps import get_session
+from tulip_api.errors import (
+    LastAdminDeletionError,
+    UserNotFoundError,
+    problem_response,
+)
+from tulip_storage.models import AuditLog, User, UserRole
+from tulip_storage.repositories import AuditLogWriter
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from tulip_api.auth.tokens import Claims
+
+
+router = APIRouter(prefix="/v1/users", tags=["users"])
+
+
+@router.delete(
+    "/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("user.not_found"),
+        409: problem_response("user.last_admin"),
+    },
+)
+def delete_user(
+    user_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> None:
+    """Erase one user account from the caller's household.
+
+    Cascade: schema-level ``ondelete="CASCADE"`` removes the user's
+    ``sessions`` rows and ``mfa_recovery_codes`` rows. The user's
+    ``id`` survives as a pseudonym in any historic ``audit_log`` row's
+    ``actor_user_id`` / ``entity_id`` column; PII inside the JSON
+    snapshot blobs of those rows is nulled.
+
+    Refuses when the target is the last admin — without an admin no
+    one can grant another user admin permissions, leaving the household
+    self-locked.
+    """
+    user = session.get(User, (claims.household_id, user_id))
+    if user is None:
+        raise UserNotFoundError()
+
+    if user.role == UserRole.ADMIN:
+        admin_count = session.execute(
+            select(func.count())
+            .select_from(User)
+            .where(User.household_id == claims.household_id, User.role == UserRole.ADMIN)
+        ).scalar_one()
+        if admin_count <= 1:
+            raise LastAdminDeletionError()
+
+    # Redact historic audit-log PII for rows referencing this user (either as
+    # actor or as the entity being acted on). Tombstone row is written
+    # afterward so it isn't caught by the same UPDATE.
+    session.execute(
+        update(AuditLog)
+        .where(
+            AuditLog.household_id == claims.household_id,
+            or_(AuditLog.actor_user_id == user_id, AuditLog.entity_id == user_id),
+        )
+        .values(before_snapshot=None, after_snapshot=None, metadata_=None)
+    )
+
+    # Tombstone: structural only — role + caller-id, no email or display name.
+    AuditLogWriter(session, claims.household_id).write(
+        action="user.deleted",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="user",
+        entity_id=user_id,
+        metadata={"deleted_role": user.role.value},
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    session.delete(user)
+    session.commit()
+
+
+def _request_uuid(request: Request) -> UUID | None:
+    rid = request.headers.get("x-request-id")
+    if rid:
+        try:
+            return UUID(rid)
+        except ValueError:
+            return None
+    return None
+
+
+def _client_ip(request: Request) -> str | None:
+    return request.client.host if request.client else None

--- a/packages/tulip-api/tests/test_erasure_endpoints.py
+++ b/packages/tulip-api/tests/test_erasure_endpoints.py
@@ -1,0 +1,438 @@
+"""Tests for the right-to-erasure flow (H-2 + H-3, #235).
+
+Covers:
+* ``DELETE /v1/users/{user_id}`` — admin-only, last-admin guard,
+  schema cascade (sessions + MFA codes), audit redaction.
+* ``POST /v1/households/me/erase-request`` — issues a fresh token.
+* ``DELETE /v1/households/me`` — two-step confirmation, schema cascade,
+  attachment ciphertext unlink on disk.
+* ``AttachmentRepository.delete()`` — refcount + blob unlink.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from _problem_details import assert_problem
+from tulip_storage.models import (
+    Attachment,
+    AuditLog,
+    Household,
+    PendingHouseholdErasure,
+    User,
+    UserRole,
+)
+from tulip_storage.repositories import AttachmentRepository
+
+REG_PASSWORD = "correct horse battery staple"
+
+
+@pytest.fixture
+def registered(client: TestClient) -> dict[str, str]:
+    body = {
+        "email": "alice@example.com",
+        "password": REG_PASSWORD,
+        "display_name": "Alice",
+        "household_name": "Smith",
+    }
+    r = client.post("/v1/auth/register", json=body)
+    assert r.status_code == 201, r.text
+    return body
+
+
+def _access_token(client: TestClient, email: str) -> str:
+    r = client.post("/v1/auth/login", json={"email": email, "password": REG_PASSWORD})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _seed_second_admin(session_maker: sessionmaker[Session], household_id, *, email: str) -> User:
+    """Insert a second admin user directly so we can test the last-admin guard."""
+    from uuid import uuid4
+
+    from tulip_api.auth.passwords import hash_password
+
+    with session_maker() as s:
+        u = User(
+            household_id=household_id,
+            id=uuid4(),
+            email=email,
+            password_hash=hash_password(REG_PASSWORD),
+            display_name=email.split("@")[0].title(),
+            role=UserRole.ADMIN,
+        )
+        s.add(u)
+        s.commit()
+        return u
+
+
+class TestDeleteUser:
+    def test_admin_can_delete_a_member(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        # Promote Alice to admin (she already is via register), seed a member.
+        from uuid import uuid4
+
+        from tulip_api.auth.passwords import hash_password
+
+        with session_maker() as s:
+            h = s.execute(select(Household)).scalar_one()
+            member = User(
+                household_id=h.id,
+                id=uuid4(),
+                email="bob@example.com",
+                password_hash=hash_password(REG_PASSWORD),
+                display_name="Bob",
+                role=UserRole.MEMBER,
+            )
+            s.add(member)
+            s.commit()
+            member_id = member.id
+
+        access = _access_token(client, registered["email"])
+        r = client.delete(
+            f"/v1/users/{member_id}",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert r.status_code == 204, r.text
+
+        with session_maker() as s:
+            assert s.get(User, (h.id, member_id)) is None
+            actions = [
+                row.action
+                for row in s.execute(select(AuditLog).order_by(AuditLog.occurred_at)).scalars()
+            ]
+        assert "user.deleted" in actions
+
+    def test_refuses_to_delete_last_admin(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        with session_maker() as s:
+            u = s.execute(select(User)).scalar_one()
+            user_id = u.id
+
+        access = _access_token(client, registered["email"])
+        r = client.delete(
+            f"/v1/users/{user_id}",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert_problem(r, code="user.last_admin", status=409)
+
+    def test_can_delete_one_of_two_admins(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        with session_maker() as s:
+            h = s.execute(select(Household)).scalar_one()
+            household_id = h.id
+        second = _seed_second_admin(session_maker, household_id, email="carol@example.com")
+
+        access = _access_token(client, registered["email"])
+        r = client.delete(
+            f"/v1/users/{second.id}",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert r.status_code == 204, r.text
+
+    def test_redacts_historic_audit_pii(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        # Seed a second admin who registers, then delete them; their
+        # registration audit row (which has email in after_snapshot)
+        # must have its JSON blobs nulled.
+        with session_maker() as s:
+            h = s.execute(select(Household)).scalar_one()
+            household_id = h.id
+        second = _seed_second_admin(session_maker, household_id, email="carol@example.com")
+
+        with session_maker() as s:
+            # Mimic a register-style audit row for carol so we have PII to scrub.
+            from uuid import uuid4
+
+            from tulip_storage.repositories import AuditLogWriter
+
+            AuditLogWriter(s, household_id).write(
+                action="register",
+                actor_kind="user",
+                actor_user_id=second.id,
+                entity_type="user",
+                entity_id=second.id,
+                after={"email": "carol@example.com", "role": "admin"},
+                request_id=uuid4(),
+            )
+            s.commit()
+
+        access = _access_token(client, registered["email"])
+        r = client.delete(
+            f"/v1/users/{second.id}",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert r.status_code == 204
+
+        with session_maker() as s:
+            rows = (
+                s.execute(
+                    select(AuditLog).where(
+                        AuditLog.entity_id == second.id, AuditLog.action == "register"
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        # The register row still exists (we keep the pseudonymous user id
+        # under Art. 17(3)(e)) but its PII payload is nulled.
+        assert rows
+        assert all(r.after_snapshot is None and r.before_snapshot is None for r in rows)
+
+    def test_member_cannot_delete_anyone(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        with session_maker() as s:
+            u = s.execute(select(User)).scalar_one()
+            u.role = UserRole.MEMBER
+            s.commit()
+
+        access = _access_token(client, registered["email"])
+        from uuid import uuid4
+
+        r = client.delete(
+            f"/v1/users/{uuid4()}",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert_problem(r, code="auth.forbidden", status=403)
+
+
+class TestEraseHousehold:
+    def test_two_step_flow_deletes_household_and_files(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+        settings,
+    ):
+        # Seed an attachment so we can prove the file is unlinked.
+        with session_maker() as s:
+            h = s.execute(select(Household)).scalar_one()
+            household_id = h.id
+            repo = AttachmentRepository(
+                s,
+                household_id,
+                master_key=settings.master_key,
+                attachment_root=settings.attachment_root,
+            )
+            att = repo.create(
+                filename="statement.pdf",
+                content_type="application/pdf",
+                raw_bytes=b"hello tulip",
+            )
+            s.commit()
+            content_hash = att.content_hash
+
+        blob = settings.attachment_root / content_hash
+        assert blob.exists()
+
+        access = _access_token(client, registered["email"])
+        r1 = client.post(
+            "/v1/households/me/erase-request",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert r1.status_code == 200, r1.text
+        token = r1.json()["token"]
+
+        r2 = client.delete(
+            "/v1/households/me",
+            headers={
+                "Authorization": f"Bearer {access}",
+                "X-Erasure-Token": token,
+            },
+        )
+        assert r2.status_code == 204, r2.text
+
+        # Household gone.
+        with session_maker() as s:
+            assert s.get(Household, household_id) is None
+            assert s.get(PendingHouseholdErasure, household_id) is None
+            # Cascade purged attachments.
+            attachments = s.execute(select(Attachment)).scalars().all()
+            assert attachments == []
+
+        # Ciphertext gone from disk.
+        assert not blob.exists()
+
+    def test_delete_without_token_refused(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+    ):
+        access = _access_token(client, registered["email"])
+        r = client.delete(
+            "/v1/households/me",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert_problem(r, code="household.erasure_not_requested", status=409)
+
+    def test_delete_with_wrong_token_refused(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+    ):
+        access = _access_token(client, registered["email"])
+        client.post(
+            "/v1/households/me/erase-request",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        r = client.delete(
+            "/v1/households/me",
+            headers={
+                "Authorization": f"Bearer {access}",
+                "X-Erasure-Token": "wrong-token",
+            },
+        )
+        assert_problem(r, code="household.erasure_token_invalid", status=401)
+
+    def test_member_cannot_initiate_or_confirm(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        with session_maker() as s:
+            u = s.execute(select(User)).scalar_one()
+            u.role = UserRole.MEMBER
+            s.commit()
+
+        access = _access_token(client, registered["email"])
+        r1 = client.post(
+            "/v1/households/me/erase-request",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert_problem(r1, code="auth.forbidden", status=403)
+
+        r2 = client.delete(
+            "/v1/households/me",
+            headers={
+                "Authorization": f"Bearer {access}",
+                "X-Erasure-Token": "irrelevant",
+            },
+        )
+        assert_problem(r2, code="auth.forbidden", status=403)
+
+
+class TestAttachmentDelete:
+    def test_delete_unlinks_blob_when_refcount_zero(
+        self,
+        session_maker: sessionmaker[Session],
+        settings,
+    ):
+        # Seed a household + one attachment row, then delete; the
+        # ciphertext must disappear from disk.
+        from uuid import uuid4
+
+        with session_maker() as s:
+            h = Household(id=uuid4(), name="X", base_currency="USD")
+            s.add(h)
+            s.commit()
+            repo = AttachmentRepository(
+                s,
+                h.id,
+                master_key=settings.master_key,
+                attachment_root=settings.attachment_root,
+            )
+            att = repo.create(
+                filename="t.pdf",
+                content_type="application/pdf",
+                raw_bytes=b"abc",
+            )
+            s.commit()
+            attachment_id = att.id
+            content_hash = att.content_hash
+
+        blob = settings.attachment_root / content_hash
+        assert blob.exists()
+
+        with session_maker() as s:
+            repo = AttachmentRepository(
+                s,
+                h.id,
+                master_key=settings.master_key,
+                attachment_root=settings.attachment_root,
+            )
+            ok = repo.delete(attachment_id)
+            assert ok is True
+            s.commit()
+
+        assert not blob.exists()
+
+
+class TestAttachmentGc:
+    def test_run_gc_unlinks_orphans_only(
+        self,
+        session_maker: sessionmaker[Session],
+        settings,
+        tmp_path: Path,
+    ):
+        from uuid import uuid4
+
+        from tulip_storage.runner.handlers import run_attachment_gc
+
+        attachment_root: Path = settings.attachment_root
+        attachment_root.mkdir(parents=True, exist_ok=True)
+
+        with session_maker() as s:
+            h = Household(id=uuid4(), name="X", base_currency="USD")
+            s.add(h)
+            s.commit()
+            repo = AttachmentRepository(
+                s,
+                h.id,
+                master_key=settings.master_key,
+                attachment_root=attachment_root,
+            )
+            kept = repo.create(
+                filename="kept.pdf",
+                content_type="application/pdf",
+                raw_bytes=b"kept",
+            )
+            s.commit()
+            kept_hash = kept.content_hash
+
+        # Drop a fake orphan blob with a sha256-shaped name.
+        orphan_hash = "0" * 64
+        orphan = attachment_root / orphan_hash
+        orphan.write_bytes(b"orphan")
+
+        # Files older than min_age_seconds get swept; back-date both.
+        import os
+
+        old = 1_000_000.0
+        os.utime(orphan, (old, old))
+        os.utime(attachment_root / kept_hash, (old, old))
+
+        deleted = run_attachment_gc(
+            session_maker,
+            attachment_root,
+            now_seconds=old + 7200.0,  # 2 hours later → over min_age
+            min_age_seconds=3600,
+        )
+        assert deleted == 1
+        assert not orphan.exists()
+        assert (attachment_root / kept_hash).exists()

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260513_1400_e8b5c2a9d1f4_add_pending_household_erasures.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260513_1400_e8b5c2a9d1f4_add_pending_household_erasures.py
@@ -1,0 +1,53 @@
+"""Add pending_household_erasures table.
+
+Two-step confirmation for ``DELETE /v1/households/me`` (right-to-erasure).
+See H-2 in #235.
+
+Revision ID: e8b5c2a9d1f4
+Revises: d4f7a9e1c8b3
+Create Date: 2026-05-13 14:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from tulip_storage.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision: str = "e8b5c2a9d1f4"
+down_revision: str | None = "d4f7a9e1c8b3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the pending_household_erasures table."""
+    op.create_table(
+        "pending_household_erasures",
+        sa.Column("household_id", GUID(length=36), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "requested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("requested_by_user_id", GUID(length=36), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["household_id"],
+            ["households.id"],
+            name=op.f("fk_pending_household_erasures_household_id_households"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("household_id", name=op.f("pk_pending_household_erasures")),
+    )
+
+
+def downgrade() -> None:
+    """Drop the pending_household_erasures table."""
+    op.drop_table("pending_household_erasures")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -32,6 +32,7 @@ from tulip_storage.models.notification import (
     NotificationKind,
     NotificationSeverity,
 )
+from tulip_storage.models.pending_household_erasure import PendingHouseholdErasure
 from tulip_storage.models.pending_proposal import (
     PendingProposal,
     ProposalCreatorKind,
@@ -86,6 +87,7 @@ __all__ = [
     "Notification",
     "NotificationKind",
     "NotificationSeverity",
+    "PendingHouseholdErasure",
     "PendingProposal",
     "Period",
     "PeriodStatus",

--- a/packages/tulip-storage/src/tulip_storage/models/pending_household_erasure.py
+++ b/packages/tulip-storage/src/tulip_storage/models/pending_household_erasure.py
@@ -1,0 +1,40 @@
+"""``pending_household_erasures`` — two-step household-delete confirmation.
+
+Right-to-erasure (GDPR Art. 17 / CCPA §1798.105) is destructive enough
+that we gate the actual ``DELETE /v1/households/me`` call behind a fresh
+confirmation token issued by ``POST /v1/households/me/erase-request``.
+This table stores that token. A request is valid for a short TTL (15
+minutes) — long enough to read the confirmation copy, short enough that
+a token leaked from an old browser tab can't be replayed.
+
+One row per household at most (PK ``household_id``); requesting again
+overwrites the previous token. See H-2 in #235.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class PendingHouseholdErasure(Base):
+    """One household's outstanding erasure confirmation."""
+
+    __tablename__ = "pending_household_erasures"
+
+    household_id: Mapped[UUID] = mapped_column(
+        GUID(),
+        ForeignKey("households.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    requested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    requested_by_user_id: Mapped[UUID] = mapped_column(GUID(), nullable=False)

--- a/packages/tulip-storage/src/tulip_storage/repositories/attachment.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/attachment.py
@@ -17,15 +17,18 @@ when they have one (`find_by_hash`).
 from __future__ import annotations
 
 import hashlib
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from tulip_storage.encryption import encrypt_field
 from tulip_storage.models import Attachment
+
+log = logging.getLogger("tulip_storage.repositories.attachment")
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -114,3 +117,35 @@ class AttachmentRepository:
         path = self._attachment_root / att.content_hash
         ciphertext = path.read_bytes()
         return decrypt_field(ciphertext, self._master_key)
+
+    def delete(self, attachment_id: UUID) -> bool:
+        """Delete an attachment row and unlink its ciphertext if no rows remain.
+
+        Within-household dedup means one blob on disk may back several
+        attachment rows (different filenames, same content). The blob is
+        unlinked only when the last row referencing its content_hash is
+        deleted — refcount check across the whole ``attachments`` table.
+
+        Returns True if the row existed and was deleted; False if no
+        such attachment was found in this household. Caller commits.
+        """
+        att = self.get(attachment_id)
+        if att is None:
+            return False
+        content_hash = att.content_hash
+        self._session.delete(att)
+        self._session.flush()
+        remaining = self._session.execute(
+            select(func.count())
+            .select_from(Attachment)
+            .where(Attachment.content_hash == content_hash)
+        ).scalar_one()
+        if remaining == 0:
+            blob = self._attachment_root / content_hash
+            try:
+                blob.unlink()
+            except FileNotFoundError:
+                # Already gone (concurrent GC, partial-write, manual cleanup) —
+                # not an error; the row is deleted either way.
+                log.info("attachment.blob_already_missing", extra={"content_hash": content_hash})
+        return True

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/__init__.py
@@ -11,7 +11,16 @@ fire. Future handlers (reconciliation reminders, AI cost reports) will
 register the same way.
 """
 
+from tulip_storage.runner.handlers.attachment_gc import (
+    make_attachment_gc_handler,
+    run_attachment_gc,
+)
 from tulip_storage.runner.handlers.daily_insights import make_daily_insights_handler
 from tulip_storage.runner.handlers.envelope_refill import make_envelope_refill_handler
 
-__all__ = ["make_daily_insights_handler", "make_envelope_refill_handler"]
+__all__ = [
+    "make_attachment_gc_handler",
+    "make_daily_insights_handler",
+    "make_envelope_refill_handler",
+    "run_attachment_gc",
+]

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/attachment_gc.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/attachment_gc.py
@@ -1,0 +1,117 @@
+"""``attachment_gc`` runner handler — unlink orphaned attachment ciphertext.
+
+Attachments persist their ciphertext at ``attachment_root / <content_hash>``
+and a metadata row at ``attachments.content_hash``. When the last row
+referencing a hash is deleted (e.g. via ``DELETE /v1/households/me``
+cascade, or per-attachment delete), this handler is what removes the
+file from disk.
+
+The household-erasure path triggers an immediate GC pass; this scheduled
+handler is the periodic safety net that catches any blob whose row
+disappeared without a matching unlink (manual SQL, crash mid-delete, etc.).
+
+Race-safety: a freshly written but not-yet-committed attachment file
+would be visible on disk before its row appears in the DB. To avoid
+deleting such files, the GC ignores any file whose mtime is younger
+than ``_MIN_AGE_SECONDS`` (1 hour). The endpoint-driven path doesn't
+have this window because it queries the row first; this handler is
+the lazy backstop and is intentionally conservative.
+
+See H-3 in #235.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from tulip_storage.models import Attachment
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session, sessionmaker
+
+    from tulip_storage.models import ScheduledJob
+    from tulip_storage.runner.clock import Clock
+    from tulip_storage.runner.runner import HandlerCallback
+
+log = logging.getLogger("tulip_storage.runner.attachment_gc")
+
+#: Files newer than this are skipped to avoid racing with concurrent
+#: attachment writes whose row hasn't committed yet.
+_MIN_AGE_SECONDS: int = 60 * 60
+
+
+def run_attachment_gc(
+    session_maker: sessionmaker[Session],
+    attachment_root: Path,
+    *,
+    now_seconds: float,
+    min_age_seconds: int = _MIN_AGE_SECONDS,
+) -> int:
+    """Walk ``attachment_root`` and unlink files not referenced by any row.
+
+    Pure-ish helper for tests: takes ``now_seconds`` explicitly so a test
+    can simulate "old" files without sleeping. Returns the count of
+    files deleted.
+    """
+    if not attachment_root.exists():
+        return 0
+
+    with session_maker() as session:
+        referenced = {
+            row[0] for row in session.execute(select(Attachment.content_hash).distinct()).all()
+        }
+
+    deleted = 0
+    for path in attachment_root.iterdir():
+        if not path.is_file():
+            continue
+        # Filenames are SHA-256 hex (64 chars); anything else is foreign.
+        if len(path.name) != 64:
+            continue
+        if path.name in referenced:
+            continue
+        try:
+            age = now_seconds - path.stat().st_mtime
+        except FileNotFoundError:
+            continue
+        if age < min_age_seconds:
+            continue
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
+        deleted += 1
+        log.info("attachment_gc.unlinked", extra={"content_hash": path.name})
+
+    if deleted:
+        log.info("attachment_gc.summary", extra={"deleted": deleted})
+    return deleted
+
+
+def make_attachment_gc_handler(
+    session_maker: sessionmaker[Session],
+    attachment_root: Path,
+) -> HandlerCallback:
+    """Build the ``attachment_gc`` handler bound to a session factory + root.
+
+    Register at runner construction time alongside the other handlers::
+
+        runner.register_handler(
+            "attachment_gc",
+            make_attachment_gc_handler(session_maker, settings.attachment_root),
+        )
+    """
+    import time
+
+    async def handle(job: ScheduledJob, clock: Clock) -> None:
+        run_attachment_gc(
+            session_maker,
+            attachment_root,
+            now_seconds=time.time(),
+        )
+
+    return handle

--- a/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
@@ -75,6 +75,15 @@ _ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
         # Reconciliation summary report (P7.1) reads the model for
         # display; never writes. Same justification as csv_profiles.py.
         "tulip-reports/src/tulip_reports/reports/reconciliation_summary.py",
+        # Attachment GC handler (#235) reads Attachment.content_hash to
+        # decide which files on disk are orphaned. It never writes the
+        # row — the unlink is on disk only; row writes still go through
+        # AttachmentRepository.
+        "tulip-storage/src/tulip_storage/runner/handlers/attachment_gc.py",
+        # Household-erasure endpoint (#235) reads Attachment.content_hash
+        # before the cascade delete to know which blobs to unlink from
+        # disk afterward. Same read-only justification.
+        "tulip-api/src/tulip_api/routers/households.py",
     }
 )
 

--- a/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
@@ -44,6 +44,7 @@ _ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
         # runner; the type-only import is required for typing.
         "tulip-storage/src/tulip_storage/runner/handlers/envelope_refill.py",
         "tulip-storage/src/tulip_storage/runner/handlers/daily_insights.py",
+        "tulip-storage/src/tulip_storage/runner/handlers/attachment_gc.py",
         # Read-only repository for the API to query schedules. Writes
         # still go through the Runner (the architecture test's actual
         # invariant). The class doesn't construct or mutate ScheduledJob


### PR DESCRIPTION
## Summary

GDPR Art. 17 / CCPA §1798.105 right-to-erasure had **no application path** today: every household-scoped model declared ``ondelete=\"CASCADE\"`` so the schema was ready, but there was no API to invoke it and no path to unlink the encrypted attachment ciphertext from disk.

### Endpoints

- ``DELETE /v1/users/{user_id}`` — admin-only; refuses to delete the last admin; writes a structural-only tombstone audit row; redacts ``before_snapshot``, ``after_snapshot``, and ``metadata`` JSON blobs in every historic ``audit_log`` row that named the deleted user (either as actor or as the entity acted on). The pseudonymous UUID stays in ``actor_user_id`` / ``entity_id`` under Art. 17(3)(e).
- ``POST /v1/households/me/erase-request`` — admin issues a fresh confirmation token (returned exactly once; stored SHA-256). 15-minute TTL.
- ``DELETE /v1/households/me`` — admin submits the token in ``X-Erasure-Token``; on match, the household row is deleted (cascade clears every child table), then orphan attachment ciphertext files are unlinked from disk.

### Attachment GC

- ``AttachmentRepository.delete(attachment_id)`` deletes the row and unlinks the blob when its refcount drops to zero (within-household dedup means one blob can back multiple rows).
- New ``attachment_gc`` scheduler handler walks ``attachment_root`` and unlinks files whose hash no longer appears in ``attachments``. Conservative ``min_age_seconds=3600`` threshold avoids racing with concurrent uploads whose row hasn't committed yet.

### Schema

- New ``pending_household_erasures`` table — one-row-per-household outstanding confirmation token + ``expires_at``. Migration ``e8b5c2a9d1f4``.

### Three new typed errors

- ``user.not_found`` (404)
- ``user.last_admin`` (409)
- ``household.erasure_not_requested`` (409)
- ``household.erasure_token_invalid`` (401)

## Test plan

- [x] ` uv run pytest packages ` → 1588 passed, 1 skipped, 3 deselected
- [x] ` just lint ` → All checks passed
- [x] ` just typecheck ` → Success
- [x] ``TestDeleteUser`` covers happy path, last-admin guard, two-admin case, audit redaction, role-forbidden
- [x] ``TestEraseHousehold`` covers full two-step flow with attachment unlink, no-token / wrong-token / member-forbidden paths
- [x] ``TestAttachmentDelete`` proves repo-level refcount + blob unlink
- [x] ``TestAttachmentGc`` proves the periodic sweep deletes orphans and keeps referenced files
- [x] Two architecture allowlists updated to reflect the new read-only ``Attachment`` consumers
- [ ] CI green on this PR