### PR TITLE
feat: honest DELETE responses + redact endpoints for accounts/envelopes/sinking-funds

### DIFF
--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -791,6 +791,55 @@ class SinkingFundNotFoundError(TulipProblem):
         )
 
 
+class AccountNotRedactableError(TulipProblem):
+    """A redact was attempted on an account that is still active (#236)."""
+
+    def __init__(self) -> None:
+        """Build the account.not_redactable problem."""
+        super().__init__(
+            code="account.not_redactable",
+            title="Account not redactable",
+            status=409,
+            detail=(
+                "Only deactivated accounts can be redacted. Delete (deactivate) "
+                "the account first, then redact it to erase its PII."
+            ),
+        )
+
+
+class EnvelopeNotRedactableError(TulipProblem):
+    """A redact was attempted on an envelope that is still active (#236)."""
+
+    def __init__(self) -> None:
+        """Build the envelope.not_redactable problem."""
+        super().__init__(
+            code="envelope.not_redactable",
+            title="Envelope not redactable",
+            status=409,
+            detail=(
+                "Only deactivated envelopes can be redacted. Delete (deactivate) "
+                "the envelope first, then redact it to erase its PII."
+            ),
+        )
+
+
+class SinkingFundNotRedactableError(TulipProblem):
+    """A redact was attempted on a sinking fund that is still active (#236)."""
+
+    def __init__(self) -> None:
+        """Build the sinking_fund.not_redactable problem."""
+        super().__init__(
+            code="sinking_fund.not_redactable",
+            title="Sinking fund not redactable",
+            status=409,
+            detail=(
+                "Only deactivated sinking funds can be redacted. Delete "
+                "(deactivate) the sinking fund first, then redact it to erase "
+                "its PII."
+            ),
+        )
+
+
 class PoolTransferSamePoolError(TulipProblem):
     """A transfer was requested with identical source and destination pools."""
 

--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from datetime import date as date_type
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -13,6 +14,7 @@ from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.deps import get_session
 from tulip_api.errors import (
     AccountNotFoundError,
+    AccountNotRedactableError,
     AccountParentCurrencyMismatchError,
     AccountParentCycleError,
     AccountParentNotFoundError,
@@ -23,6 +25,7 @@ from tulip_api.errors import (
 )
 from tulip_api.schemas.account import AccountCreate, AccountRead, AccountUpdate
 from tulip_api.schemas.balance import AccountBalanceRead
+from tulip_api.schemas.lifecycle import DeactivationResponse, RedactionResponse
 from tulip_core.money import Money
 from tulip_storage.models import AccountType
 from tulip_storage.repositories import AccountRepository, AuditLogWriter, TransactionRepository
@@ -373,9 +376,13 @@ def get_account_balance(
     )
 
 
+#: Field types an account retains after a soft-delete (deactivate). Erased
+#: only by a follow-up POST /v1/accounts/{id}/redact (#236).
+_ACCOUNT_PII_FIELDS = ["name", "external_account_number_encrypted", "notes_encrypted"]
+
+
 @router.delete(
     "/{account_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     responses={
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
@@ -387,8 +394,14 @@ def deactivate_account(
     request: Request,
     claims: Claims = Depends(require_role("admin")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
-) -> None:
-    """Soft-delete (deactivate) an account. Admin only."""
+) -> DeactivationResponse:
+    """Soft-delete (deactivate) an account. Admin only.
+
+    DELETE *deactivates* — it does not erase. The account row, ``name``,
+    and the encrypted PII columns all survive (posting FKs are
+    ``ON DELETE RESTRICT``). The response says so honestly; use
+    ``POST /v1/accounts/{id}/redact`` afterwards to erase the PII.
+    """
     repo = AccountRepository(session, claims.household_id)
     try:
         a = repo.deactivate(account_id)
@@ -405,6 +418,52 @@ def deactivate_account(
         request_id=_request_uuid(request),
     )
     session.commit()
+    return DeactivationResponse(data_retained=_ACCOUNT_PII_FIELDS)
+
+
+@router.post(
+    "/{account_id}/redact",
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("account.not_found"),
+        409: problem_response("account.not_redactable"),
+    },
+)
+def redact_account(
+    account_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> RedactionResponse:
+    """Erase a deactivated account's PII. Admin only.
+
+    Nulls ``external_account_number_encrypted`` / ``notes_encrypted`` and
+    replaces ``name`` with a non-PII placeholder. Postings keep their FK
+    and amounts — ledger history is preserved. The account must already
+    be deactivated (``409 account.not_redactable`` otherwise); there is
+    no API path to re-activate it, so the erasure is final.
+    """
+    repo = AccountRepository(session, claims.household_id)
+    a = repo.get(account_id)
+    if a is None:
+        raise AccountNotFoundError()
+    if a.is_active:
+        raise AccountNotRedactableError()
+    placeholder = f"redacted-account-{hashlib.sha256(str(account_id).encode()).hexdigest()[:8]}"
+    repo.redact(account_id, name=placeholder)
+    AuditLogWriter(session, claims.household_id).write(
+        action="redact",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="account",
+        entity_id=account_id,
+        before={"redacted": False},
+        after={"redacted": True, "name": placeholder},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    return RedactionResponse(fields_redacted=_ACCOUNT_PII_FIELDS)
 
 
 def _request_uuid(request: Request) -> UUID | None:

--- a/packages/tulip-api/src/tulip_api/routers/envelopes.py
+++ b/packages/tulip-api/src/tulip_api/routers/envelopes.py
@@ -9,6 +9,7 @@ transaction (Unallocated -X / envelope +X) — see
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import UTC, datetime
 from datetime import date as date_type
@@ -23,6 +24,7 @@ from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.deps import get_session
 from tulip_api.errors import (
     EnvelopeNotFoundError,
+    EnvelopeNotRedactableError,
     ForbiddenError,
     problem_response,
 )
@@ -39,6 +41,7 @@ from tulip_api.schemas.envelope import (
     RefillRequest,
     RefillRuleSchema,
 )
+from tulip_api.schemas.lifecycle import DeactivationResponse, RedactionResponse
 from tulip_api.schemas.pool import PoolBalanceRead
 from tulip_core.allocation import (
     PoolType as DomainPoolType,
@@ -289,9 +292,13 @@ def update_envelope(
     return _to_read(pool, env)
 
 
+#: Field types an envelope (its allocation pool) retains after a
+#: soft-delete. Erased only by POST /v1/envelopes/{id}/redact (#236).
+_ENVELOPE_PII_FIELDS = ["name"]
+
+
 @router.delete(
     "/{envelope_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     responses={
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
@@ -303,8 +310,12 @@ def deactivate_envelope(
     request: Request,
     claims: Claims = Depends(require_role("admin")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
-) -> None:
-    """Soft-delete (deactivate) an envelope. Admin only."""
+) -> DeactivationResponse:
+    """Soft-delete (deactivate) an envelope. Admin only.
+
+    DELETE *deactivates* — the pool row and its ``name`` survive. Use
+    ``POST /v1/envelopes/{id}/redact`` afterwards to erase the name.
+    """
     found = EnvelopeRepository(session, claims.household_id).get(envelope_id)
     if found is None:
         raise EnvelopeNotFoundError()
@@ -327,6 +338,50 @@ def deactivate_envelope(
         request_id=_request_uuid(request),
     )
     session.commit()
+    return DeactivationResponse(data_retained=_ENVELOPE_PII_FIELDS)
+
+
+@router.post(
+    "/{envelope_id}/redact",
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("envelope.not_found"),
+        409: problem_response("envelope.not_redactable"),
+    },
+)
+def redact_envelope(
+    envelope_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> RedactionResponse:
+    """Erase a deactivated envelope's PII (its pool ``name``). Admin only.
+
+    The envelope must already be deactivated (``409 envelope.not_redactable``
+    otherwise). The pool's user-supplied ``name`` is replaced with a
+    non-PII placeholder; shadow-ledger postings keep their FK and amounts.
+    """
+    found = EnvelopeRepository(session, claims.household_id).get(envelope_id)
+    if found is None:
+        raise EnvelopeNotFoundError()
+    pool, _env = found
+    if pool.is_active:
+        raise EnvelopeNotRedactableError()
+    placeholder = f"redacted-envelope-{hashlib.sha256(str(envelope_id).encode()).hexdigest()[:8]}"
+    AllocationPoolRepository(session, claims.household_id).redact(envelope_id, name=placeholder)
+    AuditLogWriter(session, claims.household_id).write(
+        action="redact",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="envelope",
+        entity_id=pool.id,
+        before={"redacted": False},
+        after={"redacted": True, "name": placeholder},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    return RedactionResponse(fields_redacted=_ENVELOPE_PII_FIELDS)
 
 
 @router.get(

--- a/packages/tulip-api/src/tulip_api/routers/sinking_funds.py
+++ b/packages/tulip-api/src/tulip_api/routers/sinking_funds.py
@@ -6,6 +6,7 @@ through transfer or — eventually — a scheduled-tx runner in P4.3).
 
 from __future__ import annotations
 
+import hashlib
 from datetime import UTC, datetime
 from datetime import date as date_type
 from decimal import Decimal
@@ -20,9 +21,11 @@ from tulip_api.deps import get_session
 from tulip_api.errors import (
     ForbiddenError,
     SinkingFundNotFoundError,
+    SinkingFundNotRedactableError,
     problem_response,
 )
 from tulip_api.routers._pool_helpers import filter_for_role
+from tulip_api.schemas.lifecycle import DeactivationResponse, RedactionResponse
 from tulip_api.schemas.pool import PoolBalanceRead
 from tulip_api.schemas.sinking_fund import (
     SinkingFundCreate,
@@ -235,9 +238,13 @@ def update_sinking_fund(
     return _to_read(pool, sf)
 
 
+#: Field types a sinking fund (its allocation pool) retains after a
+#: soft-delete. Erased only by POST /v1/sinking-funds/{id}/redact (#236).
+_SINKING_FUND_PII_FIELDS = ["name"]
+
+
 @router.delete(
     "/{sinking_fund_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
     responses={
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
@@ -249,8 +256,12 @@ def deactivate_sinking_fund(
     request: Request,
     claims: Claims = Depends(require_role("admin")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
-) -> None:
-    """Soft-delete (deactivate) a sinking fund. Admin only."""
+) -> DeactivationResponse:
+    """Soft-delete (deactivate) a sinking fund. Admin only.
+
+    DELETE *deactivates* — the pool row and its ``name`` survive. Use
+    ``POST /v1/sinking-funds/{id}/redact`` afterwards to erase the name.
+    """
     found = SinkingFundRepository(session, claims.household_id).get(sinking_fund_id)
     if found is None:
         raise SinkingFundNotFoundError()
@@ -273,6 +284,53 @@ def deactivate_sinking_fund(
         request_id=_request_uuid(request),
     )
     session.commit()
+    return DeactivationResponse(data_retained=_SINKING_FUND_PII_FIELDS)
+
+
+@router.post(
+    "/{sinking_fund_id}/redact",
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("sinking_fund.not_found"),
+        409: problem_response("sinking_fund.not_redactable"),
+    },
+)
+def redact_sinking_fund(
+    sinking_fund_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> RedactionResponse:
+    """Erase a deactivated sinking fund's PII (its pool ``name``). Admin only.
+
+    The sinking fund must already be deactivated
+    (``409 sinking_fund.not_redactable`` otherwise). The pool's
+    user-supplied ``name`` is replaced with a non-PII placeholder;
+    shadow-ledger postings keep their FK and amounts.
+    """
+    found = SinkingFundRepository(session, claims.household_id).get(sinking_fund_id)
+    if found is None:
+        raise SinkingFundNotFoundError()
+    pool, _sf = found
+    if pool.is_active:
+        raise SinkingFundNotRedactableError()
+    placeholder = (
+        f"redacted-sinking-fund-{hashlib.sha256(str(sinking_fund_id).encode()).hexdigest()[:8]}"
+    )
+    AllocationPoolRepository(session, claims.household_id).redact(sinking_fund_id, name=placeholder)
+    AuditLogWriter(session, claims.household_id).write(
+        action="redact",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="sinking_fund",
+        entity_id=pool.id,
+        before={"redacted": False},
+        after={"redacted": True, "name": placeholder},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    return RedactionResponse(fields_redacted=_SINKING_FUND_PII_FIELDS)
 
 
 @router.get(

--- a/packages/tulip-api/src/tulip_api/schemas/lifecycle.py
+++ b/packages/tulip-api/src/tulip_api/schemas/lifecycle.py
@@ -1,0 +1,37 @@
+"""Response schemas for resource lifecycle actions — deactivate + redact (#236)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class DeactivationResponse(BaseModel):
+    """Honest body for a ``DELETE /v1/<resource>/{id}`` soft-delete.
+
+    The DELETE verb *deactivates* (``is_active=False``) rather than hard-
+    deleting — posting FKs are ``ON DELETE RESTRICT`` and rewriting ledger
+    history just to drop a label is wrong. ``data_retained`` names the
+    field types that survive the deactivation, so the caller knows a
+    follow-up ``POST .../redact`` is needed to actually erase the PII.
+    """
+
+    action: Literal["deactivated"] = "deactivated"
+    data_retained: list[str] = Field(
+        description="Field types that still hold data after deactivation.",
+    )
+
+
+class RedactionResponse(BaseModel):
+    """Body for a ``POST /v1/<resource>/{id}/redact`` action.
+
+    Redaction nulls / placeholder-fills the PII columns on an already-
+    deactivated row. Ledger postings keep their FK and amounts — history
+    is preserved, the PII is gone.
+    """
+
+    action: Literal["redacted"] = "redacted"
+    fields_redacted: list[str] = Field(
+        description="Field types that were nulled or placeholder-filled.",
+    )

--- a/packages/tulip-api/tests/test_accounts_endpoints.py
+++ b/packages/tulip-api/tests/test_accounts_endpoints.py
@@ -96,11 +96,105 @@ class TestAccountCrud:
             json={"name": "Bye", "type": "asset", "currency": "USD"},
         ).json()
         r = client.delete(f"/v1/accounts/{a['id']}", headers=auth_h)
-        assert r.status_code == 204
+        assert r.status_code == 200
+        # The response is honest: DELETE deactivates, it doesn't erase (#236).
+        assert r.json() == {
+            "action": "deactivated",
+            "data_retained": [
+                "name",
+                "external_account_number_encrypted",
+                "notes_encrypted",
+            ],
+        }
 
         # No longer listed.
         rows = client.get("/v1/accounts", headers=auth_h).json()
         assert all(row["id"] != a["id"] for row in rows)
+
+    def test_redact_account_nulls_pii_and_keeps_postings(
+        self, client: TestClient, auth_h: dict[str, str], session_maker
+    ):
+        """#236: redact erases PII but ledger postings still link to the account."""
+        from datetime import date
+        from decimal import Decimal
+        from uuid import UUID
+
+        from sqlalchemy import select
+
+        from tulip_storage.models import Account, Posting
+
+        sensitive = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Sensitive Acct", "type": "asset", "currency": "USD"},
+        ).json()
+        counterpart = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Groceries", "type": "expense", "currency": "USD"},
+        ).json()
+        # Post a balanced transaction touching the sensitive account.
+        client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": date.today().isoformat(),
+                "description": "Lunch",
+                "postings": [
+                    {"account_id": counterpart["id"], "amount": "12.50", "currency": "USD"},
+                    {"account_id": sensitive["id"], "amount": "-12.50", "currency": "USD"},
+                ],
+            },
+        ).raise_for_status()
+
+        client.delete(f"/v1/accounts/{sensitive['id']}", headers=auth_h).raise_for_status()
+        r = client.post(f"/v1/accounts/{sensitive['id']}/redact", headers=auth_h)
+        assert r.status_code == 200, r.text
+        assert r.json() == {
+            "action": "redacted",
+            "fields_redacted": [
+                "name",
+                "external_account_number_encrypted",
+                "notes_encrypted",
+            ],
+        }
+        with session_maker() as s:
+            row = s.execute(select(Account).where(Account.id == UUID(sensitive["id"]))).scalar_one()
+            postings = list(
+                s.execute(select(Posting).where(Posting.account_id == UUID(sensitive["id"])))
+                .scalars()
+                .all()
+            )
+        # PII erased.
+        assert row.name != "Sensitive Acct"
+        assert row.name.startswith("redacted-account-")
+        assert row.external_account_number_encrypted is None
+        assert row.notes_encrypted is None
+        # Ledger history preserved — the posting still links to the redacted account.
+        assert len(postings) == 1
+        assert postings[0].amount == Decimal("-12.50")
+
+    def test_redact_active_account_returns_409(self, client: TestClient, auth_h: dict[str, str]):
+        """An account must be deactivated before it can be redacted (#236)."""
+        a = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Still Active", "type": "asset", "currency": "USD"},
+        ).json()
+        r = client.post(f"/v1/accounts/{a['id']}/redact", headers=auth_h)
+        assert_problem(r, code="account.not_redactable", status=409)
+
+    def test_redact_unknown_account_returns_404(self, client: TestClient, auth_h: dict[str, str]):
+        from uuid import uuid4
+
+        r = client.post(f"/v1/accounts/{uuid4()}/redact", headers=auth_h)
+        assert_problem(r, code="account.not_found", status=404)
+
+    def test_redact_requires_auth(self, client: TestClient):
+        from uuid import uuid4
+
+        r = client.post(f"/v1/accounts/{uuid4()}/redact")
+        assert r.status_code == 401
 
     def test_validation_rejects_unknown_type(self, client: TestClient, auth_h: dict[str, str]):
         r = client.post(

--- a/packages/tulip-api/tests/test_envelopes_endpoints.py
+++ b/packages/tulip-api/tests/test_envelopes_endpoints.py
@@ -225,7 +225,9 @@ class TestDeactivateEnvelope:
             },
         ).json()
         r = client.delete(f"/v1/envelopes/{created['id']}", headers=auth_h)
-        assert r.status_code == 204
+        assert r.status_code == 200
+        # Honest body: DELETE deactivates, it doesn't erase (#236).
+        assert r.json() == {"action": "deactivated", "data_retained": ["name"]}
         # No longer in list_active.
         listed = client.get("/v1/envelopes", headers=auth_h).json()
         assert listed == []
@@ -233,6 +235,57 @@ class TestDeactivateEnvelope:
     def test_delete_unknown_returns_404(self, client: TestClient, auth_h: dict[str, str]):
         r = client.delete(f"/v1/envelopes/{uuid4()}", headers=auth_h)
         assert_problem(r, code="envelope.not_found", status=404)
+
+    def test_redact_envelope_renames_pool(
+        self, client: TestClient, auth_h: dict[str, str], session_maker
+    ):
+        """#236: redact replaces a deactivated envelope's pool name with a placeholder."""
+        from sqlalchemy import select
+
+        from tulip_storage.models import AllocationPool
+
+        created = client.post(
+            "/v1/envelopes",
+            headers=auth_h,
+            json={
+                "name": "Sensitive Envelope",
+                "currency": "USD",
+                "budget_period": "monthly",
+                "rollover_policy": "reset",
+            },
+        ).json()
+        client.delete(f"/v1/envelopes/{created['id']}", headers=auth_h).raise_for_status()
+        r = client.post(f"/v1/envelopes/{created['id']}/redact", headers=auth_h)
+        assert r.status_code == 200, r.text
+        assert r.json() == {"action": "redacted", "fields_redacted": ["name"]}
+        with session_maker() as s:
+            pool = s.execute(
+                select(AllocationPool).where(AllocationPool.id == UUID(created["id"]))
+            ).scalar_one()
+        assert pool.name != "Sensitive Envelope"
+        assert pool.name.startswith("redacted-envelope-")
+
+    def test_redact_active_envelope_returns_409(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/envelopes",
+            headers=auth_h,
+            json={
+                "name": "Still Active",
+                "currency": "USD",
+                "budget_period": "monthly",
+                "rollover_policy": "reset",
+            },
+        ).json()
+        r = client.post(f"/v1/envelopes/{created['id']}/redact", headers=auth_h)
+        assert_problem(r, code="envelope.not_redactable", status=409)
+
+    def test_redact_unknown_envelope_returns_404(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.post(f"/v1/envelopes/{uuid4()}/redact", headers=auth_h)
+        assert_problem(r, code="envelope.not_found", status=404)
+
+    def test_redact_requires_auth(self, client: TestClient):
+        r = client.post(f"/v1/envelopes/{uuid4()}/redact")
+        assert r.status_code == 401
 
 
 # ---- Balance --------------------------------------------------------

--- a/packages/tulip-api/tests/test_sinking_funds_endpoints.py
+++ b/packages/tulip-api/tests/test_sinking_funds_endpoints.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from fastapi.testclient import TestClient
@@ -174,8 +174,67 @@ class TestDeactivateSinkingFund:
             },
         ).json()
         r = client.delete(f"/v1/sinking-funds/{created['id']}", headers=auth_h)
-        assert r.status_code == 204
+        assert r.status_code == 200
+        # Honest body: DELETE deactivates, it doesn't erase (#236).
+        assert r.json() == {"action": "deactivated", "data_retained": ["name"]}
         assert client.get("/v1/sinking-funds", headers=auth_h).json() == []
+
+    def test_redact_sinking_fund_renames_pool(
+        self, client: TestClient, auth_h: dict[str, str], session_maker
+    ):
+        """#236: redact replaces a deactivated sinking fund's pool name with a placeholder."""
+        from sqlalchemy import select
+
+        from tulip_storage.models import AllocationPool
+
+        created = client.post(
+            "/v1/sinking-funds",
+            headers=auth_h,
+            json={
+                "name": "Sensitive Fund",
+                "currency": "USD",
+                "target_amount": "3000",
+                "target_date": _future_date(),
+                "contribution_strategy": "manual",
+            },
+        ).json()
+        client.delete(f"/v1/sinking-funds/{created['id']}", headers=auth_h).raise_for_status()
+        r = client.post(f"/v1/sinking-funds/{created['id']}/redact", headers=auth_h)
+        assert r.status_code == 200, r.text
+        assert r.json() == {"action": "redacted", "fields_redacted": ["name"]}
+        with session_maker() as s:
+            pool = s.execute(
+                select(AllocationPool).where(AllocationPool.id == UUID(created["id"]))
+            ).scalar_one()
+        assert pool.name != "Sensitive Fund"
+        assert pool.name.startswith("redacted-sinking-fund-")
+
+    def test_redact_active_sinking_fund_returns_409(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        created = client.post(
+            "/v1/sinking-funds",
+            headers=auth_h,
+            json={
+                "name": "Still Active",
+                "currency": "USD",
+                "target_amount": "3000",
+                "target_date": _future_date(),
+                "contribution_strategy": "manual",
+            },
+        ).json()
+        r = client.post(f"/v1/sinking-funds/{created['id']}/redact", headers=auth_h)
+        assert_problem(r, code="sinking_fund.not_redactable", status=409)
+
+    def test_redact_unknown_sinking_fund_returns_404(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        r = client.post(f"/v1/sinking-funds/{uuid4()}/redact", headers=auth_h)
+        assert_problem(r, code="sinking_fund.not_found", status=404)
+
+    def test_redact_requires_auth(self, client: TestClient):
+        r = client.post(f"/v1/sinking-funds/{uuid4()}/redact")
+        assert r.status_code == 401
 
 
 class TestSinkingFundBalance:

--- a/packages/tulip-storage/src/tulip_storage/repositories/account.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/account.py
@@ -92,3 +92,22 @@ class AccountRepository:
         a.is_active = False
         self._session.flush()
         return a
+
+    def redact(self, account_id: UUID, *, name: str) -> Account:
+        """Null an account's PII columns; replace ``name`` with a placeholder.
+
+        Erases ``name`` (to the caller-supplied non-PII placeholder),
+        ``external_account_number_encrypted`` and ``notes_encrypted``.
+        Postings keep their FK and amounts — ledger history is preserved.
+        The caller (the API redact endpoint) enforces the precondition
+        that the account is already deactivated. Raises ``LookupError``
+        if the account is missing.
+        """
+        a = self.get(account_id)
+        if a is None:
+            raise LookupError(f"account {account_id} not found in household {self._household_id}")
+        a.name = name
+        a.external_account_number_encrypted = None
+        a.notes_encrypted = None
+        self._session.flush()
+        return a

--- a/packages/tulip-storage/src/tulip_storage/repositories/allocation_pool.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/allocation_pool.py
@@ -122,6 +122,21 @@ class AllocationPoolRepository:
         self._session.flush()
         return p
 
+    def redact(self, pool_id: UUID, *, name: str) -> AllocationPool:
+        """Replace a pool's ``name`` with a placeholder — its only PII column.
+
+        Pools (envelopes / sinking funds) carry no encrypted fields; the
+        user-supplied ``name`` is the lone PII column. The caller (the API
+        redact endpoint) enforces that the pool is already deactivated.
+        Raises ``LookupError`` if the pool is missing.
+        """
+        p = self.get(pool_id)
+        if p is None:
+            raise LookupError(f"pool {pool_id} not found in household {self._household_id}")
+        p.name = name
+        self._session.flush()
+        return p
+
     def get_system_pool(self, *, pool_type: PoolType, currency: str) -> AllocationPool | None:
         """Return the system pool for ``(household, pool_type, currency)``, or None."""
         if pool_type not in _SYSTEM_POOL_TYPES:


### PR DESCRIPTION
## Summary

Closes #236 (deep privacy audit H-4). `DELETE` on accounts / envelopes / sinking-funds is a soft-delete (`is_active=False`) — the row, `name`, and the encrypted PII columns all survive — but the `204 No Content` response implied erasure. The deactivation itself is *correct* for ledger integrity (posting FKs are `ON DELETE RESTRICT`); the fix is to make the contract honest and add a separate explicit erasure path.

- **DELETE now returns `200` + `DeactivationResponse`** — `{"action": "deactivated", "data_retained": [...]}`. The body names the field types that survive, so the caller knows a follow-up redact is needed. (A `204` can't carry a body — hence the status change.)
- **New admin-only `POST /v1/<resource>/{id}/redact`** — nulls the encrypted PII columns and replaces the user-supplied `name` with a non-PII placeholder (`redacted-<resource>-<hash>`). Ledger postings keep their FK and amounts — history is preserved. The row must already be deactivated (`409 <resource>.not_redactable` otherwise).
- **Re-activation rejection** — there is no API path to flip `is_active` back to `True` (no `PATCH` exposes it), so a redacted row's erasure is final by construction. Documented in the route docstrings.
- `AccountRepository.redact()` + `AllocationPoolRepository.redact()`; a shared `schemas/lifecycle.py`; three no-arg `*NotRedactableError` classes.
- Redaction is audited (`action=redact`, before/after state — deliberately **no PII** in the snapshot).

Pools have no standalone DELETE endpoint; envelopes and sinking funds are the only non-system pools, so `redact` is mirrored on those two routes (each redacts the underlying pool's `name`).

## Test plan

- [x] 3 existing DELETE tests updated for the `200` + body contract
- [x] New per-resource redact tests: happy-path (PII nulled / pool renamed), `409` on active, `404` on unknown, `401` unauthenticated
- [x] `test_redact_account_nulls_pii_and_keeps_postings` posts a balanced transaction, redacts the account, and asserts the posting still links — the H-4 "ledger history preserved" guarantee
- [x] `uv run pytest packages/tulip-api/tests/` — 744 passed, 3 skipped
- [x] `uv run pytest packages/tulip-storage/tests/` — 205 passed
- [x] `ruff check` + `mypy --strict` clean; no new openapi-contract path collisions
- [ ] CI green on this PR