### PR TITLE
fix: render amounts at currency-natural precision (closes #213)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/_money_format.py
+++ b/packages/tulip-cli/src/tulip_cli/_money_format.py
@@ -1,0 +1,78 @@
+"""Currency-natural display formatting for CLI rendering (issue #213).
+
+The Tulip API serializes monetary amounts as ``Decimal`` strings at full
+storage precision (e.g. ``"12.20000000"`` for a value that came in via QIF
+or OFX). For machine consumers that's the right answer — the trailing
+digits preserve the imported precision. For humans reading a ``tulip
+imports show`` table or a ``tulip balance`` trial-balance it is just
+visual noise.
+
+This helper quantises an amount string to the currency's natural minor-unit
+precision for display only (USD/EUR/GBP → 2, JPY → 0, BHD → 3, etc.). The
+canonical minor-units table lives in :mod:`tulip_core.currency`; we
+duplicate the subset we need here rather than importing ``tulip_core``,
+because ARCHITECTURE.md §9 forbids ``tulip-cli`` from depending on
+``tulip-core`` directly (CLI is a network client of the API).
+
+The duplication is small and the values are ISO 4217 — they don't drift.
+Unknown currencies fall back to two decimals (the overwhelmingly common
+case) so this never raises on display.
+"""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_EVEN, Decimal, InvalidOperation
+from typing import Final
+
+# Mirror of the ``tulip_core.currency._MINOR_UNITS`` table. Kept in sync by
+# convention — ISO 4217 minor-unit assignments don't churn. When a new
+# currency is added to ``tulip-core``, mirror it here.
+_DISPLAY_MINOR_UNITS: Final[dict[str, int]] = {
+    "USD": 2,
+    "EUR": 2,
+    "GBP": 2,
+    "JPY": 0,
+    "CAD": 2,
+    "AUD": 2,
+    "CHF": 2,
+    "CNY": 2,
+    "BHD": 3,
+}
+
+_DEFAULT_MINOR_UNITS: Final[int] = 2
+
+
+def _minor_units(currency: str | None) -> int:
+    """Return the display precision for ``currency`` (defaults to 2)."""
+    if not currency:
+        return _DEFAULT_MINOR_UNITS
+    return _DISPLAY_MINOR_UNITS.get(currency.upper(), _DEFAULT_MINOR_UNITS)
+
+
+def format_amount(amount: object, currency: str | None) -> str:
+    """Render ``amount`` at ``currency``'s natural minor-unit precision.
+
+    ``amount`` may be a ``Decimal``, a string (the API's JSON encoding),
+    an ``int``, or anything else — non-numeric input is passed through
+    via ``str()`` unchanged so the rendering never crashes on display.
+
+    Banker's rounding (``ROUND_HALF_EVEN``) matches the rest of Tulip's
+    money handling (``Money.quantize_to_currency``).
+    """
+    if amount is None:
+        return ""
+    try:
+        if isinstance(amount, Decimal):
+            dec = amount
+        else:
+            dec = Decimal(str(amount))
+    except (InvalidOperation, ValueError):
+        return str(amount)
+
+    minor = _minor_units(currency)
+    quantum = Decimal(1).scaleb(-minor) if minor > 0 else Decimal(1)
+    quantized = dec.quantize(quantum, rounding=ROUND_HALF_EVEN)
+    return str(quantized)
+
+
+__all__ = ["format_amount"]

--- a/packages/tulip-cli/src/tulip_cli/commands/balance.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/balance.py
@@ -30,14 +30,20 @@ def _client(config: Config, *, as_json: bool) -> TulipClient:
 
 def _render_account_balance(body: dict[str, Any]) -> None:
     """Render a single ``AccountBalanceRead`` body."""
+    from tulip_cli._money_format import format_amount
+
     code = body.get("code") or "—"
+    currency = body.get("currency", "")
+    balance = format_amount(body.get("balance"), currency)
     typer.echo(f"{code} — {body.get('name', '')}")
-    typer.echo(f"  balance: {body.get('balance', '')} {body.get('currency', '')}")
+    typer.echo(f"  balance: {balance} {currency}")
     typer.echo(f"  as of:   {body.get('as_of', '')}")
 
 
 def _render_trial_balance(body: dict[str, Any]) -> None:
     """Render a ``TrialBalanceRead`` body as a table + totals."""
+    from tulip_cli._money_format import format_amount
+
     rows = body.get("rows") or []
     if not rows:
         typer.echo(f"No postings on or before {body.get('as_of', 'today')}.")
@@ -50,12 +56,13 @@ def _render_trial_balance(body: dict[str, Any]) -> None:
     table.add_column("currency")
     table.add_column("balance", justify="right")
     for r in rows:
+        currency = r.get("currency") or ""
         table.add_row(
             r.get("code") or "—",
             r.get("name") or "",
             r.get("type") or "",
-            r.get("currency") or "",
-            r.get("balance") or "",
+            currency,
+            format_amount(r.get("balance"), currency),
         )
     console = Console()
     console.print(table)
@@ -63,9 +70,13 @@ def _render_trial_balance(body: dict[str, Any]) -> None:
     totals = body.get("totals_by_currency") or []
     for t in totals:
         currency = t.get("currency", "")
-        debits = t.get("debits", "")
-        credits = t.get("credits", "")
-        marker = "✓" if debits == credits else "⚠"
+        debits_raw = t.get("debits", "")
+        credits_raw = t.get("credits", "")
+        debits = format_amount(debits_raw, currency) if debits_raw != "" else ""
+        credits = format_amount(credits_raw, currency) if credits_raw != "" else ""
+        # Compare the raw (full-precision) values so the equal/unequal marker
+        # isn't fooled by quantization (e.g. .005 vs .004 both round to .00).
+        marker = "✓" if debits_raw == credits_raw else "⚠"
         console.print(
             f"  {currency}: debits {debits}, credits {credits} {marker}",
         )

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -359,17 +359,20 @@ def _render_batch(body: dict[str, Any]) -> None:
     table.add_column("ccy")
     table.add_column("description")
     table.add_column("flag")
+    from tulip_cli._money_format import format_amount
+
     for line in lines:
         flag_bits: list[str] = []
         if line.get("is_excluded"):
             flag_bits.append("excluded")
         if line.get("reconciliation_match_id"):
             flag_bits.append("reconciled")
+        currency = str(line.get("currency", ""))
         table.add_row(
             str(line.get("line_number", "")),
             str(line.get("posted_date", "")),
-            str(line.get("amount", "")),
-            str(line.get("currency", "")),
+            format_amount(line.get("amount"), currency),
+            currency,
             str(line.get("description", "") or ""),
             ", ".join(flag_bits),
         )

--- a/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
@@ -937,10 +937,17 @@ def _run_wizard_loop(
         tx = txs_by_id.get(match["ledger_transaction_id"], {})
         confidence = str(match.get("confidence") or "?").upper()
         console.print(f"\n[bold][{idx}/{total}] {confidence} confidence[/bold]")
+        from tulip_cli._money_format import format_amount
+
+        line_currency = str(line.get("currency", ""))
+        line_amount_raw = line.get("amount")
+        line_amount = (
+            format_amount(line_amount_raw, line_currency) if line_amount_raw is not None else "?"
+        )
         console.print(
             f"  statement: {line.get('posted_date', '?')}  "
             f"{(line.get('description') or '')[:50]}  "
-            f"{line.get('amount', '?')} {line.get('currency', '')}"
+            f"{line_amount} {line_currency}"
         )
         console.print(
             f"  ledger tx: {str(tx.get('id', ''))[:8]}  {tx.get('date', '?')}  "

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -102,14 +102,16 @@ def _client(config: Config, *, as_json: bool) -> TulipClient:
 
 
 def _render_transaction(body: dict[str, Any]) -> None:
+    from tulip_cli._money_format import format_amount
+
     typer.echo(f"Created transaction {body.get('id', '')}")
     typer.echo(f"  date:        {body.get('date', '')}")
     typer.echo(f"  description: {body.get('description', '')}")
     typer.echo(f"  status:      {body.get('status', '')}")
     typer.echo("  postings:")
     for p in body.get("postings", []):
-        amount = p.get("amount", "")
         currency = p.get("currency", "")
+        amount = format_amount(p.get("amount"), currency)
         account = p.get("account_id", "")
         typer.echo(f"    {account}: {amount} {currency}")
 
@@ -439,6 +441,8 @@ def _resolve_tx_id(client: TulipClient, identifier: str, *, as_json: bool) -> UU
 
 
 def _render_tx_list_table(rows: list[dict[str, Any]]) -> None:
+    from tulip_cli._money_format import format_amount
+
     table = Table(show_header=True, show_lines=False)
     table.add_column("id")
     table.add_column("date")
@@ -450,8 +454,8 @@ def _render_tx_list_table(rows: list[dict[str, Any]]) -> None:
         postings = row.get("postings") or []
         summary_parts = []
         for p in postings:
-            amount = p.get("amount", "")
             currency = p.get("currency", "")
+            amount = format_amount(p.get("amount"), currency)
             account = p.get("account_id", "")
             short = str(account)[:8] if account else "—"
             summary_parts.append(f"{short} {amount} {currency}")
@@ -469,6 +473,8 @@ def _render_tx_list_table(rows: list[dict[str, Any]]) -> None:
 
 
 def _render_tx_detail(tx: dict[str, Any]) -> None:
+    from tulip_cli._money_format import format_amount
+
     typer.echo(f"id:           {tx.get('id', '')}")
     typer.echo(f"date:         {tx.get('date', '')}")
     typer.echo(f"description:  {tx.get('description', '')}")
@@ -481,10 +487,11 @@ def _render_tx_detail(tx: dict[str, Any]) -> None:
     table.add_column("currency")
     table.add_column("memo")
     for p in tx.get("postings") or []:
+        currency = str(p.get("currency", ""))
         table.add_row(
             str(p.get("account_id", "")),
-            str(p.get("amount", "")),
-            str(p.get("currency", "")),
+            format_amount(p.get("amount"), currency),
+            currency,
             str(p.get("memo") or ""),
         )
     Console().print(table)

--- a/packages/tulip-cli/tests/test_display_precision.py
+++ b/packages/tulip-cli/tests/test_display_precision.py
@@ -1,0 +1,203 @@
+"""Regression tests for currency-natural display precision (issue #213).
+
+The bug: amounts posted to the API at full storage precision (e.g.
+``12.20000000`` from a QIF import) were rendered verbatim by ``tulip
+transactions list``, ``tulip transactions show``, ``tulip balance``, and
+``tulip imports show``. The display layer should quantise to the
+currency's natural minor-unit precision (USD → 2 decimals → ``12.20``).
+
+These end-to-end tests post a transaction whose amount has trailing
+zeros beyond USD's two-decimal precision, then assert the CLI renders
+``12.20`` and never ``12.20000000``. Strips ANSI before scanning so
+Rich's styling can't make the substring miss.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+_PASSWORD = "long-enough-password"
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _run_cli(
+    *args: str, api_url: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    # COLUMNS=200 keeps Rich from wrapping table cells and breaking the
+    # amount substring we're asserting on; see test_import_command.py for
+    # the precedent.
+    import os
+
+    env = dict(os.environ)
+    env.setdefault("COLUMNS", "200")
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=20,
+        env=env,
+    )
+
+
+def _create_account(
+    api_url: str,
+    access_token: str,
+    *,
+    code: str,
+    name: str,
+    type_: str = "asset",
+) -> dict[str, object]:
+    r = httpx.post(
+        f"{api_url}/v1/accounts",
+        json={
+            "code": code,
+            "name": name,
+            "type": type_,
+            "currency": "USD",
+            "visibility": "shared",
+        },
+        headers={"authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return dict(r.json())
+
+
+def _post_tx_with_storage_precision(
+    api_url: str,
+    access_token: str,
+    *,
+    debit_id: str,
+    credit_id: str,
+) -> str:
+    """Post a USD transaction whose amount carries trailing-zero noise.
+
+    Returns the transaction id so the test can use it as a TXID for
+    ``tulip transactions show``.
+    """
+    r = httpx.post(
+        f"{api_url}/v1/transactions",
+        json={
+            "date": date.today().isoformat(),
+            "description": "12.20-precision-noise",
+            "postings": [
+                {"account_id": debit_id, "amount": "12.20000000", "currency": "USD"},
+                {"account_id": credit_id, "amount": "-12.20000000", "currency": "USD"},
+            ],
+        },
+        headers={"authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+    r.raise_for_status()
+    return str(r.json()["id"])
+
+
+@pytest.fixture
+def authed_session(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[str, str]:
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    cli_login = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert cli_login.returncode == 0, cli_login.stderr
+    api_login = httpx.post(
+        f"{live_api}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    api_login.raise_for_status()
+    return live_api, str(api_login.json()["access_token"])
+
+
+@pytest.mark.integration
+def test_transactions_list_renders_currency_natural_precision(
+    authed_session: tuple[str, str],
+) -> None:
+    """`tulip transactions list` must render USD amounts to 2 decimals.
+
+    Regression test for issue #213: a posting persisted at storage
+    precision (``12.20000000``) renders as ``12.20`` in the table, not
+    as ``12.20000000``.
+    """
+    api_url, access = authed_session
+    cash = _create_account(api_url, access, code="assets:cash", name="Cash")
+    food = _create_account(api_url, access, code="expenses:food", name="Food", type_="expense")
+    _post_tx_with_storage_precision(
+        api_url, access, debit_id=str(food["id"]), credit_id=str(cash["id"])
+    )
+
+    result = _run_cli("transactions", "list", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    plain = _strip_ansi(result.stdout)
+    # Quantised form is present, full-precision form is not.
+    assert "12.20" in plain
+    assert "12.20000000" not in plain
+
+
+@pytest.mark.integration
+def test_transactions_show_renders_currency_natural_precision(
+    authed_session: tuple[str, str],
+) -> None:
+    """`tulip transactions show TXID` must render postings at 2-decimal USD precision."""
+    api_url, access = authed_session
+    cash = _create_account(api_url, access, code="assets:cash", name="Cash")
+    food = _create_account(api_url, access, code="expenses:food", name="Food", type_="expense")
+    tx_id = _post_tx_with_storage_precision(
+        api_url, access, debit_id=str(food["id"]), credit_id=str(cash["id"])
+    )
+
+    result = _run_cli("transactions", "show", tx_id, api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    plain = _strip_ansi(result.stdout)
+    assert "12.20" in plain
+    assert "12.20000000" not in plain
+
+
+@pytest.mark.integration
+def test_balance_renders_currency_natural_precision(
+    authed_session: tuple[str, str],
+) -> None:
+    """`tulip balance` trial-balance must show USD totals at 2 decimals."""
+    api_url, access = authed_session
+    cash = _create_account(api_url, access, code="assets:cash", name="Cash")
+    food = _create_account(api_url, access, code="expenses:food", name="Food", type_="expense")
+    _post_tx_with_storage_precision(
+        api_url, access, debit_id=str(food["id"]), credit_id=str(cash["id"])
+    )
+
+    result = _run_cli("balance", api_url=api_url)
+    assert result.returncode == 0, result.stderr
+    plain = _strip_ansi(result.stdout)
+    assert "12.20" in plain
+    assert "12.20000000" not in plain

--- a/packages/tulip-cli/tests/test_money_format.py
+++ b/packages/tulip-cli/tests/test_money_format.py
@@ -1,0 +1,65 @@
+"""Unit tests for the CLI display-precision helper (issue #213)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from tulip_cli._money_format import format_amount
+
+
+class TestFormatAmount:
+    def test_strips_excess_trailing_zeros_for_usd(self) -> None:
+        # The motivating case: QIF imports persist amounts at full storage
+        # precision (8 decimals); the display layer must shorten to 2 for USD.
+        assert format_amount("12.20000000", "USD") == "12.20"
+
+    def test_pads_short_decimals_for_usd(self) -> None:
+        assert format_amount("12", "USD") == "12.00"
+        assert format_amount("12.5", "USD") == "12.50"
+
+    def test_jpy_uses_zero_decimals(self) -> None:
+        assert format_amount("100.50000000", "JPY") == "100"
+        # Banker's rounding: .5 rounds to nearest even, so 100.5 → 100.
+        assert format_amount("100.5", "JPY") == "100"
+        assert format_amount("101.5", "JPY") == "102"
+
+    def test_bhd_uses_three_decimals(self) -> None:
+        assert format_amount("1.20000000", "BHD") == "1.200"
+
+    def test_unknown_currency_falls_back_to_two_decimals(self) -> None:
+        assert format_amount("12.20000000", "XYZ") == "12.20"
+
+    def test_empty_currency_falls_back_to_two_decimals(self) -> None:
+        assert format_amount("12.20000000", "") == "12.20"
+        assert format_amount("12.20000000", None) == "12.20"
+
+    def test_decimal_input(self) -> None:
+        assert format_amount(Decimal("12.2"), "USD") == "12.20"
+
+    def test_none_amount_renders_empty_string(self) -> None:
+        assert format_amount(None, "USD") == ""
+
+    def test_negative_amount(self) -> None:
+        assert format_amount("-42.17000000", "USD") == "-42.17"
+
+    def test_non_numeric_passthrough(self) -> None:
+        # The renderer must not crash on garbage; falls back to str().
+        assert format_amount("not-a-number", "USD") == "not-a-number"
+
+    def test_currency_is_case_insensitive(self) -> None:
+        assert format_amount("100.5", "jpy") == "100"
+
+
+@pytest.mark.parametrize(
+    ("amount", "currency", "expected"),
+    [
+        ("12.20000000", "USD", "12.20"),
+        ("0.00000000", "USD", "0.00"),
+        ("1234.56789", "EUR", "1234.57"),  # banker's rounding to 2dp
+        ("100", "JPY", "100"),
+    ],
+)
+def test_parametrized(amount: str, currency: str, expected: str) -> None:
+    assert format_amount(amount, currency) == expected

--- a/packages/tulip-reports/src/tulip_reports/engine.py
+++ b/packages/tulip-reports/src/tulip_reports/engine.py
@@ -30,15 +30,25 @@ from typing import Final
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 
+from tulip_core.currency import Currency
+from tulip_core.money import Money
+
 _TEMPLATES_DIR: Final[Path] = Path(__file__).resolve().parent / "templates"
+
+# Fallback used when no currency is supplied; matches the historical hardcoded
+# precision (and what most callers want).
+_DEFAULT_MINOR_UNITS: Final[int] = 2
 
 
 def _format_money(value: object, currency: str | None = None) -> str:
-    """Render a Decimal-like value with thousand separators + 2 decimals.
+    """Render a Decimal-like value with thousand separators + currency-natural precision.
 
     Negative values get a leading minus sign (not parens; parens are
     accountancy convention but make scanning harder on screen). Currency
-    is appended when provided so callers can pass per-row currencies.
+    is appended when provided so callers can pass per-row currencies, and
+    when known governs the decimal precision (USD/EUR → 2, JPY → 0, BHD → 3)
+    via :meth:`Money.quantize_to_currency` so reports match the rest of the
+    Tulip rendering surfaces (issue #213).
     """
     if value is None:
         return ""
@@ -47,10 +57,21 @@ def _format_money(value: object, currency: str | None = None) -> str:
             value = Decimal(str(value))
         except (ArithmeticError, ValueError):
             return str(value)
-    quantized = value.quantize(Decimal("0.01"), rounding=ROUND_HALF_EVEN)
+
+    minor_units = _DEFAULT_MINOR_UNITS
+    if currency:
+        try:
+            quantized = Money(value, currency).quantize_to_currency().amount
+            minor_units = Currency.from_code(currency).minor_units
+        except (ArithmeticError, ValueError):
+            # Unknown currency: fall back to the historical 2dp behaviour.
+            quantized = value.quantize(Decimal("0.01"), rounding=ROUND_HALF_EVEN)
+    else:
+        quantized = value.quantize(Decimal("0.01"), rounding=ROUND_HALF_EVEN)
+
     sign = "-" if quantized < 0 else ""
     absolute = abs(quantized)
-    formatted = f"{absolute:,.2f}"
+    formatted = f"{absolute:,.{minor_units}f}"
     out = f"{sign}{formatted}"
     if currency:
         out += f" {currency}"

--- a/packages/tulip-reports/src/tulip_reports/journal/export.py
+++ b/packages/tulip-reports/src/tulip_reports/journal/export.py
@@ -58,11 +58,19 @@ def _account_path(account_code: str | None, account_name: str, account_type: str
 def _format_amount(amount: Decimal, currency: str) -> str:
     """Format ``amount`` as hledger's canonical ``<value> <currency>`` form.
 
-    Banker's rounding to two decimal places — same as the rest of the
-    Tulip CSV / HTML / PDF output. Hledger accepts arbitrary precision
-    but two decimals matches what users see in the UI.
+    Banker's rounding to the currency's natural minor-unit precision —
+    USD/EUR → 2, JPY → 0, BHD → 3 — via :meth:`Money.quantize_to_currency`
+    so the journal export matches the rest of the Tulip rendering surfaces
+    (issue #213). Hledger accepts arbitrary precision but the currency-
+    natural representation matches what users see in the UI. Unknown
+    currencies fall back to two decimals.
     """
-    quantized = amount.quantize(Decimal("0.01"))
+    from tulip_core.money import Money
+
+    try:
+        quantized = Money(amount, currency).quantize_to_currency().amount
+    except (ArithmeticError, ValueError):
+        quantized = amount.quantize(Decimal("0.01"))
     return f"{quantized} {currency}"
 
 

--- a/packages/tulip-reports/tests/test_engine.py
+++ b/packages/tulip-reports/tests/test_engine.py
@@ -31,6 +31,23 @@ class TestMoneyFilter:
     def test_string_input_coerced(self) -> None:
         assert _format_money("42.10") == "42.10"
 
+    def test_jpy_uses_zero_decimals(self) -> None:
+        # Issue #213: currency-natural precision — JPY has 0 minor units.
+        assert _format_money(Decimal("100.5"), "JPY") == "100 JPY"
+
+    def test_bhd_uses_three_decimals(self) -> None:
+        # Issue #213: BHD has 3 minor units.
+        assert _format_money(Decimal("1.2"), "BHD") == "1.200 BHD"
+
+    def test_unknown_currency_falls_back_to_two_decimals(self) -> None:
+        # Two-decimal fallback for unknown ISO 4217 codes. Banker's rounding:
+        # .555 → .56 (5 rounds to nearest even — .56 is even).
+        assert _format_money(Decimal("12.555"), "XYZ") == "12.56 XYZ"
+
+    def test_storage_precision_amount_quantizes_to_usd(self) -> None:
+        # Issue #213: an 8-decimal storage amount renders as 2-decimal USD.
+        assert _format_money(Decimal("12.20000000"), "USD") == "12.20 USD"
+
 
 class TestDateFilter:
     def test_iso_date(self) -> None:


### PR DESCRIPTION
## Summary

- The Money type stores amounts at full precision (8 decimals from QIF/OFX imports) and the rendering paths surfaced that verbatim — `tulip imports show` printed `12.20000000` where users expected `12.20`. Display-layer fix: quantise to each currency's natural minor-unit precision (USD/EUR → 2, JPY → 0, BHD → 3) at every human-facing render path.
- New `tulip_cli._money_format.format_amount` helper. Lives inside `tulip-cli` so it preserves the ARCHITECTURE.md §9 boundary that forbids the CLI from importing `tulip-core` directly; mirrors the small ISO 4217 minor-units table and falls back to 2 decimals for unknown codes.
- Wired through `tulip transactions list/show`, `tulip balance` (single-account + trial-balance), `tulip imports show`, and the reconcile wizard's statement-line summary line.
- `tulip-reports` engine `_format_money` filter now honours currency `minor_units` via `Money.quantize_to_currency` (was hardcoded to 2). Journal export `_format_amount` likewise — hledger output now matches the rest of the UI for JPY/BHD.
- Storage shape and API JSON shape unchanged: only the rendering layer quantises, so machine consumers still see full-precision amounts (intentional — keeps the door open for investment / FX use cases).

## Test plan

- [x] `uv run pytest packages -q` — 1681 passed, 1 skipped (unrelated openapi path-collision skip), 3 deselected.
- [x] `just lint` — all checks passed.
- [x] `just typecheck` — no issues in 242 source files.
- [x] New unit tests: `packages/tulip-cli/tests/test_money_format.py` (15 cases) cover known + unknown currencies, decimal/string input, None handling.
- [x] New end-to-end regression: `packages/tulip-cli/tests/test_display_precision.py` posts a `12.20000000` USD transaction and asserts `tulip transactions list/show` and `tulip balance` render `12.20` (and never `12.20000000`). ANSI is stripped before substring checks; `COLUMNS=200` mirrors `test_import_command.py` so Rich doesn't wrap mid-cell.
- [x] New reports-engine tests: `packages/tulip-reports/tests/test_engine.py` covers JPY (0 decimals), BHD (3 decimals), unknown-currency fallback, and the 8-decimal-storage → 2-decimal-USD case.
- [ ] CI green on this PR.