### PR TITLE
fix: document 400 response on /v1/ai/proposals/{id}/reject (closes #194)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/proposals.py
+++ b/packages/tulip-api/src/tulip_api/routers/proposals.py
@@ -227,6 +227,7 @@ async def approve_proposal(
     "/{proposal_id}/reject",
     response_model=ProposalRead,
     responses={
+        400: problem_response("request.body_invalid"),
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
         404: problem_response("proposal.not_found"),


### PR DESCRIPTION
## Summary
Documentation-only fix — the endpoint already returns 400 when the body is malformed, but the OpenAPI responses block didn't declare it. Adds the `request.body_invalid` problem entry to match the sibling endpoints.

## Test plan
- [x] `just lint` + `just typecheck`
- [x] OpenAPI contract test green
- [x] CI green on this PR