### PR TITLE
feat: expose transaction-level notes (closes #271)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -11,6 +11,7 @@ import structlog
 from fastapi import APIRouter, Depends, Query, Request, status
 
 from tulip_api.auth.deps import get_current_claims, require_role
+from tulip_api.config import get_settings
 from tulip_api.deps import get_session
 from tulip_api.errors import (
     AccountUnknownError,
@@ -71,6 +72,9 @@ from tulip_storage.repositories import (
     PeriodRepository,
     ShadowTransactionRepository,
     TransactionRepository,
+)
+from tulip_storage.repositories.transaction import (
+    UNSET,
 )
 from tulip_storage.repositories.transaction import (
     TransactionNotDeletableError as RepoNotDeletableError,
@@ -232,8 +236,9 @@ def create_transaction(
         # invariant. Always a Tulip bug, not user input.
         raise ShadowLedgerInternalError() from exc
 
-    tx_repo = TransactionRepository(session, claims.household_id)
-    saved = tx_repo.save_balanced(posted)
+    settings = get_settings()
+    tx_repo = TransactionRepository(session, claims.household_id, master_key=settings.master_key)
+    saved = tx_repo.save_balanced(posted, notes=body.notes)
 
     paired_shadow_tx_id: UUID | None = None
     if shadow_tx is not None:
@@ -422,6 +427,16 @@ def get_transaction(
     return _read_response(tx_id, claims.household_id, session)
 
 
+def _resolve_notes_patch(body: TransactionUpdate) -> str | None | object:
+    """Return UNSET if ``notes`` was omitted; else the body value (str or None).
+
+    Distinguishes "don't touch the column" from "explicitly clear it".
+    """
+    if "notes" in body.model_fields_set:
+        return body.notes
+    return UNSET
+
+
 @router.patch(
     "/{tx_id}",
     response_model=TransactionRead,
@@ -442,7 +457,8 @@ def patch_transaction(
     session: Session = Depends(get_session),  # noqa: B008
 ) -> TransactionRead:
     """Edit a PENDING transaction. POSTED / RECONCILED return 409."""
-    tx_repo = TransactionRepository(session, claims.household_id)
+    settings = get_settings()
+    tx_repo = TransactionRepository(session, claims.household_id, master_key=settings.master_key)
     existing = tx_repo.get(tx_id)
     if existing is None:
         raise TransactionNotFoundError()
@@ -482,11 +498,14 @@ def patch_transaction(
             for p in existing_postings
         )
 
-    before_snapshot = {
+    before_snapshot: dict[str, object] = {
         "date": existing.date.isoformat(),
         "description": existing.description,
         "reference": existing.reference,
     }
+    notes_patch = _resolve_notes_patch(body)
+    if notes_patch is not UNSET:
+        before_snapshot["notes_present"] = existing.notes_encrypted is not None
     try:
         tx_repo.update_pending(
             tx_id,
@@ -494,10 +513,18 @@ def patch_transaction(
             description=new_desc,
             reference=new_ref,
             postings=new_postings,
+            notes=notes_patch,  # type: ignore[arg-type]
         )
     except RepoNotEditableError as exc:
         raise TransactionNotEditableError() from exc
 
+    after_snapshot: dict[str, object] = {
+        "date": new_date.isoformat(),
+        "description": new_desc,
+        "reference": new_ref,
+    }
+    if notes_patch is not UNSET:
+        after_snapshot["notes_present"] = notes_patch is not None
     AuditLogWriter(session, claims.household_id).write(
         action="update",
         actor_kind="user",
@@ -505,11 +532,7 @@ def patch_transaction(
         entity_type="transaction",
         entity_id=tx_id,
         before=before_snapshot,
-        after={
-            "date": new_date.isoformat(),
-            "description": new_desc,
-            "reference": new_ref,
-        },
+        after=after_snapshot,
         request_id=_request_uuid(request),
     )
     session.commit()
@@ -656,7 +679,8 @@ def _read_response(
     *,
     paired_shadow_tx_id: UUID | None = None,
 ) -> TransactionRead:
-    repo = TransactionRepository(session, household_id)
+    settings = get_settings()
+    repo = TransactionRepository(session, household_id, master_key=settings.master_key)
     header = repo.get(tx_id)
     assert header is not None  # caller verifies before invoking  # noqa: S101
     postings = repo.list_postings(tx_id)
@@ -670,6 +694,7 @@ def _read_response(
         date=header.date,
         description=header.description,
         reference=header.reference,
+        notes=repo.decrypt_notes(header),
         status=header.status.value,
         postings=[
             PostingRead(

--- a/packages/tulip-api/src/tulip_api/schemas/transaction.py
+++ b/packages/tulip-api/src/tulip_api/schemas/transaction.py
@@ -32,6 +32,15 @@ class TransactionCreate(BaseModel):
     date: date_type
     description: str = Field(min_length=1, max_length=500)
     reference: str | None = Field(default=None, max_length=200)
+    notes: str | None = Field(
+        default=None,
+        description=(
+            "Optional free-text transaction-level annotation. Stored "
+            "encrypted at rest; round-trips on GET. Distinct from the "
+            "headline ``description`` (which is required and short) and "
+            "from posting-level ``memo`` (which belongs on the leg)."
+        ),
+    )
     postings: list[PostingCreate] = Field(min_length=2)
 
 
@@ -53,6 +62,7 @@ class TransactionRead(BaseModel):
     date: date_type
     description: str
     reference: str | None
+    notes: str | None = None
     status: str
     postings: list[PostingRead]
     paired_shadow_tx_id: UUID | None = None
@@ -89,9 +99,21 @@ class TransactionVoidResponse(BaseModel):
 
 
 class TransactionUpdate(BaseModel):
-    """PATCH /v1/transactions/{id} body — PENDING-only, all fields optional."""
+    """PATCH /v1/transactions/{id} body — PENDING-only, all fields optional.
+
+    For ``notes`` specifically, omitting the key keeps the current value;
+    sending ``null`` clears the encrypted-notes column. The router
+    distinguishes the two via Pydantic's ``model_fields_set``.
+    """
 
     date: date_type | None = None
     description: str | None = Field(default=None, min_length=1, max_length=500)
     reference: str | None = Field(default=None, max_length=200)
+    notes: str | None = Field(
+        default=None,
+        description=(
+            "Free-text transaction-level annotation. Omit to leave "
+            "unchanged; send ``null`` to clear."
+        ),
+    )
     postings: list[PostingCreate] | None = Field(default=None, min_length=2)

--- a/packages/tulip-api/tests/test_transactions_notes_endpoint.py
+++ b/packages/tulip-api/tests/test_transactions_notes_endpoint.py
@@ -1,0 +1,232 @@
+"""Tests for transaction-level notes through the API (issue #271)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    """Register + log in an admin; return their access token."""
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r.json()["access_token"]
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    """Authorization header bag using the admin token."""
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+@pytest.fixture
+def cash_and_food(client: TestClient, auth_h: dict[str, str]) -> tuple[str, str]:
+    """Seed cash + food accounts and return their UUIDs."""
+    cash = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Cash", "type": "asset", "currency": "USD", "code": "1110"},
+    ).json()
+    food = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Food", "type": "expense", "currency": "USD", "code": "5100"},
+    ).json()
+    return cash["id"], food["id"]
+
+
+def _create_lunch(
+    client: TestClient,
+    auth_h: dict[str, str],
+    cash: str,
+    food: str,
+    *,
+    notes: str | None = None,
+) -> dict:
+    body: dict = {
+        "date": date.today().isoformat(),
+        "description": "Lunch",
+        "postings": [
+            {"account_id": food, "amount": "12.50", "currency": "USD"},
+            {"account_id": cash, "amount": "-12.50", "currency": "USD"},
+        ],
+    }
+    if notes is not None:
+        body["notes"] = notes
+    r = client.post("/v1/transactions", headers=auth_h, json=body)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestCreateWithNotes:
+    def test_notes_round_trip_on_get(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        created = _create_lunch(client, auth_h, cash, food, notes="Reimbursed by Carol on 1/15.")
+        tx_id = created["id"]
+
+        # Notes round-trips on the create response itself.
+        assert created["notes"] == "Reimbursed by Carol on 1/15."
+
+        # And on subsequent GETs.
+        r = client.get(f"/v1/transactions/{tx_id}", headers=auth_h)
+        assert r.status_code == 200, r.text
+        assert r.json()["notes"] == "Reimbursed by Carol on 1/15."
+
+    def test_omitting_notes_yields_null_on_get(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        cash, food = cash_and_food
+        created = _create_lunch(client, auth_h, cash, food)
+        r = client.get(f"/v1/transactions/{created['id']}", headers=auth_h)
+        assert r.status_code == 200, r.text
+        assert r.json()["notes"] is None
+
+
+@pytest.fixture
+def pending_tx_with_notes(
+    app, session_maker, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+):
+    """Seed a PENDING transaction with a notes value, via the storage layer.
+
+    The HTTP API only emits POSTED transactions today, so we go via the
+    repo to exercise the PATCH-side notes contract on PENDING rows.
+    """
+    import base64
+    import json
+    from decimal import Decimal
+    from uuid import UUID, uuid4
+
+    from tulip_api.config import get_settings
+    from tulip_core.money import Money
+    from tulip_core.transactions import Posting as DomainPosting
+    from tulip_core.transactions import Transaction as DomainTransaction
+    from tulip_core.transactions import TransactionStatus as DomainTxStatus
+    from tulip_storage.repositories import TransactionRepository
+
+    cash, food = cash_and_food
+    token = auth_h["Authorization"].removeprefix("Bearer ")
+    payload = token.split(".")[1] + "=="
+    claims = json.loads(base64.urlsafe_b64decode(payload))
+    household_id = UUID(claims["household_id"])
+
+    tx_id = uuid4()
+    settings = get_settings()
+    with session_maker() as session:
+        domain_tx = DomainTransaction(
+            id=tx_id,
+            household_id=household_id,
+            date=date.today(),
+            description="Pending lunch",
+            postings=(
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=UUID(food),
+                    amount=Money(Decimal("12.50"), "USD"),
+                ),
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=UUID(cash),
+                    amount=Money(Decimal("-12.50"), "USD"),
+                ),
+            ),
+            status=DomainTxStatus.PENDING,
+        )
+        TransactionRepository(session, household_id, master_key=settings.master_key).save_balanced(
+            domain_tx, notes="original notes"
+        )
+        session.commit()
+    return str(tx_id)
+
+
+class TestPatchNotes:
+    def test_patch_sets_notes(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        pending_tx_with_notes: str,
+    ):
+        r = client.patch(
+            f"/v1/transactions/{pending_tx_with_notes}",
+            headers=auth_h,
+            json={"notes": "edited notes"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["notes"] == "edited notes"
+
+    def test_patch_with_null_clears_notes(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        pending_tx_with_notes: str,
+    ):
+        r = client.patch(
+            f"/v1/transactions/{pending_tx_with_notes}",
+            headers=auth_h,
+            json={"notes": None},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["notes"] is None
+
+    def test_patch_omitting_notes_preserves_notes(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        pending_tx_with_notes: str,
+    ):
+        r = client.patch(
+            f"/v1/transactions/{pending_tx_with_notes}",
+            headers=auth_h,
+            json={"description": "Lunch (renamed)"},  # no `notes` key
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["description"] == "Lunch (renamed)"
+        # Notes preserved.
+        assert r.json()["notes"] == "original notes"
+
+
+class TestEncryptedAtRest:
+    def test_notes_stored_as_ciphertext_not_plaintext(
+        self,
+        app,
+        session_maker,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ):
+        """Encrypted-at-rest invariant via the API: raw row bytes != plaintext."""
+        from uuid import UUID
+
+        from tulip_storage.models import Transaction as TxModel
+
+        cash, food = cash_and_food
+        plaintext = "Sensitive memo content"
+        created = _create_lunch(client, auth_h, cash, food, notes=plaintext)
+        tx_id = UUID(created["id"])
+
+        with session_maker() as session:
+            row = session.query(TxModel).filter_by(id=tx_id).one()
+            assert row.notes_encrypted is not None
+            assert row.notes_encrypted != plaintext.encode("utf-8")
+            assert plaintext.encode("utf-8") not in row.notes_encrypted

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -474,6 +474,13 @@ def _render_tx_detail(tx: dict[str, Any]) -> None:
     typer.echo(f"description:  {tx.get('description', '')}")
     typer.echo(f"reference:    {tx.get('reference') or '—'}")
     typer.echo(f"status:       {tx.get('status', '')}")
+    notes = tx.get("notes")
+    if notes:
+        # Indent multi-line notes so the "Notes:" header is unambiguous.
+        first, *rest = str(notes).splitlines() or [""]
+        typer.echo(f"Notes:        {first}")
+        for line in rest:
+            typer.echo(f"              {line}")
     typer.echo("postings:")
     table = Table(show_header=True, show_lines=False)
     table.add_column("account_id")
@@ -776,8 +783,9 @@ def edit_transaction(
                 if _looks_empty(edited):
                     typer.echo("No changes saved (empty buffer).")
                     return
+                stripped, notes_value = _extract_notes_block(edited)
                 try:
-                    parsed = parse_ledger_text(edited)
+                    parsed = parse_ledger_text(stripped)
                 except LedgerParseError as exc:
                     buffer = _with_banner(edited, str(exc))
                     continue
@@ -786,11 +794,14 @@ def edit_transaction(
                         client,
                         [ParsedPosting(p.account, p.amount, p.currency) for p in parsed.postings],
                     )
-                    body = {
+                    body: dict[str, Any] = {
                         "date": parsed.date.isoformat(),
                         "description": parsed.description,
                         "postings": resolved_postings,
                     }
+                    if not isinstance(notes_value, _UNSET_TYPE):
+                        # Explicit value (including None to clear).
+                        body["notes"] = notes_value
                     response = client.patch(
                         f"/v1/transactions/{resolved}",
                         json=body,
@@ -818,7 +829,9 @@ def _render_tx_for_edit(tx: dict[str, Any], accounts_by_id: dict[str, dict[str, 
     """Render an existing transaction back into the hledger-subset format.
 
     Uses account ``code`` when available; falls back to UUID. Inverse of
-    :func:`tulip_cli.commands._ledger.parse_ledger_text`.
+    :func:`tulip_cli.commands._ledger.parse_ledger_text`. Notes (if any)
+    are rendered as a bracketed comment block at the bottom of the
+    buffer; see :func:`_extract_notes_block`.
     """
     lines: list[str] = [_EDITOR_TEMPLATE_HEADER, ""]
     lines.append(f"{tx.get('date', '')} {tx.get('description', '')}")
@@ -829,4 +842,83 @@ def _render_tx_for_edit(tx: dict[str, Any], accounts_by_id: dict[str, dict[str, 
         amount = p.get("amount", "")
         currency = p.get("currency", "")
         lines.append(f"  {account_ref}  {amount} {currency}")
+    notes = tx.get("notes")
+    lines.append("")
+    lines.extend(_render_notes_block(notes if isinstance(notes, str) else None))
     return "\n".join(lines) + "\n"
+
+
+# Markers that bracket the multi-line notes block in the editor buffer.
+# Anything BETWEEN these two lines is extracted as notes plaintext (each
+# content line is expected to be prefixed by ``# `` so the ledger parser
+# treats the section as a no-op block of comments).
+_NOTES_BLOCK_START = "# ─── notes (delete the lines below to clear, edit to change) ───"
+_NOTES_BLOCK_END = "# ─── end notes ───"
+_NOTES_PREFIX = "# "
+
+
+def _render_notes_block(notes: str | None) -> list[str]:
+    """Render the notes block lines (markers + comment-prefixed content)."""
+    block: list[str] = [_NOTES_BLOCK_START]
+    if notes:
+        for line in notes.splitlines() or [notes]:
+            block.append(f"{_NOTES_PREFIX}{line}")
+    block.append(_NOTES_BLOCK_END)
+    return block
+
+
+def _extract_notes_block(text: str) -> tuple[str, str | None | _UNSET_TYPE]:
+    """Strip the notes block from ``text`` and return ``(stripped, notes)``.
+
+    Returns:
+        stripped: ``text`` with the notes block (markers + content) removed.
+            Safe to feed to :func:`parse_ledger_text`.
+        notes: the extracted plaintext, ``None`` if the block is empty
+            (meaning "clear"), or ``_UNSET`` if no block was present in
+            the buffer (meaning "leave column alone"). The ``_UNSET``
+            sentinel is local — the caller maps it to "omit the ``notes``
+            field from the PATCH body".
+
+    """
+    lines = text.splitlines()
+    try:
+        start = lines.index(_NOTES_BLOCK_START)
+    except ValueError:
+        return text, _UNSET
+    try:
+        end_offset = lines[start + 1 :].index(_NOTES_BLOCK_END)
+    except ValueError:
+        # Opener without closer — treat the rest of the buffer as notes
+        # content, but only the comment-prefixed lines.
+        content_lines = lines[start + 1 :]
+        end = len(lines)
+    else:
+        content_lines = lines[start + 1 : start + 1 + end_offset]
+        end = start + 1 + end_offset + 1  # include the end marker
+
+    note_text_lines: list[str] = []
+    for raw in content_lines:
+        if raw.startswith(_NOTES_PREFIX):
+            note_text_lines.append(raw[len(_NOTES_PREFIX) :])
+        elif raw.strip() == "#":
+            # Bare ``#`` represents an empty line inside notes.
+            note_text_lines.append("")
+        # Non-comment lines inside the block are ignored — keeps the
+        # parser focused on lines the user explicitly marked as notes.
+    notes_value: str | None
+    if note_text_lines:
+        notes_value = "\n".join(note_text_lines).strip("\n")
+        if not notes_value:
+            notes_value = None
+    else:
+        notes_value = None
+
+    stripped_lines = lines[:start] + lines[end:]
+    return "\n".join(stripped_lines), notes_value
+
+
+class _UNSET_TYPE:
+    """Sentinel for "notes block absent from the buffer entirely"."""
+
+
+_UNSET: _UNSET_TYPE = _UNSET_TYPE()

--- a/packages/tulip-cli/tests/test_transactions_notes_cli.py
+++ b/packages/tulip-cli/tests/test_transactions_notes_cli.py
@@ -1,0 +1,224 @@
+"""Unit tests for the CLI notes surface (issue #271).
+
+Covers the pure helpers — buffer rendering, notes-block extraction, and
+the ``show`` Notes line — without spinning up the live API. Round-trip
+behavior end-to-end lives in the API tests.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+
+import typer
+
+from tulip_cli.commands.transactions import (
+    _NOTES_BLOCK_END,
+    _NOTES_BLOCK_START,
+    _UNSET,
+    _extract_notes_block,
+    _render_notes_block,
+    _render_tx_detail,
+    _render_tx_for_edit,
+)
+
+
+class TestRenderTxDetailNotes:
+    def test_show_prints_notes_when_present(self) -> None:
+        buf = io.StringIO()
+        tx = {
+            "id": "abc",
+            "date": "2026-05-13",
+            "description": "Lunch",
+            "reference": None,
+            "status": "posted",
+            "notes": "Reimbursed by Carol.",
+            "postings": [],
+        }
+        with redirect_stdout(buf):
+            try:
+                _render_tx_detail(tx)
+            except typer.Exit:
+                pass
+        out = buf.getvalue()
+        assert "Notes:" in out
+        assert "Reimbursed by Carol." in out
+
+    def test_show_omits_notes_when_absent(self) -> None:
+        buf = io.StringIO()
+        tx = {
+            "id": "abc",
+            "date": "2026-05-13",
+            "description": "Lunch",
+            "reference": None,
+            "status": "posted",
+            "notes": None,
+            "postings": [],
+        }
+        with redirect_stdout(buf):
+            try:
+                _render_tx_detail(tx)
+            except typer.Exit:
+                pass
+        out = buf.getvalue()
+        assert "Notes:" not in out
+
+    def test_show_omits_notes_when_key_missing(self) -> None:
+        buf = io.StringIO()
+        tx = {
+            "id": "abc",
+            "date": "2026-05-13",
+            "description": "Lunch",
+            "reference": None,
+            "status": "posted",
+            "postings": [],
+        }
+        with redirect_stdout(buf):
+            try:
+                _render_tx_detail(tx)
+            except typer.Exit:
+                pass
+        out = buf.getvalue()
+        assert "Notes:" not in out
+
+    def test_show_indents_multiline_notes(self) -> None:
+        buf = io.StringIO()
+        tx = {
+            "id": "abc",
+            "date": "2026-05-13",
+            "description": "Lunch",
+            "reference": None,
+            "status": "posted",
+            "notes": "line one\nline two",
+            "postings": [],
+        }
+        with redirect_stdout(buf):
+            try:
+                _render_tx_detail(tx)
+            except typer.Exit:
+                pass
+        out = buf.getvalue()
+        assert "Notes:        line one" in out
+        assert "              line two" in out
+
+
+class TestRenderNotesBlock:
+    def test_rendered_block_has_markers(self) -> None:
+        block = _render_notes_block("hello")
+        assert block[0] == _NOTES_BLOCK_START
+        assert block[-1] == _NOTES_BLOCK_END
+
+    def test_rendered_content_lines_are_comment_prefixed(self) -> None:
+        block = _render_notes_block("hello\nworld")
+        assert "# hello" in block
+        assert "# world" in block
+
+    def test_none_renders_empty_block(self) -> None:
+        block = _render_notes_block(None)
+        assert block == [_NOTES_BLOCK_START, _NOTES_BLOCK_END]
+
+
+class TestExtractNotesBlock:
+    def test_no_block_returns_unset(self) -> None:
+        buf = "2026-05-13 lunch\n  food  10.00 USD\n  cash  -10.00 USD\n"
+        stripped, notes = _extract_notes_block(buf)
+        assert stripped == buf
+        assert notes is _UNSET
+
+    def test_empty_block_returns_none(self) -> None:
+        buf = (
+            "2026-05-13 lunch\n"
+            "  food  10.00 USD\n"
+            "  cash  -10.00 USD\n"
+            f"{_NOTES_BLOCK_START}\n"
+            f"{_NOTES_BLOCK_END}\n"
+        )
+        stripped, notes = _extract_notes_block(buf)
+        assert notes is None
+        assert _NOTES_BLOCK_START not in stripped
+        assert _NOTES_BLOCK_END not in stripped
+
+    def test_block_with_content_returns_plaintext(self) -> None:
+        buf = (
+            "2026-05-13 lunch\n"
+            "  food  10.00 USD\n"
+            "  cash  -10.00 USD\n"
+            f"{_NOTES_BLOCK_START}\n"
+            "# Reimbursed by Carol.\n"
+            "# See email thread.\n"
+            f"{_NOTES_BLOCK_END}\n"
+        )
+        stripped, notes = _extract_notes_block(buf)
+        assert notes == "Reimbursed by Carol.\nSee email thread."
+        assert _NOTES_BLOCK_START not in stripped
+
+    def test_bare_hash_yields_empty_inner_line(self) -> None:
+        buf = f"{_NOTES_BLOCK_START}\n# line a\n#\n# line c\n{_NOTES_BLOCK_END}\n"
+        _, notes = _extract_notes_block(buf)
+        assert notes == "line a\n\nline c"
+
+
+class TestRenderTxForEdit:
+    def test_buffer_round_trips_with_existing_notes(self) -> None:
+        tx = {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "date": "2026-05-13",
+            "description": "Lunch",
+            "reference": None,
+            "status": "pending",
+            "notes": "Reimbursed by Carol.",
+            "postings": [
+                {
+                    "account_id": "22222222-2222-2222-2222-222222222222",
+                    "amount": "10.00",
+                    "currency": "USD",
+                    "memo": None,
+                },
+                {
+                    "account_id": "33333333-3333-3333-3333-333333333333",
+                    "amount": "-10.00",
+                    "currency": "USD",
+                    "memo": None,
+                },
+            ],
+        }
+        buf = _render_tx_for_edit(tx, accounts_by_id={})
+        # Notes block is present, with the plaintext embedded as a # comment.
+        assert _NOTES_BLOCK_START in buf
+        assert "# Reimbursed by Carol." in buf
+        assert _NOTES_BLOCK_END in buf
+
+        # Round-trip: extract then verify.
+        _, notes = _extract_notes_block(buf)
+        assert notes == "Reimbursed by Carol."
+
+    def test_buffer_without_notes_still_emits_empty_block(self) -> None:
+        """An empty block means the editor flow always offers a place to add notes."""
+        tx = {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "date": "2026-05-13",
+            "description": "Lunch",
+            "reference": None,
+            "status": "pending",
+            "notes": None,
+            "postings": [
+                {
+                    "account_id": "22222222-2222-2222-2222-222222222222",
+                    "amount": "10.00",
+                    "currency": "USD",
+                    "memo": None,
+                },
+                {
+                    "account_id": "33333333-3333-3333-3333-333333333333",
+                    "amount": "-10.00",
+                    "currency": "USD",
+                    "memo": None,
+                },
+            ],
+        }
+        buf = _render_tx_for_edit(tx, accounts_by_id={})
+        assert _NOTES_BLOCK_START in buf
+        assert _NOTES_BLOCK_END in buf
+        _, notes = _extract_notes_block(buf)
+        # Empty block means "explicitly clear" — None.
+        assert notes is None

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
@@ -19,6 +19,7 @@ from uuid import UUID
 
 from sqlalchemy import String, cast, delete, func, select, update
 
+from tulip_storage.encryption import decrypt_field, encrypt_field
 from tulip_storage.models import Posting, Transaction, TransactionStatus
 
 if TYPE_CHECKING:
@@ -29,6 +30,28 @@ if TYPE_CHECKING:
     from tulip_core.transactions import Posting as DomainPosting
     from tulip_core.transactions import Transaction as DomainTransaction
     from tulip_core.transactions import TransactionStatus as DomainTxStatus
+
+
+class _Unset:
+    """Sentinel — distinguishes "field omitted from PATCH" from "set to None"."""
+
+    _instance: _Unset | None = None
+
+    def __new__(cls) -> _Unset:
+        """Singleton: ``UNSET is UNSET`` always holds."""
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+
+UNSET: _Unset = _Unset()
+
+
+class MasterKeyRequiredError(RuntimeError):
+    """Raised when a notes write is attempted without a master key configured."""
 
 
 class TransactionAlreadyVoidedError(ValueError):
@@ -70,10 +93,42 @@ class TrialBalanceRow:
 class TransactionRepository:
     """Persists Transactions and queries existing ones, scoped to one household."""
 
-    def __init__(self, session: Session, household_id: UUID) -> None:
-        """Bind the repository to a session and a tenant scope."""
+    def __init__(
+        self,
+        session: Session,
+        household_id: UUID,
+        *,
+        master_key: bytes | None = None,
+    ) -> None:
+        """Bind the repository to a session and a tenant scope.
+
+        ``master_key`` is required only when the caller passes a ``notes``
+        plaintext to ``save_balanced`` / ``update_pending`` (or reads it
+        back via :meth:`decrypt_notes`). Read-only and non-notes write
+        paths work without one — keeping the legions of existing callers
+        (reconciliation, reports, balance queries) untouched.
+        """
         self._session = session
         self._household_id = household_id
+        self._master_key = master_key
+
+    def _require_master_key(self) -> bytes:
+        if self._master_key is None:
+            raise MasterKeyRequiredError(
+                "TransactionRepository requires a master_key to encrypt or "
+                "decrypt transaction notes; construct with master_key=..."
+            )
+        return self._master_key
+
+    def decrypt_notes(self, header: Transaction) -> str | None:
+        """Return the plaintext notes for ``header`` or None when unset.
+
+        Decoded as UTF-8. Requires a configured master key.
+        """
+        if header.notes_encrypted is None:
+            return None
+        key = self._require_master_key()
+        return decrypt_field(header.notes_encrypted, key).decode("utf-8")
 
     def get(self, tx_id: UUID) -> Transaction | None:
         """Return the Transaction header by id, or None."""
@@ -217,6 +272,7 @@ class TransactionRepository:
         domain_tx: DomainTransaction,
         *,
         imported_from_id: UUID | None = None,
+        notes: str | None = None,
     ) -> Transaction:
         """Persist a balanced Domain Transaction.
 
@@ -227,9 +283,20 @@ class TransactionRepository:
         ``imported_from_id`` links the persisted row to the
         ``import_batches`` row that produced it (used by the apply /
         promote flow in P5.4.a).
+
+        ``notes`` is the transaction-level annotation (free text). When
+        provided, it is AES-256-GCM-encrypted with the constructor's
+        master key and stored in ``notes_encrypted``; ``None`` leaves
+        the column unset. Passing a non-None ``notes`` without a
+        configured master key raises :class:`MasterKeyRequiredError`.
         """
         target_status = self._domain_to_storage(domain_tx.status)
-        return self._save(domain_tx, target_status, imported_from_id=imported_from_id)
+        return self._save(
+            domain_tx,
+            target_status,
+            imported_from_id=imported_from_id,
+            notes=notes,
+        )
 
     def _save(
         self,
@@ -237,7 +304,13 @@ class TransactionRepository:
         target_status: TransactionStatus,
         *,
         imported_from_id: UUID | None = None,
+        notes: str | None = None,
     ) -> Transaction:
+        notes_blob: bytes | None = None
+        if notes is not None:
+            key = self._require_master_key()
+            notes_blob = encrypt_field(notes.encode("utf-8"), key)
+
         header = Transaction(
             household_id=self._household_id,
             id=domain_tx.id,
@@ -248,6 +321,7 @@ class TransactionRepository:
             created_by_user_id=domain_tx.created_by_user_id,
             posted_at=datetime.now(tz=UTC) if target_status is TransactionStatus.POSTED else None,
             imported_from_id=imported_from_id,
+            notes_encrypted=notes_blob,
         )
         self._session.add(header)
         self._session.flush()
@@ -374,12 +448,19 @@ class TransactionRepository:
         description: str,
         reference: str | None,
         postings: tuple[DomainPosting, ...],
+        notes: str | None | _Unset = UNSET,
     ) -> Transaction:
         """Update fields and replace postings on a PENDING transaction.
+
+        ``notes`` follows PATCH semantics: ``UNSET`` (the default) leaves
+        the column unchanged; an explicit ``None`` clears it; a string
+        encrypts and stores the new plaintext. A non-UNSET, non-None
+        ``notes`` requires a configured master key.
 
         Raises:
             LookupError: ``tx_id`` does not exist in this household.
             TransactionNotEditableError: transaction is not PENDING.
+            MasterKeyRequiredError: notes is a string but no master_key.
 
         """
         existing = self.get(tx_id)
@@ -390,13 +471,24 @@ class TransactionRepository:
                 f"transaction {tx_id} is {existing.status.value}; "
                 "only PENDING transactions may be edited (use void otherwise)"
             )
+        header_values: dict[str, object] = {
+            "date": date,
+            "description": description,
+            "reference": reference,
+        }
+        if not isinstance(notes, _Unset):
+            if notes is None:
+                header_values["notes_encrypted"] = None
+            else:
+                key = self._require_master_key()
+                header_values["notes_encrypted"] = encrypt_field(notes.encode("utf-8"), key)
         self._session.execute(
             update(Transaction)
             .where(
                 Transaction.household_id == self._household_id,
                 Transaction.id == tx_id,
             )
-            .values(date=date, description=description, reference=reference)
+            .values(**header_values)
         )
         # Replace postings wholesale: simpler than diff-merge and the trigger
         # is a no-op on PENDING transactions.

--- a/packages/tulip-storage/tests/test_transaction_repository_notes.py
+++ b/packages/tulip-storage/tests/test_transaction_repository_notes.py
@@ -1,0 +1,247 @@
+"""Tests for transaction-level notes round-trip + clearing (issue #271)."""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_core.money import Money
+from tulip_core.transactions import Posting as DomainPosting
+from tulip_core.transactions import Transaction as DomainTransaction
+from tulip_core.transactions import TransactionStatus as DomainTxStatus
+from tulip_storage.models import (
+    Account as AccountModel,
+)
+from tulip_storage.models import (
+    AccountType,
+    Household,
+)
+from tulip_storage.models import (
+    Transaction as TxModel,
+)
+from tulip_storage.repositories import (
+    AccountRepository,
+    TransactionRepository,
+)
+from tulip_storage.repositories.transaction import (
+    UNSET,
+    MasterKeyRequiredError,
+)
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    """Seed a household for the test session."""
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+@pytest.fixture
+def master_key() -> bytes:
+    """Random 32-byte AES-256 key, fresh per test."""
+    return os.urandom(32)
+
+
+def _seed_accounts(session: Session, household: Household) -> tuple[AccountModel, AccountModel]:
+    repo = AccountRepository(session, household.id)
+    cash = repo.create(code="1110", name="Cash", type=AccountType.ASSET, currency="USD")
+    food = repo.create(code="5100", name="Food", type=AccountType.EXPENSE, currency="USD")
+    session.commit()
+    return cash, food
+
+
+def _balanced_postings(
+    food: AccountModel, cash: AccountModel
+) -> tuple[DomainPosting, DomainPosting]:
+    return (
+        DomainPosting(
+            id=uuid4(),
+            account_id=food.id,
+            amount=Money(Decimal("12.50"), "USD"),
+        ),
+        DomainPosting(
+            id=uuid4(),
+            account_id=cash.id,
+            amount=Money(Decimal("-12.50"), "USD"),
+        ),
+    )
+
+
+def _lunch_domain(
+    household: Household,
+    food: AccountModel,
+    cash: AccountModel,
+    *,
+    status: DomainTxStatus = DomainTxStatus.PENDING,
+) -> DomainTransaction:
+    return DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 6, 1),
+        description="Lunch",
+        postings=_balanced_postings(food, cash),
+        status=status,
+    )
+
+
+class TestSaveBalancedNotes:
+    def test_save_with_notes_round_trips(
+        self, session: Session, household: Household, master_key: bytes
+    ):
+        cash, food = _seed_accounts(session, household)
+        domain_tx = _lunch_domain(household, food, cash)
+        repo = TransactionRepository(session, household.id, master_key=master_key)
+
+        plaintext = "Reimbursed by Carol on 1/15.\nSee email thread."
+        saved = repo.save_balanced(domain_tx, notes=plaintext)
+        session.commit()
+
+        loaded = repo.get(saved.id)
+        assert loaded is not None
+        assert repo.decrypt_notes(loaded) == plaintext
+
+    def test_save_without_notes_leaves_column_null(
+        self, session: Session, household: Household, master_key: bytes
+    ):
+        cash, food = _seed_accounts(session, household)
+        domain_tx = _lunch_domain(household, food, cash)
+        repo = TransactionRepository(session, household.id, master_key=master_key)
+
+        saved = repo.save_balanced(domain_tx)
+        session.commit()
+
+        loaded = session.query(TxModel).filter_by(id=saved.id).one()
+        assert loaded.notes_encrypted is None
+        assert repo.decrypt_notes(loaded) is None
+
+    def test_save_with_notes_stores_ciphertext_not_plaintext(
+        self, session: Session, household: Household, master_key: bytes
+    ):
+        """Encrypted-at-rest invariant: raw row bytes never equal the plaintext."""
+        cash, food = _seed_accounts(session, household)
+        domain_tx = _lunch_domain(household, food, cash)
+        repo = TransactionRepository(session, household.id, master_key=master_key)
+
+        plaintext = "Sensitive memo about the transaction"
+        saved = repo.save_balanced(domain_tx, notes=plaintext)
+        session.commit()
+
+        # Re-query the row directly so we observe the on-disk ciphertext.
+        session.expire_all()
+        raw = session.query(TxModel).filter_by(id=saved.id).one()
+        assert raw.notes_encrypted is not None
+        assert raw.notes_encrypted != plaintext.encode("utf-8")
+        assert plaintext.encode("utf-8") not in raw.notes_encrypted
+
+    def test_save_with_notes_requires_master_key(self, session: Session, household: Household):
+        cash, food = _seed_accounts(session, household)
+        domain_tx = _lunch_domain(household, food, cash)
+        repo = TransactionRepository(session, household.id)  # no master_key
+
+        with pytest.raises(MasterKeyRequiredError):
+            repo.save_balanced(domain_tx, notes="oops")
+
+    def test_save_without_notes_works_without_master_key(
+        self, session: Session, household: Household
+    ):
+        """Existing callers that don't touch notes shouldn't need a key."""
+        cash, food = _seed_accounts(session, household)
+        domain_tx = _lunch_domain(household, food, cash)
+        repo = TransactionRepository(session, household.id)
+
+        saved = repo.save_balanced(domain_tx)
+        session.commit()
+        assert saved.notes_encrypted is None
+
+
+class TestUpdatePendingNotes:
+    def _save_pending(
+        self,
+        session: Session,
+        household: Household,
+        food: AccountModel,
+        cash: AccountModel,
+        master_key: bytes,
+        *,
+        initial_notes: str | None = None,
+    ) -> TxModel:
+        domain_tx = _lunch_domain(household, food, cash)
+        repo = TransactionRepository(session, household.id, master_key=master_key)
+        saved = repo.save_balanced(domain_tx, notes=initial_notes)
+        session.commit()
+        return saved
+
+    def test_update_pending_sets_notes(
+        self, session: Session, household: Household, master_key: bytes
+    ):
+        cash, food = _seed_accounts(session, household)
+        saved = self._save_pending(session, household, food, cash, master_key)
+        repo = TransactionRepository(session, household.id, master_key=master_key)
+
+        repo.update_pending(
+            saved.id,
+            date=saved.date,
+            description=saved.description,
+            reference=saved.reference,
+            postings=_balanced_postings(food, cash),
+            notes="Added later",
+        )
+        session.commit()
+
+        loaded = repo.get(saved.id)
+        assert loaded is not None
+        assert repo.decrypt_notes(loaded) == "Added later"
+
+    def test_update_pending_clears_notes_with_explicit_none(
+        self, session: Session, household: Household, master_key: bytes
+    ):
+        cash, food = _seed_accounts(session, household)
+        saved = self._save_pending(
+            session, household, food, cash, master_key, initial_notes="will be cleared"
+        )
+        repo = TransactionRepository(session, household.id, master_key=master_key)
+
+        repo.update_pending(
+            saved.id,
+            date=saved.date,
+            description=saved.description,
+            reference=saved.reference,
+            postings=_balanced_postings(food, cash),
+            notes=None,
+        )
+        session.commit()
+
+        session.expire_all()
+        loaded = session.query(TxModel).filter_by(id=saved.id).one()
+        assert loaded.notes_encrypted is None
+
+    def test_update_pending_with_unset_preserves_notes(
+        self, session: Session, household: Household, master_key: bytes
+    ):
+        cash, food = _seed_accounts(session, household)
+        saved = self._save_pending(
+            session, household, food, cash, master_key, initial_notes="keep me"
+        )
+        repo = TransactionRepository(session, household.id, master_key=master_key)
+
+        # Update other fields; pass UNSET (the default) for notes.
+        repo.update_pending(
+            saved.id,
+            date=saved.date,
+            description="Lunch (renamed)",
+            reference=saved.reference,
+            postings=_balanced_postings(food, cash),
+            notes=UNSET,
+        )
+        session.commit()
+
+        loaded = repo.get(saved.id)
+        assert loaded is not None
+        assert repo.decrypt_notes(loaded) == "keep me"


### PR DESCRIPTION
## Summary

- ``transactions.notes_encrypted`` (provisioned in migration 0001, never wired until now) now round-trips through the repository, API, and CLI as a first-class free-text transaction-level annotation — distinct from the short ``description`` headline and from posting-level ``memo``.
- ``TransactionRepository`` takes an optional ``master_key=`` constructor kwarg; ``save_balanced`` / ``update_pending`` accept ``notes`` plaintext that is AES-256-GCM-encrypted via the existing ``encrypt_field`` helper. PATCH callers can distinguish "omit notes" (keep current) from "send null" (clear) via an ``UNSET`` sentinel.
- ``POST`` + ``GET`` + ``PATCH /v1/transactions`` plumb ``settings.master_key`` to the repo; the PATCH router maps Pydantic's ``model_fields_set`` onto UNSET so the route layer matches the repo's PATCH semantics.
- ``tulip transactions show`` prints ``Notes:`` (multi-line aware) only when present. ``tulip transactions edit`` renders existing notes as a bracketed ``# notes`` comment block in the editor buffer and parses edits back. Empty block → clear.

## Test plan

- [x] ``uv run pytest packages -q`` — 1686 passed, 1 skipped, 3 deselected.
- [x] ``just lint`` — clean.
- [x] ``just typecheck`` — Success: no issues found in 241 source files.
- [x] New storage tests cover save round-trip, save without notes, encrypted-at-rest invariant, master-key gating, update_pending set / clear / UNSET-preserves.
- [x] New API tests cover POST-with-notes round-trip on GET, PATCH set / clear (null) / omit-preserves, encrypted-at-rest invariant via the HTTP surface.
- [x] New CLI tests cover ``_render_tx_detail`` show formatting (single + multi-line), ``_render_notes_block`` / ``_extract_notes_block`` round-trip including the empty-block clear semantics.
- [ ] CI green on this PR.

### Manual smoke test

```bash
export TULIP_API_BASE_URL=http://localhost:8000
tulip auth register --email demo@example.com --household "Demo HH"
tulip auth login --email demo@example.com --password-stdin <<<'long-enough-password'
tulip accounts add --name Checking --code assets:checking --type asset --currency USD
tulip accounts add --name Food --code expenses:food --type expense --currency USD

# Create a transaction with notes via the HTTP API directly (CLI ``add`` doesn't
# expose --notes today; that's a separate slice if we want a flag-mode surface).
TOKEN=$(jq -r '.[].access_token' < ~/.tulip/tokens.json)
TX_ID=$(curl -s -X POST http://localhost:8000/v1/transactions \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{
    "date":"2026-05-13","description":"Lunch","notes":"Reimbursed by Carol on 1/15.",
    "postings":[
      {"account_id":"<food-id>","amount":"12.50","currency":"USD"},
      {"account_id":"<cash-id>","amount":"-12.50","currency":"USD"}]
  }' | jq -r .id)

# Show prints Notes: when present.
tulip transactions show "$TX_ID"
# Expected output contains:
#   Notes:        Reimbursed by Carol on 1/15.

# Clear via PATCH.
curl -s -X PATCH "http://localhost:8000/v1/transactions/$TX_ID" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"notes":null}' | jq .notes
# Expected: null

# Subsequent show omits the Notes: line entirely.
tulip transactions show "$TX_ID"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)