### PR TITLE
feat: ai_invocations retention + scrub on log_prompts consent withdrawal

### DIFF
--- a/docs/adrs/0005-ai-integration.md
+++ b/docs/adrs/0005-ai-integration.md
@@ -348,6 +348,13 @@ P6.1 is the high-risk slice — it lays down the redactor, the audit writer, the
 3. **`prompt_json` defaulting to NULL** means operators wanting full forensic logs have to opt in. The `prompt_hash` column gives "was the same prompt sent twice" answerable without prompt storage; the trade-off favours privacy by default.
 4. **API keys live in two tables (household + user).** The two-place storage is the smallest expression of "users can override household for their own actions"; a per-key precedence helper resolves at call time. Tests cover the precedence.
 
+### Retention of `ai_invocations` (added #243, deep privacy audit H-16)
+
+`ai_invocations` is append-only at the *writer* — but not unbounded. Two lifecycle controls were added post-audit:
+
+- **Consent-withdrawal scrub.** Flipping `households.ai_policy.log_prompts` from `true` to `false` via `PUT /v1/ai/config` runs a household-scoped `UPDATE` that nulls `prompt_json` + `response_text` on every row — atomically in the same commit as the policy change (GDPR Art. 17(1)(b)). The row, `prompt_hash`, and cost metadata survive for the audit chain; the scrub itself is recorded as an `audit_log` row (`action="ai.prompt_log_scrubbed"`).
+- **TTL garbage collection.** The `ai_retention` scheduled handler deletes non-proposal-linked `ai_invocations` older than `AI_INVOCATION_RETENTION_DAYS` (90). A row is preserved while any `pending_proposals` row references it via `pending_proposals.ai_invocation_id`; once the proposal is gone (e.g. rejected + deleted per #240) the invocation becomes collectable. This also bounds the accumulation of pseudonymous `prompt_hash` rows even for households that never enable `log_prompts`. The policy is surfaced read-only in `GET /v1/ai/config` (`invocation_retention_days`) and `tulip ai config show`.
+
 ## Alternatives considered
 
 ### Q1 — `tulip-ai` lives inside `tulip-api`

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -128,11 +128,21 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
             # ciphertext files get swept periodically. The runner reads
             # ``scheduled_jobs`` for the actual fire cadence; an installer
             # is expected to seed a daily rrule for ``attachment_gc``.
-            from tulip_storage.runner.handlers import make_attachment_gc_handler
+            from tulip_storage.runner.handlers import (
+                make_ai_retention_handler,
+                make_attachment_gc_handler,
+            )
 
             runner.register_handler(
                 "attachment_gc",
                 make_attachment_gc_handler(session_maker, settings.attachment_root),
+            )
+            # H-16 (#243): TTL garbage-collection of ai_invocations. Like
+            # attachment_gc, the runner reads ``scheduled_jobs`` for the
+            # fire cadence; an installer seeds a daily rrule.
+            runner.register_handler(
+                "ai_retention",
+                make_ai_retention_handler(session_maker),
             )
             app.state.runner = runner
             _register_ai_categorizer(session_maker)

--- a/packages/tulip-api/src/tulip_api/routers/ai.py
+++ b/packages/tulip-api/src/tulip_api/routers/ai.py
@@ -48,6 +48,8 @@ from tulip_core.money import Money
 from tulip_core.reconciliation.statement_line import StatementLine
 from tulip_storage.encryption import decrypt_field, encrypt_field
 from tulip_storage.models import Account, AccountType, Household
+from tulip_storage.repositories import AIInvocationRepository, AuditLogWriter
+from tulip_storage.runner.handlers import AI_INVOCATION_RETENTION_DAYS
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -409,6 +411,7 @@ def get_ai_config(
         fallback_provider=_get_str("fallback_provider"),
         fallback_model=_get_str("fallback_model"),
         log_prompts=bool(ai_policy.get("log_prompts", False)),
+        invocation_retention_days=AI_INVOCATION_RETENTION_DAYS,
         capabilities={
             cap: _cap_overrides(ai_policy, cap)
             for cap in ("categorize", "nl_query", "forecast", "agentic")
@@ -483,7 +486,23 @@ def put_ai_config(
     household = session.get(Household, claims.household_id)
     assert household is not None  # noqa: S101
     ai_policy: dict[str, object] = dict(household.ai_policy or {})
+    was_logging = bool(ai_policy.get("log_prompts", False))
     household.ai_policy = _apply_household_patch(ai_policy, body)
+    now_logging = bool(household.ai_policy.get("log_prompts", False))
+    if was_logging and not now_logging:
+        # GDPR Art. 17(1)(b): withdrawing log_prompts consent retroactively
+        # scrubs the prompt + response bodies logged while it was on. The
+        # scrub is atomic with the policy change — same commit (#243).
+        scrubbed = AIInvocationRepository(session, claims.household_id).scrub_prompt_logs()
+        AuditLogWriter(session, claims.household_id).write(
+            action="ai.prompt_log_scrubbed",
+            actor_kind="user",
+            actor_user_id=claims.user_id,
+            entity_type="household",
+            entity_id=claims.household_id,
+            before={"log_prompts": True},
+            after={"log_prompts": False, "rows_scrubbed": scrubbed},
+        )
     session.commit()
     log.info("ai.config_set", household_id=str(claims.household_id))
     return get_ai_config(claims=claims, session=session)

--- a/packages/tulip-api/src/tulip_api/schemas/ai.py
+++ b/packages/tulip-api/src/tulip_api/schemas/ai.py
@@ -122,6 +122,9 @@ class AIConfigRead(BaseModel):
     fallback_provider: str | None
     fallback_model: str | None
     log_prompts: bool
+    #: Read-only. Non-proposal-linked ai_invocations older than this are
+    #: GC'd by the ``ai_retention`` scheduled handler (#243).
+    invocation_retention_days: int
     capabilities: dict[str, AIConfigCapability]
 
 

--- a/packages/tulip-api/tests/test_ai_endpoints.py
+++ b/packages/tulip-api/tests/test_ai_endpoints.py
@@ -217,6 +217,97 @@ class TestConfigPut:
         body = client.get("/v1/ai/config", headers=auth_h).json()
         assert body["default_provider"] == "anthropic"
 
+    def test_config_exposes_invocation_retention_days(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """#243: the retention policy is surfaced read-only on the config."""
+        from tulip_storage.runner.handlers import AI_INVOCATION_RETENTION_DAYS
+
+        body = client.get("/v1/ai/config", headers=auth_h).json()
+        assert body["invocation_retention_days"] == AI_INVOCATION_RETENTION_DAYS
+
+    def test_withdrawing_log_prompts_scrubs_prompt_logs(
+        self, client: TestClient, auth_h: dict[str, str], session_maker
+    ) -> None:
+        """#243: flipping log_prompts true->false nulls prompt_json + response_text."""
+        from uuid import uuid4
+
+        from sqlalchemy import select
+
+        from tulip_storage.models import AIInvocation, AuditLog, Household
+
+        client.put("/v1/ai/config", headers=auth_h, json={"log_prompts": True}).raise_for_status()
+        with session_maker() as s:
+            household_id = s.execute(select(Household)).scalar_one().id
+            for _ in range(2):
+                s.add(
+                    AIInvocation(
+                        household_id=household_id,
+                        id=uuid4(),
+                        capability="nl_query",
+                        policy_resolved="permissive",
+                        profile="default",
+                        outcome="success",
+                        prompt_hash=b"\x00" * 32,
+                        prompt_json='{"q": "secret question"}',
+                        response_text="secret answer",
+                    )
+                )
+            s.commit()
+
+        r = client.put("/v1/ai/config", headers=auth_h, json={"log_prompts": False})
+        assert r.status_code == 200, r.text
+        assert r.json()["log_prompts"] is False
+
+        with session_maker() as s:
+            rows = list(s.execute(select(AIInvocation)).scalars().all())
+            audit = list(
+                s.execute(select(AuditLog).where(AuditLog.action == "ai.prompt_log_scrubbed"))
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 2
+        # Bodies erased; the row + prompt_hash survive for the audit chain.
+        assert all(row.prompt_json is None and row.response_text is None for row in rows)
+        assert all(row.prompt_hash == b"\x00" * 32 for row in rows)
+        assert len(audit) == 1
+        assert audit[0].after_snapshot["rows_scrubbed"] == 2
+
+    def test_no_scrub_when_log_prompts_not_a_true_to_false_transition(
+        self, client: TestClient, auth_h: dict[str, str], session_maker
+    ) -> None:
+        """The scrub only fires on the true->false edge — not on a false->false PUT."""
+        from uuid import uuid4
+
+        from sqlalchemy import select
+
+        from tulip_storage.models import AIInvocation, Household
+
+        with session_maker() as s:
+            household_id = s.execute(select(Household)).scalar_one().id
+            s.add(
+                AIInvocation(
+                    household_id=household_id,
+                    id=uuid4(),
+                    capability="nl_query",
+                    policy_resolved="permissive",
+                    profile="default",
+                    outcome="success",
+                    prompt_hash=b"\x00" * 32,
+                    prompt_json='{"q": "kept"}',
+                    response_text="kept",
+                )
+            )
+            s.commit()
+
+        # Default policy has no log_prompts → this PUT is a false->false no-op.
+        client.put("/v1/ai/config", headers=auth_h, json={"log_prompts": False}).raise_for_status()
+
+        with session_maker() as s:
+            row = s.execute(select(AIInvocation)).scalar_one()
+        assert row.prompt_json == '{"q": "kept"}'
+        assert row.response_text == "kept"
+
     def test_clears_with_sentinel(self, client: TestClient, auth_h: dict[str, str]) -> None:
         client.put("/v1/ai/config", headers=auth_h, json={"default_provider": "anthropic"})
         r = client.put("/v1/ai/config", headers=auth_h, json={"default_provider": "__CLEAR__"})

--- a/packages/tulip-cli/src/tulip_cli/commands/ai.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/ai.py
@@ -550,6 +550,13 @@ def config_show(ctx: typer.Context) -> None:
     for name in _HOUSEHOLD_KEYS:
         value = body.get(name)
         typer.echo(f"  {name:24s} = {value if value is not None else '(unset)'}")
+    retention = body.get("invocation_retention_days")
+    if retention is not None:
+        # Read-only — set by the server's ai_retention handler, not via `set`.
+        typer.echo(
+            f"  {'invocation_retention':24s} = {retention} days "
+            "(non-proposal ai_invocations; read-only)"
+        )
     typer.echo("Per-capability overrides:")
     for cap in _CAPABILITIES:
         cfg = (body.get("capabilities") or {}).get(cap) or {}

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -10,6 +10,7 @@ higher layers (the API) call it on every business mutation.
 """
 
 from tulip_storage.repositories.account import AccountRepository
+from tulip_storage.repositories.ai_invocation import AIInvocationRepository
 from tulip_storage.repositories.allocation_pool import AllocationPoolRepository
 from tulip_storage.repositories.attachment import AttachmentRepository
 from tulip_storage.repositories.attachment_link import AttachmentLinkRepository
@@ -35,6 +36,7 @@ from tulip_storage.repositories.transaction import (
 )
 
 __all__ = [
+    "AIInvocationRepository",
     "AccountRepository",
     "AllocationPoolRepository",
     "AttachmentLinkRepository",

--- a/packages/tulip-storage/src/tulip_storage/repositories/ai_invocation.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/ai_invocation.py
@@ -1,0 +1,48 @@
+"""AIInvocationRepository — household-scoped lifecycle ops on ai_invocations.
+
+Row *creation* is the sole responsibility of
+``tulip_ai.audit.AIInvocationWriter`` (ADR-0005 §Q6). This repository
+carries the privacy-lifecycle operations that mutate existing rows —
+currently the consent-withdrawal scrub (#243). The periodic TTL
+collection lives in the ``ai_retention`` runner handler.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+from uuid import UUID
+
+from sqlalchemy import update
+
+from tulip_storage.models import AIInvocation
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import CursorResult
+    from sqlalchemy.orm import Session
+
+
+class AIInvocationRepository:
+    """Household-scoped lifecycle operations over ai_invocations."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the repository to a session and tenant scope."""
+        self._session = session
+        self._household_id = household_id
+
+    def scrub_prompt_logs(self) -> int:
+        """Null ``prompt_json`` + ``response_text`` on every row in this household.
+
+        Used when a household withdraws ``log_prompts`` consent (#243) —
+        GDPR Art. 17(1)(b). The row, ``prompt_hash``, and the cost
+        metadata survive for the audit chain; only the opt-in prompt /
+        response bodies are erased. Returns the number of rows updated.
+        """
+        result = self._session.execute(
+            update(AIInvocation)
+            .where(AIInvocation.household_id == self._household_id)
+            .values(prompt_json=None, response_text=None)
+        )
+        self._session.flush()
+        # session.execute() on a bulk UPDATE returns a CursorResult at runtime;
+        # the Session.execute signature only narrows to Result.
+        return cast("CursorResult[Any]", result).rowcount or 0

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/__init__.py
@@ -11,6 +11,11 @@ fire. Future handlers (reconciliation reminders, AI cost reports) will
 register the same way.
 """
 
+from tulip_storage.runner.handlers.ai_retention import (
+    AI_INVOCATION_RETENTION_DAYS,
+    make_ai_retention_handler,
+    run_ai_retention,
+)
 from tulip_storage.runner.handlers.attachment_gc import (
     make_attachment_gc_handler,
     run_attachment_gc,
@@ -19,8 +24,11 @@ from tulip_storage.runner.handlers.daily_insights import make_daily_insights_han
 from tulip_storage.runner.handlers.envelope_refill import make_envelope_refill_handler
 
 __all__ = [
+    "AI_INVOCATION_RETENTION_DAYS",
+    "make_ai_retention_handler",
     "make_attachment_gc_handler",
     "make_daily_insights_handler",
     "make_envelope_refill_handler",
+    "run_ai_retention",
     "run_attachment_gc",
 ]

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/ai_retention.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/ai_retention.py
@@ -1,0 +1,91 @@
+"""``ai_retention`` runner handler — TTL garbage-collection of ai_invocations.
+
+``ai_invocations`` is append-only by design (ADR-0005 §Q6): every row
+carries ``prompt_hash``; ``prompt_json`` / ``response_text`` land only
+when the household has ``log_prompts=true``. Even hash-only rows
+accumulate forever otherwise — and ``prompt_hash`` is pseudonymous over
+a small per-household input space (#243 / audit M-5).
+
+This handler deletes non-proposal-linked ``ai_invocations`` rows older
+than ``AI_INVOCATION_RETENTION_DAYS``. A row is "proposal-linked" — and
+therefore preserved — while any ``pending_proposals`` row still
+references it via ``pending_proposals.ai_invocation_id``; once that
+proposal is gone (e.g. rejected + deleted per #240) the invocation
+becomes eligible for collection. See H-16 in #243.
+
+Mirrors the ``attachment_gc`` GC-handler shape: a pure ``run_*`` helper
+(testable with an explicit ``now``) plus a ``make_*_handler`` factory.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, cast
+
+from sqlalchemy import delete, select
+
+from tulip_storage.models import AIInvocation, PendingProposal
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import CursorResult
+    from sqlalchemy.orm import Session, sessionmaker
+
+    from tulip_storage.models import ScheduledJob
+    from tulip_storage.runner.clock import Clock
+    from tulip_storage.runner.runner import HandlerCallback
+
+log = logging.getLogger("tulip_storage.runner.ai_retention")
+
+#: Non-proposal-linked ai_invocations older than this are GC'd. Surfaced
+#: read-only in ``GET /v1/ai/config`` so operators can see the policy.
+AI_INVOCATION_RETENTION_DAYS: int = 90
+
+
+def run_ai_retention(
+    session_maker: sessionmaker[Session],
+    *,
+    now: datetime,
+    retention_days: int = AI_INVOCATION_RETENTION_DAYS,
+) -> int:
+    """Delete ai_invocations older than the TTL, excluding proposal-linked rows.
+
+    Pure-ish helper for tests: takes ``now`` explicitly so a test can
+    simulate "old" rows without waiting. Runs across all households (a
+    periodic system GC, like ``attachment_gc``). Returns the count of
+    rows deleted.
+    """
+    cutoff = now - timedelta(days=retention_days)
+    with session_maker() as session:
+        proposal_linked = select(PendingProposal.ai_invocation_id).where(
+            PendingProposal.ai_invocation_id.is_not(None)
+        )
+        result = session.execute(
+            delete(AIInvocation).where(
+                AIInvocation.created_at < cutoff,
+                AIInvocation.id.not_in(proposal_linked),
+            )
+        )
+        session.commit()
+        # session.execute() on a bulk DELETE returns a CursorResult at runtime;
+        # the Session.execute signature only narrows to Result.
+        deleted = cast("CursorResult[Any]", result).rowcount or 0
+    if deleted:
+        log.info("ai_retention.summary", extra={"deleted": deleted})
+    return deleted
+
+
+def make_ai_retention_handler(session_maker: sessionmaker[Session]) -> HandlerCallback:
+    """Build the ``ai_retention`` handler bound to a session factory.
+
+    Register at runner construction time alongside the other handlers::
+
+        runner.register_handler(
+            "ai_retention", make_ai_retention_handler(session_maker)
+        )
+    """
+
+    async def handle(job: ScheduledJob, clock: Clock) -> None:
+        run_ai_retention(session_maker, now=datetime.now(tz=UTC))
+
+    return handle

--- a/packages/tulip-storage/tests/test_ai_retention_handler.py
+++ b/packages/tulip-storage/tests/test_ai_retention_handler.py
@@ -1,0 +1,88 @@
+"""Tests for the ``ai_retention`` runner handler (#243)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+
+from tulip_storage.models import AIInvocation, Household, PendingProposal
+from tulip_storage.runner.handlers import AI_INVOCATION_RETENTION_DAYS, run_ai_retention
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+def _household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+def _invocation(session: Session, household_id: UUID, *, created_at: datetime) -> UUID:
+    inv = AIInvocation(
+        household_id=household_id,
+        id=uuid4(),
+        capability="nl_query",
+        policy_resolved="permissive",
+        profile="default",
+        outcome="success",
+        prompt_hash=b"\x00" * 32,
+        created_at=created_at,
+    )
+    session.add(inv)
+    session.commit()
+    return inv.id
+
+
+def test_retention_deletes_old_unlinked_keeps_recent_and_proposal_linked(
+    session_maker: sessionmaker[Session],
+) -> None:
+    """Old non-proposal rows are GC'd; recent rows and proposal-linked rows survive."""
+    now = datetime(2026, 6, 1, tzinfo=UTC)
+    old = now - timedelta(days=AI_INVOCATION_RETENTION_DAYS + 100)
+    recent = now - timedelta(days=10)
+
+    with session_maker() as s:
+        hh = _household(s)
+        old_unlinked = _invocation(s, hh.id, created_at=old)
+        recent_unlinked = _invocation(s, hh.id, created_at=recent)
+        old_linked = _invocation(s, hh.id, created_at=old)
+        # A pending proposal pins old_linked — it must survive the GC.
+        s.add(
+            PendingProposal(
+                household_id=hh.id,
+                id=uuid4(),
+                kind="envelope_budget_update",
+                title="keep me",
+                payload={},
+                status="pending",
+                created_by_kind="ai_agent",
+                ai_invocation_id=old_linked,
+            )
+        )
+        s.commit()
+
+    deleted = run_ai_retention(session_maker, now=now)
+
+    assert deleted == 1
+    with session_maker() as s:
+        surviving = {r.id for r in s.execute(select(AIInvocation)).scalars().all()}
+    assert old_unlinked not in surviving
+    assert recent_unlinked in surviving
+    assert old_linked in surviving
+
+
+def test_retention_is_a_noop_when_nothing_is_stale(
+    session_maker: sessionmaker[Session],
+) -> None:
+    """A run with only recent rows deletes nothing."""
+    now = datetime(2026, 6, 1, tzinfo=UTC)
+    with session_maker() as s:
+        hh = _household(s)
+        _invocation(s, hh.id, created_at=now - timedelta(days=1))
+
+    assert run_ai_retention(session_maker, now=now) == 0

--- a/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_scheduled_job_writes.py
@@ -45,6 +45,7 @@ _ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
         "tulip-storage/src/tulip_storage/runner/handlers/envelope_refill.py",
         "tulip-storage/src/tulip_storage/runner/handlers/daily_insights.py",
         "tulip-storage/src/tulip_storage/runner/handlers/attachment_gc.py",
+        "tulip-storage/src/tulip_storage/runner/handlers/ai_retention.py",
         # Read-only repository for the API to query schedules. Writes
         # still go through the Runner (the architecture test's actual
         # invariant). The class doesn't construct or mutate ScheduledJob


### PR DESCRIPTION
## Summary

Closes #243 (deep privacy audit H-16). `ai_invocations` is append-only at the writer (ADR-0005 §Q6) but had no lifecycle controls — toggling `log_prompts` off left historical prompt bodies in place, and even hash-only rows accumulated forever (`prompt_hash` is pseudonymous over a small per-household input space).

- **Scrub on consent withdrawal** — `PUT /v1/ai/config` flipping `log_prompts` `true → false` runs a household-scoped `UPDATE` nulling `prompt_json` + `response_text` on every row, **atomically in the same commit** as the policy change (GDPR Art. 17(1)(b)). The row, `prompt_hash`, and cost metadata survive for the audit chain. Recorded as an `audit_log` row (`action=ai.prompt_log_scrubbed`). New `AIInvocationRepository.scrub_prompt_logs()`.
- **TTL retention** — a new `ai_retention` scheduled handler deletes non-proposal-linked `ai_invocations` older than `AI_INVOCATION_RETENTION_DAYS` (90). A row is preserved while any `pending_proposals` row references it via `ai_invocation_id`; once the proposal is gone (e.g. rejected + deleted per #240) the invocation becomes collectable. Mirrors the `attachment_gc` handler shape (pure `run_*` helper + factory), registered in the app lifespan.
- The retention policy is surfaced read-only as `invocation_retention_days` on `GET /v1/ai/config` and in `tulip ai config show`; documented in ADR-0005.

No migration — both operations work on existing columns.

## Test plan

- [x] `test_ai_retention_handler.py` — old non-proposal rows GC'd; recent + proposal-linked rows survive; no-op when nothing stale
- [x] `test_ai_endpoints.py` — `log_prompts` true→false scrubs `prompt_json`/`response_text` + writes the audit row; false→false PUT does **not** scrub; config exposes `invocation_retention_days`
- [x] `test_architecture_no_direct_scheduled_job_writes.py` — `ai_retention.py` added to the handler allowlist
- [x] `uv run pytest packages/tulip-api/tests/` — 754 passed, 3 skipped; `packages/tulip-storage/tests/` — 206 passed
- [x] `ruff check` + `mypy --strict` clean
- [ ] CI green on this PR