### PR TITLE
fix: tulip-cli Rich Console honors COLUMNS for stable non-TTY rendering (closes #285)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/_console.py
+++ b/packages/tulip-cli/src/tulip_cli/_console.py
@@ -1,0 +1,62 @@
+"""Rich ``Console`` factory that honors the ``COLUMNS`` env var (#285).
+
+Rich only reads ``COLUMNS`` when stdout is a TTY. In a piped or
+subprocess context — CI, ``tulip ... | less``, the test harness — it
+falls back to a fixed 80-column width, which truncates table and panel
+content unpredictably. Several CLI tests have had to work around this
+one site at a time (pinning ``COLUMNS`` in the subprocess env, then
+discovering it had no effect).
+
+This factory threads an explicit ``width=`` through from ``COLUMNS``
+when it's set to a positive integer, so callers and tests get the width
+they ask for. When ``COLUMNS`` is unset or junk, it falls back to
+Rich's normal auto-detection (``width=None``) — identical to today's
+behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+
+from rich.console import Console
+
+#: Width to fall back to when ``COLUMNS`` is set but unusable. Matches
+#: Rich's own conventional non-TTY default. Used only to *override* a
+#: junk ``COLUMNS`` — see ``_resolve_width``.
+_SAFE_DEFAULT_WIDTH = 80
+
+
+def _resolve_width() -> int | None:
+    """Decide the explicit ``width=`` to hand Rich, based on ``COLUMNS``.
+
+    Three cases:
+
+    * ``COLUMNS`` unset → return ``None`` so Rich auto-detects (real
+      terminal size on a TTY, 80 otherwise).
+    * ``COLUMNS`` is a positive integer → use it. This is the whole
+      point of the helper: Rich ignores ``COLUMNS`` off a TTY.
+    * ``COLUMNS`` set but junk / zero / negative → return a safe default
+      rather than ``None``. ``None`` isn't enough here: Rich's *own*
+      auto-detect also reads ``COLUMNS`` and would render at width 0 for
+      ``COLUMNS=0`` (seen in some CI shells). Forcing the default
+      overrides that.
+    """
+    raw = os.environ.get("COLUMNS")
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if stripped.isdigit():
+        value = int(stripped)
+        if value > 0:
+            return value
+    return _SAFE_DEFAULT_WIDTH
+
+
+def make_console(*, stderr: bool = False, highlight: bool = True) -> Console:
+    """Build a Rich ``Console`` that respects ``COLUMNS`` even off a TTY.
+
+    ``stderr`` and ``highlight`` are the only ``Console`` kwargs the CLI
+    actually uses; keeping the signature explicit avoids a catch-all
+    ``**kwargs`` and the ``ANN401`` it would attract.
+    """
+    return Console(stderr=stderr, highlight=highlight, width=_resolve_width())

--- a/packages/tulip-cli/src/tulip_cli/commands/accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/accounts.py
@@ -20,10 +20,10 @@ from typing import Annotated, Any
 from uuid import UUID
 
 import typer
-from rich.console import Console
 from rich.table import Table
 from rich.tree import Tree
 
+from tulip_cli._console import make_console
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.config import Config
 from tulip_cli.errors import EXIT_USER, CliError
@@ -259,7 +259,7 @@ def _render_table(accounts: list[dict[str, Any]]) -> None:
             a.get("currency") or "",
             a.get("visibility") or "",
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 def _render_tree(accounts: list[dict[str, Any]]) -> None:
@@ -303,7 +303,7 @@ def _render_tree(accounts: list[dict[str, Any]]) -> None:
     for a in orphans:
         node = root.add(_label(a) + " [yellow](parent not visible)[/yellow]")
         _attach(node, a)
-    Console().print(root)
+    make_console().print(root)
 
 
 def _has_nesting(accounts: list[dict[str, Any]]) -> bool:

--- a/packages/tulip-cli/src/tulip_cli/commands/balance.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/balance.py
@@ -14,9 +14,9 @@ from datetime import date as date_type
 from typing import Annotated, Any
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._console import make_console
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands.accounts import _resolve_account
 from tulip_cli.config import Config
@@ -64,7 +64,7 @@ def _render_trial_balance(body: dict[str, Any]) -> None:
             currency,
             format_amount(r.get("balance"), currency),
         )
-    console = Console()
+    console = make_console()
     console.print(table)
 
     totals = body.get("totals_by_currency") or []

--- a/packages/tulip-cli/src/tulip_cli/commands/csv_profiles.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/csv_profiles.py
@@ -8,9 +8,9 @@ from typing import Annotated, Any
 
 import httpx
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._console import make_console
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.config import Config
 from tulip_cli.errors import CliError
@@ -59,7 +59,7 @@ def _render_profile_table(rows: list[dict[str, Any]]) -> None:
             repr(row.get("delimiter", "")),
             str(row.get("id", ""))[:8],
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 @csv_profiles_app.command("add")

--- a/packages/tulip-cli/src/tulip_cli/commands/envelopes.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/envelopes.py
@@ -18,9 +18,9 @@ import sys
 from typing import Annotated, Any
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._console import make_console
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands._pools import _resolve_envelope, _summarize_refill_rule
 from tulip_cli.config import Config
@@ -62,7 +62,7 @@ def _render_table(
             balances.get(env.get("id", ""), "—"),
             _summarize_refill_rule(env.get("refill_rule")),
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 def _fetch_balances(client: TulipClient, pool_ids: list[str]) -> dict[str, str]:

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -265,8 +265,9 @@ def list_imports(
 
 def _render_list_table(items: list[dict[str, Any]]) -> None:
     """Render a list of ``ImportBatchListItem`` dicts as a Rich table."""
-    from rich.console import Console
     from rich.table import Table
+
+    from tulip_cli._console import make_console
 
     table = Table(show_header=True, show_lines=False)
     table.add_column("id")
@@ -293,7 +294,7 @@ def _render_list_table(items: list[dict[str, Any]]) -> None:
             str(item.get("source_filename") or ""),
             f"{item.get('imported_count', 0)}/{item.get('skipped_count', 0)}",
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 @imports_app.command("show")
@@ -325,10 +326,11 @@ def show_import(
 
 def _render_batch(body: dict[str, Any]) -> None:
     """Render an ``ImportBatchRead`` body to stdout."""
-    from rich.console import Console
     from rich.table import Table
 
-    console = Console()
+    from tulip_cli._console import make_console
+
+    console = make_console()
     header_lines = [
         f"Batch:    {body.get('id', '')}",
         f"Source:   {body.get('source_filename', '')} ({body.get('source_format', '?').upper()})",

--- a/packages/tulip-cli/src/tulip_cli/commands/notifications.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/notifications.py
@@ -7,9 +7,9 @@ from typing import Annotated
 from uuid import UUID
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._console import make_console
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.config import Config
 from tulip_cli.errors import CliError
@@ -81,7 +81,7 @@ def list_notifications(
             str(r.get("title", "")),
             "yes" if r.get("dismissed_at") else "no",
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 @notifications_app.command("dismiss")

--- a/packages/tulip-cli/src/tulip_cli/commands/periods.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/periods.py
@@ -13,9 +13,9 @@ from typing import Annotated
 from uuid import UUID
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._console import make_console
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.config import Config
 from tulip_cli.errors import CliError
@@ -52,7 +52,7 @@ def _render_table(periods: list[dict[str, object]]) -> None:
             status_styled,
             str(p.get("closed_at") or "—"),
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 @periods_app.command("list")

--- a/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
@@ -25,6 +25,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._console import make_console
 from tulip_cli._picker import is_interactive, pick
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands.accounts import _resolve_account
@@ -152,7 +153,7 @@ def _render_unmatched_txs(console: Console, txs: list[dict[str, Any]]) -> None:
 
 def _render_inbox(body: dict[str, Any]) -> None:
     """Render the four-section reconciliation review pane."""
-    console = Console()
+    console = make_console()
     _render_envelope(console, body["reconciliation"])
     _render_matches(console, body["matches"])
     _render_unmatched_lines(console, body["unmatched_statement_lines"])
@@ -309,7 +310,7 @@ def list_command(
             item["status"],
             str(item["statement_ending_balance"]),
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 # ---- show -----------------------------------------------------------------
@@ -789,7 +790,7 @@ def walk_command(
     if as_json:
         raise typer.BadParameter("--json is incompatible with the paper-walk wizard")
 
-    console = Console()
+    console = make_console()
     try:
         with _client(config, as_json=as_json) as client:
             inbox = client.get(
@@ -907,7 +908,7 @@ def interactive_command(
     if as_json:
         raise typer.BadParameter("--json is incompatible with the interactive wizard")
 
-    console = Console()
+    console = make_console()
     try:
         with _client(config, as_json=as_json) as client:
             inbox = client.get(

--- a/packages/tulip-cli/src/tulip_cli/commands/refills.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/refills.py
@@ -12,9 +12,9 @@ import sys
 from typing import Annotated
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._console import make_console
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands._pools import _resolve_envelope
 from tulip_cli.config import Config
@@ -121,7 +121,7 @@ def list_refills(ctx: typer.Context) -> None:
             str(j.get("last_run_at") or "—"),
             j.get("idempotency_key") or "—",
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 @refills_app.command("show")

--- a/packages/tulip-cli/src/tulip_cli/commands/sinking_funds.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/sinking_funds.py
@@ -14,9 +14,9 @@ import sys
 from typing import Annotated, Any
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._console import make_console
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands._pools import _resolve_sinking_fund
 from tulip_cli.config import Config
@@ -56,7 +56,7 @@ def _render_table(
             sf.get("contribution_strategy") or "",
             balances.get(sf.get("id", ""), "—"),
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 def _fetch_balances(client: TulipClient, pool_ids: list[str]) -> dict[str, str]:

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -32,9 +32,9 @@ from typing import Annotated, Any
 from uuid import UUID
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from tulip_cli._console import make_console
 from tulip_cli._picker import is_interactive, pick
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands._editor import edit_buffer
@@ -515,7 +515,7 @@ def _render_tx_list_table(
             row.get("status") or "",
             summary,
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 def _render_tx_detail(
@@ -550,7 +550,7 @@ def _render_tx_detail(
             currency,
             str(p.get("memo") or ""),
         )
-    Console().print(table)
+    make_console().print(table)
 
 
 @transactions_app.command("list")

--- a/packages/tulip-cli/src/tulip_cli/errors.py
+++ b/packages/tulip-cli/src/tulip_cli/errors.py
@@ -24,8 +24,9 @@ from dataclasses import dataclass
 from typing import Any, Final
 
 import httpx
-from rich.console import Console
 from rich.text import Text
+
+from tulip_cli._console import make_console
 
 EXIT_OK: Final[int] = 0
 EXIT_USER: Final[int] = 1
@@ -180,7 +181,7 @@ class CliError(Exception):
         if self.as_json:
             sys.stdout.write(json.dumps(self.problem) + "\n")
             return
-        console = Console(stderr=True, highlight=False)
+        console = make_console(stderr=True, highlight=False)
         title = Text(str(self.problem.get("title", "Error")), style="bold red")
         console.print(title)
         detail = self.problem.get("detail")

--- a/packages/tulip-cli/tests/test_console.py
+++ b/packages/tulip-cli/tests/test_console.py
@@ -1,0 +1,60 @@
+"""Tests for the COLUMNS-honoring Rich ``Console`` factory (#285).
+
+Rich only reads ``COLUMNS`` off a TTY; ``make_console`` threads it
+through explicitly so piped / subprocess output (CI, the test harness)
+renders at the requested width instead of a fixed 80 columns.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_cli._console import make_console
+
+
+@pytest.mark.parametrize("columns", ["120", "160", "240"])
+def test_make_console_honors_columns_env(monkeypatch: pytest.MonkeyPatch, columns: str) -> None:
+    monkeypatch.setenv("COLUMNS", columns)
+    assert make_console().width == int(columns)
+
+
+def test_make_console_columns_changes_rendered_width(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The acceptance check from #285: COLUMNS=N actually changes width."""
+    monkeypatch.setenv("COLUMNS", "160")
+    narrow = make_console()
+    monkeypatch.setenv("COLUMNS", "240")
+    wide = make_console()
+    assert narrow.width == 160
+    assert wide.width == 240
+    assert narrow.width != wide.width
+
+
+def test_make_console_unset_columns_falls_back_to_autodetect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COLUMNS", raising=False)
+    # No explicit width forced — Rich auto-detects (80 off a TTY-less
+    # pipe). We only assert we didn't crash and produced a usable width.
+    assert make_console().width > 0
+
+
+def test_make_console_zero_or_negative_columns_uses_safe_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # COLUMNS=0 is real (some CI shells export it). Rich's own auto-detect
+    # would honor it and render at width 0, so the helper must *override*
+    # a junk COLUMNS with a safe default rather than just declining to
+    # force a width.
+    from tulip_cli._console import _SAFE_DEFAULT_WIDTH
+
+    for bad in ("0", "-40", "not-a-number"):
+        monkeypatch.setenv("COLUMNS", bad)
+        assert make_console().width == _SAFE_DEFAULT_WIDTH
+
+
+def test_make_console_stderr_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COLUMNS", raising=False)
+    assert make_console(stderr=True).stderr is True
+    assert make_console().stderr is False


### PR DESCRIPTION
## Summary

Rich only reads `COLUMNS` when stdout is a TTY. In a pipe / subprocess / CI it falls back to a fixed 80-column width, which truncates table and panel content mid-word. Five recent PRs (#278, #280, #281, #283, #284) hit this and patched it test-side, one site at a time.

New `tulip_cli._console.make_console()` factory threads an explicit `width=` through from `COLUMNS`:

- `COLUMNS` a positive int → use it (the whole point — Rich ignores it off a TTY).
- `COLUMNS` unset → `width=None`, Rich auto-detects (unchanged behaviour).
- `COLUMNS` set but junk / zero / negative → safe 80-col default. `None` isn't enough here: Rich's *own* auto-detect also reads `COLUMNS` and renders at width 0 for `COLUMNS=0` (seen in some CI shells), so the helper has to actively override a junk value.

All 18 `Console(...)` call sites across the 12 CLI modules now route through the helper. `reconcile.py` keeps its `rich.console.Console` import — it's used as a type annotation on the section-render helpers, not just for instantiation.

The test-side `COLUMNS` pins from the earlier PRs are left in place; they're harmless and now actually take effect.

## Test plan

- [x] `uv run --package tulip-cli pytest packages/tulip-cli/tests` → 433 passed
- [x] `just lint` + `just typecheck` clean
- [x] New `test_console.py`: parametrised proof that `COLUMNS=N` sets `console.width == N`; the #285 acceptance check that `COLUMNS=160` vs `COLUMNS=240` produce different widths; unset → auto-detect; junk/zero/negative → safe default
- [ ] CI green on this PR