### PR TITLE
feat: pair cross-account QIF transfers into balanced transactions (#195b)

### DIFF
--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -1111,6 +1111,40 @@ class ImportQifAccountNotFoundError(TulipProblem):
         )
 
 
+class ImportQifAccountUnmappedError(TulipProblem):
+    """A multi-account QIF declares accounts the account_map doesn't cover (#195b)."""
+
+    def __init__(self, *, unmapped: list[str]) -> None:
+        """Build the import.qif_account_unmapped problem (400)."""
+        super().__init__(
+            code="import.qif_account_unmapped",
+            title="Account map is missing QIF accounts",
+            status=400,
+            detail=(
+                f"The QIF declares {len(unmapped)} account(s) the --account-map "
+                f"doesn't cover: {', '.join(unmapped)}. Add them to the map so "
+                "every account routes to a tulip account."
+            ),
+            extensions={"unmapped": unmapped},
+        )
+
+
+class ImportAccountMapInvalidError(TulipProblem):
+    """The ``account_map`` form field isn't a JSON object of name→account-id (#195b)."""
+
+    def __init__(self, *, reason: str) -> None:
+        """Build the import.account_map_invalid problem (400)."""
+        super().__init__(
+            code="import.account_map_invalid",
+            title="Invalid account map",
+            status=400,
+            detail=(
+                f"The account_map form field must be a JSON object mapping each "
+                f"QIF account name to a tulip account UUID: {reason}"
+            ),
+        )
+
+
 class ImportCsvParseFailedError(TulipProblem):
     """The uploaded bytes could not be parsed as CSV per the supplied profile (P5.2.c)."""
 

--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -21,9 +21,10 @@ from __future__ import annotations
 import base64
 import binascii
 import hashlib
+import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Final
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import structlog
 from fastapi import APIRouter, Depends, File, Form, Query, Request, UploadFile, status
@@ -35,6 +36,7 @@ from tulip_api.errors import (
     AccountUnknownError,
     CsvProfileNotFoundError,
     ForbiddenError,
+    ImportAccountMapInvalidError,
     ImportAlreadyAppliedError,
     ImportBatchNotFoundError,
     ImportCategorizeUnknownAccountError,
@@ -44,6 +46,7 @@ from tulip_api.errors import (
     ImportMultiAccountQifError,
     ImportOfxParseFailedError,
     ImportQifAccountNotFoundError,
+    ImportQifAccountUnmappedError,
     ImportQifParseFailedError,
     ImportUnsupportedFormatError,
     RequestPayloadTooLargeError,
@@ -59,6 +62,7 @@ from tulip_api.schemas.import_batch import (
     ImportBatchListResponse,
     ImportBatchRead,
     ImportBatchSummary,
+    MultiAccountImportSummary,
     StatementLinePromoteResponse,
     StatementLineRead,
 )
@@ -70,7 +74,11 @@ from tulip_api.services.import_apply import (
     apply_batch,
     promote_statement_line,
 )
+from tulip_api.services.qif_multi_account import pair_transfers
 from tulip_core.reconciliation.categorizer import get_categorizer
+from tulip_core.transactions import Posting as DomainPosting
+from tulip_core.transactions import Transaction as DomainTransaction
+from tulip_core.transactions import TransactionStatus as DomainTxStatus
 from tulip_importers.csv import CsvParseError, CsvProfile
 from tulip_importers.csv import parse as csv_parse
 from tulip_importers.ofx import OfxParseError
@@ -86,12 +94,15 @@ from tulip_storage.repositories import (
     CsvProfileRepository,
     ImportBatchRepository,
     StatementLineRepository,
+    TransactionRepository,
 )
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from tulip_api.auth.tokens import Claims
+    from tulip_core.reconciliation import ParsedStatementLine
+    from tulip_storage.models import Account, ImportBatch, StatementLine
 
 
 router = APIRouter(prefix="/v1/imports", tags=["imports"])
@@ -406,6 +417,264 @@ async def upload_import(
         skipped_count=batch.skipped_count,
         error_count=batch.error_count,
         created_at=batch.created_at,
+    )
+
+
+def _parse_account_map(account_map: str) -> dict[str, UUID]:
+    """Parse + validate the ``account_map`` form field (#195b).
+
+    Expects a JSON object mapping each QIF !Account name to a tulip
+    account UUID string — the CLI resolves codes/names to UUIDs before
+    sending, so the server only has to validate the shape.
+    """
+    try:
+        raw_map = json.loads(account_map)
+    except json.JSONDecodeError as exc:
+        raise ImportAccountMapInvalidError(reason=str(exc)) from exc
+    if not isinstance(raw_map, dict) or not raw_map:
+        raise ImportAccountMapInvalidError(reason="expected a non-empty JSON object")
+    name_to_uuid: dict[str, UUID] = {}
+    for qif_name, value in raw_map.items():
+        try:
+            name_to_uuid[str(qif_name)] = UUID(str(value))
+        except ValueError as exc:
+            raise ImportAccountMapInvalidError(
+                reason=f"{qif_name!r} maps to {value!r}, which is not a UUID"
+            ) from exc
+    return name_to_uuid
+
+
+@router.post(
+    "/multi-account",
+    response_model=MultiAccountImportSummary,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: problem_response(
+            "account.unknown",
+            "import.qif_parse_failed",
+            "import.qif_account_unmapped",
+            "import.account_map_invalid",
+        ),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        409: problem_response("import.duplicate_file"),
+        413: problem_response("request.payload_too_large"),
+    },
+)
+async def upload_multi_account_qif(
+    request: Request,
+    file: UploadFile = File(  # noqa: B008
+        ..., description="A multi-account QIF file (2+ !Account blocks)."
+    ),
+    account_map: str = Form(
+        ...,
+        description=(
+            "JSON object mapping each QIF !Account name to a tulip account "
+            "UUID. The CLI resolves codes / names / paths to UUIDs before "
+            "sending, so the server only validates the shape."
+        ),
+    ),
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> MultiAccountImportSummary:
+    """Ingest a multi-account QIF — one batch per account, transfers paired (#195b).
+
+    The file is split by !Account block; each account's transactions land
+    in their own import batch. Cross-account transfers (reciprocal
+    ``L[Account]`` legs) are landed directly as one balanced PENDING
+    transaction, with both source statement lines marked promoted to it.
+    Transfer legs that can't be paired fall back to ordinary one-sided
+    statement lines and are reported in ``warnings``.
+    """
+    raw_bytes = await file.read()
+    if len(raw_bytes) > MAX_OFX_BYTES:
+        raise RequestPayloadTooLargeError(max_bytes=MAX_OFX_BYTES)
+    if not raw_bytes:
+        raise ImportQifParseFailedError(reason="uploaded file is empty")
+
+    name_to_uuid = _parse_account_map(account_map)
+
+    chunks = qif_split_accounts(raw_bytes)
+    if not chunks:
+        raise ImportQifParseFailedError(
+            reason=(
+                "this QIF has no !Account blocks — use POST /v1/imports with "
+                "account_id for a single-account file"
+            )
+        )
+
+    # Every account the file declares must be covered by the map.
+    unmapped = sorted({c.account_name for c in chunks if c.account_name not in name_to_uuid})
+    if unmapped:
+        raise ImportQifAccountUnmappedError(unmapped=unmapped)
+
+    # Resolve + validate every mapped account up front.
+    accounts_repo = AccountRepository(session, claims.household_id)
+    account_by_name: dict[str, Account] = {}
+    for chunk in chunks:
+        acct = accounts_repo.get(name_to_uuid[chunk.account_name])
+        if acct is None:
+            raise AccountUnknownError(account_id=str(name_to_uuid[chunk.account_name]))
+        account_by_name[chunk.account_name] = acct
+
+    # Parse each chunk against its account's currency.
+    parsed_by_account: dict[str, list[ParsedStatementLine]] = {}
+    for chunk in chunks:
+        try:
+            parsed_by_account[chunk.account_name] = qif_parse(
+                chunk.qif_text.encode("utf-8"),
+                currency=account_by_name[chunk.account_name].currency,
+            )
+        except QifParseError as exc:
+            raise ImportQifParseFailedError(
+                reason=f"account {chunk.account_name!r}: {exc}"
+            ) from exc
+
+    # Match reciprocal cross-account transfer legs.
+    pairs, warnings = pair_transfers(parsed_by_account, name_to_uuid)
+
+    # Attachment + per-account dedup. The attachment covers the whole file;
+    # re-importing it is a duplicate for every account it touches.
+    settings = get_settings()
+    attachment_repo = AttachmentRepository(
+        session,
+        claims.household_id,
+        master_key=settings.master_key,
+        attachment_root=settings.attachment_root,
+    )
+    batch_repo = ImportBatchRepository(session, claims.household_id)
+    content_hash = hashlib.sha256(raw_bytes).hexdigest()
+    existing_attachment = attachment_repo.find_by_hash(content_hash)
+    if existing_attachment is not None:
+        for chunk in chunks:
+            dup = batch_repo.find_for_attachment(
+                account_id=name_to_uuid[chunk.account_name],
+                attachment_id=existing_attachment.id,
+            )
+            if dup is not None:
+                raise ImportDuplicateFileError(
+                    content_hash=content_hash, existing_batch_id=str(dup.id)
+                )
+        attachment = existing_attachment
+    else:
+        attachment = attachment_repo.create(
+            filename=file.filename or "upload.qif",
+            content_type=file.content_type or "application/qif",
+            raw_bytes=raw_bytes,
+            uploaded_by_user_id=claims.user_id,
+        )
+
+    # One batch per account; bulk-insert every parsed line (transfer legs
+    # included — they're marked promoted below, not omitted).
+    line_repo = StatementLineRepository(session, claims.household_id)
+    batches: dict[str, ImportBatch] = {}
+    line_index: dict[tuple[str, int], StatementLine] = {}
+    for chunk in chunks:
+        parsed = parsed_by_account[chunk.account_name]
+        batch = batch_repo.create(
+            account_id=name_to_uuid[chunk.account_name],
+            source_format=SourceFormat.QIF,
+            source_filename=file.filename or "upload.qif",
+            source_file_attachment_id=attachment.id,
+            created_by_user_id=claims.user_id,
+            summary_json={"line_count": len(parsed)},
+        )
+        batches[chunk.account_name] = batch
+        inserted = line_repo.bulk_insert(
+            batch.id,
+            [
+                {
+                    "line_number": p.line_number,
+                    "posted_date": p.posted_date,
+                    "amount": p.amount.amount,
+                    "currency": p.amount.currency,
+                    "description": p.description,
+                    "counterparty": p.counterparty,
+                    "reference": p.reference,
+                    "fitid": p.fitid,
+                    "raw_json": str(dict(p.raw)),
+                }
+                for p in parsed
+            ],
+        )
+        for sl in inserted:
+            line_index[(chunk.account_name, sl.line_number)] = sl
+        batch.imported_count = len(parsed)
+        AuditLogWriter(session, claims.household_id).write(
+            action="import_create",
+            actor_kind="user",
+            actor_user_id=claims.user_id,
+            entity_type="import_batch",
+            entity_id=batch.id,
+            after={
+                "account_id": str(name_to_uuid[chunk.account_name]),
+                "source_format": "qif",
+                "source_filename": file.filename or "upload.qif",
+                "line_count": len(parsed),
+                "qif_account": chunk.account_name,
+            },
+            request_id=_request_uuid(request),
+        )
+
+    # Land each matched transfer pair as one balanced PENDING transaction;
+    # mark both source statement lines promoted to it so a later `apply`
+    # skips them.
+    tx_repo = TransactionRepository(session, claims.household_id)
+    for pair in pairs:
+        from_line = pair.from_line
+        to_line = pair.to_line
+        domain_tx = DomainTransaction(
+            id=uuid4(),
+            household_id=claims.household_id,
+            date=from_line.posted_date,
+            description=from_line.description,
+            postings=(
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=name_to_uuid[pair.from_account],
+                    amount=from_line.amount,
+                ),
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=name_to_uuid[pair.to_account],
+                    amount=to_line.amount,
+                ),
+            ),
+            status=DomainTxStatus.PENDING,
+            created_by_user_id=claims.user_id,
+        )
+        tx = tx_repo.save_balanced(domain_tx, imported_from_id=batches[pair.from_account].id)
+        from_sl = line_index[(pair.from_account, from_line.line_number)]
+        to_sl = line_index[(pair.to_account, to_line.line_number)]
+        line_repo.mark_promoted(from_sl.id, tx.id)
+        line_repo.mark_promoted(to_sl.id, tx.id)
+
+    session.commit()
+    log.info(
+        "import.multi_account.created",
+        batch_count=len(chunks),
+        transfer_count=len(pairs),
+        warning_count=len(warnings),
+    )
+
+    return MultiAccountImportSummary(
+        batches=[
+            ImportBatchSummary(
+                id=batches[chunk.account_name].id,
+                account_id=name_to_uuid[chunk.account_name],
+                source_format="qif",
+                source_filename=batches[chunk.account_name].source_filename,
+                status=batches[chunk.account_name].status.value,
+                statement_line_count=batches[chunk.account_name].imported_count,
+                imported_count=batches[chunk.account_name].imported_count,
+                skipped_count=batches[chunk.account_name].skipped_count,
+                error_count=batches[chunk.account_name].error_count,
+                created_at=batches[chunk.account_name].created_at,
+            )
+            for chunk in chunks
+        ],
+        transfer_count=len(pairs),
+        warnings=warnings,
     )
 
 

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -87,6 +87,8 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
         "qif_account": "Checking",
         "available": ["Savings", "Credit Card"],
     },
+    "ImportQifAccountUnmappedError": {"unmapped": ["Savings", "Credit Card"]},
+    "ImportAccountMapInvalidError": {"reason": "expected a JSON object, got a list"},
     "ImportCsvParseFailedError": {"reason": "row 7: date '13/45/2026' doesn't match ..."},
     "ImportUnsupportedFormatError": {
         "format_name": "csv",

--- a/packages/tulip-api/src/tulip_api/schemas/import_batch.py
+++ b/packages/tulip-api/src/tulip_api/schemas/import_batch.py
@@ -47,6 +47,34 @@ class ImportBatchSummary(BaseModel):
     created_at: datetime
 
 
+class MultiAccountImportSummary(BaseModel):
+    """Response for ``POST /v1/imports/multi-account`` (#195b).
+
+    One :class:`ImportBatchSummary` per QIF ``!Account`` block, plus the
+    count of cross-account transfers landed directly as balanced PENDING
+    transactions and any non-fatal warnings (e.g. a transfer leg whose
+    partner couldn't be resolved, landed one-sided instead).
+    """
+
+    batches: list[ImportBatchSummary]
+    transfer_count: int = Field(
+        description=(
+            "Cross-account transfer pairs landed as balanced PENDING "
+            "transactions. The two source statement lines of each pair are "
+            "marked promoted to that transaction, so a later `apply` skips "
+            "them."
+        )
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Non-fatal issues — a transfer leg whose reciprocal or target "
+            "account couldn't be resolved is landed as an ordinary "
+            "one-sided statement line and noted here."
+        ),
+    )
+
+
 class ImportBatchRead(BaseModel):
     """Response for ``GET /v1/imports/{id}`` — summary + full line list."""
 

--- a/packages/tulip-api/src/tulip_api/services/qif_multi_account.py
+++ b/packages/tulip-api/src/tulip_api/services/qif_multi_account.py
@@ -1,0 +1,111 @@
+"""Cross-account transfer pairing for multi-account QIF imports (#195b).
+
+A QIF transfer is two records: the money-out account carries
+``L[Destination]`` with a negative amount, the money-in account carries
+``L[Source]`` with the reciprocal positive amount. Imported naively
+(195a), each leg becomes its own one-sided ``Imbalance`` transaction and
+the money double-counts.
+
+:func:`pair_transfers` matches the reciprocal legs so the import
+endpoint can land each pair as a single balanced PENDING transaction
+(account A -X / account B +X). Legs that can't be paired — the target
+account isn't in the import's account map, or no reciprocal record
+exists — are returned only as warnings; the caller lands those as
+ordinary one-sided statement lines (the user's call to fix up).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tulip_importers.qif import transfer_target
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from tulip_core.reconciliation import ParsedStatementLine
+
+
+@dataclass(frozen=True, slots=True)
+class TransferPair:
+    """A matched cross-account transfer — two reciprocal QIF legs.
+
+    ``from_account`` / ``to_account`` are QIF account names (keys of the
+    import's account map); ``from_line`` is always the money-out leg
+    (negative amount), ``to_line`` the money-in leg.
+    """
+
+    from_account: str
+    to_account: str
+    from_line: ParsedStatementLine
+    to_line: ParsedStatementLine
+
+
+def pair_transfers(
+    parsed_by_account: dict[str, list[ParsedStatementLine]],
+    account_map: dict[str, UUID],
+) -> tuple[list[TransferPair], list[str]]:
+    """Match reciprocal QIF transfer legs across the imported accounts.
+
+    Two legs pair when they are reciprocal: ``A → B`` for ``-X`` on date
+    ``D`` and ``B → A`` for ``+X`` on the same date, in the same
+    currency, with both accounts present in ``account_map``. Matching is
+    greedy — the first eligible reciprocal wins — which is correct for
+    QIF exports, where a transfer's two legs are exact mirrors.
+
+    Returns ``(pairs, warnings)``. Each warning names a leg that could
+    not be paired (unmapped target, or no reciprocal); the caller lands
+    those as ordinary one-sided statement lines.
+    """
+    # Collect every transfer leg as (account, target, line). Non-transfer
+    # records and legs pointing at an unmapped account are skipped here —
+    # the latter with a warning, since the user probably meant to map it.
+    legs: list[tuple[str, str, ParsedStatementLine]] = []
+    warnings: list[str] = []
+    for account, lines in parsed_by_account.items():
+        for line in lines:
+            target = transfer_target(line.raw)
+            if target is None:
+                continue  # ordinary record — becomes a normal statement line
+            if target not in account_map:
+                warnings.append(
+                    f"{account!r} line {line.line_number}: transfer to unmapped "
+                    f"account {target!r} — landed as a one-sided line."
+                )
+                continue
+            legs.append((account, target, line))
+
+    pairs: list[TransferPair] = []
+    consumed: set[int] = set()
+    for i, (acct_a, target_b, line_a) in enumerate(legs):
+        if i in consumed:
+            continue
+        partner_idx: int | None = None
+        for j, (acct_b, target_a, line_b) in enumerate(legs):
+            if j in consumed or j == i:
+                continue
+            if (
+                acct_b == target_b
+                and target_a == acct_a
+                and line_b.amount.currency == line_a.amount.currency
+                and line_b.amount.amount == -line_a.amount.amount
+                and line_b.posted_date == line_a.posted_date
+            ):
+                partner_idx = j
+                break
+        if partner_idx is None:
+            warnings.append(
+                f"{acct_a!r} line {line_a.line_number}: transfer to {target_b!r} "
+                f"has no matching reciprocal leg — landed as a one-sided line."
+            )
+            continue
+        consumed.add(i)
+        consumed.add(partner_idx)
+        line_b = legs[partner_idx][2]
+        # Orient the pair so from_line is always the money-out (negative) leg.
+        if line_a.amount.amount < 0:
+            pairs.append(TransferPair(acct_a, target_b, line_a, line_b))
+        else:
+            pairs.append(TransferPair(target_b, acct_a, line_b, line_a))
+    return pairs, warnings

--- a/packages/tulip-api/tests/test_imports_endpoint.py
+++ b/packages/tulip-api/tests/test_imports_endpoint.py
@@ -386,6 +386,167 @@ class TestUploadQif:
         assert body["format"] == "journal"
 
 
+class TestUploadMultiAccountQif:
+    """POST /v1/imports/multi-account — split, per-account batches, transfer pairing (#195b)."""
+
+    @staticmethod
+    def _acct(client: TestClient, auth_h: dict[str, str], name: str, code: str) -> str:
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": name, "type": "asset", "currency": "USD", "code": code},
+        )
+        assert r.status_code == 201, r.text
+        return str(r.json()["id"])
+
+    def test_transfer_pair_lands_as_one_balanced_transaction(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        session_maker,
+    ):
+        import json
+        from decimal import Decimal
+
+        from sqlalchemy import select
+
+        from tulip_storage.models import Posting, StatementLine, Transaction
+
+        checking = self._acct(client, auth_h, "Checking", "1110")
+        savings = self._acct(client, auth_h, "Savings", "1200")
+        body_bytes = (_OFX_FIXTURES.parent / "qif" / "multi_account_transfer.qif").read_bytes()
+
+        r = client.post(
+            "/v1/imports/multi-account",
+            headers=auth_h,
+            files={"file": ("multi.qif", body_bytes, "application/qif")},
+            data={"account_map": json.dumps({"Checking": checking, "Savings": savings})},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert len(body["batches"]) == 2
+        assert body["transfer_count"] == 1
+        assert body["warnings"] == []
+
+        with session_maker() as s:
+            # Exactly one PENDING transaction — the paired transfer — with a
+            # posting on each account that nets to zero.
+            txns = list(s.execute(select(Transaction)).scalars())
+            assert len(txns) == 1
+            postings = list(
+                s.execute(select(Posting).where(Posting.transaction_id == txns[0].id)).scalars()
+            )
+            assert len(postings) == 2
+            amounts = sorted(p.amount for p in postings)
+            assert amounts == [Decimal("-200.00"), Decimal("200.00")]
+            assert {str(p.account_id) for p in postings} == {checking, savings}
+            # Both transfer-leg statement lines are marked promoted to it.
+            promoted = list(
+                s.execute(
+                    select(StatementLine).where(StatementLine.promoted_transaction_id == txns[0].id)
+                ).scalars()
+            )
+            assert len(promoted) == 2
+
+    def test_unpaired_transfer_leg_falls_back_with_warning(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        # multi_account.qif's Savings leg targets Checking but Checking has
+        # no reciprocal — it lands as a plain line + a warning.
+        import json
+
+        checking = self._acct(client, auth_h, "Checking", "1110")
+        savings = self._acct(client, auth_h, "Savings", "1200")
+        credit = self._acct(client, auth_h, "Credit Card", "2100")
+        body_bytes = (_OFX_FIXTURES.parent / "qif" / "multi_account.qif").read_bytes()
+
+        r = client.post(
+            "/v1/imports/multi-account",
+            headers=auth_h,
+            files={"file": ("multi.qif", body_bytes, "application/qif")},
+            data={
+                "account_map": json.dumps(
+                    {"Checking": checking, "Savings": savings, "Credit Card": credit}
+                )
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["transfer_count"] == 0
+        assert len(body["warnings"]) == 1
+        assert "no matching reciprocal" in body["warnings"][0]
+
+    def test_unmapped_account_is_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        import json
+
+        checking = self._acct(client, auth_h, "Checking", "1110")
+        body_bytes = (_OFX_FIXTURES.parent / "qif" / "multi_account_transfer.qif").read_bytes()
+        # Map omits "Savings".
+        r = client.post(
+            "/v1/imports/multi-account",
+            headers=auth_h,
+            files={"file": ("multi.qif", body_bytes, "application/qif")},
+            data={"account_map": json.dumps({"Checking": checking})},
+        )
+        body = assert_problem(r, code="import.qif_account_unmapped", status=400)
+        assert body["unmapped"] == ["Savings"]
+
+    def test_invalid_account_map_json_is_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        body_bytes = (_OFX_FIXTURES.parent / "qif" / "multi_account_transfer.qif").read_bytes()
+        r = client.post(
+            "/v1/imports/multi-account",
+            headers=auth_h,
+            files={"file": ("multi.qif", body_bytes, "application/qif")},
+            data={"account_map": "{not valid json"},
+        )
+        assert_problem(r, code="import.account_map_invalid", status=400)
+
+    def test_single_account_qif_is_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        import json
+
+        # minimal.qif has no !Account blocks — the wrong endpoint for it.
+        body_bytes = (_OFX_FIXTURES.parent / "qif" / "minimal.qif").read_bytes()
+        r = client.post(
+            "/v1/imports/multi-account",
+            headers=auth_h,
+            files={"file": ("single.qif", body_bytes, "application/qif")},
+            data={"account_map": json.dumps({"Whatever": str(__import__("uuid").uuid4())})},
+        )
+        assert_problem(r, code="import.qif_parse_failed", status=400)
+
+    def test_unknown_tulip_account_uuid_is_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ):
+        import json
+        from uuid import uuid4
+
+        checking = self._acct(client, auth_h, "Checking", "1110")
+        body_bytes = (_OFX_FIXTURES.parent / "qif" / "multi_account_transfer.qif").read_bytes()
+        r = client.post(
+            "/v1/imports/multi-account",
+            headers=auth_h,
+            files={"file": ("multi.qif", body_bytes, "application/qif")},
+            data={"account_map": json.dumps({"Checking": checking, "Savings": str(uuid4())})},
+        )
+        assert_problem(r, code="account.unknown", status=400)
+
+
 class TestUploadCsv:
     @pytest.fixture
     def chase_profile_id(self, client: TestClient, auth_h: dict[str, str]) -> str:

--- a/packages/tulip-api/tests/test_openapi_contract.py
+++ b/packages/tulip-api/tests/test_openapi_contract.py
@@ -161,17 +161,19 @@ def test_api_conforms_to_schema(case: schemathesis.Case) -> None:
     undocumented response, or the documented schema doesn't actually
     describe what comes back. Both are real bugs.
     """
-    # Path-collision skip (P5.2.c): POST /v1/imports/profiles/import is a
-    # static path; the sibling PATCH/DELETE/GET on /v1/imports/profiles/{id_or_name}
-    # also matches "import" as a path-param value. Schemathesis fuzzes
-    # PATCH /v1/imports/profiles/import expecting 405 (since the spec
-    # only documents POST), but it routes to update_profile(id_or_name="import")
-    # and returns 401 (auth) or 404 (no such profile). The collision is
-    # harmless — `import` would be a confusing profile name regardless —
-    # but schemathesis flags it. Skip non-POST methods on the static path.
-    if str(case.path) == "/v1/imports/profiles/import" and case.method.upper() != "POST":
+    # Path-collision skip: a static path under /v1/imports/ shadows the
+    # parameterised GET /v1/imports/{batch_id} (and the profiles variant)
+    # for any non-declared method. Schemathesis fuzzes e.g.
+    # GET /v1/imports/multi-account expecting 405 (only POST is documented
+    # there), but `multi-account` is a syntactically valid {batch_id}
+    # value so it routes to get_import_batch and 401s on auth first. The
+    # collision is harmless — batch ids are UUIDs and profile names like
+    # `import` / `multi-account` would be confusing regardless — but
+    # schemathesis can't tell. Skip non-POST methods on the static paths.
+    _STATIC_IMPORT_PATHS = ("/v1/imports/profiles/import", "/v1/imports/multi-account")
+    if str(case.path) in _STATIC_IMPORT_PATHS and case.method.upper() != "POST":
         pytest.skip(
-            "path-collision: PATCH/DELETE on /import routes to /{id_or_name}; "
-            "harmless — see comment."
+            "path-collision: non-POST on a static /v1/imports/* path routes to "
+            "a parameterised sibling; harmless — see comment."
         )
     case.call_and_validate()

--- a/packages/tulip-api/tests/test_qif_multi_account_service.py
+++ b/packages/tulip-api/tests/test_qif_multi_account_service.py
@@ -1,0 +1,146 @@
+"""Unit tests for the QIF cross-account transfer pairing service (#195b)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from types import MappingProxyType
+from uuid import uuid4
+
+from tulip_api.services.qif_multi_account import pair_transfers
+from tulip_core.money import Money
+from tulip_core.reconciliation import ParsedStatementLine
+
+
+def _line(
+    line_number: int,
+    amount: str,
+    *,
+    target: str | None,
+    currency: str = "USD",
+    on: date = date(2026, 1, 10),
+) -> ParsedStatementLine:
+    """Build a ParsedStatementLine; ``target`` becomes a QIF L[Account] field."""
+    raw = {"L": f"[{target}]"} if target is not None else {}
+    return ParsedStatementLine(
+        line_number=line_number,
+        posted_date=on,
+        amount=Money(Decimal(amount), currency),
+        description=f"line {line_number}",
+        counterparty=None,
+        reference=None,
+        fitid=None,
+        raw=MappingProxyType(raw),
+    )
+
+
+_CHECKING = uuid4()
+_SAVINGS = uuid4()
+_MAP = {"Checking": _CHECKING, "Savings": _SAVINGS}
+
+
+def test_reciprocal_legs_pair() -> None:
+    parsed = {
+        "Checking": [_line(1, "-200.00", target="Savings")],
+        "Savings": [_line(1, "200.00", target="Checking")],
+    }
+    pairs, warnings = pair_transfers(parsed, _MAP)
+    assert warnings == []
+    assert len(pairs) == 1
+    pair = pairs[0]
+    # from is always the money-out (negative) leg.
+    assert pair.from_account == "Checking"
+    assert pair.to_account == "Savings"
+    assert pair.from_line.amount.amount == Decimal("-200.00")
+    assert pair.to_line.amount.amount == Decimal("200.00")
+
+
+def test_orientation_is_independent_of_account_order() -> None:
+    # Savings listed first, but the negative leg still becomes `from`.
+    parsed = {
+        "Savings": [_line(1, "200.00", target="Checking")],
+        "Checking": [_line(1, "-200.00", target="Savings")],
+    }
+    pairs, warnings = pair_transfers(parsed, _MAP)
+    assert warnings == []
+    assert [(p.from_account, p.to_account) for p in pairs] == [("Checking", "Savings")]
+
+
+def test_leg_with_no_reciprocal_warns_and_is_not_paired() -> None:
+    parsed = {
+        "Checking": [_line(1, "-200.00", target="Savings")],
+        "Savings": [_line(1, "50.00", target=None)],  # plain deposit, not a transfer
+    }
+    pairs, warnings = pair_transfers(parsed, _MAP)
+    assert pairs == []
+    assert len(warnings) == 1
+    assert "no matching reciprocal" in warnings[0]
+    assert "Checking" in warnings[0]
+
+
+def test_transfer_to_unmapped_account_warns() -> None:
+    parsed = {"Checking": [_line(1, "-200.00", target="Brokerage")]}
+    pairs, warnings = pair_transfers(parsed, _MAP)
+    assert pairs == []
+    assert len(warnings) == 1
+    assert "unmapped account 'Brokerage'" in warnings[0]
+
+
+def test_non_transfer_lines_are_ignored() -> None:
+    parsed = {
+        "Checking": [
+            _line(1, "-58.99", target=None),
+            ParsedStatementLine(
+                line_number=2,
+                posted_date=date(2026, 1, 11),
+                amount=Money(Decimal("-12.00"), "USD"),
+                description="groceries",
+                counterparty=None,
+                reference=None,
+                fitid=None,
+                raw=MappingProxyType({"L": "Expenses:Groceries"}),
+            ),
+        ],
+        "Savings": [_line(1, "50.00", target=None)],
+    }
+    pairs, warnings = pair_transfers(parsed, _MAP)
+    assert pairs == []
+    assert warnings == []
+
+
+def test_cross_currency_legs_do_not_pair() -> None:
+    # Different currencies can't form a balanced transaction; the amount
+    # check is currency-aware, so both legs fall through to warnings.
+    parsed = {
+        "Checking": [_line(1, "-200.00", target="Savings", currency="USD")],
+        "Savings": [_line(1, "200.00", target="Checking", currency="EUR")],
+    }
+    pairs, warnings = pair_transfers(parsed, _MAP)
+    assert pairs == []
+    assert len(warnings) == 2
+
+
+def test_date_mismatch_does_not_pair() -> None:
+    parsed = {
+        "Checking": [_line(1, "-200.00", target="Savings", on=date(2026, 1, 10))],
+        "Savings": [_line(1, "200.00", target="Checking", on=date(2026, 1, 12))],
+    }
+    pairs, warnings = pair_transfers(parsed, _MAP)
+    assert pairs == []
+    assert len(warnings) == 2
+
+
+def test_two_transfers_same_amount_pair_greedily() -> None:
+    parsed = {
+        "Checking": [
+            _line(1, "-200.00", target="Savings"),
+            _line(2, "-200.00", target="Savings"),
+        ],
+        "Savings": [
+            _line(1, "200.00", target="Checking"),
+            _line(2, "200.00", target="Checking"),
+        ],
+    }
+    pairs, warnings = pair_transfers(parsed, _MAP)
+    assert warnings == []
+    assert len(pairs) == 2

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -556,30 +556,39 @@ def _render_starter_map(account_names: list[str]) -> None:
     typer.echo(json.dumps(starter, indent=2), err=True)
 
 
-def _post_qif_chunk(
+def _post_qif_single(
     client: TulipClient,
     file_path: Path,
     raw_bytes: bytes,
     *,
     account_id: str,
-    qif_account: str | None = None,
 ) -> dict[str, Any]:
-    """POST a QIF upload to /v1/imports; return the batch summary dict.
-
-    ``qif_account`` selects one ``!Account`` block from a multi-account
-    QIF — the server splits the file and ingests just that account's
-    transactions against ``account_id``.
-    """
-    data: dict[str, str] = {"account_id": account_id, "source_format": "qif"}
-    if qif_account is not None:
-        data["qif_account"] = qif_account
+    """POST a single-account QIF to /v1/imports; return the batch summary dict."""
     response = client.post_multipart(
         "/v1/imports",
         files={"file": (file_path.name, raw_bytes, "application/qif")},
-        data=data,
+        data={"account_id": account_id, "source_format": "qif"},
         authenticated=True,
     )
     return dict(response.json())
+
+
+def _render_multi_account_summary(body: dict[str, Any], uuid_to_name: dict[str, str]) -> None:
+    """Render a ``MultiAccountImportSummary``: per-account batches + transfers."""
+    for batch in body.get("batches", []):
+        account_id = str(batch.get("account_id", ""))
+        name = uuid_to_name.get(account_id, account_id)
+        typer.echo(f"[{name}] ", nl=False)
+        _render_summary(batch)
+    transfer_count = body.get("transfer_count", 0)
+    if transfer_count:
+        plural = "" if transfer_count == 1 else "s"
+        typer.echo(
+            f"Paired {transfer_count} cross-account transfer{plural} "
+            "into balanced PENDING transactions."
+        )
+    for warning in body.get("warnings", []):
+        typer.echo(f"  warning: {warning}", err=True)
 
 
 @imports_app.command("qif")
@@ -649,7 +658,7 @@ def import_qif(
         try:
             with _client(config, as_json=as_json) as client:
                 account_record = _resolve_account(client, account)
-                summary = _post_qif_chunk(
+                summary = _post_qif_single(
                     client, file_path, raw_bytes, account_id=str(account_record["id"])
                 )
         except CliError as err:
@@ -665,32 +674,29 @@ def import_qif(
         return
 
     # Multi-account path: resolve every map entry up front (a bad code
-    # fails before any batch lands), then POST one chunk per account.
+    # fails before any batch lands), then POST the whole file + the
+    # resolved map in one request. The server splits it by !Account,
+    # creates a batch per account, and pairs cross-account transfers.
     assert account_map is not None  # noqa: S101 — guarded by the checks above
     name_to_identifier = _load_account_map(account_map)
-    summaries: list[dict[str, Any]] = []
     try:
         with _client(config, as_json=as_json) as client:
-            resolved: dict[str, str] = {}
-            for qif_name, identifier in name_to_identifier.items():
-                resolved[qif_name] = str(_resolve_account(client, identifier)["id"])
-            for qif_name, account_id in resolved.items():
-                summaries.append(
-                    _post_qif_chunk(
-                        client,
-                        file_path,
-                        raw_bytes,
-                        account_id=account_id,
-                        qif_account=qif_name,
-                    )
-                )
+            resolved: dict[str, str] = {
+                qif_name: str(_resolve_account(client, identifier)["id"])
+                for qif_name, identifier in name_to_identifier.items()
+            }
+            response = client.post_multipart(
+                "/v1/imports/multi-account",
+                files={"file": (file_path.name, raw_bytes, "application/qif")},
+                data={"account_map": json.dumps(resolved)},
+                authenticated=True,
+            )
     except CliError as err:
         err.render()
         raise typer.Exit(err.exit_code) from None
 
+    body = dict(response.json())
     if as_json:
-        sys.stdout.write(json.dumps(summaries) + "\n")
+        sys.stdout.write(json.dumps(body) + "\n")
         return
-    for qif_name, summary in zip(resolved, summaries, strict=True):
-        typer.echo(f"[{qif_name}] ", nl=False)
-        _render_summary(summary)
+    _render_multi_account_summary(body, {v: k for k, v in resolved.items()})

--- a/packages/tulip-cli/tests/test_import_command.py
+++ b/packages/tulip-cli/tests/test_import_command.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 import sys
+from decimal import Decimal
 from pathlib import Path
 
 import httpx
@@ -510,6 +511,67 @@ def test_import_qif_multi_account_with_map_lands_per_account(
     # Checking has two records in the fixture; Savings + Credit Card one each.
     assert "Imported 2 statement lines" in result.stdout
     assert result.stdout.count("Imported 1 statement line") == 2
+
+
+@pytest.mark.integration
+def test_import_qif_multi_account_pairs_transfers(authed_session: str, tmp_path: Path) -> None:
+    # #195b: a reciprocal L[Account] pair lands as one balanced PENDING tx.
+    _seed_account(authed_session, name="Checking", code="1110")
+    _seed_account(authed_session, name="Savings", code="1200")
+    account_map = tmp_path / "account-map.json"
+    account_map.write_text(json.dumps({"Checking": "1110", "Savings": "1200"}))
+    fixture = _OFX_FIXTURES.parent / "qif" / "multi_account_transfer.qif"
+
+    result = _run_cli(
+        "import",
+        "qif",
+        str(fixture),
+        "--account-map",
+        str(account_map),
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "[Checking]" in result.stdout
+    assert "[Savings]" in result.stdout
+    # The Checking -> Savings transfer is paired into one balanced tx.
+    assert "Paired 1 cross-account transfer" in result.stdout
+
+    # That balanced PENDING transaction is queryable and nets to zero.
+    txns = _run_cli("--json", "transactions", "list", api_url=authed_session)
+    assert txns.returncode == 0, txns.stderr
+    rows = json.loads(txns.stdout)
+    transfer = next(r for r in rows if "Transfer to savings" in r["description"])
+    # JSON carries full storage precision — compare as Decimals.
+    amounts = sorted(Decimal(str(p["amount"])) for p in transfer["postings"])
+    assert amounts == [Decimal("-200.00"), Decimal("200.00")]
+
+
+@pytest.mark.integration
+def test_import_qif_multi_account_unpaired_transfer_warns(
+    authed_session: str, tmp_path: Path
+) -> None:
+    # multi_account.qif's Savings leg has no reciprocal — it lands as a
+    # plain line and the CLI surfaces the warning.
+    _seed_account(authed_session, name="Checking", code="1110")
+    _seed_account(authed_session, name="Savings", code="1200")
+    _seed_account(authed_session, name="Credit Card", code="2100", type_="liability")
+    account_map = tmp_path / "account-map.json"
+    account_map.write_text(
+        json.dumps({"Checking": "1110", "Savings": "1200", "Credit Card": "2100"})
+    )
+    fixture = _OFX_FIXTURES.parent / "qif" / "multi_account.qif"
+
+    result = _run_cli(
+        "import",
+        "qif",
+        str(fixture),
+        "--account-map",
+        str(account_map),
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "warning" in (result.stdout + result.stderr).lower()
+    assert "reciprocal" in (result.stdout + result.stderr).lower()
 
 
 @pytest.mark.integration

--- a/packages/tulip-importers/src/tulip_importers/qif/__init__.py
+++ b/packages/tulip-importers/src/tulip_importers/qif/__init__.py
@@ -5,6 +5,13 @@ from tulip_importers.qif.parser import (
     QifParseError,
     parse,
     split_accounts,
+    transfer_target,
 )
 
-__all__ = ["QifAccountChunk", "QifParseError", "parse", "split_accounts"]
+__all__ = [
+    "QifAccountChunk",
+    "QifParseError",
+    "parse",
+    "split_accounts",
+    "transfer_target",
+]

--- a/packages/tulip-importers/src/tulip_importers/qif/parser.py
+++ b/packages/tulip-importers/src/tulip_importers/qif/parser.py
@@ -74,6 +74,7 @@ locate the bad row.
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import date as date_type
 from decimal import Decimal, InvalidOperation
@@ -83,6 +84,11 @@ from tulip_core.reconciliation import ParsedStatementLine
 
 #: Each transaction record ends with this single-character line.
 _RECORD_TERMINATOR = "^"
+
+#: A QIF transfer marks its other side as ``L[Account Name]`` — a
+#: bracketed account name in the category field. A plain category
+#: (``LExpenses:Food``) doesn't match.
+_TRANSFER_TARGET_RE = re.compile(r"^\[(?P<name>.+)\]$")
 
 #: Header line introduces the account type. Conventional but optional.
 _HEADER_RE = re.compile(r"^!Type:(.+)$", re.IGNORECASE)
@@ -547,6 +553,22 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
         )
 
     return out
+
+
+def transfer_target(raw: Mapping[str, str]) -> str | None:
+    """Return the destination account name if ``raw`` is a QIF transfer leg.
+
+    QIF encodes a cross-account transfer's other side as ``L[Account
+    Name]`` — a bracketed account name in the category field. A plain
+    category (``LExpenses:Groceries``) or a missing ``L`` field returns
+    None. The bracket form is the unambiguous transfer marker; #195b
+    pairs the two legs of a transfer into one balanced transaction.
+    """
+    value = raw.get("L")
+    if value is None:
+        return None
+    match = _TRANSFER_TARGET_RE.match(value.strip())
+    return match.group("name").strip() if match else None
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/tulip-importers/tests/fixtures/qif/multi_account_transfer.qif
+++ b/packages/tulip-importers/tests/fixtures/qif/multi_account_transfer.qif
@@ -1,0 +1,29 @@
+!Account
+NChecking
+TBank
+^
+!Type:Bank
+D1/2/26
+T-58.99
+PCenterPoint Energy
+MGas bill
+^
+D1/10/26
+T-200.00
+PTransfer to savings
+L[Savings]
+^
+!Account
+NSavings
+TBank
+^
+!Type:Bank
+D1/10/26
+T200.00
+PTransfer from checking
+L[Checking]
+^
+D1/15/26
+T50.00
+PMonthly interest
+^

--- a/packages/tulip-importers/tests/test_qif_parser.py
+++ b/packages/tulip-importers/tests/test_qif_parser.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from tulip_core.reconciliation import ParsedStatementLine
-from tulip_importers.qif import QifParseError, parse, split_accounts
+from tulip_importers.qif import QifParseError, parse, split_accounts, transfer_target
 
 FIXTURES = Path(__file__).parent / "fixtures" / "qif"
 
@@ -285,6 +285,26 @@ class TestSplitAccounts:
         checking = parse(chunks[0].qif_text.encode("utf-8"), currency="USD")
         # Only the two real !Type:Bank transactions, no category/security rows.
         assert len(checking) == 2
+
+
+class TestTransferTarget:
+    """Per #195b: a QIF transfer marks its other side as L[Account Name]."""
+
+    def test_bracketed_category_is_a_transfer_target(self):
+        assert transfer_target({"L": "[Checking]"}) == "Checking"
+
+    def test_account_name_with_spaces(self):
+        assert transfer_target({"L": "[Credit Card]"}) == "Credit Card"
+
+    def test_brackets_and_padding_are_stripped(self):
+        assert transfer_target({"L": "  [ Savings ] "}) == "Savings"
+
+    def test_plain_category_is_not_a_transfer(self):
+        assert transfer_target({"L": "Expenses:Groceries"}) is None
+
+    def test_missing_l_field_is_not_a_transfer(self):
+        assert transfer_target({}) is None
+        assert transfer_target({"P": "Some Payee"}) is None
 
 
 class TestParseErrors:


### PR DESCRIPTION
## Summary

Second slice of #195. 195a routed a multi-account QIF to per-account batches, but every cross-account transfer still landed as two one-sided `Imbalance` rows — money double-counting through the suspense account. This pairs the legs.

### Parser (`tulip-importers`)
- New `transfer_target(raw)` — returns the bracketed account name from a QIF `L[Account]` category field (the transfer marker), `None` for a plain category or missing `L`.

### Service (`tulip-api`)
- New `qif_multi_account.pair_transfers` matches reciprocal legs across accounts: `A → B` for `-X` on date `D` pairs with `B → A` for `+X` on date `D`, same currency, both accounts in the import's map. Greedy — correct for QIF exports, whose two legs are exact mirrors. Returns matched pairs plus warnings for legs that can't pair (unmapped target, or no reciprocal).

### API
- New `POST /v1/imports/multi-account`: ingests the whole multi-account QIF in **one** request — `file` + an `account_map` JSON form field. Splits by `!Account`, creates one batch per account with all statement lines, then lands each transfer pair as a single balanced PENDING transaction and marks both source statement lines promoted to it (so a later `apply` skips them).
- Unpaireable legs fall back to ordinary one-sided statement lines and are reported in `warnings` — the user's call to fix up.
- New errors: `import.qif_account_unmapped`, `import.account_map_invalid`.
- The 195a single-account `/v1/imports` endpoint + its `qif_account` selector are untouched.

### CLI
- `tulip imports qif --account-map` now makes **one** POST to `/v1/imports/multi-account` (instead of 195a's N per-account POSTs), so the server sees every account at once and can pair transfers. Renders per-account batch summaries, the transfer count, and any warnings.

## Test plan

- [x] `uv run pytest packages` → 1827 passed, 2 skipped, 3 deselected
- [x] `just lint` + `just typecheck` clean
- [x] Parser: `TestTransferTarget` — bracketed vs plain category vs missing `L`
- [x] Service: `test_qif_multi_account_service.py` — reciprocal pairing, orientation independence, no-reciprocal warning, unmapped-target warning, non-transfer lines ignored, cross-currency excluded, date-mismatch excluded, greedy multi-pair
- [x] API: `TestUploadMultiAccountQif` — transfer pair lands as one balanced tx with both legs promoted; unpaired leg → warning; unmapped account → 400; invalid map JSON → 400; single-account QIF → 400; unknown tulip UUID → 400
- [x] CLI: `--account-map` pairs transfers (verified the balanced tx via `transactions list`); unpaired-leg warning surfaced
- [x] New `multi_account_transfer.qif` fixture (reciprocal Checking↔Savings pair)
- [x] schemathesis path-collision skip extended for the static `/v1/imports/multi-account` path (same harmless family as the existing `profiles/import` skip)
- [ ] CI green on this PR