### PR TITLE
feat: GDPR Art. 15 data-subject-access export endpoints

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/users.py
+++ b/packages/tulip-api/src/tulip_api/routers/users.py
@@ -15,20 +15,42 @@ Admin-only; refuses when the target is the last admin in the household.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy import func, or_, select, update
 
-from tulip_api.auth.deps import require_role
+from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.deps import get_session
 from tulip_api.errors import (
     LastAdminDeletionError,
     UserNotFoundError,
     problem_response,
 )
-from tulip_storage.models import AuditLog, User, UserRole
+from tulip_api.schemas.user import (
+    AIInvocationExport,
+    AttachmentMetadataExport,
+    AuditLogExport,
+    ProposalExport,
+    RecoveryCodesStatusExport,
+    SessionExport,
+    TransactionExport,
+    UserDataExport,
+    UserRecordExport,
+)
+from tulip_storage.models import (
+    AIInvocation,
+    Attachment,
+    AuditLog,
+    MfaRecoveryCode,
+    PendingProposal,
+    Transaction,
+    User,
+    UserRole,
+)
+from tulip_storage.models import Session as DbSession
 from tulip_storage.repositories import AuditLogWriter
 
 if TYPE_CHECKING:
@@ -108,6 +130,239 @@ def delete_user(
 
     session.delete(user)
     session.commit()
+
+
+def _build_user_export(session: Session, user: User) -> UserDataExport:
+    """Assemble the full data-subject-access envelope for ``user`` (#241).
+
+    All queries are scoped to the user's household; the per-table filters
+    select rows where this user is the actor / creator / uploader. The
+    user's ``id`` is the stable pseudonym those columns carry.
+    """
+    hh = user.household_id
+    uid = user.id
+
+    sessions = [
+        SessionExport(
+            id=r.id,
+            created_at=r.created_at,
+            expires_at=r.expires_at,
+            revoked_at=r.revoked_at,
+            ip_address=r.ip_address,
+            user_agent=r.user_agent,
+        )
+        for r in session.execute(
+            select(DbSession).where(DbSession.household_id == hh, DbSession.user_id == uid)
+        ).scalars()
+    ]
+    audit = [
+        AuditLogExport(
+            id=r.id,
+            occurred_at=r.occurred_at,
+            actor_kind=r.actor_kind,
+            action=r.action,
+            entity_type=r.entity_type,
+            entity_id=r.entity_id,
+            before_snapshot=r.before_snapshot,
+            after_snapshot=r.after_snapshot,
+            request_id=r.request_id,
+            ip_address=r.ip_address,
+            user_agent=r.user_agent,
+            metadata=r.metadata_,
+        )
+        for r in session.execute(
+            select(AuditLog).where(AuditLog.household_id == hh, AuditLog.actor_user_id == uid)
+        ).scalars()
+    ]
+    invocations = [
+        AIInvocationExport(
+            id=r.id,
+            created_at=r.created_at,
+            capability=r.capability,
+            provider=r.provider,
+            model=r.model,
+            tokens_in=r.tokens_in,
+            tokens_out=r.tokens_out,
+            cost_estimate_usd=r.cost_estimate_usd,
+            outcome=r.outcome,
+            prompt_json=r.prompt_json,
+            response_text=r.response_text,
+        )
+        for r in session.execute(
+            select(AIInvocation).where(
+                AIInvocation.household_id == hh, AIInvocation.actor_user_id == uid
+            )
+        ).scalars()
+    ]
+
+    def _proposal(r: PendingProposal) -> ProposalExport:
+        return ProposalExport(
+            id=r.id,
+            created_at=r.created_at,
+            kind=r.kind,
+            title=r.title,
+            status=r.status,
+            created_by_kind=r.created_by_kind,
+            decided_at=r.decided_at,
+            decision_note=r.decision_note,
+        )
+
+    proposals_created = [
+        _proposal(r)
+        for r in session.execute(
+            select(PendingProposal).where(
+                PendingProposal.household_id == hh,
+                PendingProposal.created_by_user_id == uid,
+            )
+        ).scalars()
+    ]
+    proposals_decided = [
+        _proposal(r)
+        for r in session.execute(
+            select(PendingProposal).where(
+                PendingProposal.household_id == hh,
+                PendingProposal.decided_by_user_id == uid,
+            )
+        ).scalars()
+    ]
+    attachments = [
+        AttachmentMetadataExport(
+            id=r.id,
+            filename=r.filename,
+            content_type=r.content_type,
+            size_bytes=r.size_bytes,
+            content_hash=r.content_hash,
+            uploaded_at=r.uploaded_at,
+        )
+        for r in session.execute(
+            select(Attachment).where(
+                Attachment.household_id == hh, Attachment.uploaded_by_user_id == uid
+            )
+        ).scalars()
+    ]
+    recovery_rows = list(
+        session.execute(
+            select(MfaRecoveryCode).where(
+                MfaRecoveryCode.household_id == hh, MfaRecoveryCode.user_id == uid
+            )
+        ).scalars()
+    )
+    recovery = RecoveryCodesStatusExport(
+        total=len(recovery_rows),
+        remaining=sum(1 for r in recovery_rows if r.used_at is None),
+        used_at=sorted(r.used_at for r in recovery_rows if r.used_at is not None),
+    )
+    transactions = [
+        TransactionExport(
+            id=r.id,
+            date=r.date,
+            description=r.description,
+            reference=r.reference,
+            status=r.status.value,
+            created_at=r.created_at,
+        )
+        for r in session.execute(
+            select(Transaction).where(
+                Transaction.household_id == hh, Transaction.created_by_user_id == uid
+            )
+        ).scalars()
+    ]
+
+    return UserDataExport(
+        generated_at=datetime.now(tz=UTC),
+        user=UserRecordExport(
+            id=user.id,
+            email=user.email,
+            password_hash="***",  # noqa: S106 — masked placeholder, never the real hash
+            display_name=user.display_name,
+            role=user.role.value,
+            totp_enrolled_at=user.totp_enrolled_at,
+            last_login_at=user.last_login_at,
+            created_at=user.created_at,
+            updated_at=user.updated_at,
+        ),
+        sessions=sessions,
+        audit_log_where_actor=audit,
+        ai_invocations=invocations,
+        proposals_created=proposals_created,
+        proposals_decided=proposals_decided,
+        attachments_uploaded=attachments,
+        recovery_codes=recovery,
+        transactions_created=transactions,
+    )
+
+
+@router.get(
+    "/me/export",
+    response_model=UserDataExport,
+    responses={401: problem_response("auth.unauthorized")},
+)
+def export_own_data(
+    request: Request,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> UserDataExport:
+    """Export everything held about the calling user (GDPR Art. 15 / CCPA §1798.110).
+
+    Any authenticated user may export their own data. The access itself
+    is recorded as an ``audit_log`` row.
+    """
+    user = session.get(User, (claims.household_id, claims.user_id))
+    if user is None:
+        raise UserNotFoundError()
+    export = _build_user_export(session, user)
+    AuditLogWriter(session, claims.household_id).write(
+        action="user.data_exported",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="user",
+        entity_id=claims.user_id,
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    return export
+
+
+@router.get(
+    "/{user_id}/export",
+    response_model=UserDataExport,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("user.not_found"),
+    },
+)
+def export_member_data(
+    user_id: UUID,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> UserDataExport:
+    """Admin: export everything held about a member of the caller's household.
+
+    Scoped to the admin's household — a ``user_id`` from another
+    household resolves to ``404``. The access is audited, attributing
+    both the acting admin and the subject.
+    """
+    user = session.get(User, (claims.household_id, user_id))
+    if user is None:
+        raise UserNotFoundError()
+    export = _build_user_export(session, user)
+    AuditLogWriter(session, claims.household_id).write(
+        action="user.data_exported",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="user",
+        entity_id=user_id,
+        metadata={"exported_by_admin": True},
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    return export
 
 
 def _request_uuid(request: Request) -> UUID | None:

--- a/packages/tulip-api/src/tulip_api/schemas/user.py
+++ b/packages/tulip-api/src/tulip_api/schemas/user.py
@@ -1,0 +1,134 @@
+"""Schemas for the GDPR Art. 15 / CCPA data-subject-access export (#241).
+
+``UserDataExport`` is the envelope returned by ``GET /v1/users/me/export``
+and ``GET /v1/users/{user_id}/export`` — it enumerates everything the
+system holds about one data subject. The nested models are deliberately
+shaped to the *subject's* data: rows where they are the actor / creator /
+uploader, plus their own user record (with ``password_hash`` masked).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class UserRecordExport(BaseModel):
+    """The ``users`` row itself. ``password_hash`` is always masked."""
+
+    id: UUID
+    email: str
+    password_hash: str
+    display_name: str
+    role: str
+    totp_enrolled_at: datetime | None
+    last_login_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class SessionExport(BaseModel):
+    """One refresh-token session. The token hash itself is not exported."""
+
+    id: UUID
+    created_at: datetime
+    expires_at: datetime
+    revoked_at: datetime | None
+    ip_address: str | None
+    user_agent: str | None
+
+
+class AuditLogExport(BaseModel):
+    """An ``audit_log`` row where the subject is the actor."""
+
+    id: UUID
+    occurred_at: datetime
+    actor_kind: str
+    action: str
+    entity_type: str
+    entity_id: UUID
+    before_snapshot: dict[str, Any] | None
+    after_snapshot: dict[str, Any] | None
+    request_id: UUID | None
+    ip_address: str | None
+    user_agent: str | None
+    metadata: dict[str, Any] | None
+
+
+class AIInvocationExport(BaseModel):
+    """An ``ai_invocations`` row attributed to the subject."""
+
+    id: UUID
+    created_at: datetime
+    capability: str
+    provider: str | None
+    model: str | None
+    tokens_in: int
+    tokens_out: int
+    # The model annotates this float; it's a per-call USD estimate for
+    # cost-cap accounting, not ledger money — no Money value object here.
+    cost_estimate_usd: float
+    outcome: str
+    prompt_json: str | None
+    response_text: str | None
+
+
+class ProposalExport(BaseModel):
+    """A ``pending_proposals`` row the subject created or decided."""
+
+    id: UUID
+    created_at: datetime
+    kind: str
+    title: str
+    status: str
+    created_by_kind: str
+    decided_at: datetime | None
+    decision_note: str | None
+
+
+class AttachmentMetadataExport(BaseModel):
+    """Metadata for an attachment the subject uploaded — never the bytes."""
+
+    id: UUID
+    filename: str
+    content_type: str
+    size_bytes: int
+    content_hash: str
+    uploaded_at: datetime
+
+
+class RecoveryCodesStatusExport(BaseModel):
+    """MFA recovery-code status — counts + use timestamps, never the hashes."""
+
+    total: int
+    remaining: int
+    used_at: list[datetime]
+
+
+class TransactionExport(BaseModel):
+    """A ``transactions`` row the subject created. ``notes_encrypted`` excluded."""
+
+    id: UUID
+    date: date
+    description: str
+    reference: str | None
+    status: str
+    created_at: datetime
+
+
+class UserDataExport(BaseModel):
+    """Everything held about one data subject (GDPR Art. 15 / CCPA §1798.110)."""
+
+    generated_at: datetime
+    user: UserRecordExport
+    sessions: list[SessionExport]
+    audit_log_where_actor: list[AuditLogExport]
+    ai_invocations: list[AIInvocationExport]
+    proposals_created: list[ProposalExport]
+    proposals_decided: list[ProposalExport]
+    attachments_uploaded: list[AttachmentMetadataExport]
+    recovery_codes: RecoveryCodesStatusExport
+    transactions_created: list[TransactionExport]

--- a/packages/tulip-api/tests/test_export_endpoints.py
+++ b/packages/tulip-api/tests/test_export_endpoints.py
@@ -1,0 +1,180 @@
+"""Tests for the GDPR Art. 15 data-subject-access export (#241).
+
+Covers ``GET /v1/users/me/export`` (self) and
+``GET /v1/users/{user_id}/export`` (admin-only, household-scoped).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from _problem_details import assert_problem
+from tulip_storage.models import AIInvocation, AuditLog, Household, MfaRecoveryCode, User, UserRole
+
+REG_PASSWORD = "correct horse battery staple"
+
+
+@pytest.fixture
+def registered(client: TestClient) -> dict[str, str]:
+    body = {
+        "email": "alice@example.com",
+        "password": REG_PASSWORD,
+        "display_name": "Alice",
+        "household_name": "Smith",
+    }
+    r = client.post("/v1/auth/register", json=body)
+    assert r.status_code == 201, r.text
+    return body
+
+
+def _access_token(client: TestClient, email: str) -> str:
+    r = client.post("/v1/auth/login", json={"email": email, "password": REG_PASSWORD})
+    assert r.status_code == 200, r.text
+    return str(r.json()["access_token"])
+
+
+def _seed_member(session_maker: sessionmaker[Session], household_id, *, email: str) -> User:
+    """Seed a non-admin member who can log in (hashed REG_PASSWORD)."""
+    from tulip_api.auth.passwords import hash_password
+
+    with session_maker() as s:
+        u = User(
+            household_id=household_id,
+            id=uuid4(),
+            email=email,
+            password_hash=hash_password(REG_PASSWORD),
+            display_name=email.split("@")[0].title(),
+            role=UserRole.MEMBER,
+        )
+        s.add(u)
+        s.commit()
+        return u
+
+
+class TestExportOwnData:
+    def test_envelope_shape_and_masked_password(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ) -> None:
+        with session_maker() as s:
+            user = s.execute(select(User)).scalar_one()
+            s.add(
+                AIInvocation(
+                    household_id=user.household_id,
+                    id=uuid4(),
+                    actor_user_id=user.id,
+                    capability="nl_query",
+                    policy_resolved="permissive",
+                    profile="default",
+                    outcome="success",
+                    prompt_hash=b"\x00" * 32,
+                )
+            )
+            s.add(
+                MfaRecoveryCode(
+                    id=uuid4(),
+                    household_id=user.household_id,
+                    user_id=user.id,
+                    code_hash="hashed-code",
+                )
+            )
+            s.commit()
+
+        access = _access_token(client, registered["email"])
+        r = client.get("/v1/users/me/export", headers={"Authorization": f"Bearer {access}"})
+        assert r.status_code == 200, r.text
+        body = r.json()
+
+        assert body["user"]["email"] == registered["email"]
+        assert body["user"]["password_hash"] == "***"
+        # The login that minted `access` created a session row.
+        assert len(body["sessions"]) >= 1
+        assert len(body["ai_invocations"]) == 1
+        assert body["recovery_codes"]["total"] == 1
+        assert body["recovery_codes"]["remaining"] == 1
+        # Every envelope key is present.
+        assert set(body) >= {
+            "generated_at",
+            "user",
+            "sessions",
+            "audit_log_where_actor",
+            "ai_invocations",
+            "proposals_created",
+            "proposals_decided",
+            "attachments_uploaded",
+            "recovery_codes",
+            "transactions_created",
+        }
+
+    def test_export_is_audited(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ) -> None:
+        access = _access_token(client, registered["email"])
+        client.get(
+            "/v1/users/me/export", headers={"Authorization": f"Bearer {access}"}
+        ).raise_for_status()
+        with session_maker() as s:
+            actions = [row.action for row in s.execute(select(AuditLog)).scalars()]
+        assert "user.data_exported" in actions
+
+    def test_requires_auth(self, client: TestClient) -> None:
+        r = client.get("/v1/users/me/export")
+        assert r.status_code == 401
+
+
+class TestExportMemberData:
+    def test_admin_can_export_a_member(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ) -> None:
+        with session_maker() as s:
+            household_id = s.execute(select(Household)).scalar_one().id
+        member = _seed_member(session_maker, household_id, email="bob@example.com")
+
+        access = _access_token(client, registered["email"])  # Alice is admin
+        r = client.get(
+            f"/v1/users/{member.id}/export",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["user"]["email"] == "bob@example.com"
+        assert body["user"]["password_hash"] == "***"
+
+    def test_member_cannot_export_another_user(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ) -> None:
+        with session_maker() as s:
+            admin_id = s.execute(select(User)).scalar_one().id
+            household_id = s.execute(select(Household)).scalar_one().id
+        _seed_member(session_maker, household_id, email="bob@example.com")
+
+        member_access = _access_token(client, "bob@example.com")
+        r = client.get(
+            f"/v1/users/{admin_id}/export",
+            headers={"Authorization": f"Bearer {member_access}"},
+        )
+        assert_problem(r, code="auth.forbidden", status=403)
+
+    def test_unknown_user_returns_404(self, client: TestClient, registered: dict[str, str]) -> None:
+        access = _access_token(client, registered["email"])
+        r = client.get(
+            f"/v1/users/{uuid4()}/export",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert_problem(r, code="user.not_found", status=404)

--- a/packages/tulip-cli/src/tulip_cli/commands/household.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/household.py
@@ -1,0 +1,49 @@
+"""``tulip household`` — household-admin commands: member data export (#241)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Annotated
+from uuid import UUID
+
+import typer
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+household_app = typer.Typer(
+    name="household",
+    help="Household-admin operations — member data exports.",
+    no_args_is_help=True,
+)
+
+
+@household_app.command("member-export")
+def member_export(
+    ctx: typer.Context,
+    user_id: Annotated[
+        UUID,
+        typer.Argument(
+            help="UUID of the household member to export.",
+            metavar="USER_ID",
+        ),
+    ],
+) -> None:
+    """Admin: export everything Tulip holds about a member of your household.
+
+    Fulfils a GDPR Art. 15 access request on a member's behalf. Prints
+    the full JSON envelope to stdout; the access is recorded in the
+    audit log, attributing both you and the subject.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with TulipClient(config, token_store=default_token_store(), as_json=as_json) as client:
+            response = client.get(f"/v1/users/{user_id}/export", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+    sys.stdout.write(json.dumps(response.json(), indent=2) + "\n")

--- a/packages/tulip-cli/src/tulip_cli/commands/user.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/user.py
@@ -1,0 +1,37 @@
+"""``tulip user`` — user-scoped commands: GDPR Art. 15 data export (#241)."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import typer
+
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+
+user_app = typer.Typer(
+    name="user",
+    help="User-scoped operations — currently your GDPR data export.",
+    no_args_is_help=True,
+)
+
+
+@user_app.command("export")
+def export(ctx: typer.Context) -> None:
+    """Export everything Tulip holds about you (GDPR Art. 15 / CCPA access right).
+
+    Prints the full JSON envelope to stdout — redirect it to a file to
+    keep a copy. The access is recorded in the audit log.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    try:
+        with TulipClient(config, token_store=default_token_store(), as_json=as_json) as client:
+            response = client.get("/v1/users/me/export", authenticated=True)
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+    sys.stdout.write(json.dumps(response.json(), indent=2) + "\n")

--- a/packages/tulip-cli/src/tulip_cli/main.py
+++ b/packages/tulip-cli/src/tulip_cli/main.py
@@ -25,6 +25,7 @@ from tulip_cli.commands.backup_restore import (
 from tulip_cli.commands.balance import balance as balance_command
 from tulip_cli.commands.doctor import doctor as doctor_command
 from tulip_cli.commands.envelopes import envelopes_app
+from tulip_cli.commands.household import household_app
 from tulip_cli.commands.imports import imports_app
 from tulip_cli.commands.journal import journal_app
 from tulip_cli.commands.notifications import notifications_app
@@ -45,6 +46,7 @@ from tulip_cli.commands.reports import reports_app
 from tulip_cli.commands.sinking_funds import sinking_funds_app
 from tulip_cli.commands.transactions import add as add_command
 from tulip_cli.commands.transactions import transactions_app
+from tulip_cli.commands.user import user_app
 from tulip_cli.config import Config, load_config
 from tulip_cli.errors import EXIT_OK, CliError
 from tulip_cli.http import TulipClient
@@ -134,6 +136,8 @@ app.add_typer(imports_app, name="import")
 app.add_typer(journal_app, name="journal")
 app.add_typer(reconcile_app, name="reconcile")
 app.add_typer(reports_app, name="reports")
+app.add_typer(user_app, name="user")
+app.add_typer(household_app, name="household")
 app.command("backup")(backup_command)
 app.command("restore")(restore_command)
 app.command("backup-inspect")(manifest_command)

--- a/packages/tulip-cli/tests/test_user_export.py
+++ b/packages/tulip-cli/tests/test_user_export.py
@@ -1,0 +1,102 @@
+"""E2E tests for ``tulip user export`` + ``tulip household member-export`` (#241).
+
+Run against the ``live_api`` fixture — register + login, then exercise
+the data-export CLI surface end to end.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from _cli_asserts import assert_cli_usage_error
+
+_PASSWORD = "long-enough-password"
+
+
+def _run_cli(*args: str, api_url: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tulip_cli", "--api-url", api_url, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
+@pytest.fixture
+def token_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "tokens.json"
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(path))
+    return path
+
+
+@pytest.fixture
+def authed(live_api: str, token_file: Path) -> str:
+    """Register + login an admin user; return the api_url."""
+    httpx.post(
+        f"{live_api}/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": _PASSWORD,
+            "display_name": "Admin",
+            "household_name": "Export House",
+        },
+        timeout=10,
+    ).raise_for_status()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tulip_cli",
+            "--api-url",
+            live_api,
+            "auth",
+            "login",
+            "--email",
+            "admin@example.com",
+            "--password-stdin",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        input=f"{_PASSWORD}\n",
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return live_api
+
+
+@pytest.mark.integration
+def test_user_export_emits_parseable_json(authed: str) -> None:
+    result = _run_cli("user", "export", api_url=authed)
+    assert result.returncode == 0, result.stderr
+    body = json.loads(result.stdout)
+    assert body["user"]["email"] == "admin@example.com"
+    assert body["user"]["password_hash"] == "***"
+    assert "sessions" in body
+    assert "transactions_created" in body
+
+
+@pytest.mark.integration
+def test_household_member_export_unknown_user_renders_404(authed: str) -> None:
+    result = _run_cli(
+        "household",
+        "member-export",
+        "00000000-0000-0000-0000-000000000000",
+        api_url=authed,
+    )
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "not found" in combined or "user.not_found" in combined
+
+
+@pytest.mark.integration
+def test_household_member_export_rejects_non_uuid_arg(authed: str) -> None:
+    result = _run_cli("household", "member-export", "not-a-uuid", api_url=authed)
+    assert_cli_usage_error(result)

--- a/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
@@ -84,6 +84,11 @@ _ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
         # before the cascade delete to know which blobs to unlink from
         # disk afterward. Same read-only justification.
         "tulip-api/src/tulip_api/routers/households.py",
+        # GDPR Art. 15 data-export endpoint (#241) reads Attachment
+        # metadata uploaded by the subject for the export envelope. The
+        # select is household-scoped; it never writes — same read-only
+        # justification as households.py.
+        "tulip-api/src/tulip_api/routers/users.py",
     }
 )
 


### PR DESCRIPTION
## Summary

Closes #241 (deep privacy audit H-13). Enumerating everything held about a data subject required raw SQLite queries — there was no application path for a GDPR Art. 15 / CCPA §1798.110 access request.

- **`GET /v1/users/me/export`** — any authenticated user exports their own data. **`GET /v1/users/{user_id}/export`** — admin-only, scoped to the admin's household (a foreign `user_id` resolves to `404`).
- The `UserDataExport` envelope gathers: the `users` row (`password_hash` masked to `***`), `sessions`, `audit_log` rows where the user is the actor, `ai_invocations`, `pending_proposals` created + decided, attachment metadata uploaded, MFA recovery-code status (counts + use dates — never the hashes), and transactions created.
- Each access writes a `user.data_exported` audit-log row, attributing the actor (and, for the admin path, the subject).
- **CLI:** `tulip user export` (self) and `tulip household member-export <user_id>` (admin) — both emit the pretty-printed JSON envelope to stdout.

**Deferred:** notifications are *not* in the envelope yet — they need `notifications.target_user_id`, which is H-8 (not shipped). Noted in the schema-design comment.

No migration — the export reads existing columns.

## Test plan

- [x] `test_export_endpoints.py` — envelope shape + masked password; sessions/ai_invocations/recovery-code-status populated; the export is audited; admin-can-export-member; **member cannot export another user (403)**; unknown user → 404; unauth → 401
- [x] `test_user_export.py` — `tulip user export` emits parseable JSON with the masked password; `household member-export` renders a 404 cleanly and rejects a non-UUID arg
- [x] `uv run pytest packages/tulip-api/tests/` — 755 passed, 3 skipped; `packages/tulip-cli/tests/` — 455 passed
- [x] `ruff check` + `mypy --strict` clean; no new openapi-contract path collisions
- [ ] CI green on this PR