### PR TITLE
feat: --pending / include_pending — fold PENDING transactions into balances (closes #274)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -322,22 +322,41 @@ def get_account_balance(
             "transactions on or before this date. Defaults to today."
         ),
     ),
+    include_pending: bool = Query(
+        default=False,
+        description=(
+            "When true, fold PENDING transactions into the balance — the "
+            "'what if all pending is real' view. Default false keeps the "
+            "posted-only ledger semantics. The response then carries "
+            "pending_included=true and pending_count."
+        ),
+    ),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> AccountBalanceRead:
     """Return the ledger balance of an account in its primary currency.
 
-    Pending transactions are excluded — only POSTED + RECONCILED contribute.
-    Postings in other currencies on this account (e.g. FX postings) are
-    not included; use the trial-balance report for the multi-currency view.
+    By default only POSTED + RECONCILED contribute. ``include_pending=true``
+    (#274) widens the sum to PENDING transactions too. Postings in other
+    currencies on this account (e.g. FX postings) are not included; use
+    the trial-balance report for the multi-currency view.
     """
     a = AccountRepository(session, claims.household_id).get(account_id)
     if a is None or not _filter_for_role(a, claims):
         raise AccountNotFoundError()
 
     effective_as_of = as_of or date_type.today()
-    raw_balance = TransactionRepository(session, claims.household_id).balance_for_account(
-        a.id, currency=a.currency, as_of=effective_as_of
+    tx_repo = TransactionRepository(session, claims.household_id)
+    raw_balance = tx_repo.balance_for_account(
+        a.id,
+        currency=a.currency,
+        as_of=effective_as_of,
+        include_pending=include_pending,
+    )
+    pending_count = (
+        tx_repo.count_pending_for_account(a.id, currency=a.currency, as_of=effective_as_of)
+        if include_pending
+        else 0
     )
     # Quantize to the currency's minor units so the JSON representation
     # is the natural "12.50" rather than the storage-precision "12.50000000".
@@ -349,6 +368,8 @@ def get_account_balance(
         currency=a.currency,
         balance=balance,
         as_of=effective_as_of,
+        pending_included=include_pending,
+        pending_count=pending_count,
     )
 
 

--- a/packages/tulip-api/src/tulip_api/routers/reports.py
+++ b/packages/tulip-api/src/tulip_api/routers/reports.py
@@ -9,10 +9,10 @@ the zero-sum invariant.
 P7.1 adds ``?format=html`` to render via ``tulip_reports``; default
 remains JSON for backward compatibility.
 
-Pending transactions are excluded (they're workflow state, not ledger
-state). Role-based filtering matches ``GET /v1/accounts`` — admins see
-private accounts, members and viewers only see shared accounts and
-their own.
+Pending transactions are excluded by default (they're workflow state,
+not ledger state); ``?include_pending=true`` (#274) folds them in.
+Role-based filtering matches ``GET /v1/accounts`` — admins see private
+accounts, members and viewers only see shared accounts and their own.
 """
 
 from __future__ import annotations
@@ -84,12 +84,23 @@ def trial_balance(
             "rendered HTML document for screen review or printing."
         ),
     ),
+    include_pending: bool = Query(
+        default=False,
+        description=(
+            "When true, fold PENDING transactions into the report — the "
+            "'what if all pending is real' view. Default false keeps the "
+            "posted-only ledger semantics. The response then carries "
+            "pending_included=true, pending_count, and has_pending on each "
+            "row that drew a PENDING posting."
+        ),
+    ),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
     """Return per-account, per-currency balances for the household ledger.
 
-    Pending transactions are excluded. Visibility filtering matches the
+    By default only POSTED + RECONCILED contribute; ``include_pending=true``
+    (#274) folds PENDING transactions in. Visibility filtering matches the
     accounts list — accounts the caller can't see don't appear here.
     """
     effective_as_of = as_of or date_type.today()
@@ -97,7 +108,10 @@ def trial_balance(
     account_repo = AccountRepository(session, claims.household_id)
 
     accounts_by_id = {a.id: a for a in account_repo.list_active()}
-    raw = tx_repo.trial_balance(as_of=effective_as_of)
+    raw = tx_repo.trial_balance(as_of=effective_as_of, include_pending=include_pending)
+    pending_count = (
+        tx_repo.count_pending_transactions(as_of=effective_as_of) if include_pending else 0
+    )
 
     rows: list[TrialBalanceRow] = []
     debits_by_currency: dict[str, Decimal] = {}
@@ -115,6 +129,7 @@ def trial_balance(
                 type=a.type.value,
                 currency=r.currency,
                 balance=balance,
+                has_pending=r.has_pending,
             )
         )
         if balance > 0:
@@ -138,7 +153,13 @@ def trial_balance(
         for c in currencies
     ]
 
-    json_body = TrialBalanceRead(as_of=effective_as_of, rows=rows, totals_by_currency=totals)
+    json_body = TrialBalanceRead(
+        as_of=effective_as_of,
+        rows=rows,
+        totals_by_currency=totals,
+        pending_included=include_pending,
+        pending_count=pending_count,
+    )
     if format in ("html", "pdf", "csv"):
         from tulip_reports.reports import trial_balance as report_module
 
@@ -147,6 +168,7 @@ def trial_balance(
             household_id=claims.household_id,
             as_of=effective_as_of,
             visible_account_filter=lambda vis, by: _filter_for_role(vis, by, claims),
+            include_pending=include_pending,
         )
         return _report_response(
             data,

--- a/packages/tulip-api/src/tulip_api/schemas/balance.py
+++ b/packages/tulip-api/src/tulip_api/schemas/balance.py
@@ -18,11 +18,27 @@ class AccountBalanceRead(BaseModel):
     currency: str
     balance: Decimal = Field(
         description=(
-            "Sum of POSTED + RECONCILED postings on this account in its currency. "
-            "Pending transactions are not included."
+            "Sum of POSTED + RECONCILED postings on this account in its "
+            "currency. When pending_included is true, PENDING transactions "
+            "are folded in as well."
         ),
     )
     as_of: date
+    pending_included: bool = Field(
+        default=False,
+        description=(
+            "True when the request passed include_pending=true and the "
+            "balance reflects PENDING transactions, not just the posted "
+            "ledger."
+        ),
+    )
+    pending_count: int = Field(
+        default=0,
+        description=(
+            "Number of PENDING transactions contributing to this balance. "
+            "Always 0 when pending_included is false."
+        ),
+    )
 
 
 class TrialBalanceRow(BaseModel):
@@ -34,6 +50,13 @@ class TrialBalanceRow(BaseModel):
     type: str
     currency: str
     balance: Decimal
+    has_pending: bool = Field(
+        default=False,
+        description=(
+            "True when pending_included is set and at least one PENDING "
+            "transaction contributed to this row's balance."
+        ),
+    )
 
 
 class CurrencyTotal(BaseModel):
@@ -54,5 +77,21 @@ class TrialBalanceRead(BaseModel):
             "Per-currency totals of positive (debit) and negative (credit) "
             "balances. They sum to zero per currency in a healthy ledger; a "
             "non-zero sum indicates a data issue."
+        ),
+    )
+    pending_included: bool = Field(
+        default=False,
+        description=(
+            "True when the request passed include_pending=true. The rows "
+            "and totals then reflect PENDING transactions on top of the "
+            "posted ledger; rows that drew a PENDING posting carry "
+            "has_pending=true."
+        ),
+    )
+    pending_count: int = Field(
+        default=0,
+        description=(
+            "Number of PENDING transactions folded into this report. "
+            "Always 0 when pending_included is false."
         ),
     )

--- a/packages/tulip-api/tests/test_balance_endpoints.py
+++ b/packages/tulip-api/tests/test_balance_endpoints.py
@@ -1,22 +1,72 @@
-"""Tests for the balance-read endpoints (#31).
+"""Tests for the balance-read endpoints (#31, #274).
 
 * ``GET /v1/accounts/{id}/balance`` — single-account ledger balance.
 * ``GET /v1/reports/trial-balance`` — household-wide per-account
   per-currency balances + totals.
 
-Both endpoints exclude pending transactions (POSTED + RECONCILED only)
-and accept an optional ``as_of=YYYY-MM-DD`` query for point-in-time
-balances.
+Both endpoints default to POSTED + RECONCILED only and accept an
+optional ``as_of=YYYY-MM-DD`` query for point-in-time balances.
+``include_pending=true`` (#274) folds PENDING transactions in.
 """
 
 from __future__ import annotations
 
 from datetime import date
+from decimal import Decimal
 
 import pytest
 from fastapi.testclient import TestClient
 
 from _problem_details import assert_problem
+
+
+def _seed_pending_tx(
+    session_maker: object,
+    *,
+    debit: str,
+    credit: str,
+    amount: str,
+    on: date | None = None,
+) -> None:
+    """Insert a PENDING transaction directly via the repo.
+
+    ``POST /v1/transactions`` always promotes to POSTED, so the only way
+    to get a PENDING row for the #274 tests is through the repository —
+    the same path the importer uses.
+    """
+    from uuid import UUID, uuid4
+
+    from sqlalchemy import select
+
+    from tulip_core.money import Money
+    from tulip_core.transactions import Posting as DomainPosting
+    from tulip_core.transactions import Transaction as DomainTransaction
+    from tulip_core.transactions import TransactionStatus as DomainTxStatus
+    from tulip_storage.models import Household
+    from tulip_storage.repositories import TransactionRepository
+
+    on = on or date.today()
+    with session_maker() as s:  # type: ignore[operator]
+        household_id = s.execute(select(Household.id)).scalar_one()
+        tx = DomainTransaction(
+            id=uuid4(),
+            household_id=household_id,
+            date=on,
+            description=f"pending {amount}",
+            postings=(
+                DomainPosting(
+                    id=uuid4(), account_id=UUID(debit), amount=Money(Decimal(amount), "USD")
+                ),
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=UUID(credit),
+                    amount=Money(Decimal(f"-{amount}"), "USD"),
+                ),
+            ),
+            status=DomainTxStatus.PENDING,
+        )
+        TransactionRepository(s, household_id).save_balanced(tx)
+        s.commit()
 
 
 @pytest.fixture
@@ -123,6 +173,37 @@ class TestAccountBalance:
         r = client.get(f"/v1/accounts/{cash}/balance")
         assert_problem(r, code="auth.unauthorized", status=401)
 
+    def test_default_excludes_pending(
+        self, client: TestClient, auth_h: dict[str, str], session_maker: object
+    ):
+        # #274: without the flag, PENDING transactions don't count.
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="10.00")
+        _seed_pending_tx(session_maker, debit=food, credit=cash, amount="99.00")
+
+        body = client.get(f"/v1/accounts/{food}/balance", headers=auth_h).json()
+        assert body["balance"] == "10.00"
+        assert body["pending_included"] is False
+        assert body["pending_count"] == 0
+
+    def test_include_pending_folds_in_pending(
+        self, client: TestClient, auth_h: dict[str, str], session_maker: object
+    ):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="10.00")
+        _seed_pending_tx(session_maker, debit=food, credit=cash, amount="99.00")
+
+        body = client.get(
+            f"/v1/accounts/{food}/balance",
+            headers=auth_h,
+            params={"include_pending": "true"},
+        ).json()
+        assert body["balance"] == "109.00"
+        assert body["pending_included"] is True
+        assert body["pending_count"] == 1
+
 
 class TestTrialBalance:
     def test_empty_household_yields_empty_rows(self, client: TestClient, auth_h: dict[str, str]):
@@ -178,6 +259,59 @@ class TestTrialBalance:
     def test_no_token_returns_unauthorized(self, client: TestClient):
         r = client.get("/v1/reports/trial-balance")
         assert_problem(r, code="auth.unauthorized", status=401)
+
+    def test_default_excludes_pending(
+        self, client: TestClient, auth_h: dict[str, str], session_maker: object
+    ):
+        # #274: default report is posted-only.
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="10.00")
+        _seed_pending_tx(session_maker, debit=food, credit=cash, amount="99.00")
+
+        body = client.get("/v1/reports/trial-balance", headers=auth_h).json()
+        rows_by_account = {r["account_id"]: r for r in body["rows"]}
+        assert rows_by_account[food]["balance"] == "10.00"
+        assert rows_by_account[food]["has_pending"] is False
+        assert body["pending_included"] is False
+        assert body["pending_count"] == 0
+
+    def test_include_pending_folds_in_and_flags_rows(
+        self, client: TestClient, auth_h: dict[str, str], session_maker: object
+    ):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="10.00")
+        _seed_pending_tx(session_maker, debit=food, credit=cash, amount="99.00")
+
+        body = client.get(
+            "/v1/reports/trial-balance",
+            headers=auth_h,
+            params={"include_pending": "true"},
+        ).json()
+        rows_by_account = {r["account_id"]: r for r in body["rows"]}
+        assert rows_by_account[food]["balance"] == "109.00"
+        assert rows_by_account[food]["has_pending"] is True
+        assert body["pending_included"] is True
+        assert body["pending_count"] == 1
+
+    def test_include_pending_html_shows_subtitle(
+        self, client: TestClient, auth_h: dict[str, str], session_maker: object
+    ):
+        cash = _account(client, auth_h, name="Cash", code="1110")
+        food = _account(client, auth_h, name="Food", type="expense", code="5100")
+        _post_tx(client, auth_h, debit=food, credit=cash, amount="10.00")
+        _seed_pending_tx(session_maker, debit=food, credit=cash, amount="99.00")
+
+        r = client.get(
+            "/v1/reports/trial-balance",
+            headers=auth_h,
+            params={"format": "html", "include_pending": "true"},
+        )
+        assert r.status_code == 200, r.text
+        assert "1 pending transaction" in r.text
+        # The pending-affected row carries the (P) marker.
+        assert "(P)" in r.text
 
     def test_format_html_returns_html_response(self, client: TestClient, auth_h: dict[str, str]):
         """``?format=html`` returns toner-friendly HTML rendered by tulip-reports (P7.1)."""

--- a/packages/tulip-cli/src/tulip_cli/commands/balance.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/balance.py
@@ -35,9 +35,15 @@ def _render_account_balance(body: dict[str, Any]) -> None:
     code = body.get("code") or "—"
     currency = body.get("currency", "")
     balance = format_amount(body.get("balance"), currency)
+    pending_included = bool(body.get("pending_included"))
+    label = "balance (incl. pending)" if pending_included else "balance"
     typer.echo(f"{code} — {body.get('name', '')}")
-    typer.echo(f"  balance: {balance} {currency}")
+    typer.echo(f"  {label}: {balance} {currency}")
     typer.echo(f"  as of:   {body.get('as_of', '')}")
+    if pending_included:
+        count = body.get("pending_count", 0)
+        plural = "" if count == 1 else "s"
+        typer.echo(f"  includes {count} pending transaction{plural}")
 
 
 def _render_trial_balance(body: dict[str, Any]) -> None:
@@ -49,17 +55,30 @@ def _render_trial_balance(body: dict[str, Any]) -> None:
         typer.echo(f"No postings on or before {body.get('as_of', 'today')}.")
         return
 
-    table = Table(title=f"Trial balance as of {body.get('as_of', '')}", show_header=True)
+    pending_included = bool(body.get("pending_included"))
+    title = f"Trial balance as of {body.get('as_of', '')}"
+    if pending_included:
+        count = body.get("pending_count", 0)
+        plural = "" if count == 1 else "s"
+        title += f"  (incl. {count} pending transaction{plural})"
+    balance_header = "balance (incl. pending)" if pending_included else "balance"
+
+    table = Table(title=title, show_header=True)
     table.add_column("code")
     table.add_column("name")
     table.add_column("type")
     table.add_column("currency")
-    table.add_column("balance", justify="right")
+    table.add_column(balance_header, justify="right")
     for r in rows:
         currency = r.get("currency") or ""
+        name = r.get("name") or ""
+        # A row that drew a PENDING posting gets a (P) marker — only
+        # meaningful when the caller opted into --pending.
+        if pending_included and r.get("has_pending"):
+            name = f"{name} (P)"
         table.add_row(
             r.get("code") or "—",
-            r.get("name") or "",
+            name,
             r.get("type") or "",
             currency,
             format_amount(r.get("balance"), currency),
@@ -98,8 +117,27 @@ def balance(
             help="Point-in-time date (YYYY-MM-DD). Defaults to today.",
         ),
     ] = None,
+    include_pending: Annotated[
+        bool,
+        typer.Option(
+            "--pending/--no-pending",
+            help=(
+                "Fold PENDING transactions into the balance — the "
+                "'what if all pending is real' view. Default is the "
+                "posted-only ledger. When on, the output is clearly "
+                "labelled and pending-affected rows carry a (P) marker."
+            ),
+        ),
+    ] = False,
 ) -> None:
-    """Show a single account's balance, or the household trial balance."""
+    """Show a single account's balance, or the household trial balance.
+
+    By default only POSTED + RECONCILED transactions count, matching the
+    trial-balance convention. ``--pending`` widens the view to include
+    PENDING transactions — useful right after an import, before the
+    batch has been reviewed. The pending-inclusive output is always
+    labelled so it's never mistaken for the posted ledger.
+    """
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
 
@@ -109,7 +147,11 @@ def balance(
         except ValueError as exc:
             raise typer.BadParameter("--as-of must be YYYY-MM-DD") from exc
 
-    params = {"as_of": as_of} if as_of else None
+    params: dict[str, str] = {}
+    if as_of:
+        params["as_of"] = as_of
+    if include_pending:
+        params["include_pending"] = "true"
 
     try:
         with _client(config, as_json=as_json) as client:
@@ -117,14 +159,14 @@ def balance(
                 response = client.get(
                     "/v1/reports/trial-balance",
                     authenticated=True,
-                    params=params,
+                    params=params or None,
                 )
             else:
                 resolved = _resolve_account(client, account)
                 response = client.get(
                     f"/v1/accounts/{resolved['id']}/balance",
                     authenticated=True,
-                    params=params,
+                    params=params or None,
                 )
     except CliError as err:
         err.render()

--- a/packages/tulip-cli/tests/test_balance.py
+++ b/packages/tulip-cli/tests/test_balance.py
@@ -221,6 +221,124 @@ def test_balance_respects_as_of(authed_session: tuple[str, str]) -> None:
     assert "12.00" in later.stdout
 
 
+def _seed_pending_tx(tmp_path: Path, *, debit_id: str, credit_id: str, amount: str) -> None:
+    """Insert a PENDING transaction straight into the spawned API's DB.
+
+    ``POST /v1/transactions`` always promotes to POSTED, so #274's
+    --pending path needs a PENDING row planted via the repo. The live
+    API's SQLite file lives at ``tmp_path / 'tulip.db'`` (see the
+    ``live_api`` conftest fixture); a brief direct connection while
+    uvicorn is idle is safe under SQLite's single-writer lock.
+    """
+    from datetime import date as _date
+    from decimal import Decimal
+    from uuid import UUID, uuid4
+
+    from sqlalchemy import create_engine, event, select
+    from sqlalchemy.orm import sessionmaker
+
+    from tulip_core.money import Money
+    from tulip_core.transactions import Posting as DomainPosting
+    from tulip_core.transactions import Transaction as DomainTransaction
+    from tulip_core.transactions import TransactionStatus as DomainTxStatus
+    from tulip_storage.models import Household
+    from tulip_storage.repositories import TransactionRepository
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'tulip.db'}", future=True)
+
+    @event.listens_for(engine, "connect")
+    def _fk(dbapi_conn, _record):  # type: ignore[no-untyped-def]
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    try:
+        with sessionmaker(engine)() as s:
+            household_id = s.execute(select(Household.id)).scalar_one()
+            tx = DomainTransaction(
+                id=uuid4(),
+                household_id=household_id,
+                date=_date.today(),
+                description=f"pending {amount}",
+                postings=(
+                    DomainPosting(
+                        id=uuid4(),
+                        account_id=UUID(debit_id),
+                        amount=Money(Decimal(amount), "USD"),
+                    ),
+                    DomainPosting(
+                        id=uuid4(),
+                        account_id=UUID(credit_id),
+                        amount=Money(Decimal(f"-{amount}"), "USD"),
+                    ),
+                ),
+                status=DomainTxStatus.PENDING,
+            )
+            TransactionRepository(s, household_id).save_balanced(tx)
+            s.commit()
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.integration
+def test_balance_pending_flag_folds_in_and_labels_output(
+    live_api: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#274: --pending widens the balance and the output says so."""
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "alice@example.com",
+            "password": _PASSWORD,
+            "display_name": "Alice",
+            "household_name": "Alice's Household",
+        },
+        timeout=10,
+    ).raise_for_status()
+    login = httpx.post(
+        f"{live_api}/v1/auth/login",
+        json={"email": "alice@example.com", "password": _PASSWORD},
+        timeout=10,
+    )
+    login.raise_for_status()
+    access = str(login.json()["access_token"])
+    cli_login = _run_cli(
+        "auth",
+        "login",
+        "--email",
+        "alice@example.com",
+        "--password-stdin",
+        api_url=live_api,
+        stdin=f"{_PASSWORD}\n",
+    )
+    assert cli_login.returncode == 0, cli_login.stderr
+
+    cash = _create_account(live_api, access, code="assets:cash", name="Cash")
+    food = _create_account(live_api, access, code="expenses:food", name="Food", type_="expense")
+    _post_tx(live_api, access, debit_id=str(food["id"]), credit_id=str(cash["id"]), amount="10.00")
+    _seed_pending_tx(tmp_path, debit_id=str(food["id"]), credit_id=str(cash["id"]), amount="99.00")
+
+    # Default: posted-only, plain "balance" label.
+    default = _run_cli("balance", "expenses:food", api_url=live_api)
+    assert default.returncode == 0, default.stderr
+    assert "10.00" in default.stdout
+    assert "incl. pending" not in default.stdout
+
+    # --pending: widened balance, clearly labelled.
+    pending = _run_cli("balance", "expenses:food", "--pending", api_url=live_api)
+    assert pending.returncode == 0, pending.stderr
+    assert "109.00" in pending.stdout
+    assert "incl. pending" in pending.stdout
+    assert "1 pending transaction" in pending.stdout
+
+    # Trial-balance view also honours --pending and flags the row.
+    trial = _run_cli("balance", "--pending", api_url=live_api)
+    assert trial.returncode == 0, trial.stderr
+    assert "109.00" in trial.stdout
+    assert "(P)" in trial.stdout
+
+
 @pytest.mark.integration
 def test_balance_unknown_code_yields_user_error(authed_session: tuple[str, str]) -> None:
     api_url, _ = authed_session

--- a/packages/tulip-reports/src/tulip_reports/reports/trial_balance.py
+++ b/packages/tulip-reports/src/tulip_reports/reports/trial_balance.py
@@ -37,6 +37,7 @@ class TrialBalanceRow:
     type: str  # asset / liability / equity / income / expense
     currency: str
     balance: Decimal
+    has_pending: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,6 +58,8 @@ class TrialBalanceData:
     totals_by_currency: list[CurrencyTotal]
     household_name: str
     generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    pending_included: bool = False
+    pending_count: int = 0
 
 
 VisibleAccountFilter = Callable[[str, UUID | None], bool]
@@ -68,6 +71,7 @@ def build(
     household_id: UUID,
     as_of: date_type | None = None,
     visible_account_filter: VisibleAccountFilter | None = None,
+    include_pending: bool = False,
 ) -> TrialBalanceData:
     """Compute trial-balance rows + totals for one household.
 
@@ -78,6 +82,10 @@ def build(
     Defaults to a permissive filter that returns all accounts; tests
     use the default, the API endpoint passes its
     :func:`_filter_for_role`.
+
+    ``include_pending`` (#274) folds PENDING transactions into the
+    balances and stamps ``has_pending`` on each row that drew one; the
+    rendered report shows a "includes N pending transactions" subtitle.
     """
     from tulip_storage.models import Household
     from tulip_storage.repositories import AccountRepository, TransactionRepository
@@ -86,7 +94,10 @@ def build(
     account_repo = AccountRepository(session, household_id)
     accounts_by_id = {a.id: a for a in account_repo.list_active()}
     effective_as_of = as_of or date_type.today()
-    raw = tx_repo.trial_balance(as_of=effective_as_of)
+    raw = tx_repo.trial_balance(as_of=effective_as_of, include_pending=include_pending)
+    pending_count = (
+        tx_repo.count_pending_transactions(as_of=effective_as_of) if include_pending else 0
+    )
     household = session.get(Household, household_id)
     assert household is not None  # noqa: S101 — caller already authenticated
 
@@ -110,6 +121,7 @@ def build(
                 type=a.type.value,
                 currency=r.currency,
                 balance=balance,
+                has_pending=r.has_pending,
             )
         )
         if balance > 0:
@@ -136,6 +148,8 @@ def build(
         rows=rows,
         totals_by_currency=totals,
         household_name=household.name,
+        pending_included=include_pending,
+        pending_count=pending_count,
     )
 
 

--- a/packages/tulip-reports/src/tulip_reports/templates/trial_balance.html
+++ b/packages/tulip-reports/src/tulip_reports/templates/trial_balance.html
@@ -7,6 +7,10 @@
 <dl class="meta">
   <dt>Household:</dt><dd>{{ data.household_name }}</dd>
   <dt>As of:</dt><dd>{{ data.as_of | isodate }}</dd>
+  {% if data.pending_included %}
+  <dt>Pending:</dt>
+  <dd>Includes {{ data.pending_count }} pending transaction{{ "" if data.pending_count == 1 else "s" }}</dd>
+  {% endif %}
 </dl>
 {% endblock %}
 
@@ -26,7 +30,7 @@
     {% for row in data.rows %}
     <tr>
       <td>{{ row.code or "" }}</td>
-      <td>{{ row.name }}</td>
+      <td>{{ row.name }}{% if row.has_pending %} <span class="pending-marker" title="includes pending transactions">(P)</span>{% endif %}</td>
       <td>{{ row.type }}</td>
       <td class="num{% if row.balance is negative %} negative{% endif %}">
         {{ row.balance | money }}

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import String, cast, delete, func, select, update
+from sqlalchemy import String, case, cast, delete, func, select, update
 
 from tulip_storage.encryption import decrypt_field, encrypt_field
 from tulip_storage.models import Posting, Transaction, TransactionStatus
@@ -80,14 +80,30 @@ _DOMAIN_TO_STORAGE_STATUS: dict[str, TransactionStatus] = {
 #: are workflow state, not ledger state, and are excluded from balances.
 _LEDGER_STATUSES = (TransactionStatus.POSTED, TransactionStatus.RECONCILED)
 
+#: The ledger statuses plus PENDING — the filter used when a caller opts
+#: into the "what if all pending is real" view (#274).
+_LEDGER_PLUS_PENDING = (*_LEDGER_STATUSES, TransactionStatus.PENDING)
+
+
+def _balance_statuses(*, include_pending: bool) -> tuple[TransactionStatus, ...]:
+    """Pick the status filter for a balance query (#274)."""
+    return _LEDGER_PLUS_PENDING if include_pending else _LEDGER_STATUSES
+
 
 @dataclass(frozen=True, slots=True)
 class TrialBalanceRow:
-    """One row of a per-(account, currency) trial-balance result."""
+    """One row of a per-(account, currency) trial-balance result.
+
+    ``has_pending`` is True when ``include_pending`` was requested *and*
+    at least one PENDING transaction contributed to this row's balance —
+    it's what the CLI uses to flag a row with a ``(P)`` marker. It's
+    always False on the posted-only path.
+    """
 
     account_id: UUID
     currency: str
     balance: Decimal
+    has_pending: bool = False
 
 
 class TransactionRepository:
@@ -204,12 +220,14 @@ class TransactionRepository:
         *,
         currency: str,
         as_of: date_type | None = None,
+        include_pending: bool = False,
     ) -> Decimal:
         """Sum the ledger postings on ``account_id`` in ``currency``.
 
-        Pending transactions are excluded — only POSTED and RECONCILED
-        contribute. ``as_of`` limits to transactions on or before that
-        date; ``None`` means "all time."
+        By default only POSTED + RECONCILED contribute. ``include_pending``
+        (#274) widens the sum to PENDING transactions too — the "what if
+        all pending is real" view. ``as_of`` limits to transactions on or
+        before that date; ``None`` means "all time."
         """
         query = (
             select(func.coalesce(func.sum(Posting.amount), 0))
@@ -218,7 +236,7 @@ class TransactionRepository:
                 Posting.household_id == self._household_id,
                 Posting.account_id == account_id,
                 Posting.currency == currency,
-                Transaction.status.in_(_LEDGER_STATUSES),
+                Transaction.status.in_(_balance_statuses(include_pending=include_pending)),
             )
         )
         if as_of is not None:
@@ -229,29 +247,79 @@ class TransactionRepository:
         # a type drift on the empty-result branch.
         return Decimal(str(result))
 
+    def count_pending_for_account(
+        self,
+        account_id: UUID,
+        *,
+        currency: str,
+        as_of: date_type | None = None,
+    ) -> int:
+        """Count distinct PENDING transactions with a posting on this account.
+
+        Drives the ``pending_count`` field on the account-balance
+        response (#274). ``distinct`` because one transaction can carry
+        more than one posting on the same account.
+        """
+        query = (
+            select(func.count(func.distinct(Transaction.id)))
+            .join(Posting, Posting.transaction_id == Transaction.id)
+            .where(
+                Posting.household_id == self._household_id,
+                Posting.account_id == account_id,
+                Posting.currency == currency,
+                Transaction.status == TransactionStatus.PENDING,
+            )
+        )
+        if as_of is not None:
+            query = query.where(Transaction.date <= as_of)
+        return int(self._session.execute(query).scalar_one())
+
+    def count_pending_transactions(self, *, as_of: date_type | None = None) -> int:
+        """Count PENDING transactions household-wide (#274).
+
+        Drives the ``pending_count`` field on the trial-balance response.
+        """
+        query = select(func.count()).where(
+            Transaction.household_id == self._household_id,
+            Transaction.status == TransactionStatus.PENDING,
+        )
+        if as_of is not None:
+            query = query.where(Transaction.date <= as_of)
+        return int(self._session.execute(query).scalar_one())
+
     def trial_balance(
         self,
         *,
         as_of: date_type | None = None,
+        include_pending: bool = False,
     ) -> list[TrialBalanceRow]:
         """Return one row per (account_id, currency) for the household's ledger.
 
-        Pending transactions are excluded. ``as_of`` filters to
-        transactions on or before that date; ``None`` means "all time."
-        Accounts with no postings (or only zero-net postings) still
-        appear when they have any matching posting at all — callers may
-        filter zeros if they want.
+        By default only POSTED + RECONCILED contribute. ``include_pending``
+        (#274) widens the sum to PENDING transactions too, and sets
+        ``has_pending`` on each row that drew at least one PENDING
+        posting. ``as_of`` filters to transactions on or before that
+        date; ``None`` means "all time." Accounts with no postings (or
+        only zero-net postings) still appear when they have any matching
+        posting at all — callers may filter zeros if they want.
         """
+        # MAX over a 0/1 case expression collapses to "any pending in the
+        # group" — one extra column, no second query.
+        is_pending = case(
+            (Transaction.status == TransactionStatus.PENDING, 1),
+            else_=0,
+        )
         query = (
             select(
                 Posting.account_id,
                 Posting.currency,
                 func.coalesce(func.sum(Posting.amount), 0).label("balance"),
+                func.max(is_pending).label("has_pending"),
             )
             .join(Transaction, Transaction.id == Posting.transaction_id)
             .where(
                 Posting.household_id == self._household_id,
-                Transaction.status.in_(_LEDGER_STATUSES),
+                Transaction.status.in_(_balance_statuses(include_pending=include_pending)),
             )
             .group_by(Posting.account_id, Posting.currency)
         )
@@ -263,8 +331,9 @@ class TransactionRepository:
                 account_id=account_id,
                 currency=currency,
                 balance=Decimal(str(balance)),
+                has_pending=include_pending and bool(has_pending),
             )
-            for account_id, currency, balance in rows
+            for account_id, currency, balance, has_pending in rows
         ]
 
     def save_balanced(

--- a/packages/tulip-storage/tests/test_repositories.py
+++ b/packages/tulip-storage/tests/test_repositories.py
@@ -546,6 +546,75 @@ class TestTransactionRepository:
         assert early[food.id] == Decimal("5.00")
         assert late[food.id] == Decimal("12.00")
 
+    def _seed_posted_and_pending(
+        self, session: Session, household: Household
+    ) -> tuple[AccountModel, AccountModel]:
+        """Seed one POSTED (10.00) and one PENDING (99.00) grocery run."""
+        cash, food = self._seed_accounts(session, household)
+        PeriodRepository(session, household.id).create(
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            status=PeriodStatus.OPEN,
+        )
+        session.commit()
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 1),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("10.00"),
+            status=DomainTxStatus.POSTED,
+        )
+        self._post_tx(
+            session,
+            household,
+            tx_date=date(2026, 6, 2),
+            debit_account=food,
+            credit_account=cash,
+            amount=Decimal("99.00"),
+            status=DomainTxStatus.PENDING,
+        )
+        return cash, food
+
+    def test_balance_for_account_include_pending_folds_in_pending(
+        self, session: Session, household: Household
+    ):
+        # #274: include_pending widens the sum to PENDING transactions.
+        _cash, food = self._seed_posted_and_pending(session, household)
+        repo = TransactionRepository(session, household.id)
+        assert repo.balance_for_account(food.id, currency="USD") == Decimal("10.00")
+        assert repo.balance_for_account(food.id, currency="USD", include_pending=True) == Decimal(
+            "109.00"
+        )
+
+    def test_count_pending_for_account(self, session: Session, household: Household):
+        _cash, food = self._seed_posted_and_pending(session, household)
+        repo = TransactionRepository(session, household.id)
+        assert repo.count_pending_for_account(food.id, currency="USD") == 1
+
+    def test_trial_balance_include_pending_folds_in_and_flags_rows(
+        self, session: Session, household: Household
+    ):
+        # #274: include_pending sums PENDING in and marks affected rows.
+        _cash, food = self._seed_posted_and_pending(session, household)
+        repo = TransactionRepository(session, household.id)
+
+        posted_only = {r.account_id: r for r in repo.trial_balance()}
+        assert posted_only[food.id].balance == Decimal("10.00")
+        assert posted_only[food.id].has_pending is False
+
+        with_pending = {r.account_id: r for r in repo.trial_balance(include_pending=True)}
+        assert with_pending[food.id].balance == Decimal("109.00")
+        assert with_pending[food.id].has_pending is True
+
+    def test_count_pending_transactions(self, session: Session, household: Household):
+        self._seed_posted_and_pending(session, household)
+        repo = TransactionRepository(session, household.id)
+        assert repo.count_pending_transactions() == 1
+        # as_of before the pending tx → zero.
+        assert repo.count_pending_transactions(as_of=date(2026, 6, 1)) == 0
+
     def test_list_headers_orders_by_date_desc(self, session: Session, household: Household):
         cash, food = self._seed_accounts(session, household)
         PeriodRepository(session, household.id).create(


### PR DESCRIPTION
## Summary

`tulip balance` and the balance endpoints default to POSTED + RECONCILED only (the trial-balance convention). This adds an opt-in *"what if all pending is real"* view — useful right after an import, before the batch has been reviewed — and makes the pending-inclusive output unmistakable so it's never confused with the posted ledger.

### Storage (`TransactionRepository`)
- `balance_for_account` / `trial_balance` take `include_pending`; when set, the status filter widens to PENDING.
- `trial_balance` rows now carry `has_pending` — computed via `MAX` over a 0/1 `case` expression, one extra column, no second query.
- New `count_pending_for_account` / `count_pending_transactions` feed the `pending_count` surfaced in responses.

### API
- `GET /v1/accounts/{id}/balance?include_pending=true`
- `GET /v1/reports/trial-balance?include_pending=true`
- Responses gain `pending_included` + `pending_count`; trial-balance rows gain `has_pending`. **Default-off** — existing callers see no change.

### Reports
- `trial_balance.build()` threads `include_pending` so `format=html/pdf/csv` numbers are correct (not stale posted-only); the HTML/PDF template gets an "Includes N pending transactions" subtitle and a `(P)` marker on affected rows.

### CLI
- `tulip balance --pending` (and `--no-pending`). The header switches to `balance (incl. pending)`, the trial-balance title notes the pending count, and pending-affected rows get a `(P)` marker. `--help` spells out the semantic difference.

## Test plan

- [x] `uv run pytest packages` → 1781 passed, 1 skipped, 3 deselected
- [x] `just lint` + `just typecheck` clean
- [x] Storage: `include_pending` folds pending in + flags rows; `count_pending_*` helpers; default-off preserved
- [x] API: both endpoints — default excludes pending; `?include_pending=true` folds in + sets `pending_included`/`pending_count`/`has_pending`; HTML subtitle + `(P)` marker
- [x] CLI: `tulip balance --pending` widens the balance and labels the output; default stays plain; trial-balance `(P)` marker
- [ ] CI green on this PR