### PR TITLE
feat: proposal lifecycle audit chain + admin-delete for rejected proposals

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/proposals.py
+++ b/packages/tulip-api/src/tulip_api/routers/proposals.py
@@ -65,6 +65,23 @@ class ProposalAlreadyDecidedError(TulipProblem):
         )
 
 
+class ProposalNotDeletableError(TulipProblem):
+    """A delete was attempted on a proposal that is not REJECTED."""
+
+    def __init__(self, current_status: str) -> None:
+        """Build the proposal.not_deletable problem (#240)."""
+        super().__init__(
+            code="proposal.not_deletable",
+            title="Proposal not deletable",
+            status=409,
+            detail=(
+                f"Proposal is in status {current_status!r}; only rejected "
+                "proposals can be hard-deleted. Approved proposals stay for "
+                "audit-chain integrity; pending proposals must be rejected first."
+            ),
+        )
+
+
 def _request_uuid(request: Request) -> UUID | None:
     rid = request.headers.get("x-request-id")
     if rid:
@@ -73,6 +90,16 @@ def _request_uuid(request: Request) -> UUID | None:
         except ValueError:
             return None
     return None
+
+
+def _ai_invocation_id_str(proposal: PendingProposal) -> str | None:
+    """Stringify a proposal's ai_invocation_id for audit-row metadata (#240).
+
+    Carried on every ``proposal.*`` audit row so the chain back to the
+    originating ``ai_invocations`` row is queryable; ``None`` for
+    user-originated proposals.
+    """
+    return str(proposal.ai_invocation_id) if proposal.ai_invocation_id else None
 
 
 def _to_read(row: PendingProposal) -> ProposalRead:
@@ -122,6 +149,7 @@ def create_proposal(
         entity_id=row.id,
         after={"kind": row.kind, "title": row.title},
         request_id=_request_uuid(request),
+        metadata={"ai_invocation_id": _ai_invocation_id_str(row)},
     )
     session.commit()
     log.info(
@@ -217,6 +245,7 @@ async def approve_proposal(
         before={"status": ProposalStatus.PENDING.value},
         after={"status": ProposalStatus.APPROVED.value, "decision_note": note},
         request_id=_request_uuid(request),
+        metadata={"ai_invocation_id": _ai_invocation_id_str(proposal)},
     )
     session.commit()
     log.info("proposal.approved", proposal_id=str(proposal_id), kind=proposal.kind)
@@ -270,10 +299,59 @@ def reject_proposal(
         before={"status": before_status},
         after={"status": ProposalStatus.REJECTED.value, "decision_note": note},
         request_id=_request_uuid(request),
+        metadata={"ai_invocation_id": _ai_invocation_id_str(proposal)},
     )
     session.commit()
     log.info("proposal.rejected", proposal_id=str(proposal_id), kind=proposal.kind)
     return _to_read(updated)
+
+
+@router.delete(
+    "/{proposal_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("proposal.not_found"),
+        409: problem_response("proposal.not_deletable"),
+    },
+)
+def delete_proposal(
+    proposal_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> None:
+    """Hard-delete a REJECTED proposal (admin-only, #240).
+
+    Only rejected proposals can be removed — an AI hallucination baked
+    into a rejected proposal's payload / rationale / title should be
+    erasable. Approved proposals stay (audit-chain integrity); pending
+    proposals must be rejected first. The deletion itself is audited.
+    """
+    repo = PendingProposalRepository(session, claims.household_id)
+    proposal = repo.get(proposal_id)
+    if proposal is None:
+        raise ProposalNotFoundError()
+    if proposal.status != ProposalStatus.REJECTED.value:
+        raise ProposalNotDeletableError(proposal.status)
+
+    before = {"status": proposal.status, "kind": proposal.kind, "title": proposal.title}
+    ai_invocation_id = _ai_invocation_id_str(proposal)
+    repo.delete(proposal_id)
+    AuditLogWriter(session, claims.household_id).write(
+        action="proposal.delete",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="proposal",
+        entity_id=proposal_id,
+        before=before,
+        after=None,
+        request_id=_request_uuid(request),
+        metadata={"ai_invocation_id": ai_invocation_id},
+    )
+    session.commit()
+    log.info("proposal.deleted", proposal_id=str(proposal_id), kind=before["kind"])
 
 
 @router.get(

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -43,6 +43,7 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
     },
     "PeriodClosedError": {"reason": "Period 2025-12-31 is closed."},
     "ProposalAlreadyDecidedError": {"current_status": "approved"},
+    "ProposalNotDeletableError": {"current_status": "pending"},
     "ProposalPayloadInvalidError": {
         "reason": (
             "envelope_budget_update payload must include envelope_id (UUID) "

--- a/packages/tulip-api/src/tulip_api/services/proposal_executor.py
+++ b/packages/tulip-api/src/tulip_api/services/proposal_executor.py
@@ -110,6 +110,9 @@ async def _execute_envelope_budget_update(
             "proposal_id": str(proposal.id),
             "proposal_kind": proposal.kind,
             "rationale": proposal.rationale or "",
+            "ai_invocation_id": (
+                str(proposal.ai_invocation_id) if proposal.ai_invocation_id else None
+            ),
         },
     )
 

--- a/packages/tulip-api/tests/test_openapi_contract.py
+++ b/packages/tulip-api/tests/test_openapi_contract.py
@@ -161,19 +161,25 @@ def test_api_conforms_to_schema(case: schemathesis.Case) -> None:
     undocumented response, or the documented schema doesn't actually
     describe what comes back. Both are real bugs.
     """
-    # Path-collision skip: a static path under /v1/imports/ shadows the
-    # parameterised GET /v1/imports/{batch_id} (and the profiles variant)
-    # for any non-declared method. Schemathesis fuzzes e.g.
-    # GET /v1/imports/multi-account expecting 405 (only POST is documented
-    # there), but `multi-account` is a syntactically valid {batch_id}
-    # value so it routes to get_import_batch and 401s on auth first. The
-    # collision is harmless — batch ids are UUIDs and profile names like
-    # `import` / `multi-account` would be confusing regardless — but
-    # schemathesis can't tell. Skip non-POST methods on the static paths.
-    _STATIC_IMPORT_PATHS = ("/v1/imports/profiles/import", "/v1/imports/multi-account")
-    if str(case.path) in _STATIC_IMPORT_PATHS and case.method.upper() != "POST":
+    # Path-collision skip: a static path segment is syntactically a valid
+    # value for a parameterised sibling, so FastAPI routes an
+    # undocumented-method probe to that sibling instead of returning 405,
+    # and schemathesis can't tell the difference. Examples:
+    #   - GET /v1/imports/multi-account → routes to GET /v1/imports/{batch_id}
+    #     (`multi-account` is a valid {batch_id}) → 401 on auth, not 405.
+    #   - DELETE /v1/ai/proposals/kinds → routes to DELETE
+    #     /v1/ai/proposals/{proposal_id} (#240) → 422 (bad UUID), not 405.
+    # Each collision is harmless. Map every shadowed static path to the one
+    # method it actually documents; skip schemathesis probes of the rest.
+    _SHADOWED_STATIC_PATHS = {
+        "/v1/imports/profiles/import": "POST",
+        "/v1/imports/multi-account": "POST",
+        "/v1/ai/proposals/kinds": "GET",
+    }
+    documented_method = _SHADOWED_STATIC_PATHS.get(str(case.path))
+    if documented_method is not None and case.method.upper() != documented_method:
         pytest.skip(
-            "path-collision: non-POST on a static /v1/imports/* path routes to "
+            "path-collision: an undocumented method on a static path routes to "
             "a parameterised sibling; harmless — see comment."
         )
     case.call_and_validate()

--- a/packages/tulip-api/tests/test_proposals_endpoints.py
+++ b/packages/tulip-api/tests/test_proposals_endpoints.py
@@ -77,6 +77,54 @@ def _propose_envelope_budget_update(
     return dict(r.json())
 
 
+def _seed_ai_proposal(
+    client: TestClient,
+    household_id: UUID,
+    *,
+    envelope_id: str,
+    new_amount: str = "175.00",
+) -> tuple[str, str]:
+    """Seed an AI-created proposal + its ai_invocations row via the repo.
+
+    The HTTP create endpoint is user-only (#218); AI proposals are
+    written by the suggest endpoint, which needs a live adapter. For
+    audit-chain tests we seed the same rows that path produces. The
+    composite FK (#231) requires ai_invocation_id to reference a real
+    ai_invocations row in the same household. Returns
+    ``(proposal_id, ai_invocation_id)``.
+    """
+    from tulip_api.deps import get_session
+    from tulip_storage.models import AIInvocation, ProposalCreatorKind
+    from tulip_storage.repositories import PendingProposalRepository
+
+    session_factory = client.app.dependency_overrides[get_session]
+    with next(session_factory()) as s:
+        invocation_id = uuid4()
+        s.add(
+            AIInvocation(
+                household_id=household_id,
+                id=invocation_id,
+                capability="agentic",
+                policy_resolved="permissive",
+                profile="default",
+                outcome="success",
+                prompt_hash=b"\x00" * 32,
+            )
+        )
+        s.flush()
+        row = PendingProposalRepository(s, household_id).create(
+            kind="envelope_budget_update",
+            title="AI-suggested",
+            payload={"envelope_id": envelope_id, "new_budget_amount": new_amount},
+            rationale="",
+            created_by_kind=ProposalCreatorKind.AI_AGENT.value,
+            created_by_user_id=None,
+            ai_invocation_id=invocation_id,
+        )
+        s.commit()
+        return str(row.id), str(invocation_id)
+
+
 class TestCreateAndList:
     def test_create_user_proposal_sets_creator_kind_user(
         self, client: TestClient, auth_h: dict[str, str]
@@ -223,62 +271,25 @@ class TestApprove:
         client: TestClient,
         auth_h: dict[str, str],
         household_id: UUID,
+        session_maker,
     ) -> None:
         """The locked rule from ARCHITECTURE.md §6.2 / THREAT_MODEL §5.3.
 
-        Per #218, AI-originated proposals can no longer be seeded via the
-        HTTP create endpoint (clients can't spoof ai_agent). Seed via the
-        repository directly — same path the SuggestBudget endpoint uses
-        in production.
+        The executor's audit row carries actor_kind=ai_agent and links
+        back to both the originating proposal and — per #240 — its
+        ai_invocation_id, for chain integrity.
         """
-        from tulip_api.deps import get_session
-        from tulip_storage.models import AIInvocation, ProposalCreatorKind
-        from tulip_storage.repositories import PendingProposalRepository
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
 
         env_id = _make_envelope(client, auth_h, budget_amount="100.00")
-        overrides = client.app.dependency_overrides
-        session_factory = overrides[get_session]
-        with next(session_factory()) as seed_session:
-            # The composite FK (#231 / M-21) requires ai_invocation_id to
-            # reference a real ai_invocations row in the same household,
-            # so seed one alongside the proposal.
-            invocation_id = uuid4()
-            seed_session.add(
-                AIInvocation(
-                    household_id=household_id,
-                    id=invocation_id,
-                    capability="agentic",
-                    policy_resolved="permissive",
-                    profile="default",
-                    outcome="success",
-                    prompt_hash=b"\x00" * 32,
-                )
-            )
-            seed_session.flush()
-            row = PendingProposalRepository(seed_session, household_id).create(
-                kind="envelope_budget_update",
-                title="AI-suggested",
-                payload={"envelope_id": env_id, "new_budget_amount": "175.00"},
-                rationale="",
-                created_by_kind=ProposalCreatorKind.AI_AGENT.value,
-                created_by_user_id=None,
-                ai_invocation_id=invocation_id,
-            )
-            seed_session.commit()
-            proposal_id = str(row.id)
+        proposal_id, invocation_id = _seed_ai_proposal(client, household_id, envelope_id=env_id)
 
         client.post(f"/v1/ai/proposals/{proposal_id}/approve", headers=auth_h).raise_for_status()
 
-        # Inspect audit_log via the test session.
-        from tulip_api.deps import get_session
-        from tulip_storage.models import AuditLog
-
-        overrides = client.app.dependency_overrides
-        session_factory = overrides[get_session]
-        with next(session_factory()) as session:
-            from sqlalchemy import select
-
-            rows = (
+        with session_maker() as session:
+            rows = list(
                 session.execute(
                     select(AuditLog).where(
                         AuditLog.entity_type == "envelope",
@@ -288,8 +299,30 @@ class TestApprove:
                 .scalars()
                 .all()
             )
-            assert len(rows) == 1
-            assert rows[0].metadata_["proposal_id"] == proposal_id
+        assert len(rows) == 1
+        assert rows[0].metadata_["proposal_id"] == proposal_id
+        assert rows[0].metadata_["ai_invocation_id"] == invocation_id
+
+    def test_approve_audit_row_carries_ai_invocation_id(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+        session_maker,
+    ) -> None:
+        """#240: the proposal.approve audit row links to the ai_invocation_id."""
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        env_id = _make_envelope(client, auth_h, budget_amount="100.00")
+        proposal_id, invocation_id = _seed_ai_proposal(client, household_id, envelope_id=env_id)
+        client.post(f"/v1/ai/proposals/{proposal_id}/approve", headers=auth_h).raise_for_status()
+        with session_maker() as s:
+            row = s.execute(
+                select(AuditLog).where(AuditLog.action == "proposal.approve")
+            ).scalar_one()
+        assert row.metadata_["ai_invocation_id"] == invocation_id
 
     def test_approve_user_proposal_writes_actor_kind_user(
         self,
@@ -402,6 +435,94 @@ class TestReject:
         # read so the strings differ in trailing 'Z'; compare the
         # underlying instant by stripping it.
         assert first.json()["decided_at"].rstrip("Z") == second.json()["decided_at"].rstrip("Z")
+
+    def test_reject_audit_row_carries_ai_invocation_id(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+        session_maker,
+    ) -> None:
+        """#240: the proposal.reject audit row links to the ai_invocation_id."""
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        env_id = _make_envelope(client, auth_h)
+        proposal_id, invocation_id = _seed_ai_proposal(client, household_id, envelope_id=env_id)
+        client.post(f"/v1/ai/proposals/{proposal_id}/reject", headers=auth_h).raise_for_status()
+        with session_maker() as s:
+            row = s.execute(
+                select(AuditLog).where(AuditLog.action == "proposal.reject")
+            ).scalar_one()
+        assert row.metadata_["ai_invocation_id"] == invocation_id
+
+
+class TestDelete:
+    def test_delete_rejected_proposal_hard_deletes(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        env_id = _make_envelope(client, auth_h)
+        proposal = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="200.00"
+        )
+        client.post(f"/v1/ai/proposals/{proposal['id']}/reject", headers=auth_h).raise_for_status()
+        r = client.delete(f"/v1/ai/proposals/{proposal['id']}", headers=auth_h)
+        assert r.status_code == 204, r.text
+        # Gone — even an unfiltered list doesn't show it.
+        body = client.get("/v1/ai/proposals?status=", headers=auth_h).json()
+        assert proposal["id"] not in [p["id"] for p in body]
+
+    def test_delete_writes_audit_row_with_ai_invocation_id(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        household_id: UUID,
+        session_maker,
+    ) -> None:
+        """#240: proposal.delete lands an audit row carrying the ai_invocation_id."""
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        env_id = _make_envelope(client, auth_h)
+        proposal_id, invocation_id = _seed_ai_proposal(client, household_id, envelope_id=env_id)
+        client.post(f"/v1/ai/proposals/{proposal_id}/reject", headers=auth_h).raise_for_status()
+        client.delete(f"/v1/ai/proposals/{proposal_id}", headers=auth_h).raise_for_status()
+        with session_maker() as s:
+            rows = list(
+                s.execute(select(AuditLog).where(AuditLog.action == "proposal.delete"))
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+        assert rows[0].entity_type == "proposal"
+        assert rows[0].metadata_["ai_invocation_id"] == invocation_id
+
+    def test_delete_approved_returns_409(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        env_id = _make_envelope(client, auth_h, budget_amount="100.00")
+        proposal = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="150.00"
+        )
+        client.post(f"/v1/ai/proposals/{proposal['id']}/approve", headers=auth_h).raise_for_status()
+        r = client.delete(f"/v1/ai/proposals/{proposal['id']}", headers=auth_h)
+        assert_problem(r, code="proposal.not_deletable", status=409)
+
+    def test_delete_pending_returns_409(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        env_id = _make_envelope(client, auth_h)
+        proposal = _propose_envelope_budget_update(
+            client, auth_h, envelope_id=env_id, new_amount="200.00"
+        )
+        r = client.delete(f"/v1/ai/proposals/{proposal['id']}", headers=auth_h)
+        assert_problem(r, code="proposal.not_deletable", status=409)
+
+    def test_delete_unknown_returns_404(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.delete(f"/v1/ai/proposals/{uuid4()}", headers=auth_h)
+        assert_problem(r, code="proposal.not_found", status=404)
+
+    def test_delete_requires_auth(self, client: TestClient) -> None:
+        r = client.delete(f"/v1/ai/proposals/{uuid4()}")
+        assert r.status_code == 401
 
 
 class TestAuth:

--- a/packages/tulip-storage/src/tulip_storage/repositories/pending_proposal.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/pending_proposal.py
@@ -59,6 +59,20 @@ class PendingProposalRepository:
             )
         ).scalar_one_or_none()
 
+    def delete(self, proposal_id: UUID) -> bool:
+        """Hard-delete one proposal. Returns ``True`` if a row was removed.
+
+        Caller is responsible for any status precondition (the API only
+        permits deleting REJECTED proposals — approved ones stay for
+        audit-chain integrity, #240).
+        """
+        row = self.get(proposal_id)
+        if row is None:
+            return False
+        self._session.delete(row)
+        self._session.flush()
+        return True
+
     def list_by_status(self, status: str | None = None) -> list[PendingProposal]:
         """List proposals, newest first. ``status=None`` returns everything."""
         query = (


### PR DESCRIPTION
## Summary

Closes #240 (deep privacy audit H-12). The proposal create/approve/reject `audit_log` rows already exist (Security Wave-1 #222 landed those); what was missing is the link back to the originating AI invocation, and a way to remove a rejected proposal whose AI-generated `payload` / `rationale` / `title` shouldn't be retained.

- **`ai_invocation_id` on every `proposal.*` audit row** — threaded onto the create, approve, and reject route audit rows plus the executor's row, via a shared `_ai_invocation_id_str` helper. `None` for user-originated proposals; the linked UUID for AI-suggested ones. Makes the `audit_log` → `ai_invocations` chain queryable.
- **`DELETE /v1/ai/proposals/{id}` — admin-only.** Hard-deletes **REJECTED** proposals only. APPROVED proposals stay (audit-chain integrity); PENDING must be rejected first — both return `409 proposal.not_deletable`. The deletion is itself audited (`action=proposal.delete`, with `ai_invocation_id` in metadata).
- `PendingProposalRepository.delete()` added.
- Generalised the openapi-contract path-collision skip into `_SHADOWED_STATIC_PATHS` — `DELETE /v1/ai/proposals/kinds` now routes to the `{proposal_id}` sibling, the same shape as the existing `/v1/imports/*` static-path collisions.

## Test plan

- [x] `test_proposals_endpoints.py` — 31 passed; new `TestDelete` (rejected/approved-409/pending-409/404/auth) + `ai_invocation_id` assertions on the approve/reject/executor audit rows
- [x] `test_openapi_contract.py` — 101 passed, 3 skipped (the 2 imports collisions + the new ai/proposals one)
- [x] `ruff check` + `mypy --strict` clean
- [x] tulip-storage suite + tulip-ai proposal tests green (run pre-untangle)
- [ ] CI green on this PR

> Note: this branch briefly had an unrelated docs commit cross-applied onto it by a parallel session; that was untangled before this commit — the branch is `6085ada` + this one commit only.