### PR TITLE
feat: resolve accounts by name or hierarchical path (closes #197)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/commands/accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/accounts.py
@@ -4,10 +4,12 @@ Read-only commands consume ``GET /v1/accounts`` and
 ``GET /v1/accounts/{id}``. Write paths (``add``, ``deactivate``) land in
 P3.4 (#21).
 
-The ``show`` command resolves an identifier as a UUID first and falls
-back to a code lookup over the listed accounts. ``code`` has no
-uniqueness constraint server-side, so duplicates produce an ambiguous-id
-error rather than silently picking the first match.
+The ``show`` command (and every ``--account`` surface, via
+:func:`_resolve_account`) resolves an identifier in this order: UUID,
+exact ``code``, unique ``name``, hierarchical colon-path. ``code`` and
+``name`` have no uniqueness constraint server-side, so duplicates
+produce an ambiguous-identifier error rather than silently picking the
+first match. See #197.
 """
 
 from __future__ import annotations
@@ -38,6 +40,24 @@ def _client(config: Config, *, as_json: bool) -> TulipClient:
     return TulipClient(config, token_store=default_token_store(), as_json=as_json)
 
 
+#: Account-type tokens accepted as the leading segment of a hierarchical
+#: path, mapped to the canonical singular the API stores. Lets a user
+#: type the plural form they see in journal exports (``assets:cash``)
+#: or the singular (``asset:cash``); both resolve. See #197.
+_TYPE_ALIASES: dict[str, str] = {
+    "asset": "asset",
+    "assets": "asset",
+    "liability": "liability",
+    "liabilities": "liability",
+    "equity": "equity",
+    "equities": "equity",
+    "income": "income",
+    "incomes": "income",
+    "expense": "expense",
+    "expenses": "expense",
+}
+
+
 def _ambiguous_code_problem(identifier: str, count: int) -> dict[str, object]:
     return {
         "type": "/.well-known/errors/account.ambiguous_code",
@@ -52,13 +72,30 @@ def _ambiguous_code_problem(identifier: str, count: int) -> dict[str, object]:
     }
 
 
+def _ambiguous_name_problem(identifier: str, full_paths: list[str]) -> dict[str, object]:
+    listed = "\n  ".join(sorted(full_paths))
+    return {
+        "type": "/.well-known/errors/account.ambiguous_name",
+        "title": "Account identifier matches multiple accounts",
+        "status": 0,
+        "detail": (
+            f"{len(full_paths)} accounts match {identifier!r}. "
+            "Disambiguate with a fuller hierarchical path, the account "
+            f"code, or the UUID:\n  {listed}"
+        ),
+        "instance": "",
+        "code": "account.ambiguous_name",
+    }
+
+
 def _not_found_problem(identifier: str) -> dict[str, object]:
     return {
         "type": "/.well-known/errors/account.not_found",
         "title": "Account not found",
         "status": 0,
         "detail": (
-            f"No account with code or id {identifier!r} is visible to this user. "
+            f"No account matching {identifier!r} (by id, code, name, or "
+            "hierarchical path) is visible to this user. "
             "Run `tulip accounts list` to see what's available."
         ),
         "instance": "",
@@ -66,16 +103,104 @@ def _not_found_problem(identifier: str) -> dict[str, object]:
     }
 
 
-def _resolve_account(client: TulipClient, identifier: str) -> dict[str, Any]:
-    """Return a single account dict by UUID or by ``code``.
+def _account_name_path(account: dict[str, Any], by_id: dict[str, dict[str, Any]]) -> list[str]:
+    """Return the lowercased ``[root_name, …, leaf_name]`` chain for an account.
 
-    UUID-shaped strings are looked up via ``GET /v1/accounts/{id}``.
-    Anything else is matched against the listed accounts' ``code`` field.
+    Walks ``parent_account_id`` to the root. The ``seen`` guard is purely
+    defensive — the server enforces a tree, but a malformed response
+    shouldn't hang the CLI.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    cur: dict[str, Any] | None = account
+    while cur is not None:
+        cur_id = str(cur["id"])
+        if cur_id in seen:
+            break
+        seen.add(cur_id)
+        names.append(str(cur["name"]).lower())
+        parent_id = cur.get("parent_account_id")
+        cur = by_id.get(str(parent_id)) if parent_id else None
+    names.reverse()
+    return names
+
+
+def _account_full_path(account: dict[str, Any], by_id: dict[str, dict[str, Any]]) -> str:
+    """Render an account's ``type:name:…:name`` path for error messages.
+
+    Uses the original-case names so the printed path is something the
+    user can read back; the type segment stays lowercased to match what
+    the API stores.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    cur: dict[str, Any] | None = account
+    while cur is not None:
+        cur_id = str(cur["id"])
+        if cur_id in seen:
+            break
+        seen.add(cur_id)
+        names.append(str(cur["name"]))
+        parent_id = cur.get("parent_account_id")
+        cur = by_id.get(str(parent_id)) if parent_id else None
+    names.reverse()
+    return ":".join([str(account["type"]).lower(), *names])
+
+
+def _match_name_or_path(accounts: list[dict[str, Any]], identifier: str) -> list[dict[str, Any]]:
+    """Return accounts matching ``identifier`` as a name or hierarchical path.
+
+    The identifier is split on ``:`` into case-insensitive segments. A
+    leading segment that names an account type (``assets``/``asset``…)
+    constrains the match to that type; the remaining segments must be a
+    suffix of the candidate's root→leaf name chain. A single segment is
+    just a plain (unique) name lookup.
+
+    Empty segments (``::``, a trailing ``:``) make the identifier
+    un-resolvable as a path — returns no matches so the caller falls
+    through to the not-found error.
+    """
+    raw_segments = [seg.strip() for seg in identifier.split(":")]
+    if any(not seg for seg in raw_segments):
+        return []
+    tokens = [seg.lower() for seg in raw_segments]
+
+    type_constraint: str | None = None
+    name_tokens = tokens
+    if len(tokens) > 1 and tokens[0] in _TYPE_ALIASES:
+        type_constraint = _TYPE_ALIASES[tokens[0]]
+        name_tokens = tokens[1:]
+    if not name_tokens:
+        return []
+
+    by_id = {str(a["id"]): a for a in accounts}
+    matches: list[dict[str, Any]] = []
+    for account in accounts:
+        if type_constraint is not None and str(account.get("type", "")).lower() != type_constraint:
+            continue
+        name_path = _account_name_path(account, by_id)
+        if len(name_path) >= len(name_tokens) and name_path[-len(name_tokens) :] == name_tokens:
+            matches.append(account)
+    return matches
+
+
+def _resolve_account(client: TulipClient, identifier: str) -> dict[str, Any]:
+    """Return a single account dict by UUID, code, name, or hierarchical path.
+
+    Resolution order (#197):
+
+    1. UUID — ``GET /v1/accounts/{id}``.
+    2. Exact ``code`` match over the listed accounts. Duplicate codes
+       raise ``account.ambiguous_code``; a no-match falls through.
+    3. Unique ``name`` / hierarchical colon-path match (case-insensitive,
+       type-prefix optional). Multiple matches raise
+       ``account.ambiguous_name`` with the full paths listed.
+    4. Nothing matched — ``account.not_found``.
     """
     try:
         UUID(identifier)
     except ValueError:
-        # Not a UUID — fall through to code lookup.
+        # Not a UUID — fall through to code / name / path lookup.
         pass
     else:
         response = client.get(f"/v1/accounts/{identifier}", authenticated=True)
@@ -83,20 +208,39 @@ def _resolve_account(client: TulipClient, identifier: str) -> dict[str, Any]:
 
     response = client.get("/v1/accounts", authenticated=True)
     accounts = response.json()
-    matches = [a for a in accounts if a.get("code") == identifier]
-    if not matches:
+
+    # 2. Exact code match. Ambiguous codes are a hard error; a clean miss
+    #    falls through to name / path resolution.
+    code_matches = [a for a in accounts if a.get("code") == identifier]
+    if len(code_matches) > 1:
         raise CliError(
-            problem=_not_found_problem(identifier),
+            problem=_ambiguous_code_problem(identifier, len(code_matches)),
             as_json=False,
             exit_code=EXIT_USER,
         )
-    if len(matches) > 1:
+    if len(code_matches) == 1:
+        return dict(code_matches[0])
+
+    # 3. Name / hierarchical-path resolution.
+    name_matches = _match_name_or_path(accounts, identifier)
+    if len(name_matches) > 1:
+        by_id = {str(a["id"]): a for a in accounts}
         raise CliError(
-            problem=_ambiguous_code_problem(identifier, len(matches)),
+            problem=_ambiguous_name_problem(
+                identifier, [_account_full_path(a, by_id) for a in name_matches]
+            ),
             as_json=False,
             exit_code=EXIT_USER,
         )
-    return dict(matches[0])
+    if len(name_matches) == 1:
+        return dict(name_matches[0])
+
+    # 4. Nothing matched.
+    raise CliError(
+        problem=_not_found_problem(identifier),
+        as_json=False,
+        exit_code=EXIT_USER,
+    )
 
 
 def _render_table(accounts: list[dict[str, Any]]) -> None:

--- a/packages/tulip-cli/tests/test_accounts.py
+++ b/packages/tulip-cli/tests/test_accounts.py
@@ -60,6 +60,7 @@ def _create_account(
     code: str | None,
     name: str,
     type_: str = "asset",
+    parent_account_id: str | None = None,
 ) -> dict[str, object]:
     body: dict[str, object] = {
         "name": name,
@@ -69,6 +70,8 @@ def _create_account(
     }
     if code is not None:
         body["code"] = code
+    if parent_account_id is not None:
+        body["parent_account_id"] = parent_account_id
     r = httpx.post(
         f"{api_url}/v1/accounts",
         json=body,
@@ -237,3 +240,166 @@ def test_accounts_list_unauthenticated_fails_clearly(
     result = _run_cli("accounts", "list", api_url=live_api)
     assert result.returncode == 2, (result.stdout, result.stderr)
     assert "not logged in" in result.stderr.lower() or "log in" in result.stderr.lower()
+
+
+# --- #197: resolve accounts by name / hierarchical path ----------------------
+
+
+class TestMatchNameOrPath:
+    """Unit tests for the pure name / path matcher behind ``_resolve_account``."""
+
+    @staticmethod
+    def _acct(
+        id_: str,
+        name: str,
+        type_: str = "asset",
+        parent: str | None = None,
+    ) -> dict[str, object]:
+        return {"id": id_, "name": name, "type": type_, "parent_account_id": parent}
+
+    def _chart(self) -> list[dict[str, object]]:
+        # asset:Cash -> asset:Cash:Joint ; liability:Cash (name collision)
+        # expense:Groceries
+        return [
+            self._acct("a-cash", "Cash"),
+            self._acct("a-cash-joint", "Joint", parent="a-cash"),
+            self._acct("l-cash", "Cash", type_="liability"),
+            self._acct("e-groceries", "Groceries", type_="expense"),
+        ]
+
+    def test_bare_unique_name_matches_one(self) -> None:
+        from tulip_cli.commands.accounts import _match_name_or_path
+
+        matches = _match_name_or_path(self._chart(), "Groceries")
+        assert [m["id"] for m in matches] == ["e-groceries"]
+
+    def test_bare_ambiguous_name_matches_all(self) -> None:
+        from tulip_cli.commands.accounts import _match_name_or_path
+
+        matches = _match_name_or_path(self._chart(), "Cash")
+        assert {m["id"] for m in matches} == {"a-cash", "l-cash"}
+
+    def test_path_segment_disambiguates(self) -> None:
+        from tulip_cli.commands.accounts import _match_name_or_path
+
+        matches = _match_name_or_path(self._chart(), "cash:joint")
+        assert [m["id"] for m in matches] == ["a-cash-joint"]
+
+    def test_type_prefix_constrains(self) -> None:
+        from tulip_cli.commands.accounts import _match_name_or_path
+
+        # Plural and singular type prefixes both resolve.
+        for ident in ("assets:cash", "asset:cash"):
+            matches = _match_name_or_path(self._chart(), ident)
+            assert [m["id"] for m in matches] == ["a-cash"], ident
+        # The liability:Cash is excluded by the asset prefix.
+        liab = _match_name_or_path(self._chart(), "liability:cash")
+        assert [m["id"] for m in liab] == ["l-cash"]
+
+    def test_full_type_prefixed_path(self) -> None:
+        from tulip_cli.commands.accounts import _match_name_or_path
+
+        matches = _match_name_or_path(self._chart(), "assets:cash:joint")
+        assert [m["id"] for m in matches] == ["a-cash-joint"]
+
+    def test_case_insensitive(self) -> None:
+        from tulip_cli.commands.accounts import _match_name_or_path
+
+        upper = _match_name_or_path(self._chart(), "ASSETS:CASH:JOINT")
+        lower = _match_name_or_path(self._chart(), "assets:cash:joint")
+        assert [m["id"] for m in upper] == [m["id"] for m in lower] == ["a-cash-joint"]
+
+    def test_wrong_type_prefix_no_match(self) -> None:
+        from tulip_cli.commands.accounts import _match_name_or_path
+
+        assert _match_name_or_path(self._chart(), "income:groceries") == []
+
+    def test_empty_segment_no_match(self) -> None:
+        from tulip_cli.commands.accounts import _match_name_or_path
+
+        assert _match_name_or_path(self._chart(), "cash:") == []
+        assert _match_name_or_path(self._chart(), "asset::joint") == []
+
+    def test_path_must_be_contiguous_suffix(self) -> None:
+        from tulip_cli.commands.accounts import _match_name_or_path
+
+        # Three-level chart: asset:Cash -> Cash:Joint -> Joint:Sub.
+        chart = [
+            self._acct("a-cash", "Cash"),
+            self._acct("a-joint", "Joint", parent="a-cash"),
+            self._acct("a-sub", "Sub", parent="a-joint"),
+        ]
+        # "joint:sub" and "cash:joint:sub" are valid contiguous suffixes.
+        assert [m["id"] for m in _match_name_or_path(chart, "joint:sub")] == ["a-sub"]
+        assert [m["id"] for m in _match_name_or_path(chart, "cash:joint:sub")] == ["a-sub"]
+        # "cash:sub" skips the intermediate "joint" — not a valid suffix.
+        assert _match_name_or_path(chart, "cash:sub") == []
+
+
+def _seed_path_chart(api_url: str) -> str:
+    """Seed Alice's household with a nested chart for path-resolution tests."""
+    alice_login = httpx.post(
+        f"{api_url}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    alice_login.raise_for_status()
+    access = str(alice_login.json()["access_token"])
+    cash = _create_account(api_url, access, code="1100", name="Cash")
+    _create_account(api_url, access, code="1110", name="Joint", parent_account_id=str(cash["id"]))
+    _create_account(api_url, access, code="5100", name="Groceries", type_="expense")
+    return access
+
+
+@pytest.mark.integration
+def test_accounts_show_by_unique_name(authed_session: str) -> None:
+    _seed_path_chart(authed_session)
+    result = _run_cli("accounts", "show", "Groceries", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "Groceries" in result.stdout
+
+
+@pytest.mark.integration
+def test_accounts_show_by_hierarchical_path(authed_session: str) -> None:
+    _seed_path_chart(authed_session)
+    # Both the type-prefixed and bare-path forms resolve the nested account.
+    for ident in ("assets:cash:joint", "cash:joint"):
+        result = _run_cli("accounts", "show", ident, api_url=authed_session)
+        assert result.returncode == 0, (ident, result.stderr)
+        assert "Joint" in result.stdout, ident
+
+
+@pytest.mark.integration
+def test_accounts_show_path_is_case_insensitive(authed_session: str) -> None:
+    _seed_path_chart(authed_session)
+    result = _run_cli("accounts", "show", "ASSETS:CASH:JOINT", api_url=authed_session)
+    assert result.returncode == 0, result.stderr
+    assert "Joint" in result.stdout
+
+
+@pytest.mark.integration
+def test_accounts_show_ambiguous_name_lists_paths(authed_session: str) -> None:
+    """Two same-named accounts under different parents → error with both paths."""
+    alice_login = httpx.post(
+        f"{authed_session}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    alice_login.raise_for_status()
+    access = str(alice_login.json()["access_token"])
+    checking = _create_account(authed_session, access, code="1100", name="Checking")
+    savings = _create_account(authed_session, access, code="1200", name="Savings")
+    _create_account(
+        authed_session, access, code=None, name="Fees", parent_account_id=str(checking["id"])
+    )
+    _create_account(
+        authed_session, access, code=None, name="Fees", parent_account_id=str(savings["id"])
+    )
+
+    result = _run_cli("accounts", "show", "Fees", api_url=authed_session)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    err = result.stderr.lower()
+    assert "ambiguous" in err or "multiple" in err
+    # Both full paths are printed so the user can pick one.
+    assert "checking:fees" in err
+    assert "savings:fees" in err


### PR DESCRIPTION
## Summary

`_resolve_account` — the shared resolver behind every `--account` surface (`accounts show`, `balance`, `imports`, `reconcile`, `transactions add/list`, `transfer`, `refill`) — now resolves four ways, in order:

1. **UUID** — `GET /v1/accounts/{id}` (unchanged).
2. **Exact `code`** — over the listed accounts. Duplicate codes still hard-error (`account.ambiguous_code`); a clean miss now *falls through* instead of erroring.
3. **Unique `name` / hierarchical colon-path** — case-insensitive. `Cash`, `cash:joint`, `assets:cash:joint` all resolve. A leading type segment (`assets`/`asset`, plural or singular) constrains the match. Path segments must be a contiguous suffix of the candidate's root→leaf parent chain, so you can't skip an intermediate.
4. **Nothing matched** — `account.not_found` (message updated to mention name/path).

Multiple name/path matches raise a new `account.ambiguous_name` problem that lists every full `type:name:…:name` path so the user can pick one — same shape as the existing ambiguous-code error.

Pure client-side resolution against `GET /v1/accounts` — **no API or schema change**. Codes that contain colons (the seeded `Imbalance:Unknown`) still resolve via the exact-code step, which runs before path parsing.

## Test plan

- [x] `uv run pytest packages` → 1764 passed, 1 skipped, 3 deselected
- [x] `just lint` + `just typecheck` clean
- [x] `TestMatchNameOrPath` — 9 unit tests on the pure matcher: bare unique/ambiguous name, path disambiguation, plural/singular type prefix, full type-prefixed path, case-insensitivity, wrong-type-prefix miss, empty-segment rejection, contiguous-suffix enforcement
- [x] Integration tests through the CLI: `accounts show <name>`, `accounts show assets:cash:joint` + bare `cash:joint`, case-insensitive `ASSETS:CASH:JOINT`, ambiguous-name error listing both full paths
- [ ] CI green on this PR