### PR TITLE
feat: right-align numeric columns across CLI tables (closes #289)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/_tables.py
+++ b/packages/tulip-cli/src/tulip_cli/_tables.py
@@ -1,0 +1,30 @@
+"""Shared Rich-table helpers for the CLI (#289).
+
+Numeric columns — amounts, balances, counts, confidence scores — must
+right-justify so digits and decimal points line up vertically when you
+scan a column. In a monospaced terminal that vertical alignment *is*
+the financial-legibility win; a left-justified amount column is the
+single most common reason a printed ledger reads badly.
+
+Routing every numeric column through :func:`add_numeric_column` keeps
+new tables from silently drifting back to Rich's left-justified
+default — the header text varies, the justification never should.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.table import Table
+
+
+def add_numeric_column(table: Table, header: str) -> None:
+    """Add a right-justified column for a monetary / numeric value.
+
+    Use for amounts, balances, counts, line numbers, percentages, and
+    confidence scores. Non-numeric columns (names, codes, dates,
+    statuses) keep Rich's default left-justification — call
+    ``table.add_column(header)`` directly for those.
+    """
+    table.add_column(header, justify="right")

--- a/packages/tulip-cli/src/tulip_cli/commands/balance.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/balance.py
@@ -17,6 +17,7 @@ import typer
 from rich.table import Table
 
 from tulip_cli._console import make_console
+from tulip_cli._tables import add_numeric_column
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands.accounts import _resolve_account
 from tulip_cli.config import Config
@@ -68,7 +69,7 @@ def _render_trial_balance(body: dict[str, Any]) -> None:
     table.add_column("name")
     table.add_column("type")
     table.add_column("currency")
-    table.add_column(balance_header, justify="right")
+    add_numeric_column(table, balance_header)
     for r in rows:
         currency = r.get("currency") or ""
         name = r.get("name") or ""

--- a/packages/tulip-cli/src/tulip_cli/commands/envelopes.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/envelopes.py
@@ -21,6 +21,7 @@ import typer
 from rich.table import Table
 
 from tulip_cli._console import make_console
+from tulip_cli._tables import add_numeric_column
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands._pools import _resolve_envelope, _summarize_refill_rule
 from tulip_cli.config import Config
@@ -49,8 +50,8 @@ def _render_table(
     table.add_column("currency")
     table.add_column("period")
     table.add_column("rollover")
-    table.add_column("budget")
-    table.add_column("balance", justify="right")
+    add_numeric_column(table, "budget")
+    add_numeric_column(table, "balance")
     table.add_column("refill")
     for env in envelopes:
         table.add_row(

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -268,6 +268,7 @@ def _render_list_table(items: list[dict[str, Any]]) -> None:
     from rich.table import Table
 
     from tulip_cli._console import make_console
+    from tulip_cli._tables import add_numeric_column
 
     table = Table(show_header=True, show_lines=False)
     table.add_column("id")
@@ -276,7 +277,7 @@ def _render_list_table(items: list[dict[str, Any]]) -> None:
     table.add_column("format")
     table.add_column("account")
     table.add_column("filename")
-    table.add_column("counts")
+    add_numeric_column(table, "counts")
     for item in items:
         batch_id = str(item.get("id") or "")
         account_id = str(item.get("account_id") or "")
@@ -329,6 +330,7 @@ def _render_batch(body: dict[str, Any]) -> None:
     from rich.table import Table
 
     from tulip_cli._console import make_console
+    from tulip_cli._tables import add_numeric_column
 
     console = make_console()
     header_lines = [
@@ -356,9 +358,9 @@ def _render_batch(body: dict[str, Any]) -> None:
         return
 
     table = Table(title=f"\nStatement lines ({len(lines)})", show_header=True)
-    table.add_column("#", justify="right")
+    add_numeric_column(table, "#")
     table.add_column("date")
-    table.add_column("amount", justify="right")
+    add_numeric_column(table, "amount")
     table.add_column("ccy")
     table.add_column("description")
     table.add_column("flag")

--- a/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/reconcile.py
@@ -27,6 +27,7 @@ from rich.table import Table
 
 from tulip_cli._console import make_console
 from tulip_cli._picker import is_interactive, pick
+from tulip_cli._tables import add_numeric_column
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands.accounts import _resolve_account
 from tulip_cli.config import Config
@@ -95,8 +96,8 @@ def _render_matches(console: Console, matches: list[dict[str, Any]]) -> None:
     table.add_column("match_id")
     table.add_column("line_id")
     table.add_column("tx_id")
-    table.add_column("amount")
-    table.add_column("confidence")
+    add_numeric_column(table, "amount")
+    add_numeric_column(table, "confidence")
     table.add_column("source")
     for m in matches:
         source = "auto" if m.get("matcher_version") else "manual"
@@ -119,7 +120,7 @@ def _render_unmatched_lines(console: Console, lines: list[dict[str, Any]]) -> No
     table = Table()
     table.add_column("line_id")
     table.add_column("date")
-    table.add_column("amount")
+    add_numeric_column(table, "amount")
     table.add_column("description")
     for line in lines:
         table.add_row(
@@ -301,7 +302,7 @@ def list_command(
     table.add_column("account_id")
     table.add_column("period")
     table.add_column("status")
-    table.add_column("ending")
+    add_numeric_column(table, "ending")
     for item in items:
         table.add_row(
             item["id"],

--- a/packages/tulip-cli/src/tulip_cli/commands/sinking_funds.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/sinking_funds.py
@@ -17,6 +17,7 @@ import typer
 from rich.table import Table
 
 from tulip_cli._console import make_console
+from tulip_cli._tables import add_numeric_column
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands._pools import _resolve_sinking_fund
 from tulip_cli.config import Config
@@ -43,10 +44,10 @@ def _render_table(
     table = Table(show_header=True, show_lines=False)
     table.add_column("name")
     table.add_column("currency")
-    table.add_column("target")
+    add_numeric_column(table, "target")
     table.add_column("target_date")
     table.add_column("strategy")
-    table.add_column("balance", justify="right")
+    add_numeric_column(table, "balance")
     for sf in sfs:
         table.add_row(
             sf.get("name") or "",

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -36,6 +36,7 @@ from rich.table import Table
 
 from tulip_cli._console import make_console
 from tulip_cli._picker import is_interactive, pick
+from tulip_cli._tables import add_numeric_column
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands._editor import edit_buffer
 from tulip_cli.commands._ledger import LedgerParseError, parse_ledger_text
@@ -539,7 +540,7 @@ def _render_tx_detail(
     typer.echo("postings:")
     table = Table(show_header=True, show_lines=False)
     table.add_column("account")
-    table.add_column("amount", justify="right")
+    add_numeric_column(table, "amount")
     table.add_column("currency")
     table.add_column("memo")
     for p in tx.get("postings") or []:

--- a/packages/tulip-cli/tests/test_tables.py
+++ b/packages/tulip-cli/tests/test_tables.py
@@ -1,0 +1,58 @@
+"""Tests for the shared Rich-table helpers (#289).
+
+The financial-legibility win is vertical alignment: amounts of
+different widths must line up on their right edge so a column of
+numbers scans cleanly. ``add_numeric_column`` is the single chokepoint
+that guarantees it.
+"""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+from rich.table import Table
+
+from tulip_cli._tables import add_numeric_column
+
+
+def test_add_numeric_column_sets_right_justify() -> None:
+    table = Table()
+    add_numeric_column(table, "balance")
+    col = table.columns[-1]
+    assert col.justify == "right"
+    assert col.header == "balance"
+
+
+def test_numeric_column_renders_amounts_right_aligned() -> None:
+    """Different-width amounts in a numeric column share a right edge.
+
+    Rendered at a pinned width so the assertion is stable regardless of
+    the runner's terminal size (the #285 lesson).
+    """
+    table = Table(show_edge=False, pad_edge=False)
+    table.add_column("name")
+    add_numeric_column(table, "amount")
+    table.add_row("groceries", "12.20")
+    table.add_row("rent", "1450.00")
+
+    console = Console(width=80, file=io.StringIO())
+    console.print(table)
+    out = console.file.getvalue()
+
+    short_line = next(ln for ln in out.splitlines() if "12.20" in ln)
+    long_line = next(ln for ln in out.splitlines() if "1450.00" in ln)
+    # Right edge = index just past the last digit of the amount.
+    short_end = short_line.index("12.20") + len("12.20")
+    long_end = long_line.index("1450.00") + len("1450.00")
+    assert short_end == long_end, (short_line, long_line)
+    # And the short value is genuinely right-padded, not left-aligned:
+    # a space sits immediately before it within the cell.
+    assert short_line[short_line.index("12.20") - 1] == " "
+
+
+def test_left_default_column_is_not_right_aligned() -> None:
+    """Control: a plain add_column stays left-justified (Rich default)."""
+    table = Table()
+    table.add_column("name")
+    assert table.columns[-1].justify == "left"


### PR DESCRIPTION
## Summary

Numeric columns were inconsistently justified. `balance.py` and the `amount` columns in `transactions` / `sinking_funds` / `envelopes` / `imports` already right-justified, but `target`, `budget`, `counts`, and every reconcile `amount` + `confidence` + `ending` column rendered left-aligned (Rich's default). In a monospaced terminal that vertical alignment *is* the financial-legibility win, so the inconsistency was a real readability bug.

- New `tulip_cli._tables.add_numeric_column(table, header)` bakes in `justify="right"`.
- All 13 numeric columns across 6 command modules (`balance`, `transactions`, `sinking_funds`, `envelopes`, `imports`, `reconcile`) now route through it — a new table can't silently drift back to the left-justified default.
- Non-numeric columns (names, codes, dates, statuses) keep Rich's default left-justification.
- `--json` output is untouched — alignment is a presentation concern only.

## Test plan

- [x] `uv run --package tulip-cli pytest packages/tulip-cli/tests` → 437 passed
- [x] `just lint` + `just typecheck` clean
- [x] New `test_tables.py`: `add_numeric_column` sets `justify="right"`; a width-pinned render proves different-width amounts share a right edge; control test confirms a plain `add_column` stays left-justified
- [ ] CI green on this PR