### PR TITLE
docs: bring doc set current through Phase 8 audits + Wave-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Honest expectations matter for internal-beta. The following are deliberately def
 - **Web / mobile UI.** Tulip is API-first with a Typer CLI client; the web client lands as a separate phase. The CLI is the supported UI.
 - **Multi-tenant cloud hosting.** Tulip is single-machine, single-tenant SQLite for internal beta. Postgres + KMS + multi-tenant scaling is a future phase.
 - **Reverse-proxy / TLS tutorial.** Run behind Caddy or Tailscale Funnel; we don't ship a TLS setup guide.
-- **Reports beyond CLI tables.** HTML / PDF / CSV rendering for all nine reports ships in Phase 7, together with `tulip journal {export,import}` for hledger round-tripping.
+- **Full-DB encryption at rest (SQLCipher).** Field-level AES-256-GCM protects the most sensitive columns + attachments today; whole-database SQLCipher is a Phase 8 hardening item still in flight.
 
 **Opt-in AI features** (auto-categorisation, NL queries, forecasts, agentic proposals) are now wired and shipped — disabled by default; bring your own provider key (Anthropic / OpenAI / local Ollama) via `tulip ai set-key` to enable. Per-household policy, per-user rate limits, monthly cost cap, and a `tulip ai status` summary all surface from the CLI. See the AI cookbook in [docs/QUICKSTART.md](docs/QUICKSTART.md) for the enablement walkthrough.
 
@@ -57,7 +57,7 @@ The full deferred-features list and the ordered roadmap is the contributor-side 
 
 ## For contributors
 
-> **Status:** Internal beta. Phases 0–7 complete (project bootstrap, storage + accounting engine, API surface, scriptable CLI, envelopes + sinking funds + scheduled refills, OFX/QIF/CSV importers + statement-driven reconciliation, opt-in AI integration with BYOK provider keys + cost-cap + rate limit + audited proposals, nine reports in HTML/PDF/CSV + hledger journal export/import + `tulip reports` and `tulip journal` CLI). See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
+> **Status:** Internal beta. Phases 0–7 complete (project bootstrap, storage + accounting engine, API surface, scriptable CLI, envelopes + sinking funds + scheduled refills, OFX/QIF/CSV importers + statement-driven reconciliation, opt-in AI integration with BYOK provider keys + cost-cap + rate limit + audited proposals, nine reports in HTML/PDF/CSV + hledger journal export/import + `tulip reports` and `tulip journal` CLI). **Phase 8 (operations + hardening) is in progress:** the deep security and deep privacy audits have shipped ([docs/audits/](docs/audits/)), along with their highest-severity Wave-1 follow-ups (auth rate limiting, single-use MFA-challenge tokens, GDPR right-to-erasure) and a post-audit CLI/importers usability bundle. See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
 
 ### Architecture at a glance
 
@@ -90,7 +90,7 @@ git clone https://github.com/rmwarriner/tulip-accounting.git
 cd tulip-accounting
 uv sync --all-packages --dev     # installs all workspace packages + dev deps
 uv run pre-commit install        # enable pre-commit hooks
-just test                        # confirm tests pass (~1545 tests, ~4 min with xdist)
+just test                        # confirm tests pass (~1830 tests, ~4 min with xdist)
 ```
 
 > **Note for committers:** `main` is branch-protected and **requires every commit to be signed**. Configure SSH or GPG commit signing before your first push (`git config --global commit.gpgsign true` plus a signing key); see [CONTRIBUTING.md](CONTRIBUTING.md#branch-protection-on-main) for the diagnostic checklist when a push is rejected as unsigned.
@@ -127,13 +127,14 @@ TULIP_JWT_SECRET="$(uv run python -c 'import secrets; print(secrets.token_urlsaf
   uv run uvicorn tulip_api.main:create_app --factory --host 127.0.0.1 --port 8000
 ```
 
-Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.0.0.1:8000/openapi.json` for the OpenAPI spec. Endpoint surface (Phases 0–7):
+Then `curl http://127.0.0.1:8000/health` for a smoke check, or `curl http://127.0.0.1:8000/openapi.json` for the OpenAPI spec. Endpoint surface (Phases 0–8):
 
-- **Auth:** `POST /v1/auth/{register,login,login/mfa,login/recover,refresh,logout}`, `POST /v1/auth/mfa/{enroll,verify,recovery-codes/regenerate}`, `GET /v1/auth/mfa/recovery-codes/status`
-- **Accounts + transactions:** `GET/POST/PATCH/DELETE /v1/accounts[/{id}]`, `GET /v1/accounts/{id}/balance`, `GET/POST/PATCH/DELETE /v1/transactions[/{id}]`, `POST /v1/transactions/{id}/void`
+- **Auth:** `POST /v1/auth/{register,login,login/mfa,login/recover,refresh,logout}`, `POST /v1/auth/mfa/{enroll,verify,recovery-codes/regenerate}`, `GET /v1/auth/mfa/recovery-codes/status`. The four abuse-exposed endpoints (`login`, `login/mfa`, `login/recover`, `refresh`) are behind per-IP `slowapi` quotas — `auth.rate_limited` (429) on exceedance.
+- **Users + households (right-to-erasure, GDPR Art. 17):** `DELETE /v1/users/{user_id}` (cascades the user's sessions + recovery codes, redacts their audit-log PII), `POST /v1/households/me/erase-request` → `DELETE /v1/households/me` (two-step token-gated household erasure with attachment-ciphertext GC)
+- **Accounts + transactions:** `GET/POST/PATCH/DELETE /v1/accounts[/{id}]`, `GET /v1/accounts/{id}/balance[?include_pending=&as_of=]`, `GET/POST/PATCH/DELETE /v1/transactions[/{id}]`, `POST /v1/transactions/{id}/void`
 - **Periods:** `GET /v1/periods`, `POST /v1/periods/{id}/{close,reopen}`
 - **Envelopes + sinking funds + pools:** `GET/POST/PATCH/DELETE /v1/envelopes[/{id}]`, `GET/POST/PATCH/DELETE /v1/sinking-funds[/{id}]`, `GET /v1/pools/{id}/balance`, `POST /v1/pools/{id}/{refill,transfer,budget-inflow}`, `POST /v1/pools/balances` (batched), `GET/POST/PATCH/DELETE /v1/refill-schedules[/{id}]`
-- **Importers + reconciliation:** `POST /v1/imports[?force=true]`, `GET /v1/imports/{id}`, `POST /v1/imports/{id}/{apply,lines/{line_id}/promote}`, `GET/POST/PATCH/DELETE /v1/imports/profiles[/{id_or_name}]` (CSV column-mapping profiles, YAML round-trip), `GET/POST/DELETE /v1/reconciliations[/{id}][?cascade=true]`, `POST /v1/reconciliations/{id}/{auto-match,complete,matches,carry-forward}`, `POST /v1/reconciliations/{id}/matches/{id}/reject`, `DELETE /v1/reconciliations/{id}/carry-forward/{tx_id}`
+- **Importers + reconciliation:** `POST /v1/imports[?force=true]`, `POST /v1/imports/multi-account` (whole-file multi-account QIF + `account_map`), `GET /v1/imports` (list, filterable by `status` / `account_id`), `GET /v1/imports/{id}`, `POST /v1/imports/{id}/{apply,lines/{line_id}/promote}`, `GET/POST/PATCH/DELETE /v1/imports/profiles[/{id_or_name}]` (CSV column-mapping profiles, YAML round-trip), `GET/POST/DELETE /v1/reconciliations[/{id}][?cascade=true]`, `POST /v1/reconciliations/{id}/{auto-match,complete,matches,carry-forward}`, `POST /v1/reconciliations/{id}/matches/{id}/reject`, `DELETE /v1/reconciliations/{id}/carry-forward/{tx_id}`
 - **AI (Phase 6, BYOK, admin-only configuration):** `POST/DELETE /v1/ai/keys/{provider}`, `GET /v1/ai/keys`, `GET/PUT /v1/ai/config`, `PUT /v1/ai/config/capabilities/{capability}`, `GET /v1/ai/status`, `POST /v1/ai/preview`, `POST /v1/ai/ask` (two-turn NL query), `GET/POST /v1/ai/proposals[?status=...]`, `GET /v1/ai/proposals/kinds`, `POST /v1/ai/proposals/{id}/{approve,reject}`, `POST /v1/ai/proposals/suggest/budget`
 - **Reports (Phase 7, JSON/HTML/PDF/CSV via `?format=`):** `GET /v1/reports/{trial-balance,balance-sheet,income-statement,cash-flow,envelope-status,sinking-fund-progress,reconciliation-summary,audit-log,custom-query}`
 - **Journal (Phase 7, hledger-format round-trip):** `GET /v1/journal/export[?start=...&end=...]`, `POST /v1/journal/import` (text/plain body → PENDING transactions)
@@ -178,7 +179,7 @@ uv run tulip reconcile complete "$RECON_ID"       # strict balance check, denorm
 
 `tulip add --edit` opens `$EDITOR` with a hledger-style template instead of taking flags. `tulip accounts list` renders a Rich tree when nesting exists, a flat table otherwise (`--flat` to force the table for scripting). Tokens persist in the OS keyring; the CLI exit-code map and full RFC 9457 error rendering are documented in [docs/ARCHITECTURE.md §7.8.5](docs/ARCHITECTURE.md).
 
-Other top-level commands: `tulip envelopes`, `tulip sinking-funds`, `tulip refills`, `tulip periods`, `tulip transfer`, `tulip refill`, `tulip budget-inflow`, `tulip transactions {show,edit,void,delete}`, `tulip imports {profiles,apply}`, `tulip notifications {list,dismiss}`, `tulip backup`, `tulip restore`, `tulip doctor`. The `tulip ai` group (Phase 6) covers BYOK + policy editing + the four capabilities: `tulip ai {set-key, forget-key, list-keys, status, preview, config {show,set,clear,set-capability,log-prompts}, ask, propose, proposals, approve, reject, suggest-budget}`. The `tulip reports` group (Phase 7) has one subcommand per report (`trial-balance`, `balance-sheet`, `income-statement`, `cash-flow`, `envelope-status`, `sinking-fund-progress`, `reconciliation-summary`, `audit-log`, `custom-query`); each accepts `--format json|html|pdf|csv` (default json, JSON/HTML default to stdout, PDF/CSV need `--output PATH`). `tulip journal {export,import}` round-trips the household ledger as hledger-format text. Each takes `--help`; the surface mirrors the API endpoints listed above.
+Other top-level commands: `tulip envelopes`, `tulip sinking-funds`, `tulip refills`, `tulip periods`, `tulip transfer`, `tulip refill`, `tulip budget-inflow`, `tulip transactions {show,edit,void,delete}`, `tulip imports {ofx,csv,qif,list,show,apply,profiles}`, `tulip reconcile {create,start,list,show,auto-match,match,walk,interactive,complete,carry-forward,reject,delete}`, `tulip notifications {list,dismiss}`, `tulip backup`, `tulip restore`, `tulip doctor`. Where a command needs a UUID it also accepts an account code / name / hierarchical path, and an interactive selectable-list picker is offered when the argument is omitted. Phase 8 usability touches: `tulip imports qif --account-map <map.json>` imports a multi-account Banktivity-style QIF in one POST (run `--account` on a multi-account file to get a starter map); `tulip imports apply --posted` lands a bulk historical migration straight to POSTED; `tulip balance --pending` folds PENDING transactions into the figure (clearly labelled, default `--no-pending`); `tulip reconcile start` opens a paper-statement reconciliation with no import batch. The `tulip ai` group (Phase 6) covers BYOK + policy editing + the four capabilities: `tulip ai {set-key, forget-key, list-keys, status, preview, config {show,set,clear,set-capability,log-prompts}, ask, propose, proposals, approve, reject, suggest-budget}`. The `tulip reports` group (Phase 7) has one subcommand per report (`trial-balance`, `balance-sheet`, `income-statement`, `cash-flow`, `envelope-status`, `sinking-fund-progress`, `reconciliation-summary`, `audit-log`, `custom-query`); each accepts `--format json|html|pdf|csv` (default json, JSON/HTML default to stdout, PDF/CSV need `--output PATH`). `tulip journal {export,import}` round-trips the household ledger as hledger-format text. Each takes `--help`; the surface mirrors the API endpoints listed above.
 
 ### Development discipline
 
@@ -195,7 +196,8 @@ This project follows test-driven development. Every feature ships with tests wri
 - [QUICKSTART](docs/QUICKSTART.md) — runnable end-to-end walkthrough (the user entry point; pin this for first-time setup questions)
 - [Architecture](docs/ARCHITECTURE.md) — full system design, data model, phase roadmap, error-handling standard (§7.8)
 - [Phase Status](docs/PHASE_STATUS.md) — what's shipped, what's queued
-- [Threat Model](docs/THREAT_MODEL.md) — lightweight security checkpoint (deep audit deferred to Phase 8)
+- [Threat Model](docs/THREAT_MODEL.md) — security checkpoint, kept current with the Phase 8 audits
+- [Audits](docs/audits/) — the Phase 8 deep security audit (2026-05-12) and deep privacy audit (2026-05-13), finding-by-finding
 - [ADRs](docs/adrs/) — architectural decision records (envelope shadow ledger, scheduler primitive, mutation testing, reconciliation, AI integration / privacy contract)
 - [CONTRIBUTING.md](CONTRIBUTING.md) — TDD discipline, coverage gates, signed commits, manual smoke test format
 - [CLAUDE.md](CLAUDE.md) — operational notes for AI-assisted development on this repo
@@ -203,12 +205,14 @@ This project follows test-driven development. Every feature ships with tests wri
 
 ### Security & privacy
 
-- **Defense-in-depth encryption at rest:** SQLCipher for the whole DB (Phase 8), AES-256-GCM field-level for the most sensitive columns (TOTP secrets, attachments) today. No single key compromise leaks everything.
+- **Defense-in-depth encryption at rest:** SQLCipher for the whole DB (Phase 8, in flight), AES-256-GCM field-level for the most sensitive columns (TOTP secrets, attachments) today. No single key compromise leaks everything.
 - **Master key** is sourced from `TULIP_MASTER_KEY` (env var) or `TULIP_KEY_FILE` (0600 file); never written to disk by Tulip itself.
-- **MFA (TOTP)** required for admin users by default; optional for household members.
+- **MFA (TOTP)** required for admin users by default; optional for household members. TOTP secrets are encrypted at rest; recovery codes are argon2id-hashed with an 80-bit entropy floor; the MFA-login flow uses a single-use challenge token that can't be replayed.
+- **Online-auth hardening (Phase 8 Wave-1):** per-IP rate limiting on the four `/v1/auth/*` abuse surfaces, a constant-time login path that closes the user-enumeration timing oracle, and email/IP redaction in structured logs by default.
+- **Right to erasure (GDPR Art. 17 / CCPA):** `DELETE /v1/users/{id}` and the two-step household-erasure flow cascade-delete the subject's data, garbage-collect attachment ciphertext from disk, and redact PII from audit-log snapshots.
 - **AI privacy posture** is per-tenant + per-user policy, with audit logging of every model invocation, a server-enforced monthly cost cap, and a per-user sliding-window rate limit. Defaults to permissive but a fresh household has no provider key — no provider is contacted until an admin opts in via `tulip ai set-key`. Users can dial up restrictions (per-capability `disabled` / `requires_approval`, `strict` / `local_only` redaction profiles) or switch to local-only models (Ollama). Prompt bodies are never stored by default; only metadata (model, latency, cost, success/fail) lands in `ai_invocations`. Full forensic prompt logging is opt-in via `tulip ai config log-prompts on`.
 
-The lightweight threat model is in [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md); a formal external audit is scheduled before external beta.
+The threat model is in [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md); the Phase 8 deep security and deep privacy audits ([docs/audits/](docs/audits/)) are document-only multi-agent reviews — their highest-severity findings have shipped as Wave-1 follow-ups, with the remainder tracked as issues.
 
 ### License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Tulip Accounting — Architectural Specification (v1)
 
-**Status:** Phases 0–7 complete. Internal-beta ready. The full v1 surface is in place: ADR-0005 AI integration end-to-end, all nine reports rendered in HTML/PDF/CSV, hledger-format journal export + import, and the `tulip reports` / `tulip journal` CLI groups.
-**Document version:** 1.2
-**Date:** 2026-04-29 (original) · 2026-05-07 (Phase 5 close + roadmap refresh) · 2026-05-12 (Phase 7 close)
+**Status:** Phases 0–7 complete; Phase 8 (operations + hardening) in progress. Internal-beta ready. The full v1 surface is in place: ADR-0005 AI integration end-to-end, all nine reports rendered in HTML/PDF/CSV, hledger-format journal export + import, and the `tulip reports` / `tulip journal` CLI groups. Phase 8 deep security + deep privacy audits have shipped, along with their highest-severity Wave-1 follow-ups and a post-audit CLI/importers usability bundle.
+**Document version:** 1.3
+**Date:** 2026-04-29 (original) · 2026-05-07 (Phase 5 close + roadmap refresh) · 2026-05-12 (Phase 7 close) · 2026-05-14 (Phase 8 audits + Wave-1)
 
 ---
 
@@ -135,6 +135,9 @@ Same shape, with:
   - `member`: see and edit shared accounts, manage own private accounts/envelopes/sinking funds.
   - `viewer`: read-only on shared accounts; no visibility into private accounts.
 - **Visibility** (per account / envelope / sinking fund): `shared` (default) or `private` (creator + admins only).
+- **Right to erasure** (GDPR Art. 17 / CCPA §1798.105 — shipped Phase 8 Wave-1):
+  - `DELETE /v1/users/{user_id}` — erases one user; cascades their `sessions` + `mfa_recovery_codes` and redacts their PII from `audit_log` snapshots. Admin-only (or self).
+  - `POST /v1/households/me/erase-request` → `DELETE /v1/households/me` — a two-step, token-gated household erasure (the confirmation token lives in `pending_household_erasures`). The `DELETE` cascades every household-scoped table via `ondelete="CASCADE"` and garbage-collects attachment ciphertext from disk. Admin-only.
 
 ---
 
@@ -324,6 +327,8 @@ periods
   reopened_by_user_id (nullable), reopened_at (nullable)
 ```
 
+**Auxiliary tables** (auth, AI, scheduling, notifications — created by migrations, not detailed in the core-entities view above): `sessions` (refresh-token store, SHA-256), `mfa_recovery_codes` (argon2id), `used_mfa_challenges` (single-use MFA-challenge `jti` burn list — Phase 8 Wave-1), `pending_household_erasures` (two-step GDPR Art. 17 erasure tokens — Phase 8 Wave-1), `pending_proposals` (AI proposals awaiting human approval), `notifications`, and `scheduled_jobs`. Two tenancy notes on these: `pending_proposals.ai_invocation_id` carries a **composite FK** `(household_id, ai_invocation_id) → ai_invocations` (Phase 8 Wave-1 — closes a gap where a proposal could reference another household's invocation); and every household-scoped table declares `ondelete="CASCADE"` from `households.id`, which is what makes the household-erasure endpoint a single `DELETE`.
+
 ### 4.2 Double-Entry Invariants
 
 - For any `transaction`, the sum of `postings.amount` per currency must equal zero. Enforced via:
@@ -380,6 +385,8 @@ Seed loader is generic — additional templates (debt-payoff, side-hustle, full 
 ### 5.1 Double-Entry Accounting
 
 Standard double-entry. The accounting engine module (`tulip.core.accounting`) is the single chokepoint for posting transactions. Any code path that writes a transaction goes through it. Direct INSERTs into `transactions`/`postings` are forbidden by lint rule and architecture-test (see §7.3).
+
+**Posted vs pending balances** (#274): balance queries default to *posted* balances (`status` in `posted`/`reconciled`). `GET /v1/accounts/{id}/balance?include_pending=true` and `GET /v1/reports/trial-balance?include_pending=true` (CLI: `tulip balance --pending`, default `--no-pending`) fold in `pending` transactions; pending-inclusive output is always labelled ("balance (incl. pending)") and pending-affected trial-balance rows carry a `(P)` marker, so it can't be mistaken for the settled ledger.
 
 ### 5.2 Envelope Budgeting
 
@@ -444,23 +451,25 @@ envelope up to `amount` per period. `percentage_of_income` contributes
 
 Both flows supported:
 
-1. **Manual flag.** Users can mark transactions as `cleared` (matched against their own records) and `reconciled` (matched against an actual statement). A reconciliation summary report shows uncleared/unreconciled.
+1. **Manual flag.** Users can mark transactions as `cleared` (matched against their own records) and `reconciled` (matched against an actual statement). A reconciliation summary report shows uncleared/unreconciled. **Paper-statement reconciliation** (#275): a reconciliation need not be backed by an uploaded statement file — `tulip reconcile start` opens one with `source_import_batch_id IS NULL` and `reconciliation_match.line_id` is nullable, so a user comparing transactions against a paper statement in hand can reconcile without an import batch.
 2. **Statement-driven matching.** User imports a statement (OFX or CSV) for an account. The reconciliation matcher compares statement entries against existing transactions and creates a `reconciliation` record. Matching algorithm: amount + date (±3 days configurable) + fuzzy description match. Unmatched statement lines become `pending` transactions awaiting categorization. Unmatched ledger transactions are flagged for review.
 
 ### 5.9 Importers (v1)
 
 | Format | Parser library | Notes |
 |---|---|---|
-| OFX | `ofxparse` (tested baseline) — verify maintenance status at implementation time | Most banks/credit cards |
-| QIF | Custom parser (format is small, public domain) | Older Quicken format |
+| OFX | `ofxtools` (chosen over `ofxparse` for active maintenance + XXE safety) | Most banks/credit cards |
+| QIF | Custom line-oriented parser (format is small, public domain) | Older Quicken format; handles `!Account` multi-account files, `S`-line splits, and `L[Account]` transfers |
 | CSV | Custom parser with column-mapping config | Per-institution mapping profiles savable as YAML |
 
 Each importer:
 - Reads the source file → produces a `proposed_import` (in-memory, with proposed transactions and postings).
-- Runs the auto-categorization AI capability if enabled (or rule-based fallback).
+- Runs the auto-categorization AI capability if enabled (or rule-based fallback). `--no-categorize` skips this for bulk historical migrations (#202).
 - Presents the proposed batch to the user for review.
 - On user `apply`, posts transactions atomically and records an `import_batch`.
 - Original file is stored as an attachment for audit trail.
+
+**Multi-account QIF** (#195a/#195b, #198): Banktivity-style QIF exports carry several accounts in one file (`!Account` section headers) and intra-file transfers (`L[Account]` links). `POST /v1/imports/multi-account` takes the whole file plus an `account_map` JSON form field (QIF account name → Tulip account) in a single POST; the importer pairs the two legs of each transfer into one balanced transaction, and an unmatched leg falls back to a one-sided line with a warning. Non-transaction QIF sections (`!Type:Cat`, `!Type:Class`, etc.) are skipped rather than erroring.
 
 ### 5.10 Journal Format Export/Import (Level 3)
 
@@ -542,10 +551,11 @@ Capability-level `null` inherits the household default. `profile` selects a reda
 
 ### 7.1 Authentication
 
-- **Password hashing:** argon2id (via `argon2-cffi`), with sensible memory/time parameters reviewed annually.
-- **Session model for first-party clients (CLI):** API issues a JWT access token (15 min) + opaque refresh token (30 days, rotating, stored hashed in DB). CLI persists tokens in OS keyring (via `keyring` library) — never plaintext on disk.
+- **Password hashing:** argon2id (via `argon2-cffi`), with OWASP-2024 minimum parameters; PHC-formatted hashes are self-describing, so `needs_rehash` re-tunes old hashes on next successful login. The login path is constant-time with respect to "user exists" (Phase 8 Wave-1 — closes a user-enumeration timing oracle).
+- **Session model for first-party clients (CLI):** API issues a JWT access token (15 min) + opaque refresh token (30 days, rotating). The refresh token is 256-bit `secrets.token_urlsafe` and stored **SHA-256** in `sessions` — full token entropy makes a slow KDF unnecessary, and the deterministic hash lets the revoke-on-logout lookup hit an index. CLI persists tokens in OS keyring (via `keyring` library) — never plaintext on disk.
 - **API tokens for non-interactive clients:** scoped, revocable, optionally with expiry. Stored hashed.
-- **MFA:** TOTP (RFC 6238) via `pyotp`. Recovery codes generated at enrollment, hashed at rest. MFA challenge required at login when enabled. Default tenant policy: required for admins, optional for members.
+- **MFA:** TOTP (RFC 6238) via `pyotp`; TOTP secrets are AES-256-GCM-encrypted at rest. Recovery codes are argon2id-hashed with an 80-bit entropy floor (Phase 8 Wave-1). MFA challenge required at login when enabled: a successful password check issues a short-lived MFA-challenge JWT carrying a single-use `jti`, redeemed at `POST /v1/auth/login/mfa` or `/login/recover`; the `jti` is burned in `used_mfa_challenges` on redemption so a captured challenge token can't be replayed (Phase 8 Wave-1). Default tenant policy: required for admins, optional for members.
+- **Auth rate limiting:** the four most abuse-exposed `/v1/auth/*` endpoints sit behind per-IP `slowapi` quotas — see §7.6.
 
 ### 7.2 Logging & Observability
 
@@ -554,7 +564,7 @@ Capability-level `null` inherits the household default. `profile` selects a reda
 - Each request gets a `request_id` (UUID) attached to the structlog context. The request_id propagates through every log line and into the `audit_log` and `ai_invocations` rows for the duration of the request.
 - Standard fields on every log line: `timestamp`, `level`, `event`, `request_id`, `household_id` (when in tenant scope), `user_id` (when authenticated), `module`.
 - Default sink: stdout (works directly with Docker, journald, syslog, or direct file capture). Configurable to file with rotation (`logging.handlers.RotatingFileHandler`).
-- **PII redaction:** structlog processor redacts known-sensitive fields (account numbers, password fields, TOTP secrets, API keys) before serialization. Redaction is whitelist-based on field names; unknown fields are emitted as-is. A test enforces redaction on every known-sensitive field.
+- **PII redaction:** structlog processor redacts known-sensitive fields (account numbers, password fields, TOTP secrets, API keys, the master key, and — as of Phase 8 Wave-1 — email addresses and IP addresses) before serialization. Redaction is whitelist-based on field names; unknown fields are emitted as-is. A test enforces redaction on every known-sensitive field.
 - **OpenTelemetry hooks:** `opentelemetry-instrumentation-fastapi` and `-sqlalchemy` are installed but disabled by default. Enable via env var; emits to OTLP endpoint. This makes future observability (Tempo, Jaeger, Honeycomb) a config flip.
 - **Log levels:** `DEBUG` for development, `INFO` for production default. `WARNING` for soft-close overrides, AI provider degradation. `ERROR` for failures requiring attention. Standard severity discipline.
 
@@ -623,8 +633,8 @@ The user has explicitly called out comprehensive testing compliant with modern T
 
 - Per-IP at the reverse-proxy layer (in production deployments).
 - Per-user/tenant at the application layer using `slowapi`:
-  - Auth endpoints: aggressive limits to deter brute force.
-  - AI endpoints: per-user (60/hour default) and per-household ($10/month default).
+  - **Auth endpoints (shipped — Phase 8 Wave-1, #219):** a single module-level `slowapi.Limiter` keyed on client IP guards the four most abuse-exposed surfaces — `POST /v1/auth/login` (`10/minute`), `/login/mfa` (`10/minute`), `/login/recover` (`10/minute`), `/refresh` (`30/minute`). Exceedance is an RFC 9457 `auth.rate_limited` (429) with a `Retry-After` header. Storage backend is in-memory (fine for single-process SQLite; switch to Redis when multi-replica). Per-email keying was considered and deferred — `slowapi`'s key function runs before the body is parsed; the per-IP gate alone defeats the bulk credential-stuffing case.
+  - AI endpoints: per-user (60/hour default) and per-household ($10/month default) — enforced server-side in `tulip_ai.cost.enforce_pre_call`.
   - Bulk endpoints (import, export): limits scaled by payload size.
 
 ### 7.7 Notifications
@@ -986,12 +996,16 @@ Per [ADR-0004](adrs/0004-reconciliation.md). Closed 2026-05-07 across nine sub-s
 - ✅ **P7.5** — hledger-compatible `POST /v1/journal/import`; account paths resolve by code first then `(type, name)`; imported transactions land in PENDING for review — same convention as the OFX / QIF / CSV importers (PR #188). Phase 7 closes.
 - ✅ **P7.1.b** — CLI surface: `tulip reports <name>` (9 subcommands, `--format json|html|pdf|csv`, `--output PATH`) and `tulip journal {export,import}` over the existing endpoints (PR #190).
 
-### Phase 8 — Operations + hardening
-- Docker compose for home server
-- Backup/restore CLI commands
-- Documentation pass: ARCHITECTURE, DEPLOYMENT, SECURITY, AI
-- **Deep security audit** — full threat model review, dependency / SBOM review, secrets handling, key management, encryption-at-rest verification (SQLCipher landing here if not earlier), tenant-scoping enforcement audit, and a pen-test pass against the self-hosted single-tenant deployment.
-- Performance pass on common queries
+### Phase 8 — Operations + hardening 🔄 in progress
+- ✅ **Deep security audit** — shipped 2026-05-12 as [docs/audits/2026-05-12-deep-security-audit.md](audits/2026-05-12-deep-security-audit.md). Multi-agent static review across seven streams (auth/session, authz/tenancy, crypto, input-validation, secrets/logging/deps, audit-log/ops, AI/backup); `pip-audit` clean. **0 Critical · 8 High · 25 Medium · 24 Low.** Document-only; findings tracked as follow-up issues. Explicitly *not* a pen test — that stays deferred to Phase 9.
+- ✅ **Deep privacy audit** — shipped 2026-05-13 as [docs/audits/2026-05-13-deep-privacy-audit.md](audits/2026-05-13-deep-privacy-audit.md). Full-system GDPR / CCPA framing — personal-data inventory, data flows, retention/deletion, user-rights infrastructure, multi-user-within-household boundaries. **1 Critical · 17 High · 28 Medium · 22 Low.**
+- ✅ **Security Wave-1 follow-ups** — the highest-severity security findings: `slowapi` rate limiting on the four `/v1/auth/*` abuse surfaces (#219), single-use MFA-challenge JWTs via the `used_mfa_challenges` table (#219), 80-bit recovery-code entropy floor (#219), constant-time login path closing the user-enumeration timing oracle, structlog email/IP redaction on by default, `AICategorizer` session-deadlock fix (#199, #200), and the proposal `actor_kind` spoofing fix.
+- ✅ **Privacy Wave-1 follow-ups** — the Critical + High privacy findings: `local_only` AI profile pins to Ollama regardless of `fallback_provider` (#233); GDPR Art. 17 right-to-erasure for users (`DELETE /v1/users/{user_id}`, #235) and households (`POST /v1/households/me/erase-request` → `DELETE /v1/households/me`, #235) with attachment-ciphertext GC and audit-log PII redaction (#234).
+- ✅ **Post-audit CLI + importers usability bundle** — surfaced during user testing, batched as friction-fixers: account resolution by unique name or hierarchical colon-path (#197) plus an interactive selectable-list picker when a UUID-required command runs without one (#273), `GET /v1/imports` + `tulip imports list` (#272), `tulip imports show` exposes `BATCH_ID` (#203), `--pending` / `include_pending` folds PENDING transactions into balances with clear labelling (#274), multi-account QIF import via `--account-map` (#195a) with cross-account transfer pairing (#195b) and non-transaction-section skipping (#198), QIF split-posting fidelity (#270), `tulip imports apply --posted` (#210) and `--no-categorize` (#202) for bulk migrations, Rich `Console` honouring `COLUMNS` for stable non-TTY rendering (#285), right-aligned numeric columns for financial legibility (#289), and a paper-statement (no-OFX) reconciliation flow (#275).
+- 🔄 **Documentation pass** — ARCHITECTURE, THREAT_MODEL, PHASE_STATUS, README, QUICKSTART brought current through Phase 8 (this pass). DEPLOYMENT, SECURITY, AI docs still pending.
+- Docker compose for home server *(pending)*
+- Backup/restore CLI commands *(pending — restore-path traversal hardening tracked from security audit H-1)*
+- Performance pass on common queries *(pending)*
 
 ### Phase 9 — Pre-cloud preparation (optional, before multi-tenant rollout)
 - Postgres backend implementation against the existing storage abstraction
@@ -1005,8 +1019,9 @@ Per [ADR-0004](adrs/0004-reconciliation.md). Closed 2026-05-07 across nine sub-s
 | Audit | When | Why then |
 |---|---|---|
 | **Lightweight threat-model checkpoint** | Between Phase 3 and Phase 4 — ✅ shipped 2026-05-01 | Captures trust boundaries, data classifications, deferred mitigations, and the constraints Phase 4–6 work must not violate. See [docs/THREAT_MODEL.md](THREAT_MODEL.md). |
-| **Privacy audit** | Before Phase 6 implementation begins — ✅ shipped 2026-05-11 as [ADR-0005](adrs/0005-ai-integration.md) | Household financial data starts leaving the local boundary at AI integration; the audit shapes the design rather than reviewing it after. |
-| **Deep security audit** | Phase 8 (operations + hardening) | First point where the system has a real deployment story (Docker, backup/restore) and a stable feature set; before any real-user rollout. |
+| **Privacy audit (AI)** | Before Phase 6 implementation begins — ✅ shipped 2026-05-11 as [ADR-0005](adrs/0005-ai-integration.md) | Household financial data starts leaving the local boundary at AI integration; the audit shapes the design rather than reviewing it after. |
+| **Deep security audit** | Phase 8 (operations + hardening) — ✅ shipped 2026-05-12 as [docs/audits/2026-05-12-deep-security-audit.md](audits/2026-05-12-deep-security-audit.md) | First point where the system has a real deployment story (Docker, backup/restore) and a stable feature set; before any real-user rollout. |
+| **Deep privacy audit** | Phase 8, alongside the security audit — ✅ shipped 2026-05-13 as [docs/audits/2026-05-13-deep-privacy-audit.md](audits/2026-05-13-deep-privacy-audit.md) | Verifies the shipped state of the ADR-0005 AI privacy posture and broadens to a full-system GDPR / CCPA review before any real-user rollout. |
 | **Pre-cloud security re-audit** | Phase 9, before multi-tenant cutover | Multi-tenant + network exposure is a new threat model; re-validates Phase 8 findings under the new constraints. |
 
 ---

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-11 · `main` @ **Phase 6 complete** (P6.0–P6.5.c shipped)
+**Last updated:** 2026-05-14 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landed, plus a CLI/importers usability bundle
 
 ---
 
@@ -24,9 +24,13 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **Phase 6 (AI integration):** ✅ shipped — P6.0–P6.5.c complete (ADR + categorize + NL query + daily-insights/anomaly + envelope AI forecast + sinking-fund AI forecast + agentic proposals + AI-driven suggestions + cost-cap/rate-limit chokepoint + `tulip ai config` editor + `log_prompts` toggle + status polish). Capability inventory: `AICategorizer`, `AINLQueryCapability`, `AIForecastCapability` (envelopes + sinking funds), `AIProposalCapability`, the proposal executor registry, the shared `enforce_pre_call` gate, and the `GET|PUT /v1/ai/config` admin surface. The daily-insights handler now forecasts both envelopes and sinking funds via a single `ForecastRequest` dataclass; production wiring of the forecaster into the runner is the only remaining no-op slot, intentionally deferred to a deploy-time toggle. Phase 6 closes.
 
-**Tests:** 1478 passing · **CI:** green on `main`
+- **Phase 7 (reports + journal export/import):** ✅ **complete** — P7.1–P7.5 shipped (9 reports in HTML, PDF via weasyprint, CSV output, hledger journal export + import) plus P7.1.b (`tulip reports` + `tulip journal` CLI, #189/#190). Phase 7 closes.
 
-**Phase 7 (reports + journal export/import):** ✅ shipped — P7.1–P7.5 complete; P7.1.b (CLI subcommands) in PR.
+- **Phase 8 (deep security audit + hardening):** ✅ **audit + Wave-1 complete** — the [deep security audit](audits/2026-05-12-deep-security-audit.md) (0 Critical / 8 High / 25 Medium / 24 Low) and the [deep privacy audit](audits/2026-05-13-deep-privacy-audit.md) (1 Critical / 17 High / …) are both merged document-only. **Security Wave-1** (15 issues, #217–#231) is fully landed: MFA defense-in-depth (80-bit recovery codes + single-use challenge `jti` + `slowapi` rate limiting on `/v1/auth/*`, #219), login timing-oracle defense (#221), `actor_kind` spoof fix (#218), gitleaks pin (#228), keyring-unavailable typed error (#227), `?force=true` admin-only (#230), `needs_rehash` wired into login (#224), structlog email/IP redaction (#220), backup-restore path-traversal defence (#217), prod ephemeral-key boot refusal (#223), composite FK on `ai_invocation_id` (#231), audit-coverage gaps (#222), report/journal visibility filter (#229). **Privacy Wave-1** Critical + first three High landed: `local_only` AI profile can no longer route to cloud (#233), AI error-path `response_text` gated on `log_prompts` (#234), household + user right-to-erasure infrastructure — `DELETE /v1/users/{id}`, two-step `DELETE /v1/households/me`, `AttachmentRepository.delete()` + GC handler (#235). Remaining privacy Wave-1 issues (#236–#243) are queued.
+
+- **CLI + importers usability bundle (post-audit):** ✅ shipped — transaction id-prefix display + prefix resolution (#207/#211), interactive reconciliation wizard (#205), `tulip imports show`/`list` (#203/#272), QIF split-posting fidelity (#270) + non-transaction-section skipping (#198) + multi-account import with transfer pairing (#195a/#195b), paper-statement reconciliation (#275), `tulip imports apply --posted` (#210), currency-natural amount precision (#213), account names in `transactions list`/`show` (#214), transaction-level notes (#271), account resolution by name / hierarchical path (#197), interactive UUID picker (#273), `--pending` balance toggle (#274), Rich `Console` honouring `COLUMNS` (#285), right-aligned numeric columns (#289), `/reject` OpenAPI 400 (#194).
+
+**Tests:** 1828 passing · **CI:** green on `main`
 
 ---
 
@@ -560,6 +564,92 @@ Closes Phase 5. Imperative CLI subcommand group with 10 commands wrapping the /v
 
 ---
 
+## Phase 8 — Operations + hardening — 🔄 in progress (audit + Wave-1 done)
+
+Per [ARCHITECTURE.md §10](ARCHITECTURE.md), Phase 8 is the deep
+security audit + hardening pass. The audits are done and the first
+remediation wave is fully landed; the slice-per-PR rhythm continued
+through it (one issue → one branch → one PR).
+
+### Audits — ✅ *(2026-05-12 / 2026-05-13)*
+
+Two document-only audits merged:
+
+- [`docs/audits/2026-05-12-deep-security-audit.md`](audits/2026-05-12-deep-security-audit.md)
+  — 0 Critical / 8 High / 25 Medium / 24 Low / 41 Info, plus a §11
+  Wave-1/2/3 remediation roadmap. Filed 15 Wave-1 follow-up issues
+  (#217–#231).
+- [`docs/audits/2026-05-13-deep-privacy-audit.md`](audits/2026-05-13-deep-privacy-audit.md)
+  — 1 Critical / 17 High / 28 Medium / 22 Low / 38 Info. Filed 17
+  Wave-1 follow-up issues (#233–#249).
+
+### Security Wave-1 — ✅ *(15 issues, #217–#231)*
+
+Every Wave-1 security follow-up shipped, one PR per issue:
+
+- **#219 — MFA defense-in-depth.** Recovery codes bumped 8→16 base32
+  chars (40→80 bits, `XXXX-XXXX-XXXX-XXXX`); MFA-challenge JWT carries a
+  single-use `jti` persisted in a new `used_mfa_challenges` table;
+  `slowapi` rate-limiting wired on `/v1/auth/login`, `/login/mfa`,
+  `/login/recover`, `/refresh`; audit rows for `login_failed` /
+  `mfa.code_rejected` / `mfa.recovery_rejected`.
+- **#221** login timing-oracle defense (dummy verify + no short-circuit);
+  **#218** drop `ai_invocation_id` from `ProposalCreate` (actor-kind
+  spoof); **#228** gitleaks Docker pin; **#227** typed error when the
+  keyring backend is unavailable; **#230** `?force=true` import-dedup
+  override is admin-only; **#224** `needs_rehash()` wired into login;
+  **#220** email/IP added to the structlog redaction whitelist + a
+  stdlib `LogRecord` redactor; **#217** backup-restore rejects
+  attachment-member path traversal; **#223** boot refuses ephemeral
+  master-key / JWT-secret under `TULIP_ENV=prod`; **#231** composite FK
+  on `pending_proposals.ai_invocation_id` + `notifications.ai_invocation_id`;
+  **#222** audit-log rows for logout / refresh / proposal / refill-schedule;
+  **#229** role-visibility filter threaded through the reports + journal
+  export.
+
+### Privacy Wave-1 — 🔄 Critical + first three High landed (#233–#235)
+
+- **#233 (C-1)** — `resolve_policy` no longer lets a `local_only` AI
+  profile resolve to a cloud provider via `fallback_provider`; pinned to
+  a `_LOCAL_PROVIDERS` allowlist (ADR-0005 §Q4 lock).
+- **#234 (H-1)** — AI error-path `response_text` is gated on
+  `policy.log_prompts`, matching the success path; the structured
+  `outcome` enum is the load-bearing field.
+- **#235 (H-2+H-3)** — right-to-erasure infrastructure:
+  `DELETE /v1/users/{user_id}` (admin-only, last-admin guard, audit-PII
+  redaction), two-step `DELETE /v1/households/me` (token-confirmed),
+  `AttachmentRepository.delete()` with refcount, and an `attachment_gc`
+  scheduler handler. New `pending_household_erasures` table.
+
+Remaining privacy Wave-1 (#236–#243: soft-delete-verb honesty,
+`import_batches.summary_json` PII, per-user AI policy, proposal-lifecycle
+audit, Art. 15 export, rectification, AI-invocation retention) is queued.
+
+### Post-audit CLI + importers usability bundle — ✅
+
+A batch of usability issues surfaced while testing, run as a
+dependency-ordered queue of one-PR-per-issue slices:
+
+- **Transactions / accounts:** id-prefix column + prefix resolution
+  (#207/#211), account names in `list`/`show` (#214), transaction-level
+  notes wired through repo/API/CLI (#271), account resolution by unique
+  name or hierarchical colon-path (#197), currency-natural amount
+  precision (#213), right-aligned numeric columns (#289).
+- **Imports:** `tulip imports show` (#203) + `tulip imports list` (#272),
+  QIF split-posting fidelity (#270), QIF non-transaction-section
+  skipping (#198), multi-account QIF import via `--account-map` with
+  cross-account transfer pairing (#195a/#195b), `tulip imports apply
+  --posted` (#210).
+- **Reconciliation:** interactive auto-match wizard (#205),
+  paper-statement (no-OFX) reconciliation flow (#275).
+- **CLI ergonomics:** interactive UUID picker when a required id is
+  omitted (#273), `tulip balance --pending` toggle (#274), Rich
+  `Console` honouring `COLUMNS` for stable non-TTY rendering (#285).
+- **API contract:** documented 400 on `/v1/ai/proposals/{id}/reject`
+  (#194).
+
+---
+
 ## Phase 7 — Reports + journal export/import — ✅ shipped
 
 Per ARCHITECTURE.md §8 + §10. v1 ships 9 reports in HTML+PDF+CSV, plus
@@ -567,7 +657,7 @@ hledger-compatible journal export + basic journal import. "Workstream
 slicing": P7.1 HTML, P7.2 PDF, P7.3 CSV, P7.4 journal export, P7.5
 journal import. P7.1.b adds the CLI surface over both.
 
-### P7.1.b — `tulip reports` + `tulip journal` CLI — 🔄 *(in PR; closes #189)*
+### P7.1.b — `tulip reports` + `tulip journal` CLI — ✅ *(2026-05-13; closes #189)*
 
 Closes the deferred CLI surface from P7.1. Both report and journal
 endpoints were API-only after Phase 7 closed; this slice wires them
@@ -1325,4 +1415,4 @@ Supporting changes:
 
 ## Reference: full phase roadmap
 
-See [ARCHITECTURE.md §10](ARCHITECTURE.md). Phases 5 through 9 (importers, AI, reports, ops, pre-cloud) are not in flight.
+See [ARCHITECTURE.md §10](ARCHITECTURE.md). Phases 0–7 are complete; Phase 8 (operations + hardening) is in progress — the deep security + privacy audits and security/privacy Wave-1 are done, Phase 9 (pre-cloud re-audit) is not yet in flight.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -159,19 +159,30 @@ uv run tulip imports show "$BATCH_ID"
 
 You should see six lines: two payroll credits, four debits.
 
+`tulip imports list` shows every batch you've uploaded, newest first —
+handy later when you've forgotten a `$BATCH_ID`; the printed 8-char
+prefix works anywhere the full UUID does.
+
 Now promote them to PENDING transactions in the ledger:
 
 ```bash
 uv run tulip imports apply "$BATCH_ID"
 ```
 
-Verify the balance:
+Verify the balance. `tulip balance` takes an account code, name, or
+UUID as a positional argument (omit it for a full trial balance):
 
 ```bash
-uv run tulip balance --account 1010
+uv run tulip balance 1010 --pending
 ```
 
-Should show `3611.88 USD` (matches the OFX `LEDGERBAL`).
+Should show `3611.88 USD` (matches the OFX `LEDGERBAL`). The
+`--pending` flag matters here: by default `tulip balance` counts only
+POSTED and RECONCILED transactions, and the lines you just applied are
+still PENDING — so the plain `tulip balance 1010` reads `0.00` until
+you reconcile in the next step. Pending-inclusive output is always
+labelled "(incl. pending)" so you can't mistake it for the settled
+ledger.
 
 ---
 
@@ -220,6 +231,14 @@ sum(matched ledger postings)`) and stamps each matched transaction
 with `reconciled_at`. If you ever see a `reconciliation.unbalanced`
 error here, look at `tulip reconcile show` first — there's a 4-section
 diff that tells you which lines aren't accounted for.
+
+> **No statement file?** If you're working from a paper statement
+> rather than an import batch, use `tulip reconcile start --account
+> 1010 --statement-date 2026-05-31 --closing-balance 3611.88` instead
+> of `reconcile create`. It opens a reconciliation with no source
+> batch, and `tulip reconcile walk` / `tulip reconcile interactive`
+> let you tick ledger transactions off one at a time against the paper
+> in hand.
 
 ---
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,12 +1,14 @@
 # Tulip Accounting — Threat Model Checkpoint
 
-**Status:** lightweight checkpoint, not a deep audit. **Deep audits** are scheduled per the [§10 audit cadence in ARCHITECTURE.md](ARCHITECTURE.md): privacy audit before Phase 6 (AI) ✅ shipped as [ADR-0005](adrs/0005-ai-integration.md); deep security audit at Phase 8 (operations + hardening); pre-cloud re-audit at Phase 9.
+**Status:** lightweight checkpoint, not a deep audit. **Deep audits** are scheduled per the [§10 audit cadence in ARCHITECTURE.md](ARCHITECTURE.md): privacy audit before Phase 6 (AI) ✅ shipped as [ADR-0005](adrs/0005-ai-integration.md); deep security audit at Phase 8 (operations + hardening) ✅ shipped as [`docs/audits/2026-05-12-deep-security-audit.md`](audits/2026-05-12-deep-security-audit.md), plus a full-system deep privacy audit ✅ shipped as [`docs/audits/2026-05-13-deep-privacy-audit.md`](audits/2026-05-13-deep-privacy-audit.md); pre-cloud re-audit at Phase 9.
 
-**Last updated:** 2026-05-12 · `main` @ Phase 7 complete (reports + hledger journal export/import shipped)
+**Last updated:** 2026-05-14 · `main` @ Phase 8 in progress — deep security + deep privacy audits shipped; security + privacy Wave-1 hardening follow-ups landed
 
-This document captures what the system protects, what it doesn't, and the constraints Phase 4–7 work must not violate. It exists because the cheap moment to lock in trust boundaries is *before* envelopes / importers / AI / reports add surface area, not after. Tracked as #56.
+This document captures what the system protects, what it doesn't, and the constraints Phase 4–8 work must not violate. It exists because the cheap moment to lock in trust boundaries is *before* envelopes / importers / AI / reports add surface area, not after. Tracked as #56.
 
 **Phase 7 surface check:** the new `/v1/reports/*` endpoints and `/v1/journal/{export,import}` reuse the existing tenant-scoped session + JWT chokepoint — they introduce no new trust boundary, no new external network dependency at runtime (weasyprint is a build-time system lib for PDF), and no new credential store. The `custom-query` report is gated by the same SQL-safety pass that backs the AI NL-query capability (ADR-0005); writes, joins outside the AI-view allowlist, and non-allowlisted table reads are all rejected with `report.unsafe_query`. Journal import lands transactions as PENDING through `TransactionRepository.save_balanced`, the same chokepoint the OFX / QIF / CSV importers use.
+
+**Phase 8 status:** the deep security and deep privacy audits ran against `main` at Phase 7 complete (see the two audit docs linked above). Both are document-only — **0 Critical / 8 High** security findings, **1 Critical / 17 High** privacy findings. A first wave of hardening follow-ups has since landed: `slowapi` rate limiting on `/v1/auth/*`, single-use MFA-challenge JWTs (`used_mfa_challenges`), an 80-bit recovery-code entropy floor, a constant-time login path, structlog email/IP redaction on by default, and GDPR Art. 17 right-to-erasure endpoints for users and households. §4 and §6 below reflect the post-Wave-1 state; the audit docs remain the authoritative finding-by-finding record and track the still-open items.
 
 ---
 
@@ -17,8 +19,8 @@ Today's deployment is single-tenant, single-machine, no network exposure beyond 
 1. **CLI process ↔ API process.** Both run as the same user on the same machine. The CLI authenticates with bearer JWTs; refresh tokens live in the OS keyring (or a JSON file when `TULIP_TOKEN_STORE` is set, used only by tests + CI). The API serves on `127.0.0.1:8000` by default; it is not bound to a public interface in any documented setup.
 2. **API process ↔ SQLite database.** The DB file is a normal file on disk, owned by the API process's user. Layer 1 SQLCipher full-DB encryption is **deferred** (see [§4](#4-known-deferred-mitigations)); today the database is unencrypted at the filesystem layer.
 3. **API process ↔ master key.** `TULIP_MASTER_KEY` (base64-encoded 32 bytes) is read from the environment at startup. If unset, an ephemeral key is generated and a warning is emitted. The key lives in process memory for the lifetime of the process and is on the structlog redaction whitelist (`tulip_api.logging_config:32-46`) so it can't accidentally appear in logs.
-4. **API process ↔ user credentials.** Passwords are hashed with argon2id (`tulip_api.auth.passwords`) using OWASP-2024 minimum parameters; PHC-formatted hashes are self-describing, so re-tuning later is a no-op for old hashes (`needs_rehash` fires on next successful login per #224). JWT access tokens are 15-minute; refresh tokens are 30-day, opaque (256-bit `secrets.token_urlsafe`) and stored as **SHA-256** in `sessions` — full token entropy makes a slow KDF unnecessary, and the deterministic hash lets the revoke-on-logout lookup hit an index rather than scanning rows (see `tulip_api.auth.tokens:97-99`). MFA TOTP secrets (`users.totp_secret_encrypted`) are AES-256-GCM-encrypted with the master key at rest. Recovery codes are argon2id-hashed.
-5. **API process ↔ HTTP clients.** Every error is RFC 9457 Problem Details, never raw exception text or tracebacks (enforced by an architecture test, `test_architecture_no_http_exception.py`). The catch-all 500 handler logs the full exception with traceback under structlog context but emits a generic `server.internal_error` body. Pydantic schemas validate every input boundary; schemathesis fuzzes every documented operation in CI.
+4. **API process ↔ user credentials.** Passwords are hashed with argon2id (`tulip_api.auth.passwords`) using OWASP-2024 minimum parameters; PHC-formatted hashes are self-describing, so re-tuning later is a no-op for old hashes (`needs_rehash` fires on next successful login per #224). JWT access tokens are 15-minute; refresh tokens are 30-day, opaque (256-bit `secrets.token_urlsafe`) and stored as **SHA-256** in `sessions` — full token entropy makes a slow KDF unnecessary, and the deterministic hash lets the revoke-on-logout lookup hit an index rather than scanning rows (see `tulip_api.auth.tokens:97-99`). MFA TOTP secrets (`users.totp_secret_encrypted`) are AES-256-GCM-encrypted with the master key at rest. Recovery codes are argon2id-hashed with an 80-bit entropy floor (Phase 8 Wave-1). The MFA-login flow issues a short-lived MFA-challenge JWT carrying a single-use `jti`; the `used_mfa_challenges` table burns the `jti` on redemption, so a captured challenge token can't be replayed (Phase 8 Wave-1).
+5. **API process ↔ HTTP clients.** Every error is RFC 9457 Problem Details, never raw exception text or tracebacks (enforced by an architecture test, `test_architecture_no_http_exception.py`). The catch-all 500 handler logs the full exception with traceback under structlog context but emits a generic `server.internal_error` body. Pydantic schemas validate every input boundary; schemathesis fuzzes every documented operation in CI. The four most abuse-exposed `/v1/auth/*` endpoints (`login`, `login/mfa`, `login/recover`, `refresh`) sit behind per-IP `slowapi` quotas; exceedance is an RFC 9457 `auth.rate_limited` (429) with a `Retry-After` header (Phase 8 Wave-1).
 6. **CLI process ↔ user terminal / editor.** `tulip add --edit` spawns `$VISUAL` / `$EDITOR` / `vi` via `shlex.split`, so shell metacharacters in `$EDITOR` aren't injected. Buffer contents are user-typed transactions, not credentials.
 
 **What is not a trust boundary today** (will become one at the listed phase):
@@ -52,6 +54,7 @@ Single-tenant local deployment scopes the actor list down hard:
 - **Local attacker with process memory access** (e.g. via a debugger or `/proc/$pid/mem` on Linux). Has the master key, the JWT secret, and any decrypted TOTP secrets currently being verified. This is "you've already lost" territory; the only mitigation is OS-level (no untrusted users on the same machine).
 - **Misbehaving CLI client** — well-formed authenticated requests with malformed payloads. Covered by Pydantic at the schema boundary, schemathesis fuzzing in CI, and the architecture test that bans raw `HTTPException` (so error responses can't leak internals).
 - **Stolen refresh token** — 30-day window. The CLI keeps refresh tokens in the OS keyring by default; an attacker with keyring access has 30 days of mint-new-access-tokens until either the token expires or the user runs `tulip auth logout` (which calls `/v1/auth/logout` to revoke the refresh token at the API).
+- **Online credential / MFA brute-force** — a local attacker who knows a valid email guessing the password, TOTP code, or recovery code (post-Phase-9, also a network attacker). The Phase 8 security audit flagged this as the one place the localhost assumption is thin — a multi-user household on a shared machine is a v1 use case. Wave-1 follow-ups bound it: per-IP `slowapi` quotas on `/v1/auth/*`, the single-use MFA-challenge `jti`, the 80-bit recovery-code entropy floor, a constant-time login path (closes the user-enumeration timing oracle), and failed-login audit rows for forensics.
 
 ### Out of scope today (becomes in-scope at the listed phase)
 
@@ -70,7 +73,7 @@ These were considered and intentionally deferred. Documented here so future audi
 | **SQLCipher full-DB encryption** (Layer 1) | Not wired. DB file is plaintext on disk. | Filesystem permissions; the deployment story (Phase 8) is single-machine home server with locked-down user. | ARCHITECTURE.md §1.3 / §7.4. Lands behind a separate engine factory; not blocking. |
 | **Per-field DEK wrapping** | `encrypt_field` uses the master key directly. One key compromise = all fields. | Single field encrypted today (TOTP secrets); blast radius is bounded. The `encrypt_field` API is stable across the future change. | ARCHITECTURE.md §7.4 (deferred from Phase 1). |
 | **SQLAlchemy tenant-scoping query event listener** with `admin_scope()` escape hatch | Not implemented. | Composite FKs make cross-tenant *FK references* impossible at the schema level. Repositories require `household_id` at construction. Both of these are tested. | ARCHITECTURE.md §3.3 + §1.3. |
-| **Rate limiting** (`slowapi`) | Installed as a dependency, not wired. | Single-tenant local deploy; no public surface. Auth endpoints have no aggressive-bruteforce mitigation yet. | ARCHITECTURE.md §7.6. |
+| ~~**Rate limiting** (`slowapi`)~~ | **Shipped — Phase 8 Wave-1.** Per-IP quotas on the four `/v1/auth/*` abuse surfaces; `auth.rate_limited` (429). | — | Re-promoted from deferral by the deep security audit (H-4). |
 | **WebAuthn / passkeys** as an MFA option | Not implemented. TOTP + recovery codes only. | TOTP is fully wired (`P2.x.1`). Adding WebAuthn later doesn't break TOTP. | ARCHITECTURE.md §12 (deferred). |
 | **OS-level audit log immutability** | App-level append-only writer, no DB-level enforcement. | Single `AuditLogWriter` chokepoint; no other code path mutates `audit_log`. An architecture test could enforce this — currently it does not. | ARCHITECTURE.md §1.3. |
 | **OpenTelemetry** | Hooks installed, off by default. | Structured JSON logs (structlog) carry the same context. | ARCHITECTURE.md §1.3 / §7.2. |
@@ -136,18 +139,20 @@ Phase 6 implementation (P6.1–P6.5.c). The *authoritative* contract is
 
 These are real concerns, but not for this checkpoint:
 
-- **Penetration testing** — Phase 8.
-- **Cryptographic review** of `encrypt_field` (key derivation, nonce reuse risk, AEAD usage details) — Phase 8.
+- **Penetration testing** — the Phase 8 deep security audit was static / document-only and explicitly *not* a pen test (see its §10). A dynamic pen-test engagement is still deferred — Phase 9 / pre-cloud.
+- **Cryptographic review** of `encrypt_field` (key derivation, nonce reuse risk, AEAD usage details) — ✅ covered by the Phase 8 deep security audit (crypto stream): primitives confirmed correctly chosen and used; AEAD AAD binding is a tracked Medium follow-up, not a v1 blocker.
 - **Multi-tenant cloud threat model** — Phase 9.
-- **Privacy audit of AI flows** — ✅ shipped as [ADR-0005](adrs/0005-ai-integration.md) (P6.0, 2026-05-11), implemented through P6.1–P6.5.c. See §5.3 above for the realised constraints.
-- **Backup/restore threat model** — backup pipeline doesn't exist yet (Phase 8).
-- **Supply chain / SBOM** — Phase 8 audit covers this.
-- **Side-channel / timing attacks** — out of v1 scope; relevant only to multi-tenant cloud (Phase 9).
+- **Privacy audit of AI flows** — ✅ shipped as [ADR-0005](adrs/0005-ai-integration.md) (P6.0, 2026-05-11), implemented through P6.1–P6.5.c; the full-system [deep privacy audit](audits/2026-05-13-deep-privacy-audit.md) (2026-05-13) re-verified the shipped state and broadened the review to the whole surface. See §5.3 above for the realised constraints.
+- **Backup/restore threat model** — the backup/restore pipeline now exists (`tulip-cli/backup.py`) and was reviewed by the Phase 8 deep security audit (H-1: path traversal on restore). A standalone backup/restore threat-model section is still deferred.
+- **Supply chain / SBOM** — the Phase 8 deep security audit reviewed the `pyproject.toml` / `uv.lock` dependency graph and ran `pip-audit` (clean); dependency-pinning gaps are tracked as Low findings. A formal SBOM artifact is still deferred.
+- **Side-channel / timing attacks** — broadly out of v1 scope; relevant to multi-tenant cloud (Phase 9). One exception is already addressed: the login user-enumeration timing oracle the security audit flagged — Phase 8 Wave-1 landed a constant-time login path.
 
 ---
 
 ## References
 
+- [Deep Security Audit — 2026-05-12](audits/2026-05-12-deep-security-audit.md) — Phase 8 deep security audit (0 Critical / 8 High); authoritative finding-by-finding record.
+- [Deep Privacy Audit — 2026-05-13](audits/2026-05-13-deep-privacy-audit.md) — Phase 8 full-system privacy audit (1 Critical / 17 High); GDPR / CCPA framing.
 - [ARCHITECTURE.md §3.3 Tenancy Model](ARCHITECTURE.md)
 - [ARCHITECTURE.md §7.4 Encryption at Rest](ARCHITECTURE.md)
 - [ARCHITECTURE.md §10 Audit Cadence](ARCHITECTURE.md)


### PR DESCRIPTION
## Summary

The five top-level docs were all stamped at *Phase 7 complete*. This pass brings them current with where `main` actually is — Phase 8 in progress, audits + Wave-1 landed.

- **`docs/PHASE_STATUS.md`** — already updated in an earlier slice; this PR carries those edits (new `## Phase 8` section: audits, Security Wave-1, Privacy Wave-1, post-audit usability bundle; `Last updated` + test count refreshed; P7.1.b marked shipped).
- **`docs/THREAT_MODEL.md`** — `Status` + `Last updated` bumped; new **Phase 8 status** paragraph linking the two audit docs; §1 trust boundaries note the MFA-challenge `jti` + `slowapi` quotas; §3 adds an online credential/MFA brute-force actor; §4 re-classes rate limiting from deferred → shipped; §6 reflects what the audits actually covered (crypto review done, pen test still deferred); audit docs added to References.
- **`docs/ARCHITECTURE.md`** — `Status`/version/date bumped; §3.4 right-to-erasure endpoints; §4 auxiliary-tables note (`used_mfa_challenges`, `pending_household_erasures`, composite FK on `ai_invocation_id`); §5.1 posted-vs-pending balances; §5.8 paper-statement reconciliation; §5.9 multi-account QIF + `ofxtools`; §7.1/§7.2/§7.6 auth hardening + rate limiting + log redaction; §10 Phase 8 section fully written out + audit-cadence table.
- **`README.md`** — status line, test count (~1830), endpoint surface (erasure, `GET /v1/imports`, `POST /v1/imports/multi-account`, `include_pending`), CLI command list, Security & privacy section, audits added to docs index.
- **`docs/QUICKSTART.md`** — fixed `tulip balance --account X` → positional `tulip balance X` (current CLI); added `tulip imports list` + `--pending` notes in §5; added a paper-statement reconciliation callout in §6.

Issue numbers cross-checked against `git log` (not the conversation summary, which had several wrong).

## Test plan

- [x] `git diff` reviewed for all five files; no code touched, docs-only
- [x] Endpoint paths verified against `tulip_api/routers/{users,households,imports}.py`
- [x] CLI surface verified against `tulip_cli/commands/{imports,balance,reconcile}.py`
- [x] Rate-limit quotas verified against `tulip_api/auth/rate_limit.py`
- [x] Test count (1828) verified via `uv run pytest --collect-only`
- [ ] CI green on this PR (docs-only — expect `lint` + `secrets-scan`, rest skipped per the path-conditional `changes` job)