### PR TITLE
fix: QIF parser skips non-transaction preamble sections (closes #198)

### DIFF
--- a/packages/tulip-importers/src/tulip_importers/qif/parser.py
+++ b/packages/tulip-importers/src/tulip_importers/qif/parser.py
@@ -48,6 +48,24 @@ A non-split record (no ``S``/``$`` lines) still emits exactly one
 ``ParsedStatementLine``, preserving the existing two-posting promotion
 shape.
 
+Section skipping (#198)
+-----------------------
+
+Real desktop-app exports (Banktivity, GnuCash, Moneydance, Quicken)
+wrap the transactions in a preamble: ``!Option:*`` / ``!Clear:*``
+directives, ``!Account`` declaration blocks, and non-transaction
+``!Type:`` sections (``!Type:Cat`` category lists, ``!Type:Security``
+security lists, ``!Type:Prices``, ``!Type:Class``, ``!Type:Memorized``).
+The parser walks the section state machine and only parses records
+inside transaction-bearing ``!Type:`` sections (``Bank``, ``CCard``,
+``Cash``, ``Oth A``, ``Oth L``, ``Invst`` — plus any unknown label, on
+the principle that silently dropping a bank's transactions is worse
+than a parse error). An ``!Account`` block's record is skipped wholesale
+— #195 grows that into real multi-account routing.
+
+A header-less QIF (``D``/``T``/``^`` records with no ``!`` directives at
+all) still parses — the historical single-account shape.
+
 Errors raise :class:`QifParseError` with the failing line number for
 debuggability — banks ship malformed QIF often and operators need to
 locate the bad row.
@@ -68,6 +86,19 @@ _RECORD_TERMINATOR = "^"
 
 #: Header line introduces the account type. Conventional but optional.
 _HEADER_RE = re.compile(r"^!Type:(.+)$", re.IGNORECASE)
+
+#: ``!Type:`` labels that introduce *non*-transaction sections — category
+#: lists, security lists, price history, memorized transactions. Their
+#: records have an entirely different field shape; parsing them as
+#: transactions is what made multi-section Banktivity / Quicken exports
+#: fail (#198). Every record inside these sections is skipped.
+#:
+#: The complementary transaction-bearing labels (``Bank``, ``CCard``,
+#: ``Cash``, ``Oth A``, ``Oth L``, ``Invst``) aren't enumerated: anything
+#: *not* in this set is parsed, including unrecognised labels — silently
+#: dropping a bank's transactions because it used an unfamiliar type
+#: string is a worse failure than a parse error.
+_NON_TXN_TYPES = frozenset({"cat", "class", "security", "prices", "memorized"})
 
 #: ISO date — try this first; unambiguous.
 _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -331,25 +362,79 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
     saw_anything = False
     saw_qif_marker = False  # ^ separator OR !Type: header OR known D/T field
 
+    # Section state (#198). ``parsing`` gates whether the current record
+    # stream is transaction-bearing. It defaults True so a header-less
+    # QIF (just ``D/T/^`` records) still parses — the historical shape.
+    # Once an ``!Account`` block or a non-transaction ``!Type:`` section
+    # is seen, ``parsing`` only goes back True on a transaction-bearing
+    # ``!Type:`` header. ``in_account_block`` marks the throwaway record
+    # that follows an ``!Account`` directive — #195 will grow this into
+    # real per-account routing; #198 just skips it cleanly.
+    parsing = True
+    in_account_block = False
+
     for source_line_number, raw_line in enumerate(text.splitlines(), start=1):
         line = raw_line.rstrip("\r")
         if not line.strip():
             continue
         saw_anything = True
 
-        # Header line — applies to all subsequent records.
+        # Directive line — ``!Type:``, ``!Account``, ``!Option:``, etc.
         if line.startswith("!"):
             saw_qif_marker = True
+            # A directive ends whatever record was mid-accumulation. In
+            # valid QIF a ``^`` always precedes the directive; this is the
+            # defensive path for hand-edited / truncated files.
+            if rec is not None and rec.has_any_field() and parsing and not in_account_block:
+                finalized = _finalize_record(
+                    rec,
+                    start_line_number=record_no + 1,
+                    currency=currency,
+                    account_type=account_type,
+                )
+                out.extend(finalized)
+                record_no += len(finalized)
+            rec = None
+
             m = _HEADER_RE.match(line)
             if m:
-                account_type = m.group(1).strip()
+                label = m.group(1).strip()
+                normalized = label.lower()
+                in_account_block = False
+                if normalized in _NON_TXN_TYPES:
+                    # Category / security / price / memorized section —
+                    # skip every record inside it.
+                    parsing = False
+                    account_type = None
+                else:
+                    # Transaction-bearing (or unknown) type — parse it.
+                    parsing = True
+                    account_type = label
                 continue
-            # Unknown bang directive — skip with a raw record marker.
+            if line.strip().lower() == "!account":
+                # The next record (until ``^``) declares an account, not a
+                # transaction. Skip it. #195 will route by account name.
+                in_account_block = True
+                parsing = False
+                continue
+            # Any other directive (``!Option:*``, ``!Clear:*``, …) — skip
+            # the line, leave section state untouched.
             continue
 
         # Record terminator.
         if line == _RECORD_TERMINATOR:
             saw_qif_marker = True
+            if in_account_block:
+                # End of the ``!Account`` declaration block — its fields
+                # were skipped, so there's nothing to finalize. ``parsing``
+                # stays False until the next ``!Type:`` header.
+                in_account_block = False
+                rec = None
+                continue
+            if not parsing:
+                # Inside a non-transaction section — drop the record.
+                rec = None
+                continue
             if rec is None or not rec.has_any_field():
                 # Stray ^ between records; ignore silently.
                 rec = None
@@ -366,6 +451,10 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
             continue
 
         # Field line: first character is the field code; rest is the value.
+        if in_account_block or not parsing:
+            # Inside an ``!Account`` declaration block or a non-transaction
+            # ``!Type:`` section — skip the field entirely.
+            continue
         if rec is None:
             rec = _RecordBuilder(line_number=source_line_number)
         code = line[0]
@@ -432,8 +521,11 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
             # fields directly.
             rec.raw[code] = value
 
-    # Trailing record without `^` (rare but legal in some emitters): finalize.
-    if rec is not None and rec.has_any_field():
+    # Trailing record without `^` (rare but legal in some emitters):
+    # finalize — but only if it's a transaction record. A file that ends
+    # mid-``!Account`` block or inside a non-transaction section leaves a
+    # ``rec`` that must be discarded, not parsed (#198).
+    if rec is not None and rec.has_any_field() and parsing and not in_account_block:
         finalized = _finalize_record(
             rec,
             start_line_number=record_no + 1,

--- a/packages/tulip-importers/tests/fixtures/qif/banktivity_preamble.qif
+++ b/packages/tulip-importers/tests/fixtures/qif/banktivity_preamble.qif
@@ -1,0 +1,41 @@
+!Option:AutoSwitch
+!Account
+NChecking
+TBank
+DEveryday checking account
+B10000.00
+^
+!Clear:AutoSwitch
+!Type:Cat
+NGroceries
+E
+^
+NSalary
+I
+^
+NUtilities:Natural Gas
+E
+^
+!Account
+NChecking
+^
+!Type:Bank
+D1/2/26
+T-58.99
+PCenterPoint Energy
+MGas bill
+^
+D1/5/26
+T1500.00
+PEmployer
+MPayroll
+^
+!Type:Security
+NAcme Corp
+SACME
+TStock
+^
+NWidget Inc
+SWGT
+TStock
+^

--- a/packages/tulip-importers/tests/test_qif_parser.py
+++ b/packages/tulip-importers/tests/test_qif_parser.py
@@ -171,6 +171,74 @@ class TestParseSplits:
             assert "L" not in line.raw
 
 
+class TestParseSectionSkipping:
+    """Per #198: skip the preamble desktop apps wrap transactions in.
+
+    Banktivity / Quicken / GnuCash exports open with ``!Option`` /
+    ``!Clear`` directives, an ``!Account`` declaration block, a full
+    ``!Type:Cat`` category list, then the transaction-bearing
+    ``!Type:Bank`` section, then a ``!Type:Security`` list. Only the
+    ``!Type:Bank`` records are transactions; everything else must be
+    skipped without erroring.
+    """
+
+    def test_banktivity_preamble_lands_only_bank_transactions(self):
+        lines = parse(_read("banktivity_preamble.qif"), currency="USD")
+        # The fixture has exactly two !Type:Bank records; the !Account
+        # block, the 3-row !Type:Cat list, and the 2-row !Type:Security
+        # list all produce zero statement lines.
+        assert len(lines) == 2
+        gas, payroll = lines
+        assert gas.posted_date == date(2026, 1, 2)
+        assert gas.amount.amount == Decimal("-58.99")
+        assert "CenterPoint Energy" in gas.description
+        assert payroll.posted_date == date(2026, 1, 5)
+        assert payroll.amount.amount == Decimal("1500.00")
+        # The Bank type header still flows onto the parsed rows.
+        assert gas.raw.get("TYPE") == "Bank"
+
+    def test_cat_section_records_are_not_transactions(self):
+        # A bare !Type:Cat section with category records and nothing else
+        # parses to zero lines — not a "missing date/amount" error.
+        cat_only = b"!Type:Cat\nNGroceries\nE\n^\nNSalary\nI\n^\n"
+        assert parse(cat_only, currency="USD") == []
+
+    def test_security_section_records_are_not_transactions(self):
+        sec_only = b"!Type:Security\nNAcme Corp\nSACME\nTStock\n^\n"
+        assert parse(sec_only, currency="USD") == []
+
+    def test_account_block_is_skipped(self):
+        # An !Account declaration block followed by a real !Type:Bank
+        # section: the block is skipped, the transaction lands.
+        qif = b"!Account\nNChecking\nTBank\nB100.00\n^\n!Type:Bank\nD1/2/26\nT-10.00\nPStore\n^\n"
+        lines = parse(qif, currency="USD")
+        assert len(lines) == 1
+        assert lines[0].amount.amount == Decimal("-10.00")
+
+    def test_option_directives_are_skipped(self):
+        qif = b"!Option:AutoSwitch\n!Type:Bank\nD1/2/26\nT5.00\nPX\n^\n!Clear:AutoSwitch\n"
+        lines = parse(qif, currency="USD")
+        assert len(lines) == 1
+        assert lines[0].amount.amount == Decimal("5.00")
+
+    def test_non_txn_section_after_bank_section_stops_parsing(self):
+        # Records under !Type:Security that follow a !Type:Bank section
+        # must not be mis-read as transactions.
+        qif = b"!Type:Bank\nD1/2/26\nT5.00\nPX\n^\n!Type:Security\nNAcme\nSACME\n^\n"
+        lines = parse(qif, currency="USD")
+        assert len(lines) == 1
+        assert lines[0].amount.amount == Decimal("5.00")
+
+    def test_unknown_type_is_still_parsed(self):
+        # An unrecognised !Type: label is parsed, not skipped — silently
+        # dropping a bank's transactions is the worse failure mode.
+        qif = b"!Type:SomethingNew\nD1/2/26\nT9.99\nPX\n^\n"
+        lines = parse(qif, currency="USD")
+        assert len(lines) == 1
+        assert lines[0].amount.amount == Decimal("9.99")
+        assert lines[0].raw.get("TYPE") == "SomethingNew"
+
+
 class TestParseErrors:
     def test_empty_bytes_raises(self):
         with pytest.raises(QifParseError):


### PR DESCRIPTION
## Summary

Real desktop-app exports (Banktivity, GnuCash, Moneydance, Quicken) wrap their transactions in a preamble: `!Option` / `!Clear` directives, an `!Account` declaration block, a full `!Type:Cat` category list — *then* the `!Type:Bank` transactions, then `!Type:Security`. The parser assumed the file opened straight into transaction records, so it mis-read the `!Account` block's `NChecking` field as a transaction and bailed with `record is missing date (D) field`. A single-account Banktivity export failed on line 3.

The parser now walks a section state machine:

- `!Type:<Cat|Class|Security|Prices|Memorized>` → non-transaction section, every record skipped.
- `!Type:<Bank|CCard|Cash|Oth A|Oth L|Invst>` — and any unrecognised label — → transaction-bearing, parsed. Unknown labels parse rather than skip: silently dropping a bank's transactions over an unfamiliar type string is the worse failure mode.
- `!Account` → the following declaration record is skipped wholesale (#195 grows this into real multi-account routing).
- `!Option:*` / `!Clear:*` / other directives → line skipped, section state untouched.
- A header-less QIF (bare `D`/`T`/`^` records, no `!` directives) still parses — the historical single-account shape.

This is the "ignore non-transaction sections" subset of #195; #195 will build the multi-account import flow (`--account-map`, cross-account transfers) on top of this cleaned-up parser.

## Test plan

- [x] `uv run pytest packages` → 1788 passed, 1 skipped, 3 deselected
- [x] `just lint` + `just typecheck` clean
- [x] New `banktivity_preamble.qif` fixture: full `!Option` + `!Account` + `!Type:Cat` + `!Type:Bank` + `!Type:Security` shape
- [x] `TestParseSectionSkipping`: Banktivity preamble lands only the 2 Bank txns; bare `!Type:Cat` / `!Type:Security` → zero lines; `!Account` block skipped; `!Option`/`!Clear` skipped; post-Bank `!Type:Security` boundary respected; unknown `!Type:` still parsed
- [x] All 18 existing QIF parser tests + the import-apply / CLI-import surface (113 tests) green — no regression
- [ ] CI green on this PR