### PR TITLE
fix: QIF importer preserves split postings (closes #270)

### DIFF
--- a/packages/tulip-importers/src/tulip_importers/qif/parser.py
+++ b/packages/tulip-importers/src/tulip_importers/qif/parser.py
@@ -9,10 +9,13 @@ supplies the account's currency since the file itself doesn't carry one.
 Field-code mapping (per ADR §Q8):
 
 - ``D`` → ``posted_date`` (multiple date formats supported; see below).
-- ``T`` → ``amount.amount``.
+- ``T`` → ``amount.amount`` (or, when splits are present, the total
+  the per-split amounts must sum to).
 - ``P`` → ``counterparty`` (and folded into ``description``).
 - ``M`` → ``description`` (concatenated with ``P``).
 - ``N`` → ``reference`` (check number).
+- ``S`` / ``$`` / ``E`` → split-category / split-amount / split-memo
+  triple (see "Split records" below).
 - ``^`` → record separator.
 
 Date parsing handles three common dialects:
@@ -21,6 +24,29 @@ Date parsing handles three common dialects:
 - US 4-digit: ``5/12/2026``.
 - US 2-digit: ``5/12/26`` (rolls to 20YY — no QIF-emitting bank issues
   19xx files in 2026+).
+
+Split records (#270)
+--------------------
+
+Banktivity and most legacy desktop apps (Quicken, Moneydance, …) encode
+a multi-category transaction as one record carrying:
+
+- One ``T<total>`` line (the net amount that hit the bank account).
+- N ``S<category>`` / ``$<amount>`` / ``E<memo>`` triples — one per
+  category. The ``$``-amounts must sum to ``T``.
+
+We emit **one ``ParsedStatementLine`` per split** rather than one line
+with the consolidated total. Each split inherits the parent record's
+date, payee, and reference; ``raw["L"]`` carries the split category for
+the categorizer; the per-split ``E`` memo is folded into ``description``
+so operator-facing renders surface the split's own purpose, not the
+parent record's generic memo. Splits whose amounts don't sum to ``T``
+are rejected with :class:`QifParseError` — silently dropping or
+rebalancing would lose money in either direction.
+
+A non-split record (no ``S``/``$`` lines) still emits exactly one
+``ParsedStatementLine``, preserving the existing two-posting promotion
+shape.
 
 Errors raise :class:`QifParseError` with the failing line number for
 debuggability — banks ship malformed QIF often and operators need to
@@ -55,6 +81,18 @@ class QifParseError(Exception):
 
 
 @dataclass(slots=True)
+class _Split:
+    """One ``S`` / ``$`` / ``E`` triple inside a split QIF record."""
+
+    #: Source-file line of the ``S`` line that opened this split — used in
+    #: error messages so operators can locate a malformed split row.
+    opened_at: int
+    category: str
+    amount_str: str | None = None
+    memo: str | None = None
+
+
+@dataclass(slots=True)
 class _RecordBuilder:
     """Mutable accumulator for a single QIF record (between two ``^`` lines)."""
 
@@ -65,9 +103,21 @@ class _RecordBuilder:
     amount_str: str | None = None
     date_str: str | None = None
     reference: str | None = None
+    splits: list[_Split] = field(default_factory=list)
+    #: Buffer for an ``E`` line that arrived *before* its ``S`` line.
+    #: Banktivity emits the split memo before the split category; the
+    #: next ``S`` claims this and clears it. None when no pending memo.
+    pending_split_memo: str | None = None
 
     def has_any_field(self) -> bool:
-        return bool(self.amount_str or self.date_str or self.payee or self.memo or self.reference)
+        return bool(
+            self.amount_str
+            or self.date_str
+            or self.payee
+            or self.memo
+            or self.reference
+            or self.splits
+        )
 
 
 def _parse_date(value: str, *, source_line: int) -> date_type:
@@ -110,37 +160,139 @@ def _parse_amount(value: str, *, source_line: int) -> Decimal:
         ) from exc
 
 
+def _compose_description(payee: str | None, memo: str | None) -> str:
+    """Join the record-level payee + memo into a single description string.
+
+    Mirrors the OFX-importer convention so the matcher's counterparty
+    heuristic sees the same shape across formats.
+    """
+    parts = [(payee or "").strip(), (memo or "").strip()]
+    return " ".join(p for p in parts if p) or "<no description>"
+
+
+def _finalize_split_record(
+    rec: _RecordBuilder,
+    *,
+    start_line_number: int,
+    currency: str,
+    account_type: str | None,
+    posted_date: date_type,
+    total: Decimal,
+) -> list[ParsedStatementLine]:
+    """Expand a split record into one ParsedStatementLine per S/$/E triple.
+
+    Each split inherits the parent's date, payee, and reference. The
+    split's category lives in ``raw["L"]`` (where downstream's
+    categorizer already looks for category hints); the split memo is
+    folded into the per-line description so operator-facing renders
+    surface the split's own purpose.
+
+    Raises:
+        QifParseError: a split is missing its ``$`` amount, or the
+            per-split amounts don't sum to the parent ``T`` total.
+
+    """
+    base_raw = dict(rec.raw)
+    if account_type:
+        base_raw["TYPE"] = account_type
+    # Strip the running ``$``/``S``/``E`` last-write-wins residue from the
+    # parent ``raw`` — each emitted line carries its own per-split values
+    # via the loop below, so leaving the parent's noise would confuse
+    # downstream consumers reading ``raw``.
+    for stale in ("$", "S", "E"):
+        base_raw.pop(stale, None)
+
+    out: list[ParsedStatementLine] = []
+    running = Decimal("0")
+    for idx, split in enumerate(rec.splits, start=0):
+        if split.amount_str is None:
+            raise QifParseError(
+                f"line {split.opened_at}: split for category {split.category!r} "
+                "is missing its $ amount line"
+            )
+        split_amount = _parse_amount(split.amount_str, source_line=split.opened_at)
+        running += split_amount
+
+        split_raw = dict(base_raw)
+        # ``L`` is the conventional QIF category field on a non-split
+        # record; reusing it here means the categorizer doesn't need a
+        # split-aware code path to read the per-split category.
+        split_raw["L"] = split.category
+        if split.memo is not None:
+            split_raw["E"] = split.memo
+
+        description = _compose_description(
+            rec.payee,
+            split.memo if split.memo is not None else rec.memo,
+        )
+
+        out.append(
+            ParsedStatementLine(
+                line_number=start_line_number + idx,
+                posted_date=posted_date,
+                amount=Money(split_amount, currency),
+                description=description,
+                counterparty=(rec.payee or None) if rec.payee else None,
+                reference=rec.reference,
+                raw=split_raw,
+            )
+        )
+
+    if running != total:
+        raise QifParseError(
+            f"line {rec.line_number}: split amounts sum to {running} "
+            f"but record total T is {total}; refusing to import a row whose "
+            "splits don't reconcile (one or more $ lines were dropped, or "
+            "the file was hand-edited)"
+        )
+    return out
+
+
 def _finalize_record(
     rec: _RecordBuilder,
     *,
-    line_number: int,
+    start_line_number: int,
     currency: str,
     account_type: str | None,
-) -> ParsedStatementLine:
-    """Convert an accumulated record into a ParsedStatementLine."""
+) -> list[ParsedStatementLine]:
+    """Convert an accumulated record into one or more ParsedStatementLine objects.
+
+    A non-split record yields one statement line (the historical shape).
+    A split record (one or more ``S`` / ``$`` triples) yields one
+    statement line per split — see ``_finalize_split_record``.
+    """
     if not rec.amount_str:
         raise QifParseError(f"line {rec.line_number}: record is missing amount (T) field")
     if not rec.date_str:
         raise QifParseError(f"line {rec.line_number}: record is missing date (D) field")
     posted_date = _parse_date(rec.date_str, source_line=rec.line_number)
-    amount = _parse_amount(rec.amount_str, source_line=rec.line_number)
+    total = _parse_amount(rec.amount_str, source_line=rec.line_number)
 
-    parts = [(rec.payee or "").strip(), (rec.memo or "").strip()]
-    description = " ".join(p for p in parts if p) or "<no description>"
+    if rec.splits:
+        return _finalize_split_record(
+            rec,
+            start_line_number=start_line_number,
+            currency=currency,
+            account_type=account_type,
+            posted_date=posted_date,
+            total=total,
+        )
 
     raw = dict(rec.raw)
     if account_type:
         raw["TYPE"] = account_type
 
-    return ParsedStatementLine(
-        line_number=line_number,
-        posted_date=posted_date,
-        amount=Money(amount, currency),
-        description=description,
-        counterparty=(rec.payee or None) if rec.payee else None,
-        reference=rec.reference,
-        raw=raw,
-    )
+    return [
+        ParsedStatementLine(
+            line_number=start_line_number,
+            posted_date=posted_date,
+            amount=Money(total, currency),
+            description=_compose_description(rec.payee, rec.memo),
+            counterparty=(rec.payee or None) if rec.payee else None,
+            reference=rec.reference,
+            raw=raw,
+        )
+    ]
 
 
 def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
@@ -152,13 +304,16 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
             its own currency; the API supplies the account's.
 
     Returns:
-        One :class:`ParsedStatementLine` per record. Empty list when the
-        QIF has a header but no transactions.
+        One :class:`ParsedStatementLine` per record, or N lines per
+        N-split record (see module docstring "Split records"). Empty
+        list when the QIF has a header but no transactions.
 
     Raises:
-        QifParseError: bytes are empty, malformed, or contain a record
-            missing its mandatory date / amount field. Errors carry the
-            source-line number to help operators locate the bad row.
+        QifParseError: bytes are empty, malformed, contain a record
+            missing its mandatory date / amount field, or contain a
+            split record whose ``$`` amounts don't sum to its ``T``
+            total. Errors carry the source-line number to help
+            operators locate the bad row.
 
     """
     if not file_bytes:
@@ -199,15 +354,14 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
                 # Stray ^ between records; ignore silently.
                 rec = None
                 continue
-            record_no += 1
-            out.append(
-                _finalize_record(
-                    rec,
-                    line_number=record_no,
-                    currency=currency,
-                    account_type=account_type,
-                )
+            finalized = _finalize_record(
+                rec,
+                start_line_number=record_no + 1,
+                currency=currency,
+                account_type=account_type,
             )
+            out.extend(finalized)
+            record_no += len(finalized)
             rec = None
             continue
 
@@ -216,33 +370,78 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
             rec = _RecordBuilder(line_number=source_line_number)
         code = line[0]
         value = line[1:]
-        rec.raw[code] = value
-        if code == "D":
+        # Split fields (S/$/E) are accumulated into rec.splits rather than
+        # the parent ``raw`` dict — last-write-wins on a single ``raw[code]``
+        # would silently drop all but the final split's category / amount /
+        # memo. See #270.
+        if code == "S":
+            # Opens a new split. Banktivity emits ``E<memo>`` immediately
+            # *before* the ``S<category>`` for that split; if a memo is
+            # pending we claim it here. Standalone ``S`` lines (no memo)
+            # also work — the split just lands with memo=None.
+            split = _Split(
+                opened_at=source_line_number,
+                category=value,
+                memo=rec.pending_split_memo,
+            )
+            rec.pending_split_memo = None
+            rec.splits.append(split)
+        elif code == "$":
+            if not rec.splits:
+                raise QifParseError(
+                    f"line {source_line_number}: $ split-amount line appeared "
+                    "before any S split-category line"
+                )
+            rec.splits[-1].amount_str = value
+        elif code == "E":
+            # ``E`` is the split memo. Banktivity emits it *before* its
+            # ``S<category>`` partner; we buffer it on the record and the
+            # next ``S`` claims it. (Quicken's older "E after S" order is
+            # supported too — see below for that compat branch.) For
+            # non-split records the buffered memo is harmless: nothing
+            # downstream reads ``pending_split_memo`` once finalize runs.
+            if rec.splits and rec.splits[-1].memo is None and rec.pending_split_memo is None:
+                # "E after S" compat path: a freshly-opened split with no
+                # memo and no pending buffer — attach directly.
+                rec.splits[-1].memo = value
+            else:
+                rec.pending_split_memo = value
+            # Keep the last-seen ``E`` in ``raw`` for backward compat with
+            # any consumer that reads ``raw["E"]`` from a non-split record.
+            rec.raw[code] = value
+        elif code == "D":
             saw_qif_marker = True
             rec.date_str = value
+            rec.raw[code] = value
         elif code == "T":
             saw_qif_marker = True
             rec.amount_str = value
+            rec.raw[code] = value
         elif code == "P":
             rec.payee = value
+            rec.raw[code] = value
         elif code == "M":
             rec.memo = value
+            rec.raw[code] = value
         elif code == "N":
             rec.reference = value.strip() or None
-        # Other codes (C cleared status, A address, etc.) are stashed in `raw`
-        # but don't drive ParsedStatementLine fields directly.
+            rec.raw[code] = value
+        else:
+            # Other codes (C cleared status, A address, L category, etc.)
+            # are stashed in `raw` but don't drive ParsedStatementLine
+            # fields directly.
+            rec.raw[code] = value
 
     # Trailing record without `^` (rare but legal in some emitters): finalize.
     if rec is not None and rec.has_any_field():
-        record_no += 1
-        out.append(
-            _finalize_record(
-                rec,
-                line_number=record_no,
-                currency=currency,
-                account_type=account_type,
-            )
+        finalized = _finalize_record(
+            rec,
+            start_line_number=record_no + 1,
+            currency=currency,
+            account_type=account_type,
         )
+        out.extend(finalized)
+        record_no += len(finalized)
 
     if not saw_anything:
         raise QifParseError("qif file contained no recognizable content")

--- a/packages/tulip-importers/tests/fixtures/qif/split_gas_bill.qif
+++ b/packages/tulip-importers/tests/fixtures/qif/split_gas_bill.qif
@@ -1,0 +1,13 @@
+!Type:Bank
+D1/2/26
+T-58.99
+CC
+PCenterPoint Energy
+MNet gas bill due
+ECurrent gas charges
+SNeeds:Utilities:Natural Gas/TulipDrive
+$-45.27
+ECurrent home service charges
+SNeeds:Insurance:Home Warranty/TulipDrive
+$-13.72
+^

--- a/packages/tulip-importers/tests/fixtures/qif/split_paycheck.qif
+++ b/packages/tulip-importers/tests/fixtures/qif/split_paycheck.qif
@@ -1,0 +1,19 @@
+!Type:Bank
+D1/15/26
+T2814.50
+CC
+PBNSF Railway
+MGross paycheck Jan 15
+EGross wages
+SIncome:Wages/BNSF
+$3500.00
+EFederal income tax
+SExpenses:Taxes:Federal/BNSF
+$-420.00
+EState income tax
+SExpenses:Taxes:State/BNSF
+$-150.00
+EFICA / Medicare
+SExpenses:Taxes:FICA/BNSF
+$-115.50
+^

--- a/packages/tulip-importers/tests/fixtures/qif/split_sum_mismatch.qif
+++ b/packages/tulip-importers/tests/fixtures/qif/split_sum_mismatch.qif
@@ -1,0 +1,10 @@
+!Type:Bank
+D1/2/26
+T-58.99
+PCenterPoint Energy
+MNet gas bill due
+SNeeds:Utilities:Natural Gas/TulipDrive
+$-45.27
+SNeeds:Insurance:Home Warranty/TulipDrive
+$-10.00
+^

--- a/packages/tulip-importers/tests/test_qif_parser.py
+++ b/packages/tulip-importers/tests/test_qif_parser.py
@@ -72,6 +72,105 @@ class TestParseHappy:
         assert lines[0].amount.amount == Decimal("-42.17")
 
 
+class TestParseSplits:
+    """Per #270: each S/$/E triple emits its own ParsedStatementLine.
+
+    QIF encodes a multi-category transaction as a single record with
+    ``S`` (split category), ``$`` (split amount), and ``E`` (split memo)
+    field-triples. Banktivity's gas-bill export from the issue body is
+    the canonical 2-split debit case; the BNSF paycheck shape is the
+    multi-split credit case (a positive gross + negative withholdings
+    netting to the deposited total).
+
+    We model splits as N statement lines — one per split — rather than
+    one transaction with N+1 postings because ``ParsedStatementLine`` is
+    the parser surface and downstream (``import_apply``) already turns
+    each statement line into a 2-posting PENDING transaction. This
+    preserves per-category fidelity (the issue's headline requirement)
+    without a schema change across packages.
+    """
+
+    def test_split_gas_bill_two_lines(self):
+        # The exact snippet from #270: -45.27 + -13.72 = -58.99.
+        lines = parse(_read("split_gas_bill.qif"), currency="USD")
+        assert len(lines) == 2
+
+        gas, warranty = lines
+        # Per-split amounts replace the consolidated T-total.
+        assert gas.amount.amount == Decimal("-45.27")
+        assert warranty.amount.amount == Decimal("-13.72")
+        # Sum reconciles to the row's T-total (cross-check, not asserted
+        # by the parser at the file level — but it must, per #270).
+        assert gas.amount.amount + warranty.amount.amount == Decimal("-58.99")
+
+    def test_split_gas_bill_carries_per_split_category_and_memo(self):
+        lines = parse(_read("split_gas_bill.qif"), currency="USD")
+        gas, warranty = lines
+
+        # QIF S-field (split category) lives in raw["L"] (categorizer's
+        # input). Per-split memo lives in raw["E"] and is folded into
+        # description so the operator-facing renderer surfaces it.
+        assert gas.raw["L"] == "Needs:Utilities:Natural Gas/TulipDrive"
+        assert warranty.raw["L"] == "Needs:Insurance:Home Warranty/TulipDrive"
+        assert "Current gas charges" in gas.description
+        assert "Current home service charges" in warranty.description
+
+    def test_split_gas_bill_shares_payee_and_date(self):
+        lines = parse(_read("split_gas_bill.qif"), currency="USD")
+        gas, warranty = lines
+
+        # All splits share the parent record's date + payee — they're
+        # the same bank transaction split across categories.
+        assert gas.posted_date == date(2026, 1, 2)
+        assert warranty.posted_date == date(2026, 1, 2)
+        assert gas.counterparty == "CenterPoint Energy"
+        assert warranty.counterparty == "CenterPoint Energy"
+        # Each split gets its own 1-based line_number so downstream
+        # idempotency (UNIQUE (batch_id, line_number)) still holds.
+        assert gas.line_number == 1
+        assert warranty.line_number == 2
+
+    def test_split_paycheck_emits_one_line_per_split(self):
+        # BNSF gross-paycheck shape: +3500 wages, -420 fed, -150 state,
+        # -115.50 FICA, netting to +2814.50 deposited.
+        lines = parse(_read("split_paycheck.qif"), currency="USD")
+        assert len(lines) == 4
+
+        amounts = [line.amount.amount for line in lines]
+        assert amounts == [
+            Decimal("3500.00"),
+            Decimal("-420.00"),
+            Decimal("-150.00"),
+            Decimal("-115.50"),
+        ]
+        assert sum(amounts) == Decimal("2814.50")
+
+        # Per-split category survives parsing.
+        categories = [line.raw["L"] for line in lines]
+        assert categories == [
+            "Income:Wages/BNSF",
+            "Expenses:Taxes:Federal/BNSF",
+            "Expenses:Taxes:State/BNSF",
+            "Expenses:Taxes:FICA/BNSF",
+        ]
+
+    def test_split_sum_mismatch_raises(self):
+        # Per #270: "If split amounts don't sum to T, the row is
+        # rejected with an import error rather than silently dropped."
+        with pytest.raises(QifParseError, match="split"):
+            parse(_read("split_sum_mismatch.qif"), currency="USD")
+
+    def test_single_line_unsplit_still_one_statement_line(self):
+        # Regression: non-split QIF entries continue to produce exactly
+        # one ParsedStatementLine (which downstream turns into a
+        # two-posting transaction, per #270's regression requirement).
+        lines = parse(_read("minimal.qif"), currency="USD")
+        assert len(lines) == 3  # three records, no splits, three lines.
+        for line in lines:
+            # Non-split lines carry no S-field; raw["L"] is absent.
+            assert "L" not in line.raw
+
+
 class TestParseErrors:
     def test_empty_bytes_raises(self):
         with pytest.raises(QifParseError):


### PR DESCRIPTION
## Summary

- Banktivity-exported QIF with ``S``/``$``/``E`` split triples was lossy: the parser ignored split fields and emitted a single ``ParsedStatementLine`` with the consolidated ``T``-total, so a 2-split gas bill (or the BNSF gross-paycheck row) promoted to a 2-posting transaction with one bucket-category leg instead of preserving each split.
- Parser now emits one ``ParsedStatementLine`` per ``S``/``$``/``E`` triple. Each split inherits the parent record's date, payee, and reference; ``raw["L"]`` carries the split category for the categorizer (matching the existing non-split convention); the per-split memo is folded into the line's description so operator-facing renders surface the split's purpose.
- Splits that don't sum to ``T`` raise ``QifParseError`` rather than getting silently dropped or rebalanced — per the issue's acceptance criterion (losing money in either direction is worse than failing the import).
- Non-split records (no ``S``/``$``) are unchanged: one record → one statement line → the existing 2-posting promotion shape. Regression-tested.
- New fixtures: ``split_gas_bill.qif`` (the exact snippet from #270 — ``-45.27 + -13.72 = -58.99``), ``split_paycheck.qif`` (BNSF-shaped 4-split: ``+3500 wages, -420 fed, -150 state, -115.50 FICA`` → ``+2814.50`` net), and ``split_sum_mismatch.qif`` (rejects with a clear error).

## Test plan

- [x] ``uv run --package tulip-importers pytest packages/tulip-importers/tests`` — 56 passed (18 in ``test_qif_parser.py``, the new ``TestParseSplits`` class adds 6).
- [x] ``uv run pytest packages`` — 1622 passed, 1 skipped (pre-existing OpenAPI path-collision skip), 3 deselected.
- [x] ``just lint`` — clean.
- [x] ``just typecheck`` — ``Success: no issues found in 240 source files``.
- [ ] CI green on this PR.