### PR TITLE
feat: interactive picker when a UUID-required command runs without one (closes #273)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/_picker.py
+++ b/packages/tulip-cli/src/tulip_cli/_picker.py
@@ -1,0 +1,112 @@
+"""Shared interactive picker for "missing UUID argument" command paths (#273).
+
+When a CLI command that takes a UUID/prefix positional argument is invoked
+without one, instead of immediately erroring out the calling command can
+fetch a short list (e.g. recent imports, in-progress reconciliations,
+recent transactions) and let the user pick by number. Non-TTY callers
+(scripts, CI) still get a clean usage error so they don't deadlock waiting
+for input.
+
+The module is intentionally tiny and dependency-free beyond ``typer`` —
+callers supply the list (already filtered to "actionable" rows where
+applicable) and a row-to-label function. The picker only knows about
+
+* whether stdin is interactive,
+* rendering numbered choices + a ``[c] cancel`` row,
+* parsing the user's response.
+
+It returns the picked id string or ``None`` when the user cancels (``c``,
+empty input, ``EOF``) so callers can map that to ``typer.Exit`` or to
+their existing usage-error path uniformly.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import typer
+
+#: Hard cap on the number of choices rendered. Lists longer than this
+#: should be narrowed with the command's existing filter flags rather
+#: than scrolled by the user.
+PICKER_MAX_ENTRIES = 20
+
+
+def is_interactive() -> bool:
+    """``True`` when stdin is a TTY — i.e. the picker can prompt safely.
+
+    Stdin (not stdout) is the relevant signal: tests and pipelines pipe
+    stdout but leave stdin attached. If stdin isn't a TTY we can't ask the
+    user a question, so the caller falls back to its legacy usage-error
+    path.
+    """
+    return sys.stdin.isatty()
+
+
+def pick(
+    items: Sequence[dict[str, Any]],
+    *,
+    label: Callable[[dict[str, Any]], str],
+    title: str,
+    empty_message: str,
+    overflow_hint: str,
+    id_key: str = "id",
+) -> str | None:
+    """Render a numbered picker and return the chosen item's id string.
+
+    Args:
+        items: Pre-filtered list of API rows. The caller is responsible
+            for any "actionable rows only" filtering (e.g. only ``parsed``
+            import batches for ``imports apply``).
+        label: ``row -> str`` that renders one row as a human-readable
+            line. Width-sensitive callers should keep these short — the
+            picker doesn't truncate.
+        title: One-line banner rendered above the choices.
+        empty_message: Rendered when ``items`` is empty; the picker then
+            returns ``None`` without prompting. Callers map that to their
+            usage-error exit.
+        overflow_hint: Rendered after the list when ``len(items) >
+            PICKER_MAX_ENTRIES``. Should name the filter flags the user
+            can use to narrow.
+        id_key: Key in each row holding the id to return. Defaults to
+            ``"id"``.
+
+    Returns:
+        The selected row's ``id_key`` value as a string, or ``None`` if
+        the user cancelled (``c``, empty input, EOF) or the list was
+        empty.
+    """
+    if not items:
+        typer.echo(empty_message, err=True)
+        return None
+
+    display = list(items[:PICKER_MAX_ENTRIES])
+    typer.echo(title, err=True)
+    for idx, row in enumerate(display, start=1):
+        typer.echo(f"  [{idx:>2}] {label(row)}", err=True)
+    typer.echo("  [ c] cancel", err=True)
+    if len(items) > PICKER_MAX_ENTRIES:
+        typer.echo(overflow_hint, err=True)
+
+    try:
+        raw = typer.prompt("Pick one", default="c", show_default=False)
+    except (EOFError, typer.Abort):
+        return None
+    choice = raw.strip().lower()
+    if choice in ("", "c", "cancel"):
+        return None
+    try:
+        position = int(choice)
+    except ValueError:
+        typer.echo(f"Not a number: {raw!r}. Cancelled.", err=True)
+        return None
+    if not 1 <= position <= len(display):
+        typer.echo(
+            f"Choice {position} out of range (1-{len(display)}). Cancelled.",
+            err=True,
+        )
+        return None
+    picked = display[position - 1]
+    return str(picked[id_key])

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -18,6 +18,7 @@ from typing import Annotated, Any
 
 import typer
 
+from tulip_cli._picker import is_interactive, pick
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands.accounts import _resolve_account
 from tulip_cli.commands.csv_profiles import csv_profiles_app
@@ -379,16 +380,73 @@ def _render_batch(body: dict[str, Any]) -> None:
     console.print(table)
 
 
+def _format_apply_picker_label(item: dict[str, Any]) -> str:
+    """One-line label for an actionable (status=parsed) batch in the picker."""
+    batch_id = str(item.get("id") or "")
+    created = str(item.get("created_at") or "")
+    if len(created) >= 19:
+        created = created[:19].replace("T", " ")
+    fmt = str(item.get("source_format") or "").upper()
+    filename = str(item.get("source_filename") or "")
+    imported = item.get("imported_count", 0)
+    skipped = item.get("skipped_count", 0)
+    return (
+        f"{batch_id[:8] if batch_id else '—'}  {created}  {fmt:>4}  "
+        f"{filename}  ({imported}/{skipped})"
+    )
+
+
+def _pick_apply_batch_id(config: Config, *, as_json: bool) -> str | None:
+    """Fetch actionable (parsed) batches and prompt the user to pick one.
+
+    Returns the picked UUID string, or ``None`` if the picker is
+    suppressed (no TTY, ``--json``) or the user cancels. Non-interactive
+    callers get a usage hint on stderr matching the legacy "missing
+    argument" message so scripts can ``grep`` it.
+    """
+    if as_json or not is_interactive():
+        typer.echo(
+            "Missing argument BATCH_ID. Run `tulip imports list --status parsed` "
+            "to find a batch, then re-run with the id.",
+            err=True,
+        )
+        return None
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get(
+                "/v1/imports",
+                authenticated=True,
+                params={"status": "parsed"},
+            )
+    except CliError as err:
+        err.render()
+        return None
+    items = response.json().get("items") or []
+    return pick(
+        items,
+        label=_format_apply_picker_label,
+        title="Pick a parsed import batch to apply:",
+        empty_message=(
+            "No parsed import batches to apply. Upload one with `tulip imports ofx/qif/csv` first."
+        ),
+        overflow_hint=("  …list truncated; narrow with `tulip imports list --account <id>`."),
+    )
+
+
 @imports_app.command("apply")
 def apply_import(
     ctx: typer.Context,
     batch_id: Annotated[
-        str,
+        str | None,
         typer.Argument(
-            help="Import batch UUID returned by `tulip imports ofx/qif/csv`.",
+            help=(
+                "Import batch UUID returned by `tulip imports ofx/qif/csv`. "
+                "Omit to pick interactively from recent parsed batches "
+                "(TTY only — scripts still get the usage error)."
+            ),
             metavar="BATCH_ID",
         ),
-    ],
+    ] = None,
     no_categorize: Annotated[
         bool,
         typer.Option(
@@ -424,6 +482,10 @@ def apply_import(
     """
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
+    if batch_id is None:
+        batch_id = _pick_apply_batch_id(config, as_json=as_json)
+        if batch_id is None:
+            raise typer.Exit(2)
     path = f"/v1/imports/{batch_id}/apply"
     query: list[str] = []
     if no_categorize:

--- a/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
@@ -25,6 +25,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._picker import is_interactive, pick
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands.accounts import _resolve_account
 from tulip_cli.config import Config
@@ -314,17 +315,67 @@ def list_command(
 # ---- show -----------------------------------------------------------------
 
 
+def _format_recon_picker_label(item: dict[str, Any]) -> str:
+    """One-line label for an in-progress reconciliation row in the picker."""
+    recon_id = str(item.get("id") or "")
+    account = str(item.get("account_id") or "")
+    period = f"{item.get('statement_period_start', '?')}..{item.get('statement_period_end', '?')}"
+    ending = str(item.get("statement_ending_balance") or "?")
+    return f"{recon_id[:8] if recon_id else '—'}  account={account[:8]}  {period}  ending={ending}"
+
+
+def _pick_reconciliation_id(config: Config, *, as_json: bool) -> str | None:
+    """Fetch in-progress reconciliations and prompt the user to pick one.
+
+    Returns the picked UUID string, or ``None`` when suppressed
+    (``--json`` / non-TTY) or the user cancels.
+    """
+    if as_json or not is_interactive():
+        typer.echo(
+            "Missing argument RECONCILIATION_ID. Run `tulip reconcile list "
+            "--status in_progress` to find an envelope, then re-run with the id.",
+            err=True,
+        )
+        return None
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get(
+                "/v1/reconciliations",
+                authenticated=True,
+                params={"status": "in_progress"},
+            )
+    except CliError as err:
+        err.render()
+        return None
+    items = response.json().get("items") or []
+    return pick(
+        items,
+        label=_format_recon_picker_label,
+        title="Pick an in-progress reconciliation:",
+        empty_message=(
+            "No in-progress reconciliations. Open one with "
+            "`tulip reconcile create` or `tulip reconcile start`."
+        ),
+        overflow_hint=("  …list truncated; narrow with `tulip reconcile list --account <id>`."),
+    )
+
+
 @reconcile_app.command("show")
 def show_command(
     ctx: typer.Context,
     reconciliation_id: Annotated[
-        UUID,
+        UUID | None,
         typer.Argument(help="Reconciliation UUID.", metavar="RECONCILIATION_ID"),
-    ],
+    ] = None,
 ) -> None:
     """Show the reconciliation envelope + the four-section review pane."""
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
+    if reconciliation_id is None:
+        picked = _pick_reconciliation_id(config, as_json=as_json)
+        if picked is None:
+            raise typer.Exit(2)
+        reconciliation_id = UUID(picked)
     try:
         with _client(config, as_json=as_json) as client:
             response = client.get(f"/v1/reconciliations/{reconciliation_id}", authenticated=True)

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -35,6 +35,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._picker import is_interactive, pick
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands._editor import edit_buffer
 from tulip_cli.commands._ledger import LedgerParseError, parse_ledger_text
@@ -644,20 +645,80 @@ def list_transactions(
     _render_tx_list_table(rows, accounts_by_id)
 
 
+def _format_tx_picker_label(item: dict[str, Any]) -> str:
+    """One-line label for a transaction row in the picker."""
+    tx_id = str(item.get("id") or "")
+    date = str(item.get("date") or "")
+    desc = str(item.get("description") or "")
+    if len(desc) > 48:
+        desc = desc[:45] + "..."
+    status = str(item.get("status") or "")
+    return f"{tx_id[:8] if tx_id else '—'}  {date}  {status:<10}  {desc}"
+
+
+def _pick_tx_id(config: Config, *, as_json: bool) -> str | None:
+    """Fetch recent transactions and prompt the user to pick one.
+
+    Returns the picked UUID string, or ``None`` when suppressed
+    (``--json`` / non-TTY) or the user cancels.
+    """
+    if as_json or not is_interactive():
+        typer.echo(
+            "Missing argument TXID. Run `tulip transactions list` to find "
+            "a transaction, then re-run with its id or prefix.",
+            err=True,
+        )
+        return None
+    try:
+        with _client(config, as_json=as_json) as client:
+            # 20 is the picker cap; ask the API for exactly that.
+            response = client.get(
+                "/v1/transactions",
+                authenticated=True,
+                params={"limit": "20"},
+            )
+    except CliError as err:
+        err.render()
+        return None
+    rows = response.json()
+    return pick(
+        rows,
+        label=_format_tx_picker_label,
+        title="Pick a recent transaction:",
+        empty_message=(
+            "No transactions yet. Use `tulip add` to create one or "
+            "`tulip imports apply` to land an imported batch."
+        ),
+        overflow_hint=(
+            "  …showing 20 most recent; narrow with "
+            "`tulip transactions list --account <id> --from <date>`."
+        ),
+    )
+
+
 @transactions_app.command("show")
 def show_transaction(
     ctx: typer.Context,
     tx_id: Annotated[
-        str,
+        str | None,
         typer.Argument(
-            help="Transaction UUID or unambiguous hex prefix.",
+            help=(
+                "Transaction UUID or unambiguous hex prefix. Omit to pick "
+                "interactively from recent transactions (TTY only — scripts "
+                "still get the usage error)."
+            ),
             metavar="TXID",
         ),
-    ],
+    ] = None,
 ) -> None:
     """Show one transaction (header + postings) by UUID or prefix."""
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
+
+    if tx_id is None:
+        tx_id = _pick_tx_id(config, as_json=as_json)
+        if tx_id is None:
+            raise typer.Exit(2)
 
     try:
         with _client(config, as_json=as_json) as client:

--- a/packages/tulip-cli/tests/test_picker.py
+++ b/packages/tulip-cli/tests/test_picker.py
@@ -1,0 +1,176 @@
+"""Unit tests for the shared interactive picker (#273).
+
+Covers the pure helper in :mod:`tulip_cli._picker`. The integration of
+the picker into individual commands is exercised by the per-command
+tests (``test_import_command``, ``test_reconcile_command``,
+``test_transactions_picker``); here we drive every branch of the
+picker itself without spawning a subprocess.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from tulip_cli._picker import PICKER_MAX_ENTRIES, is_interactive, pick
+
+
+def _rows(n: int) -> list[dict[str, str]]:
+    return [{"id": f"id-{i:02d}", "label": f"row-{i:02d}"} for i in range(n)]
+
+
+def _label(row: dict[str, str]) -> str:
+    return row["label"]
+
+
+def test_pick_returns_selected_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Numeric selection returns the matching row's id."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("2\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    picked = pick(
+        _rows(3),
+        label=_label,
+        title="Pick:",
+        empty_message="empty",
+        overflow_hint="too many",
+    )
+    assert picked == "id-01"
+
+
+def test_pick_returns_none_on_explicit_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Typing ``c`` cancels the picker; the helper returns ``None``."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("c\n"))
+    picked = pick(
+        _rows(3),
+        label=_label,
+        title="Pick:",
+        empty_message="empty",
+        overflow_hint="too many",
+    )
+    assert picked is None
+
+
+def test_pick_returns_none_on_empty_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare Enter (default ``c``) cancels."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("\n"))
+    picked = pick(
+        _rows(3),
+        label=_label,
+        title="Pick:",
+        empty_message="empty",
+        overflow_hint="too many",
+    )
+    assert picked is None
+
+
+def test_pick_returns_none_on_eof(monkeypatch: pytest.MonkeyPatch) -> None:
+    """EOF during the prompt cancels (typer raises Abort on click EOF)."""
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))  # nothing to read
+    picked = pick(
+        _rows(3),
+        label=_label,
+        title="Pick:",
+        empty_message="empty",
+        overflow_hint="too many",
+    )
+    assert picked is None
+
+
+def test_pick_returns_none_on_out_of_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A number outside ``[1, len(items)]`` cancels rather than crashing."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("99\n"))
+    picked = pick(
+        _rows(3),
+        label=_label,
+        title="Pick:",
+        empty_message="empty",
+        overflow_hint="too many",
+    )
+    assert picked is None
+
+
+def test_pick_returns_none_on_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-numeric, non-cancel input cancels with a diagnostic."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("zzz\n"))
+    picked = pick(
+        _rows(3),
+        label=_label,
+        title="Pick:",
+        empty_message="empty",
+        overflow_hint="too many",
+    )
+    assert picked is None
+
+
+def test_pick_returns_none_on_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An empty input list short-circuits to ``None`` without prompting."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("1\n"))  # would pick if prompted
+    picked = pick(
+        [],
+        label=_label,
+        title="Pick:",
+        empty_message="nothing actionable",
+        overflow_hint="too many",
+    )
+    assert picked is None
+    captured = capsys.readouterr()
+    assert "nothing actionable" in captured.err
+
+
+def test_pick_caps_choices_at_20(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Lists longer than ``PICKER_MAX_ENTRIES`` render the overflow hint."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("c\n"))
+    big = _rows(PICKER_MAX_ENTRIES + 5)
+    pick(
+        big,
+        label=_label,
+        title="Pick:",
+        empty_message="empty",
+        overflow_hint="narrow with --account",
+    )
+    captured = capsys.readouterr()
+    # Only the first PICKER_MAX_ENTRIES rows render.
+    assert "row-00" in captured.err
+    assert "row-19" in captured.err
+    assert "row-20" not in captured.err
+    assert "narrow with --account" in captured.err
+
+
+def test_is_interactive_reflects_isatty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``is_interactive`` is just ``sys.stdin.isatty()``."""
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    assert is_interactive() is True
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False, raising=False)
+    assert is_interactive() is False
+
+
+def test_pick_renders_label_for_each_row(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Caller-supplied label is invoked once per rendered row."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("c\n"))
+    seen_ids: list[str] = []
+
+    def _label_record(row: dict[str, str]) -> str:
+        seen_ids.append(row["id"])
+        return f"<{row['id']}>"
+
+    pick(
+        _rows(3),
+        label=_label_record,
+        title="Pick:",
+        empty_message="empty",
+        overflow_hint="narrow",
+    )
+    assert seen_ids == ["id-00", "id-01", "id-02"]
+    captured = capsys.readouterr()
+    assert "<id-00>" in captured.err
+    assert "<id-02>" in captured.err

--- a/packages/tulip-cli/tests/test_picker_integration.py
+++ b/packages/tulip-cli/tests/test_picker_integration.py
@@ -1,0 +1,410 @@
+"""Integration tests for the picker wired into the three target commands (#273).
+
+These cover the seam between the command's "argument missing" path and
+the shared :mod:`tulip_cli._picker` helper:
+
+- happy path: TTY + non-empty list + numeric pick → resolved id flows to
+  the HTTP call.
+- cancel path: TTY + ``c`` → no follow-up HTTP call, exit code 2.
+- non-TTY path: piped stdin → legacy usage-error stderr + exit code 2.
+
+We drive the resolver functions directly with an ``httpx.MockTransport``
+to avoid the cost of a uvicorn spawn and to keep assertions deterministic
+across machines / terminal widths.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from tulip_cli.auth.tokens import TokenSet, TokenStore
+from tulip_cli.commands.imports import _pick_apply_batch_id
+from tulip_cli.commands.reconcile import _pick_reconciliation_id
+from tulip_cli.commands.transactions import _pick_tx_id
+from tulip_cli.config import Config
+
+_API = "https://api.example.com"
+
+
+def _seeded_token_store(tmp_path: Path) -> TokenStore:
+    store = TokenStore(file_path=tmp_path / "tokens.json")
+    store.save(
+        _API,
+        TokenSet(
+            email="alice@example.com",
+            access_token="access",
+            refresh_token="refresh",
+            access_expires_at=9_999_999_999,
+        ),
+    )
+    return store
+
+
+def _config() -> Config:
+    return Config(api_url=_API)
+
+
+def _make_transport_capture(
+    handler: dict[str, Any],
+) -> tuple[httpx.MockTransport, list[httpx.Request]]:
+    """Return a transport that records every request it sees.
+
+    ``handler`` maps ``(method, path)`` → response factory or list of dicts.
+    Anything not in the map returns 500 so the test fails loudly.
+    """
+    seen: list[httpx.Request] = []
+
+    def _dispatch(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        key = f"{request.method} {request.url.path}"
+        if key in handler:
+            entry = handler[key]
+            return httpx.Response(200, json=entry)
+        return httpx.Response(500, json={"unexpected": key})
+
+    return httpx.MockTransport(_dispatch), seen
+
+
+# ---- imports apply --------------------------------------------------------
+
+
+def _patch_transport(monkeypatch: pytest.MonkeyPatch, transport: httpx.MockTransport) -> None:
+    """Make every ``TulipClient`` constructed during the call use ``transport``.
+
+    The picker resolver helpers build their own ``TulipClient`` instances,
+    so we patch the ``httpx.Client`` constructor to thread the mock
+    transport through.
+    """
+    real_init = httpx.Client.__init__
+
+    def _patched_init(self: httpx.Client, *args: Any, **kwargs: Any) -> None:
+        kwargs["transport"] = transport
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.Client, "__init__", _patched_init)
+
+
+def test_pick_apply_batch_id_returns_first_choice(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Numeric ``1`` resolves to the first parsed batch in the list."""
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin", io.StringIO("1\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    transport, seen = _make_transport_capture(
+        {
+            "GET /v1/imports": {
+                "items": [
+                    {
+                        "id": "11111111-1111-1111-1111-111111111111",
+                        "status": "parsed",
+                        "source_format": "ofx",
+                        "source_filename": "jan.ofx",
+                        "imported_count": 3,
+                        "skipped_count": 0,
+                        "created_at": "2026-01-15T10:00:00",
+                    }
+                ],
+                "next_cursor": None,
+            }
+        }
+    )
+    _patch_transport(monkeypatch, transport)
+
+    picked = _pick_apply_batch_id(_config(), as_json=False)
+    assert picked == "11111111-1111-1111-1111-111111111111"
+    assert any(r.url.path == "/v1/imports" for r in seen)
+
+
+def test_pick_apply_batch_id_filters_to_parsed_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The picker GET passes ``status=parsed`` so applied batches don't appear."""
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin", io.StringIO("c\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    transport, seen = _make_transport_capture(
+        {"GET /v1/imports": {"items": [], "next_cursor": None}}
+    )
+    _patch_transport(monkeypatch, transport)
+    _pick_apply_batch_id(_config(), as_json=False)
+    [request] = [r for r in seen if r.url.path == "/v1/imports"]
+    assert request.url.params.get("status") == "parsed"
+
+
+def test_pick_apply_batch_id_returns_none_on_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Typing ``c`` cancels the picker."""
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin", io.StringIO("c\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    transport, _ = _make_transport_capture(
+        {
+            "GET /v1/imports": {
+                "items": [
+                    {
+                        "id": "22222222-2222-2222-2222-222222222222",
+                        "status": "parsed",
+                        "source_format": "csv",
+                        "source_filename": "x.csv",
+                        "imported_count": 1,
+                        "skipped_count": 0,
+                        "created_at": "2026-02-01T08:00:00",
+                    }
+                ],
+                "next_cursor": None,
+            }
+        }
+    )
+    _patch_transport(monkeypatch, transport)
+    picked = _pick_apply_batch_id(_config(), as_json=False)
+    assert picked is None
+
+
+def test_pick_apply_batch_id_non_tty_emits_usage_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-interactive stdin → ``None`` + usage-error hint on stderr."""
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False, raising=False)
+    transport, seen = _make_transport_capture({})  # no requests expected
+    _patch_transport(monkeypatch, transport)
+    picked = _pick_apply_batch_id(_config(), as_json=False)
+    assert picked is None
+    assert seen == []
+    captured = capsys.readouterr()
+    assert "Missing argument BATCH_ID" in captured.err
+
+
+def test_pick_apply_batch_id_json_mode_skips_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--json`` callers always get the usage error, even on a TTY."""
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    transport, seen = _make_transport_capture({})
+    _patch_transport(monkeypatch, transport)
+    picked = _pick_apply_batch_id(_config(), as_json=True)
+    assert picked is None
+    assert seen == []
+    captured = capsys.readouterr()
+    assert "Missing argument BATCH_ID" in captured.err
+
+
+# ---- transactions show ----------------------------------------------------
+
+
+def test_pick_tx_id_returns_first_choice(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin", io.StringIO("1\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    transport, seen = _make_transport_capture(
+        {
+            "GET /v1/transactions": [
+                {
+                    "id": "33333333-3333-3333-3333-333333333333",
+                    "date": "2026-03-01",
+                    "description": "Grocery",
+                    "status": "posted",
+                }
+            ]
+        }
+    )
+    _patch_transport(monkeypatch, transport)
+    picked = _pick_tx_id(_config(), as_json=False)
+    assert picked == "33333333-3333-3333-3333-333333333333"
+    [list_call] = [r for r in seen if r.url.path == "/v1/transactions"]
+    # Picker asks for at most 20 rows.
+    assert list_call.url.params.get("limit") == "20"
+
+
+def test_pick_tx_id_returns_none_on_cancel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin", io.StringIO("c\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    transport, _ = _make_transport_capture(
+        {
+            "GET /v1/transactions": [
+                {
+                    "id": "44444444-4444-4444-4444-444444444444",
+                    "date": "2026-03-01",
+                    "description": "x",
+                    "status": "posted",
+                }
+            ]
+        }
+    )
+    _patch_transport(monkeypatch, transport)
+    picked = _pick_tx_id(_config(), as_json=False)
+    assert picked is None
+
+
+def test_pick_tx_id_non_tty_emits_usage_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False, raising=False)
+    transport, seen = _make_transport_capture({})
+    _patch_transport(monkeypatch, transport)
+    picked = _pick_tx_id(_config(), as_json=False)
+    assert picked is None
+    assert seen == []
+    captured = capsys.readouterr()
+    assert "Missing argument TXID" in captured.err
+
+
+# ---- reconcile show -------------------------------------------------------
+
+
+def test_pick_reconciliation_id_returns_first_choice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin", io.StringIO("1\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    transport, seen = _make_transport_capture(
+        {
+            "GET /v1/reconciliations": {
+                "items": [
+                    {
+                        "id": "55555555-5555-5555-5555-555555555555",
+                        "account_id": "66666666-6666-6666-6666-666666666666",
+                        "statement_period_start": "2026-04-01",
+                        "statement_period_end": "2026-04-30",
+                        "statement_ending_balance": "1234.56",
+                        "status": "in_progress",
+                    }
+                ]
+            }
+        }
+    )
+    _patch_transport(monkeypatch, transport)
+    picked = _pick_reconciliation_id(_config(), as_json=False)
+    assert picked == "55555555-5555-5555-5555-555555555555"
+    [request] = [r for r in seen if r.url.path == "/v1/reconciliations"]
+    # Picker filters to in_progress so completed envelopes don't appear.
+    assert request.url.params.get("status") == "in_progress"
+
+
+def test_pick_reconciliation_id_returns_none_on_cancel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin", io.StringIO("c\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    transport, _ = _make_transport_capture(
+        {
+            "GET /v1/reconciliations": {
+                "items": [
+                    {
+                        "id": "77777777-7777-7777-7777-777777777777",
+                        "account_id": "88888888-8888-8888-8888-888888888888",
+                        "statement_period_start": "2026-04-01",
+                        "statement_period_end": "2026-04-30",
+                        "statement_ending_balance": "0.00",
+                        "status": "in_progress",
+                    }
+                ]
+            }
+        }
+    )
+    _patch_transport(monkeypatch, transport)
+    picked = _pick_reconciliation_id(_config(), as_json=False)
+    assert picked is None
+
+
+def test_pick_reconciliation_id_non_tty_emits_usage_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seeded_token_store(tmp_path)
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False, raising=False)
+    transport, seen = _make_transport_capture({})
+    _patch_transport(monkeypatch, transport)
+    picked = _pick_reconciliation_id(_config(), as_json=False)
+    assert picked is None
+    assert seen == []
+    captured = capsys.readouterr()
+    assert "Missing argument RECONCILIATION_ID" in captured.err
+
+
+# ---- subprocess smoke: piped stdin → exit 2 + usage error -----------------
+#
+# These don't need a live API — the picker short-circuits to the usage
+# error before any HTTP request when stdin isn't a TTY. We spawn the CLI
+# with ``stdin=DEVNULL`` (the default for ``capture_output=True``) so the
+# child sees a non-interactive stdin.
+
+
+def _run_cli_no_tty(*args: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env.setdefault("COLUMNS", "200")
+    # Point the CLI at a non-existent URL — we never reach the network
+    # because the picker short-circuits on non-TTY stdin first.
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--api-url",
+            "http://127.0.0.1:1",
+            *args,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=env,
+    )
+
+
+def test_imports_apply_missing_arg_non_tty_exits_2() -> None:
+    """End-to-end: pipe stdin → usage error, exit 2 (no picker, no HTTP)."""
+    result = _run_cli_no_tty("imports", "apply")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Missing argument BATCH_ID" in result.stderr
+
+
+def test_transactions_show_missing_arg_non_tty_exits_2() -> None:
+    """End-to-end: pipe stdin → usage error, exit 2 (no picker, no HTTP)."""
+    result = _run_cli_no_tty("transactions", "show")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Missing argument TXID" in result.stderr
+
+
+def test_reconcile_show_missing_arg_non_tty_exits_2() -> None:
+    """End-to-end: pipe stdin → usage error, exit 2 (no picker, no HTTP)."""
+    result = _run_cli_no_tty("reconcile", "show")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Missing argument RECONCILIATION_ID" in result.stderr


### PR DESCRIPTION
## Summary

- New private `tulip_cli/_picker.py` helper: takes a pre-filtered list of API rows plus a `row -> label` callable, renders numbered choices + a first-class `[c] cancel` row, and returns the picked id string (or `None` on cancel / EOF / empty list). Caps the rendered list at 20 entries (`PICKER_MAX_ENTRIES`) with an overflow hint pointing at the command's filter flags. TTY detection is `sys.stdin.isatty()` — stdin, not stdout, is the signal for "can I prompt?".
- `tulip imports apply` — `BATCH_ID` is now optional; when omitted on a TTY the picker fetches `GET /v1/imports?status=parsed` (actionable batches only) and prompts.
- `tulip reconcile show` — `RECONCILIATION_ID` is now optional; when omitted on a TTY the picker fetches `GET /v1/reconciliations?status=in_progress` and prompts.
- `tulip transactions show` — `TXID` is now optional; when omitted on a TTY the picker fetches the 20 most recent transactions (`GET /v1/transactions?limit=20`) and prompts. A picked id still flows through the existing `_resolve_tx_id` prefix/UUID resolution.
- No regression for scripts: non-TTY stdin **and** `--json` mode short-circuit to the legacy usage-error path on stderr (`Missing argument …`) and exit `2` before any HTTP request. Cancel is a first-class option, not just Ctrl-C.

## Test plan

- [x] `uv run pytest packages/tulip-cli/tests/test_picker.py packages/tulip-cli/tests/test_picker_integration.py -q` — 24 passed. Covers the picker helper (happy-path numeric pick, explicit cancel, empty input, EOF, out-of-range, non-numeric, empty list, 20-entry cap) and the three wired commands (resolver happy path, status-filtered list query, cancel, non-TTY usage error, `--json` skips prompt, subprocess non-TTY exit-2 smoke).
- [x] `uv run pytest packages/tulip-cli -q` — 413 passed, no regressions.
- [x] `just lint` — `ruff check` clean.
- [x] `just typecheck` — `mypy --strict` clean, 243 files.
- [x] Manual: drove `_picker.pick` with a fake numeric stdin — renders the numbered list + `[ c] cancel` and returns the matching id.
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)