### PR TITLE
feat: encrypt import_batches.summary_json at rest

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -295,7 +295,7 @@ async def upload_import(
     # so the admin trail is honest about the duplicate.
     content_hash = hashlib.sha256(raw_bytes).hexdigest()
     existing_attachment = attachment_repo.find_by_hash(content_hash)
-    batch_repo = ImportBatchRepository(session, claims.household_id)
+    batch_repo = ImportBatchRepository(session, claims.household_id, master_key=settings.master_key)
     if existing_attachment is not None and not force:
         existing_batch = batch_repo.find_for_attachment(
             account_id=account_id,
@@ -542,7 +542,7 @@ async def upload_multi_account_qif(
         master_key=settings.master_key,
         attachment_root=settings.attachment_root,
     )
-    batch_repo = ImportBatchRepository(session, claims.household_id)
+    batch_repo = ImportBatchRepository(session, claims.household_id, master_key=settings.master_key)
     content_hash = hashlib.sha256(raw_bytes).hexdigest()
     existing_attachment = attachment_repo.find_by_hash(content_hash)
     if existing_attachment is not None:

--- a/packages/tulip-api/tests/services/test_import_apply.py
+++ b/packages/tulip-api/tests/services/test_import_apply.py
@@ -107,7 +107,6 @@ def setup(session_maker):
             imported_count=0,
             skipped_count=0,
             error_count=0,
-            summary_json={},
             created_at=datetime.now(UTC),
         )
         s.add(batch)

--- a/packages/tulip-api/tests/services/test_reconciliation_match.py
+++ b/packages/tulip-api/tests/services/test_reconciliation_match.py
@@ -99,7 +99,6 @@ def setup(session_maker):
             imported_count=2,
             skipped_count=0,
             error_count=0,
-            summary_json={},
             created_at=datetime.now(UTC),
         )
         s.add(batch)

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260514_1200_a2e9c4f1d8b3_encrypt_import_batch_summary_json.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260514_1200_a2e9c4f1d8b3_encrypt_import_batch_summary_json.py
@@ -1,0 +1,45 @@
+"""Encrypt import_batches.summary_json at rest.
+
+Per #238: the plaintext ``summary_json`` JSON column is shaped to carry
+source-bank identifiers (OFX BANKID/ACCTID) — sensitive data that would
+sit in plaintext parallel to the encrypted ``accounts.external_account_
+number_encrypted`` column. Replace it with ``summary_json_encrypted``
+(LargeBinary), written via ``encryption.encrypt_field`` in
+``ImportBatchRepository``.
+
+Existing ``summary_json`` values today only ever contain
+``{"line_count": int}`` — non-sensitive, and never read by any API/CLI
+consumer. Per #238's out-of-scope note ("accept that pre-fix rows remain
+plaintext; don't re-encrypt old rows"), the old values are dropped with
+the old column rather than migrated.
+
+Revision ID: a2e9c4f1d8b3
+Revises: c1d4f7a2b9e6
+Create Date: 2026-05-14 12:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a2e9c4f1d8b3"
+down_revision: str | None = "c1d4f7a2b9e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Replace the plaintext summary_json column with an encrypted blob."""
+    with op.batch_alter_table("import_batches", schema=None) as batch:
+        batch.drop_column("summary_json")
+        batch.add_column(sa.Column("summary_json_encrypted", sa.LargeBinary(), nullable=True))
+
+
+def downgrade() -> None:
+    """Restore the plaintext JSON column (encrypted values are not recoverable)."""
+    with op.batch_alter_table("import_batches", schema=None) as batch:
+        batch.drop_column("summary_json_encrypted")
+        batch.add_column(sa.Column("summary_json", sa.JSON(), nullable=True))

--- a/packages/tulip-storage/src/tulip_storage/models/import_batch.py
+++ b/packages/tulip-storage/src/tulip_storage/models/import_batch.py
@@ -1,24 +1,30 @@
 """ImportBatch model — one row per uploaded statement file (P5.1).
 
 Per ADR-0004 §Q6 / §"Schema". An import batch carries the source file
-attachment, parse status, and per-line counts. ``summary_json`` is a
-format-specific blob (e.g., OFX bank/account ids, CSV header layout) for
-audit-trail completeness; never read by the matcher.
+attachment, parse status, and per-line counts.
+
+``summary_json_encrypted`` is a format-specific blob for audit-trail
+completeness; never read by the matcher. Today every importer writes
+only ``{"line_count": int}``, but the field is *intended* to also carry
+source-bank identifiers (OFX BANKID/ACCTID, CSV header layout). It is
+AES-256-GCM-encrypted at rest (via ``encryption.encrypt_field``, applied
+in ``ImportBatchRepository``) so that future content can't sit in
+plaintext parallel to the encrypted ``accounts.external_account_number``
+column — see #238. Decrypt with ``ImportBatchRepository.decrypt_summary_json``.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
-    JSON,
     DateTime,
     ForeignKeyConstraint,
     Index,
     Integer,
+    LargeBinary,
     PrimaryKeyConstraint,
     String,
     func,
@@ -84,7 +90,7 @@ class ImportBatch(Base):
     imported_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     skipped_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     error_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    summary_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    summary_json_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     created_by_user_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -28,7 +28,11 @@ from tulip_storage.repositories.scheduled_job import ScheduledJobRepository
 from tulip_storage.repositories.shadow_transaction import ShadowTransactionRepository
 from tulip_storage.repositories.sinking_fund import SinkingFundRepository
 from tulip_storage.repositories.statement_line import StatementLineRepository
-from tulip_storage.repositories.transaction import TransactionRepository, TrialBalanceRow
+from tulip_storage.repositories.transaction import (
+    MasterKeyRequiredError,
+    TransactionRepository,
+    TrialBalanceRow,
+)
 
 __all__ = [
     "AccountRepository",
@@ -39,6 +43,7 @@ __all__ = [
     "CsvProfileRepository",
     "EnvelopeRepository",
     "ImportBatchRepository",
+    "MasterKeyRequiredError",
     "NotificationRepository",
     "PendingProposalRepository",
     "PeriodRepository",

--- a/packages/tulip-storage/src/tulip_storage/repositories/import_batch.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/import_batch.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from sqlalchemy import select
 
+from tulip_storage.encryption import decrypt_field, encrypt_field
 from tulip_storage.models import ImportBatch, ImportBatchStatus, SourceFormat
+from tulip_storage.repositories.transaction import MasterKeyRequiredError
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -17,10 +20,30 @@ if TYPE_CHECKING:
 class ImportBatchRepository:
     """Persists import batches and queries them within one household."""
 
-    def __init__(self, session: Session, household_id: UUID) -> None:
-        """Bind the repository to a session and tenant scope."""
+    def __init__(
+        self,
+        session: Session,
+        household_id: UUID,
+        *,
+        master_key: bytes | None = None,
+    ) -> None:
+        """Bind the repository to a session and tenant scope.
+
+        ``master_key`` is required only to write or read ``summary_json``
+        (it's AES-256-GCM encrypted at rest — #238). The read / list /
+        apply / revert paths all work without one.
+        """
         self._session = session
         self._household_id = household_id
+        self._master_key = master_key
+
+    def _require_master_key(self) -> bytes:
+        if self._master_key is None:
+            raise MasterKeyRequiredError(
+                "ImportBatchRepository requires a master_key to encrypt or "
+                "decrypt summary_json; construct with master_key=..."
+            )
+        return self._master_key
 
     def get(self, batch_id: UUID) -> ImportBatch | None:
         """Return the ImportBatch header by id, or None."""
@@ -106,7 +129,15 @@ class ImportBatchRepository:
         created_by_user_id: UUID | None = None,
         summary_json: dict[str, Any] | None = None,
     ) -> ImportBatch:
-        """Insert a new ImportBatch in PARSED status (default for new uploads)."""
+        """Insert a new ImportBatch in PARSED status (default for new uploads).
+
+        ``summary_json`` is encrypted at rest (#238); passing a non-None
+        value requires the repository to have a ``master_key``.
+        """
+        summary_blob: bytes | None = None
+        if summary_json is not None:
+            key = self._require_master_key()
+            summary_blob = encrypt_field(json.dumps(summary_json).encode("utf-8"), key)
         batch = ImportBatch(
             household_id=self._household_id,
             id=uuid4(),
@@ -115,13 +146,26 @@ class ImportBatchRepository:
             source_filename=source_filename,
             source_file_attachment_id=source_file_attachment_id,
             status=ImportBatchStatus.PARSED,
-            summary_json=summary_json,
+            summary_json_encrypted=summary_blob,
             created_by_user_id=created_by_user_id,
             created_at=datetime.now(tz=UTC),
         )
         self._session.add(batch)
         self._session.flush()
         return batch
+
+    def decrypt_summary_json(self, batch: ImportBatch) -> dict[str, Any] | None:
+        """Return the decrypted ``summary_json`` dict for ``batch``, or None.
+
+        Requires a configured master key when the column is non-NULL.
+        """
+        if batch.summary_json_encrypted is None:
+            return None
+        key = self._require_master_key()
+        decoded: dict[str, Any] = json.loads(
+            decrypt_field(batch.summary_json_encrypted, key).decode("utf-8")
+        )
+        return decoded
 
     def mark_applied(self, batch_id: UUID) -> ImportBatch:
         """Flip an import batch to APPLIED status."""

--- a/packages/tulip-storage/tests/test_p51_repositories.py
+++ b/packages/tulip-storage/tests/test_p51_repositories.py
@@ -26,6 +26,7 @@ from tulip_storage.repositories import (
     AttachmentRepository,
     CsvProfileRepository,
     ImportBatchRepository,
+    MasterKeyRequiredError,
     ReconciliationMatchRepository,
     ReconciliationRepository,
     StatementLineRepository,
@@ -211,6 +212,74 @@ class TestImportBatchAndStatementLine:
         assert loaded.account_id == account.id
         assert loaded.source_format is SourceFormat.OFX
         assert loaded.status.value == "parsed"
+
+    def test_create_encrypts_summary_json_at_rest(
+        self,
+        session: Session,
+        household: Household,
+        account: Account,
+        attachment,
+        master_key: bytes,
+    ):
+        """summary_json is AES-256-GCM encrypted — no plaintext in the column (#238)."""
+        repo = ImportBatchRepository(session, household.id, master_key=master_key)
+        summary = {"line_count": 3, "bank_id": "021000021", "account_id": "1234567890"}
+        batch = repo.create(
+            account_id=account.id,
+            source_format=SourceFormat.OFX,
+            source_filename="may.ofx",
+            source_file_attachment_id=attachment.id,
+            summary_json=summary,
+        )
+        session.commit()
+
+        # The stored column is opaque bytes — no source identifier survives
+        # in plaintext, unlike the pre-#238 plaintext JSON column.
+        loaded = repo.get(batch.id)
+        assert loaded is not None
+        assert isinstance(loaded.summary_json_encrypted, bytes)
+        assert b"1234567890" not in loaded.summary_json_encrypted
+        assert b"bank_id" not in loaded.summary_json_encrypted
+
+        # Round-trips back to the original dict.
+        assert repo.decrypt_summary_json(loaded) == summary
+
+    def test_create_without_summary_json_leaves_column_null(
+        self,
+        session: Session,
+        household: Household,
+        account: Account,
+        attachment,
+    ):
+        """No summary_json → NULL column, and no master key is required."""
+        repo = ImportBatchRepository(session, household.id)
+        batch = repo.create(
+            account_id=account.id,
+            source_format=SourceFormat.OFX,
+            source_filename="may.ofx",
+            source_file_attachment_id=attachment.id,
+        )
+        session.commit()
+        assert batch.summary_json_encrypted is None
+        assert repo.decrypt_summary_json(batch) is None
+
+    def test_create_with_summary_json_requires_master_key(
+        self,
+        session: Session,
+        household: Household,
+        account: Account,
+        attachment,
+    ):
+        """Encrypting summary_json without a configured master key is an error."""
+        repo = ImportBatchRepository(session, household.id)
+        with pytest.raises(MasterKeyRequiredError):
+            repo.create(
+                account_id=account.id,
+                source_format=SourceFormat.OFX,
+                source_filename="may.ofx",
+                source_file_attachment_id=attachment.id,
+                summary_json={"line_count": 1},
+            )
 
     def test_idempotency_dup_attachment_per_account_rejected(
         self,

--- a/packages/tulip-storage/tests/test_p54_apply_promote_migration.py
+++ b/packages/tulip-storage/tests/test_p54_apply_promote_migration.py
@@ -160,9 +160,9 @@ class TestForeignKey:
                     "INSERT INTO import_batches (household_id, id, account_id, "
                     "source_format, source_filename, source_file_attachment_id, "
                     "status, imported_count, skipped_count, error_count, "
-                    "summary_json, created_by_user_id, created_at) "
+                    "created_by_user_id, created_at) "
                     "VALUES (:hid, :id, :aid, 'ofx', 'x.ofx', :att, 'parsed', "
-                    "0, 0, 0, '{}', :uid, :now)"
+                    "0, 0, 0, :uid, :now)"
                 ),
                 {
                     "hid": str(h.id),


### PR DESCRIPTION
## Summary

Closes #238 (deep privacy audit H-10). `import_batches.summary_json` was a plaintext JSON column whose documented purpose is to carry format-specific blobs *including OFX BANKID/ACCTID* — sensitive financial-account identifiers that would sit in plaintext parallel to the field-encrypted `accounts.external_account_number_encrypted` column, undermining that column's protection.

- **Column** renamed `summary_json` → `summary_json_encrypted` (`LargeBinary`), AES-256-GCM encrypted via the existing `encrypt_field` flow — same pattern as `notes_encrypted` / `external_account_number_encrypted`.
- **`ImportBatchRepository`** gains an optional `master_key` kwarg + a `_require_master_key` guard. `create()` encrypts the summary dict; `decrypt_summary_json()` reads it back (mirrors `TransactionRepository.decrypt_notes` — keeps the column's audit-trail value realisable). The two upload-path repo constructions in `routers/imports.py` now pass `settings.master_key`.
- **Migration** `a2e9c4f1d8b3` drops the old column. Existing values today only ever hold `{"line_count": int}` — non-sensitive, and never read by any API/CLI consumer — so per #238's out-of-scope note ("don't re-encrypt old rows") they are not migrated.
- `MasterKeyRequiredError` is now exported from `tulip_storage.repositories` (shared by two repos).
- Model docstring inventories what each importer writes today.

## Test plan

- [x] 3 new storage tests: encrypted-at-rest (no plaintext identifier survives in the column) + round-trip decrypt + `MasterKeyRequiredError` when no key configured
- [x] `uv run pytest packages/tulip-storage/tests/` — 205 passed (incl. migration round-trip + the 3 fixed direct-construction / raw-SQL test sites)
- [x] `uv run pytest packages/tulip-api/tests/` — 721 passed, 2 skipped (pre-existing path-collision skips)
- [x] `ruff check` + `mypy --strict` clean; single alembic head confirmed
- [ ] CI green on this PR