### PR TITLE
test: shared assert_cli_usage_error helper for Typer usage-error tests

### DIFF
--- a/packages/tulip-cli/tests/_cli_asserts.py
+++ b/packages/tulip-cli/tests/_cli_asserts.py
@@ -1,0 +1,42 @@
+"""Shared assertion for Typer usage / ``BadParameter`` CLI errors (#294).
+
+Gotcha this exists to encode: Typer renders ``BadParameter`` and
+missing-argument errors through its *own* internal Rich console, which
+the CLI's ``make_console`` factory (#285) never reaches. CI runs with a
+narrower terminal than local dev, so any test asserting a substring on
+the *body* of a Typer error panel is fragile — the panel line-wraps and
+truncates mid-word, dropping the substring.
+
+The width-stable contract is the non-zero exit code plus the ``usage``
+banner Typer prints below the panel. Assert on those. Pass ``contains``
+only for substrings short enough to survive CI's panel truncation.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def assert_cli_usage_error(
+    result: subprocess.CompletedProcess[str],
+    *,
+    contains: str | None = None,
+) -> None:
+    """Assert a CLI invocation failed as a Typer usage error.
+
+    Checks a non-zero exit code and the width-stable ``usage`` banner.
+    ``contains`` is an *optional* extra substring check, applied against
+    the ANSI-stripped, lower-cased combined output — pass it only when
+    the substring is short enough to survive CI's panel truncation.
+    """
+    combined = _ANSI_RE.sub("", result.stdout + result.stderr).lower()
+    assert result.returncode != 0, (
+        f"expected a non-zero exit code, got {result.returncode}\n{combined}"
+    )
+    assert "usage" in combined, f"expected a 'usage' banner in the CLI output:\n{combined}"
+    if contains is not None:
+        needle = contains.lower()
+        assert needle in combined, f"expected {needle!r} in the CLI output:\n{combined}"

--- a/packages/tulip-cli/tests/conftest.py
+++ b/packages/tulip-cli/tests/conftest.py
@@ -27,6 +27,10 @@ import pytest
 from alembic.command import upgrade
 from alembic.config import Config
 
+# Make sibling test-helper modules (e.g. _cli_asserts.py) importable by
+# basename — pytest's importlib mode doesn't put the tests/ dir on sys.path.
+sys.path.insert(0, str(Path(__file__).parent))
+
 # Same base64 of 32 bytes the API conftest uses; never appears outside tests.
 _TEST_MASTER_KEY_B64 = "q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s="
 _TEST_JWT_SECRET = "test-secret-32bytes-test-secret!!"

--- a/packages/tulip-cli/tests/test_cli_asserts.py
+++ b/packages/tulip-cli/tests/test_cli_asserts.py
@@ -1,0 +1,60 @@
+"""Unit tests for the ``assert_cli_usage_error`` test helper (#294)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from _cli_asserts import assert_cli_usage_error
+
+
+def _result(
+    returncode: int, *, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["tulip"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_passes_on_nonzero_exit_with_usage_banner() -> None:
+    assert_cli_usage_error(_result(2, stderr="Usage: tulip import qif [OPTIONS] FILE\n"))
+
+
+def test_finds_usage_banner_on_stdout_too() -> None:
+    assert_cli_usage_error(_result(1, stdout="Usage: tulip\n"))
+
+
+def test_passes_with_matching_contains() -> None:
+    assert_cli_usage_error(
+        _result(2, stdout="Usage: tulip\n", stderr="Invalid value for '--account'"),
+        contains="--account",
+    )
+
+
+def test_contains_match_is_case_insensitive() -> None:
+    assert_cli_usage_error(
+        _result(2, stderr="USAGE: tulip\nMissing argument BATCH_ID"),
+        contains="batch_id",
+    )
+
+
+def test_strips_ansi_before_matching() -> None:
+    # Rich wraps the banner in SGR codes; the helper must strip them so the
+    # substring match doesn't break on the escape sequences.
+    assert_cli_usage_error(_result(2, stderr="\x1b[1;31mUsage:\x1b[0m tulip\n"))
+
+
+def test_raises_on_zero_exit() -> None:
+    with pytest.raises(AssertionError):
+        assert_cli_usage_error(_result(0, stderr="Usage: tulip\n"))
+
+
+def test_raises_when_usage_banner_absent() -> None:
+    with pytest.raises(AssertionError):
+        assert_cli_usage_error(_result(1, stderr="some other failure\n"))
+
+
+def test_raises_when_contains_not_found() -> None:
+    with pytest.raises(AssertionError):
+        assert_cli_usage_error(_result(2, stderr="Usage: tulip\n"), contains="missing-needle")

--- a/packages/tulip-cli/tests/test_import_command.py
+++ b/packages/tulip-cli/tests/test_import_command.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import httpx
 import pytest
 
+from _cli_asserts import assert_cli_usage_error
+
 _PASSWORD = "long-enough-password"
 
 _OFX_FIXTURES = (
@@ -591,20 +593,14 @@ def test_import_qif_account_and_account_map_are_mutually_exclusive(
         str(account_map),
         api_url=authed_session,
     )
-    assert result.returncode != 0
-    # Typer's BadParameter panel truncates mid-word in CI — assert on the
-    # width-stable usage banner rather than the message body (#285).
-    combined = (result.stdout + result.stderr).lower()
-    assert "usage" in combined or "not both" in combined
+    assert_cli_usage_error(result)
 
 
 @pytest.mark.integration
 def test_import_qif_requires_account_or_account_map(authed_session: str) -> None:
     fixture = _OFX_FIXTURES.parent / "qif" / "minimal.qif"
     result = _run_cli("import", "qif", str(fixture), api_url=authed_session)
-    assert result.returncode != 0
-    combined = (result.stdout + result.stderr).lower()
-    assert "usage" in combined or "account" in combined
+    assert_cli_usage_error(result)
 
 
 @pytest.mark.integration
@@ -620,12 +616,7 @@ def test_import_qif_account_map_invalid_json_errors(authed_session: str, tmp_pat
         str(bad_map),
         api_url=authed_session,
     )
-    assert result.returncode != 0
-    # Typer renders BadParameter in a Rich panel that CI truncates
-    # mid-word (the #285 lesson); assert on the width-stable signals —
-    # a non-zero exit plus the usage banner — rather than the message body.
-    combined = (result.stdout + result.stderr).lower()
-    assert "usage" in combined or "account-map" in combined
+    assert_cli_usage_error(result)
 
 
 @pytest.mark.integration
@@ -886,9 +877,4 @@ def test_imports_list_status_filter(authed_session: str) -> None:
 def test_imports_list_invalid_status_rejected(authed_session: str) -> None:
     """`tulip imports list --status bogus` exits with a usage error."""
     result = _run_cli("imports", "list", "--status", "bogus", api_url=authed_session)
-    assert result.returncode != 0
-    # CI's narrower Typer/Rich rendering sometimes truncates the panel
-    # before our --status substring — match any of the unambiguous
-    # error signals instead.
-    combined = (result.stdout + result.stderr).lower()
-    assert any(needle in combined for needle in ("status", "bogus", "usage"))
+    assert_cli_usage_error(result)

--- a/packages/tulip-cli/tests/test_reconcile_command.py
+++ b/packages/tulip-cli/tests/test_reconcile_command.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -17,9 +16,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-# Strip ANSI styling so substring assertions on CLI output don't break
-# when Rich line-wraps narrower in CI than in a normal terminal.
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+from _cli_asserts import assert_cli_usage_error
 
 _PASSWORD = "long-enough-password"
 _OFX_FIXTURES = (
@@ -200,8 +197,7 @@ def test_reconcile_create_invalid_period_returns_2(session_setup: dict[str, str]
         "1457.83",
         api_url=session_setup["api_url"],
     )
-    assert result.returncode != 0
-    assert "period" in (result.stdout + result.stderr).lower()
+    assert_cli_usage_error(result, contains="period")
 
 
 @pytest.mark.integration
@@ -670,9 +666,7 @@ def test_reconcile_start_invalid_date_returns_2(session_setup: dict[str, str]) -
         "1457.83",
         api_url=session_setup["api_url"],
     )
-    assert result.returncode != 0
-    combined = _ANSI_RE.sub("", (result.stdout + result.stderr)).lower()
-    assert "statement-date" in combined or "statement_date" in combined
+    assert_cli_usage_error(result)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

Closes #294. Typer renders `BadParameter` / missing-argument errors through its own internal Rich console — which the CLI's `make_console` factory (#285) never reaches — so CI's narrower terminal truncates the error panel mid-word and drops any substring a test asserts on the panel body. This pattern has bitten ~7 tests across #278/#280/#281/#283/#284/#293, each fixed the same ad-hoc way.

- New `packages/tulip-cli/tests/_cli_asserts.py` → `assert_cli_usage_error(result, *, contains=None)`: asserts the width-stable non-zero-exit + `usage` banner, ANSI-strips before matching, takes an optional short `contains` substring.
- `tulip-cli/tests/conftest.py` gains the `sys.path.insert` that makes sibling test-helper modules importable by basename — mirrors the existing `tulip-api` `_problem_details` pattern.
- Migrated the 4 hand-rolled usage-banner assertions in `test_import_command.py` and the 2 in `test_reconcile_command.py`; the latter's now-dead `_ANSI_RE` + `import re` are removed.
- `test_cli_asserts.py` covers the helper itself (8 unit tests).

## Test plan

- [x] `uv run pytest packages/tulip-cli/tests/test_cli_asserts.py` — 8/8 pass
- [x] All 6 migrated integration tests + 8 helper tests green under `COLUMNS=40` (the acceptance check)
- [x] `ruff check` + `ruff format --check` clean
- [x] mypy unaffected — `tests/` is excluded from the mypy `files` set (pyproject.toml)
- [ ] CI green on this PR