### PR TITLE
feat: tulip imports apply --posted (closes #210)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -397,15 +397,30 @@ async def apply_import(
             "migrations from another accounting tool."
         ),
     ),
+    as_posted: bool = Query(
+        default=False,
+        description=(
+            "Issue #210: if true, each promoted line lands as POSTED "
+            "(committed-but-unreconciled) instead of the default PENDING "
+            "(review queue). Useful for migration workflows from other "
+            "accounting tools where every imported line is already "
+            "cleared by the bank. The double-entry balance invariant "
+            "still holds — bank-side + categorizer-side postings sum "
+            "to zero per currency."
+        ),
+    ),
     claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> ImportBatchApplyResponse:
-    """Promote every non-excluded line in the batch to a PENDING ledger tx.
+    """Promote every non-excluded line in the batch to a ledger transaction.
 
-    Per ADR-0004 §Q4. Idempotent at the batch level: re-applying an
-    already-applied batch returns ``import.already_applied`` (409). To
-    promote a specific line individually, see
-    ``POST /v1/imports/{batch_id}/lines/{line_id}/promote``.
+    Per ADR-0004 §Q4. The new transactions are PENDING by default; pass
+    ``?as_posted=true`` (issue #210) to land them as POSTED for direct
+    migration workflows.
+
+    Idempotent at the batch level: re-applying an already-applied batch
+    returns ``import.already_applied`` (409). To promote a specific line
+    individually, see ``POST /v1/imports/{batch_id}/lines/{line_id}/promote``.
     """
     batch_repo = ImportBatchRepository(session, claims.household_id)
     batch = batch_repo.get(batch_id)
@@ -420,6 +435,7 @@ async def apply_import(
             categorizer=get_categorizer(),
             actor_user_id=claims.user_id,
             no_categorize=no_categorize,
+            as_posted=as_posted,
         )
     except BatchAlreadyAppliedError as exc:
         raise ImportAlreadyAppliedError(batch_id=str(batch_id)) from exc
@@ -436,6 +452,8 @@ async def apply_import(
             "created_count": result.created_count,
             "skipped_count": result.skipped_count,
             "transaction_ids": [str(t) for t in result.transaction_ids],
+            "no_categorize": no_categorize,
+            "as_posted": as_posted,
         },
         request_id=_request_uuid(request),
     )

--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -154,14 +154,23 @@ async def promote_statement_line(
     categorizer: Categorizer,
     actor_user_id: UUID | None,
     no_categorize: bool = False,
+    as_posted: bool = False,
 ) -> Transaction:
-    """Promote one statement line into a PENDING ledger Transaction.
+    """Promote one statement line into a ledger Transaction.
 
     ``no_categorize=True`` skips the categorizer entirely and routes the
     other-side posting to the household's ``Imbalance:Unknown`` account
     for the bank account's currency (auto-created on first use). Used
     for bulk migrations from other accounting tools where the user
     wants to assign categories manually after import.
+
+    ``as_posted=True`` lands the new transaction as ``POSTED`` instead
+    of the default ``PENDING`` (issue #210). The bank-side + other-side
+    postings already sum to zero per currency, so the POSTED balance
+    invariant holds. Useful for bulk migrations where every imported
+    line is already cleared by the source bank/tool; the user can fix
+    categorization later via ``tulip transactions edit`` (which
+    transparently void+recreates POSTED transactions).
 
     Raises:
         LineExcludedError: ``line.is_excluded`` is True (caller should
@@ -208,6 +217,7 @@ async def promote_statement_line(
 
     bank_amount = Money(line.amount, line.currency)
     other_amount = Money(-line.amount, line.currency)
+    tx_status = DomainTxStatus.POSTED if as_posted else DomainTxStatus.PENDING
     domain_tx = DomainTransaction(
         id=uuid4(),
         household_id=household_id,
@@ -217,7 +227,7 @@ async def promote_statement_line(
             DomainPosting(id=uuid4(), account_id=bank_account.id, amount=bank_amount),
             DomainPosting(id=uuid4(), account_id=other_account.id, amount=other_amount),
         ),
-        status=DomainTxStatus.PENDING,
+        status=tx_status,
         created_by_user_id=actor_user_id,
     )
     tx = TransactionRepository(session, household_id).save_balanced(
@@ -235,12 +245,18 @@ async def apply_batch(
     categorizer: Categorizer,
     actor_user_id: UUID | None,
     no_categorize: bool = False,
+    as_posted: bool = False,
 ) -> ApplyResult:
     """Promote every applicable line in ``batch``, then mark batch APPLIED.
 
     "Applicable" = not excluded and not already promoted. Excluded and
     already-promoted lines are silently skipped (counted in
     ``skipped_count``).
+
+    ``as_posted=True`` (issue #210) lands every promoted line as
+    ``POSTED`` instead of the default ``PENDING`` — bypassing the
+    review step for migration workflows where the imported lines are
+    already cleared by the source bank/tool.
 
     Idempotency is at the batch level: a batch in ``APPLIED`` state
     cannot be re-applied (raises). The caller can re-promote individual
@@ -274,6 +290,7 @@ async def apply_batch(
             categorizer=categorizer,
             actor_user_id=actor_user_id,
             no_categorize=no_categorize,
+            as_posted=as_posted,
         )
         transaction_ids.append(tx.id)
 

--- a/packages/tulip-api/tests/services/test_import_apply.py
+++ b/packages/tulip-api/tests/services/test_import_apply.py
@@ -325,6 +325,48 @@ class TestPromoteStatementLine:
             other_ids = {p.account_id for p in postings} - {setup["cash_id"]}
             assert other_ids == {other_account.id}
 
+    @pytest.mark.asyncio
+    async def test_as_posted_creates_posted_transaction(self, session_maker, setup):
+        """Issue #210: ``as_posted=True`` flips the new tx to POSTED instead of PENDING.
+
+        The two postings (bank-side + categorizer/imbalance-side) already
+        sum to zero per currency, so the POSTED balance invariant holds.
+        """
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+                as_posted=True,
+            )
+            s.commit()
+            assert tx.status == TransactionStatus.POSTED
+            # Postings still balance.
+            postings = s.query(Posting).filter_by(transaction_id=tx.id).all()
+            assert sum(p.amount for p in postings) == Decimal("0")
+
+    @pytest.mark.asyncio
+    async def test_default_is_pending(self, session_maker, setup):
+        """Default behavior (no ``as_posted``) preserves the existing PENDING contract."""
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], setup["line_ids"][0])
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            assert tx.status == TransactionStatus.PENDING
+
 
 # ---- apply_batch ----------------------------------------------------------
 
@@ -415,6 +457,45 @@ class TestApplyBatch:
                     categorizer=NullCategorizer(),
                     actor_user_id=None,
                 )
+
+    @pytest.mark.asyncio
+    async def test_as_posted_creates_all_posted_transactions(self, session_maker, setup):
+        """Issue #210: ``as_posted=True`` on apply_batch lands every line as POSTED."""
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            result = await apply_batch(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+                as_posted=True,
+            )
+            s.commit()
+            assert result.created_count == 3
+            from tulip_storage.models import Transaction
+
+            txs = s.query(Transaction).filter(Transaction.id.in_(result.transaction_ids)).all()
+            assert len(txs) == 3
+            assert {tx.status for tx in txs} == {TransactionStatus.POSTED}
+
+    @pytest.mark.asyncio
+    async def test_default_apply_batch_creates_pending(self, session_maker, setup):
+        """Default ``apply_batch`` (no flag) still produces PENDING transactions."""
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            result = await apply_batch(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            from tulip_storage.models import Transaction
+
+            txs = s.query(Transaction).filter(Transaction.id.in_(result.transaction_ids)).all()
+            assert {tx.status for tx in txs} == {TransactionStatus.PENDING}
 
     @pytest.mark.asyncio
     async def test_all_lines_excluded_is_no_op_but_flips_status(self, session_maker, setup):

--- a/packages/tulip-api/tests/test_apply_promote_endpoints.py
+++ b/packages/tulip-api/tests/test_apply_promote_endpoints.py
@@ -109,6 +109,98 @@ class TestApplyImportHappyPath:
         codes = {a.get("code") for a in accounts}
         assert "9999.USD" in codes
 
+    def test_apply_as_posted_creates_posted_transactions(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        """Issue #210: ``?as_posted=true&no_categorize=true`` lands every line as POSTED.
+
+        Combined with ``no_categorize=true`` for hermeticity — without a
+        seeded chart-of-accounts the categorizer would 409 first.
+        """
+        r = client.post(
+            f"/v1/imports/{parsed_batch}/apply?as_posted=true&no_categorize=true",
+            headers=auth_h,
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["created_count"] == 2
+        # Every returned transaction is POSTED.
+        for tx_id in body["transaction_ids"]:
+            tx_resp = client.get(f"/v1/transactions/{tx_id}", headers=auth_h)
+            assert tx_resp.status_code == 200, tx_resp.text
+            assert tx_resp.json()["status"] == "posted"
+
+    def test_apply_default_creates_pending_transactions(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        """Issue #210: without ``?as_posted``, transactions are PENDING (unchanged default)."""
+        r = client.post(
+            f"/v1/imports/{parsed_batch}/apply?no_categorize=true",
+            headers=auth_h,
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        for tx_id in body["transaction_ids"]:
+            tx_resp = client.get(f"/v1/transactions/{tx_id}", headers=auth_h)
+            assert tx_resp.status_code == 200, tx_resp.text
+            assert tx_resp.json()["status"] == "pending"
+
+    def test_apply_as_posted_audit_log_records_status(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        parsed_batch: str,
+        session_maker,
+    ):
+        """Issue #210: the import_apply audit row records ``as_posted`` so a
+        forensic audit can tell whether the batch was reviewed or auto-posted.
+        """
+        r = client.post(
+            f"/v1/imports/{parsed_batch}/apply?as_posted=true&no_categorize=true",
+            headers=auth_h,
+        )
+        assert r.status_code == 200, r.text
+
+        from tulip_storage.models import AuditLog
+
+        with session_maker() as s:
+            row = (
+                s.query(AuditLog)
+                .filter(AuditLog.action == "import_apply")
+                .order_by(AuditLog.occurred_at.desc())
+                .first()
+            )
+            assert row is not None, "expected an import_apply audit row"
+            assert row.after_snapshot is not None
+            assert row.after_snapshot.get("as_posted") is True
+
+    def test_apply_default_audit_log_records_pending_status(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        parsed_batch: str,
+        session_maker,
+    ):
+        """Issue #210: the audit row records ``as_posted=False`` on the default path too."""
+        r = client.post(
+            f"/v1/imports/{parsed_batch}/apply?no_categorize=true",
+            headers=auth_h,
+        )
+        assert r.status_code == 200, r.text
+
+        from tulip_storage.models import AuditLog
+
+        with session_maker() as s:
+            row = (
+                s.query(AuditLog)
+                .filter(AuditLog.action == "import_apply")
+                .order_by(AuditLog.occurred_at.desc())
+                .first()
+            )
+            assert row is not None
+            assert row.after_snapshot is not None
+            assert row.after_snapshot.get("as_posted") is False
+
 
 class TestApplyImportErrors:
     def test_unknown_batch_returns_404(self, client: TestClient, auth_h: dict[str, str]):

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -398,13 +398,37 @@ def apply_import(
             ),
         ),
     ] = False,
+    posted: Annotated[
+        bool,
+        typer.Option(
+            "--posted",
+            help=(
+                "Land every promoted line as POSTED instead of PENDING "
+                "(skips the review step). Each line lands committed; "
+                "use `tulip transactions edit` to fix categorizations "
+                "later. Useful when every imported line is already "
+                "cleared by the bank (migration workflows from "
+                "Banktivity, Quicken, GnuCash, etc.)."
+            ),
+        ),
+    ] = False,
 ) -> None:
-    """Apply a parsed batch: every non-excluded line becomes a PENDING ledger transaction."""
+    """Apply a parsed batch: every non-excluded line becomes a ledger transaction.
+
+    By default, new transactions are PENDING (review queue). Pass
+    ``--posted`` to land them as POSTED directly — useful for migrations
+    where every line is already cleared by the source bank/tool.
+    """
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
     path = f"/v1/imports/{batch_id}/apply"
+    query: list[str] = []
     if no_categorize:
-        path += "?no_categorize=true"
+        query.append("no_categorize=true")
+    if posted:
+        query.append("as_posted=true")
+    if query:
+        path += "?" + "&".join(query)
     try:
         with _client(config, as_json=as_json) as client:
             response = client.post(path, authenticated=True)
@@ -416,9 +440,10 @@ def apply_import(
         sys.stdout.write(response.text + "\n")
         return
     body = response.json()
+    landed_as = "POSTED" if posted else "PENDING"
     typer.echo(
         f"Applied batch {body['batch_id']}: created {body['created_count']} "
-        f"PENDING transactions, skipped {body['skipped_count']} lines."
+        f"{landed_as} transactions, skipped {body['skipped_count']} lines."
     )
 
 

--- a/packages/tulip-cli/tests/test_import_command.py
+++ b/packages/tulip-cli/tests/test_import_command.py
@@ -219,6 +219,96 @@ def test_imports_show_unknown_batch_returns_problem(authed_session: str) -> None
 
 
 @pytest.mark.integration
+def test_imports_apply_posted_lands_posted_transactions(authed_session: str) -> None:
+    """Issue #210: `tulip imports apply --posted BATCH_ID` lands each line as POSTED."""
+    _seed_checking(authed_session)
+    fixture = _OFX_FIXTURES / "minimal_ofx2.ofx"
+    upload = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            authed_session,
+            "import",
+            "ofx",
+            str(fixture),
+            "--account",
+            "1110",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert upload.returncode == 0, upload.stderr
+    batch_id = json.loads(upload.stdout)["id"]
+
+    apply_result = _run_cli(
+        "--json",
+        "imports",
+        "apply",
+        batch_id,
+        "--posted",
+        "--no-categorize",
+        api_url=authed_session,
+    )
+    assert apply_result.returncode == 0, apply_result.stderr
+    body = json.loads(apply_result.stdout)
+    assert body["created_count"] == 2
+
+    # Verify each created tx is POSTED.
+    for tx_id in body["transaction_ids"]:
+        show = _run_cli("--json", "transactions", "show", tx_id, api_url=authed_session)
+        assert show.returncode == 0, show.stderr
+        assert json.loads(show.stdout)["status"] == "posted"
+
+
+@pytest.mark.integration
+def test_imports_apply_default_lands_pending_transactions(authed_session: str) -> None:
+    """Issue #210: without ``--posted``, transactions are PENDING (unchanged default)."""
+    _seed_checking(authed_session)
+    fixture = _OFX_FIXTURES / "minimal_ofx2.ofx"
+    upload = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--json",
+            "--api-url",
+            authed_session,
+            "import",
+            "ofx",
+            str(fixture),
+            "--account",
+            "1110",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert upload.returncode == 0, upload.stderr
+    batch_id = json.loads(upload.stdout)["id"]
+
+    apply_result = _run_cli(
+        "--json",
+        "imports",
+        "apply",
+        batch_id,
+        "--no-categorize",
+        api_url=authed_session,
+    )
+    assert apply_result.returncode == 0, apply_result.stderr
+    body = json.loads(apply_result.stdout)
+    for tx_id in body["transaction_ids"]:
+        show = _run_cli("--json", "transactions", "show", tx_id, api_url=authed_session)
+        assert show.returncode == 0, show.stderr
+        assert json.loads(show.stdout)["status"] == "pending"
+
+
+@pytest.mark.integration
 def test_imports_apply_already_applied_returns_409(authed_session: str) -> None:
     """Re-applying renders the typed Problem and exits non-zero."""
     _seed_checking(authed_session)


### PR DESCRIPTION
## Summary

- Adds opt-in `--posted` flag to `tulip imports apply` (and `?as_posted=true` on `POST /v1/imports/{id}/apply`) so cleared statement lines land as `POSTED` instead of the default `PENDING`.
- Removes manual `PENDING -> POSTED` promotion friction for migration workflows (Banktivity, Quicken, GnuCash, etc.) where every imported line is already cleared by the source bank/tool.
- The two postings (bank-side + categorizer/imbalance-side) already sum to zero per currency, so the `POSTED` balance invariant holds without new validation. Works in combination with `--no-categorize` (#202).
- Audit row for `import_apply` now records both `as_posted` and `no_categorize` so a forensic audit can tell whether each batch was reviewed or auto-posted.
- Default behavior (PENDING) is preserved end-to-end; flag is purely additive.

## Test plan

- [x] `uv run pytest packages -q` (full suite green — 1669 passed, 1 skipped)
- [x] `just lint` clean (ruff all checks passed)
- [x] `just typecheck` clean (mypy: no issues in 241 source files)
- [x] New service-level tests cover `as_posted=True` and the unchanged default for both `promote_statement_line` and `apply_batch`.
- [x] New API tests assert: `?as_posted=true` produces POSTED tx, default produces PENDING tx, and the audit log records the chosen status in both directions.
- [x] New CLI integration tests run the real `tulip imports apply --posted` and the unchanged default through a live API and verify the resulting transaction status via `tulip transactions show`.
- [ ] CI green on this PR

### Manual smoke test

```bash
export TULIP_TOKEN_STORE=$(mktemp)
uv run uvicorn tulip_api.main:app --host 127.0.0.1 --port 8000 &
API_PID=$!
sleep 2

curl -sS -X POST http://127.0.0.1:8000/v1/auth/register \
  -H 'content-type: application/json' \
  -d '{"email":"smoke@example.com","password":"long-enough-password","display_name":"Smoke","household_name":"Smoke HH"}' \
  >/dev/null

uv run tulip --api-url http://127.0.0.1:8000 auth login --email smoke@example.com --password-stdin <<<'long-enough-password'
uv run tulip --api-url http://127.0.0.1:8000 accounts add --name Checking --type asset --currency USD --code 1110

FIXTURE=packages/tulip-importers/tests/fixtures/ofx/minimal_ofx2.ofx
BATCH=$(uv run tulip --json --api-url http://127.0.0.1:8000 import ofx "$FIXTURE" --account 1110 | jq -r '.id')

APPLIED=$(uv run tulip --json --api-url http://127.0.0.1:8000 imports apply "$BATCH" --posted --no-categorize)
echo "$APPLIED" | jq -r '.transaction_ids[]' | while read TX; do
  STATUS=$(uv run tulip --json --api-url http://127.0.0.1:8000 transactions show "$TX" | jq -r '.status')
  echo "tx $TX status=$STATUS"
done

# Expected: every tx prints status=posted

kill $API_PID
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)