### PR TITLE
feat: GDPR Art. 16 rectification — POSTED-tx description PATCH + profile PATCH + password change (closes #242)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-14 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landed, plus a CLI/importers usability bundle
+**Last updated:** 2026-05-14 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landing (#242 GDPR Art. 16 rectification merged), plus a CLI/importers usability bundle
 
 ---
 
@@ -609,7 +609,7 @@ Every Wave-1 security follow-up shipped, one PR per issue:
   **#229** role-visibility filter threaded through the reports + journal
   export.
 
-### Privacy Wave-1 — 🔄 Critical + first three High landed (#233–#235)
+### Privacy Wave-1 — 🔄 Critical + Highs landing (#233–#235, #242)
 
 - **#233 (C-1)** — `resolve_policy` no longer lets a `local_only` AI
   profile resolve to a cloud provider via `fallback_provider`; pinned to
@@ -622,10 +622,22 @@ Every Wave-1 security follow-up shipped, one PR per issue:
   redaction), two-step `DELETE /v1/households/me` (token-confirmed),
   `AttachmentRepository.delete()` with refcount, and an `attachment_gc`
   scheduler handler. New `pending_household_erasures` table.
+- **#242 (H-14)** — GDPR Art. 16 rectification:
+  `PATCH /v1/transactions/{id}/description` rewrites a POSTED /
+  RECONCILED transaction's `description` / `reference` / `notes` in
+  place, and rewrites the paired reversal sibling's
+  `f"Reversal of {old}: {reason}"` quote to `[redacted]` so the
+  pre-rectification PII doesn't survive at rest;
+  `PATCH /v1/users/me` mutates `display_name` (no re-auth) and `email`
+  (re-auth via `current_password` in body);
+  `POST /v1/auth/password/change` rotates the Argon2id hash and revokes
+  every outstanding refresh token. New audit actions:
+  `description_rectified` / `profile_updated` / `password_changed`.
 
-Remaining privacy Wave-1 (#236–#243: soft-delete-verb honesty,
-`import_batches.summary_json` PII, per-user AI policy, proposal-lifecycle
-audit, Art. 15 export, rectification, AI-invocation retention) is queued.
+Remaining privacy Wave-1: #237 (cross-user-within-household visibility
+filter, gated on multi-user invite) and #239 (per-user AI policy +
+per-user AI keys, finishing the half-wired `resolve_policy`). All other
+issues in the #236–#243 range have closed.
 
 ### Post-audit CLI + importers usability bundle — ✅
 

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -151,6 +151,28 @@ class ForbiddenError(TulipProblem):
         )
 
 
+class ReauthRequiredError(TulipProblem):
+    """A sensitive mutation requires re-submitting the caller's current password (#242).
+
+    Raised by ``PATCH /v1/users/me`` when the caller is trying to change
+    their email (the login identifier) without supplying ``current_password``
+    in the body. The bare access token isn't enough.
+    """
+
+    def __init__(self) -> None:
+        """Build the auth.reauth_required problem."""
+        super().__init__(
+            code="auth.reauth_required",
+            title="Re-authentication required",
+            status=401,
+            detail=(
+                "Changing your email requires submitting your current password "
+                "in the same request body. Include a 'current_password' field "
+                "and resubmit."
+            ),
+        )
+
+
 class InvalidCredentialsError(TulipProblem):
     """Login was attempted with an unknown email or wrong password."""
 
@@ -604,6 +626,29 @@ class TransactionNotEditableError(TulipProblem):
         )
 
 
+class TransactionNotRectifiableError(TulipProblem):
+    """PATCH /description was attempted on a PENDING (or otherwise unsupported) transaction (#242).
+
+    GDPR Art. 16 rectification applies to POSTED / RECONCILED transactions
+    whose description / reference / notes need correcting in place. PENDING
+    transactions still have the regular ``PATCH /v1/transactions/{id}`` open
+    to them.
+    """
+
+    def __init__(self) -> None:
+        """Build the transaction.not_rectifiable problem."""
+        super().__init__(
+            code="transaction.not_rectifiable",
+            title="Transaction is not rectifiable",
+            status=409,
+            detail=(
+                "Only POSTED or RECONCILED transactions can have their "
+                "description rectified. PENDING transactions should be "
+                "edited via PATCH /v1/transactions/{id} instead."
+            ),
+        )
+
+
 class TransactionNotDeletableError(TulipProblem):
     """DELETE was attempted on a non-PENDING transaction (P5.0)."""
 
@@ -1014,8 +1059,10 @@ def _sanitize_for_json(value: Any) -> Any:  # noqa: ANN401 — Pydantic errors a
     """Recursively coerce values to JSON-safe primitives.
 
     Pydantic's error contexts include ``Decimal`` values for numeric
-    constraints. Bytes occasionally show up in URL parsing errors. Coerce
-    both to strings so the validation 422 response can render.
+    constraints, ``bytes`` occasionally from URL parsing errors, and
+    ``Exception`` instances when a ``@model_validator(mode="after")``
+    raises ``ValueError`` (the exception object lands under ``ctx.error``).
+    Coerce all of them to strings so the validation 422 response can render.
     """
     from decimal import Decimal as _Dec  # local to avoid top-of-file import bloat
 
@@ -1027,6 +1074,8 @@ def _sanitize_for_json(value: Any) -> Any:  # noqa: ANN401 — Pydantic errors a
         return str(value)
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
+    if isinstance(value, BaseException):
+        return str(value)
     return value
 
 

--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -9,12 +9,12 @@ structlog instead.
 from __future__ import annotations
 
 from datetime import UTC, date, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 import structlog
 from fastapi import APIRouter, Depends, Request, status
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError
 
 from tulip_api.auth.deps import get_current_claims
@@ -77,6 +77,7 @@ from tulip_api.schemas.auth import (
     MfaRecoveryStatusResponse,
     MfaRegenerateRequest,
     MfaVerifyRequest,
+    PasswordChangeRequest,
     RefreshRequest,
     RegisterRequest,
     RegisterResponse,
@@ -102,6 +103,7 @@ from tulip_storage.repositories import (
 if TYPE_CHECKING:
     from uuid import UUID
 
+    from sqlalchemy.engine import CursorResult
     from sqlalchemy.orm import Session
 
 
@@ -465,6 +467,68 @@ def logout(
             user_agent=request.headers.get("user-agent"),
         )
         session.commit()
+
+
+@router.post(
+    "/password/change",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: problem_response("auth.unauthorized", "auth.invalid_credentials"),
+        400: problem_response("request.body_invalid"),
+        422: problem_response("validation.failed"),
+    },
+)
+def change_password(
+    body: PasswordChangeRequest,
+    request: Request,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> None:
+    """Rotate the caller's password and revoke their refresh tokens (#242).
+
+    Verifies ``current_password`` against the stored Argon2id hash, then
+    replaces the hash with a fresh one over ``new_password``. Every
+    outstanding (non-revoked) session for the user is revoked — a stale
+    refresh token shouldn't survive a credential rotation. The caller's
+    bare access token still works for its remaining TTL; their next
+    ``/v1/auth/refresh`` will need a fresh login.
+
+    The audit row carries no password material — only the count of
+    sessions revoked.
+    """
+    user = session.get(User, (claims.household_id, claims.user_id))
+    if user is None:
+        raise UnauthorizedError("Your account no longer exists.")
+    if not verify_password(body.current_password, user.password_hash):
+        raise InvalidCredentialsError()
+
+    user.password_hash = hash_password(body.new_password)
+
+    now = datetime.now(tz=UTC)
+    result = session.execute(
+        update(SessionRow)
+        .where(
+            SessionRow.household_id == user.household_id,
+            SessionRow.user_id == user.id,
+            SessionRow.revoked_at.is_(None),
+        )
+        .values(revoked_at=now)
+    )
+    sessions_revoked = int(cast("CursorResult[Any]", result).rowcount or 0)
+
+    AuditLogWriter(session, user.household_id).write(
+        action="password_changed",
+        actor_kind="user",
+        actor_user_id=user.id,
+        entity_type="user",
+        entity_id=user.id,
+        metadata={"sessions_revoked": sessions_revoked},
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    log.info("user.password_changed", user_id=str(user.id), sessions_revoked=sessions_revoked)
 
 
 @router.post(

--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -26,6 +26,7 @@ from tulip_api.errors import (
     TransactionNotDeletableError,
     TransactionNotEditableError,
     TransactionNotFoundError,
+    TransactionNotRectifiableError,
     TransactionNotVoidableError,
     TransactionUnbalancedError,
     problem_response,
@@ -34,6 +35,7 @@ from tulip_api.schemas.transaction import (
     PostingRead,
     TransactionCreate,
     TransactionRead,
+    TransactionRectifyRequest,
     TransactionUpdate,
     TransactionVoidRequest,
     TransactionVoidResponse,
@@ -81,6 +83,9 @@ from tulip_storage.repositories.transaction import (
 )
 from tulip_storage.repositories.transaction import (
     TransactionNotEditableError as RepoNotEditableError,
+)
+from tulip_storage.repositories.transaction import (
+    TransactionNotRectifiableError as RepoNotRectifiableError,
 )
 
 if TYPE_CHECKING:
@@ -537,6 +542,106 @@ def patch_transaction(
     )
     session.commit()
     log.info("transaction.updated", tx_id=str(tx_id))
+    return _read_response(tx_id, claims.household_id, session)
+
+
+@router.patch(
+    "/{tx_id}/description",
+    response_model=TransactionRead,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("transaction.not_found"),
+        409: problem_response("transaction.not_rectifiable"),
+        422: problem_response("validation.failed"),
+    },
+)
+def rectify_transaction_description(
+    tx_id: UUID,
+    body: TransactionRectifyRequest,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> TransactionRead:
+    """Rectify a POSTED / RECONCILED transaction's header fields (GDPR Art. 16, #242).
+
+    Mutates ``description`` / ``reference`` / ``notes_encrypted`` in place
+    on the original row; postings, status, and date are unchanged. When the
+    transaction has been voided, the reversal sibling's description (which
+    the void route built as ``f"Reversal of {old}: {reason}"``) is
+    rewritten in place so the source's pre-rectification description does
+    not survive at rest in the reversal row.
+
+    The OLD values are written verbatim into the audit row's
+    ``before_snapshot``. Per the Art. 17(3)(e) integrity carve-out, the
+    audit row preserves them until the user is later erased (at which
+    point :func:`tulip_api.routers.users.delete_user` nulls the
+    ``before_snapshot`` / ``after_snapshot`` blobs for rows referencing
+    that user).
+    """
+    settings = get_settings()
+    tx_repo = TransactionRepository(session, claims.household_id, master_key=settings.master_key)
+    existing = tx_repo.get(tx_id)
+    if existing is None:
+        raise TransactionNotFoundError()
+
+    fields_set = body.model_fields_set
+
+    before_snapshot: dict[str, object] = {}
+    if "description" in fields_set:
+        before_snapshot["description"] = existing.description
+    if "reference" in fields_set:
+        before_snapshot["reference"] = existing.reference
+    if "notes" in fields_set:
+        before_snapshot["notes_present"] = existing.notes_encrypted is not None
+
+    # The schema validator forbids body.description being None when the
+    # key is set; assert for type-narrowing.
+    description_arg: str | object
+    if "description" in fields_set:
+        assert body.description is not None  # noqa: S101 — guaranteed by schema validator
+        description_arg = body.description
+    else:
+        description_arg = UNSET
+    try:
+        _, reversal_id_rewritten = tx_repo.rectify_posted(
+            tx_id,
+            description=description_arg,
+            reference=body.reference if "reference" in fields_set else UNSET,
+            notes=body.notes if "notes" in fields_set else UNSET,
+        )
+    except RepoNotRectifiableError as exc:
+        raise TransactionNotRectifiableError() from exc
+
+    after_snapshot: dict[str, object] = {}
+    if "description" in fields_set:
+        after_snapshot["description"] = body.description
+    if "reference" in fields_set:
+        after_snapshot["reference"] = body.reference
+    if "notes" in fields_set:
+        after_snapshot["notes_present"] = body.notes is not None
+
+    metadata: dict[str, object] | None = None
+    if reversal_id_rewritten is not None:
+        metadata = {"reversal_id_rewritten": str(reversal_id_rewritten)}
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="description_rectified",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="transaction",
+        entity_id=tx_id,
+        before=before_snapshot,
+        after=after_snapshot,
+        metadata=metadata,
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "transaction.description_rectified",
+        tx_id=str(tx_id),
+        reversal_id_rewritten=str(reversal_id_rewritten) if reversal_id_rewritten else None,
+    )
     return _read_response(tx_id, claims.household_id, session)
 
 

--- a/packages/tulip-api/src/tulip_api/routers/users.py
+++ b/packages/tulip-api/src/tulip_api/routers/users.py
@@ -21,11 +21,16 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy import func, or_, select, update
+from sqlalchemy.exc import IntegrityError
 
 from tulip_api.auth.deps import get_current_claims, require_role
+from tulip_api.auth.passwords import verify_password
 from tulip_api.deps import get_session
 from tulip_api.errors import (
+    DuplicateEmailError,
+    InvalidCredentialsError,
     LastAdminDeletionError,
+    ReauthRequiredError,
     UserNotFoundError,
     problem_response,
 )
@@ -38,6 +43,8 @@ from tulip_api.schemas.user import (
     SessionExport,
     TransactionExport,
     UserDataExport,
+    UserMeRead,
+    UserProfilePatchRequest,
     UserRecordExport,
 )
 from tulip_storage.models import (
@@ -130,6 +137,82 @@ def delete_user(
 
     session.delete(user)
     session.commit()
+
+
+@router.patch(
+    "/me",
+    response_model=UserMeRead,
+    responses={
+        401: problem_response(
+            "auth.unauthorized", "auth.invalid_credentials", "auth.reauth_required"
+        ),
+        409: problem_response("auth.duplicate_email"),
+        422: problem_response("validation.failed"),
+    },
+)
+def patch_own_profile(
+    body: UserProfilePatchRequest,
+    request: Request,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> UserMeRead:
+    """Rectify the caller's own display name and/or email (GDPR Art. 16, #242).
+
+    Changing ``email`` is gated on re-auth: the caller must include
+    ``current_password`` in the same request body. ``display_name`` may
+    be updated without re-auth. The audit row records cleartext
+    before/after snapshots of the fields actually changed — these get
+    nulled when the user is later erased (right-to-erasure cascades to
+    audit-PII per :func:`delete_user`).
+    """
+    user = session.get(User, (claims.household_id, claims.user_id))
+    if user is None:
+        raise UserNotFoundError()
+
+    fields_set = body.model_fields_set
+
+    before_snapshot: dict[str, object] = {}
+    after_snapshot: dict[str, object] = {}
+
+    if "email" in fields_set:
+        if "current_password" not in fields_set or body.current_password is None:
+            raise ReauthRequiredError()
+        if not verify_password(body.current_password, user.password_hash):
+            raise InvalidCredentialsError()
+        before_snapshot["email"] = user.email
+        after_snapshot["email"] = body.email
+        user.email = body.email  # type: ignore[assignment]
+
+    if "display_name" in fields_set:
+        before_snapshot["display_name"] = user.display_name
+        after_snapshot["display_name"] = body.display_name
+        user.display_name = body.display_name  # type: ignore[assignment]
+
+    try:
+        session.flush()
+    except IntegrityError as exc:
+        session.rollback()
+        raise DuplicateEmailError() from exc
+
+    AuditLogWriter(session, claims.household_id).write(
+        action="profile_updated",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="user",
+        entity_id=user.id,
+        before=before_snapshot,
+        after=after_snapshot,
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    return UserMeRead(
+        id=user.id,
+        email=user.email,
+        display_name=user.display_name,
+        role=user.role.value,
+    )
 
 
 def _build_user_export(session: Session, user: User) -> UserDataExport:

--- a/packages/tulip-api/src/tulip_api/schemas/auth.py
+++ b/packages/tulip-api/src/tulip_api/schemas/auth.py
@@ -112,3 +112,16 @@ class MfaRecoveryStatusResponse(BaseModel):
 
     remaining: int
     total: int
+
+
+class PasswordChangeRequest(BaseModel):
+    """Body for POST /v1/auth/password/change (#242).
+
+    Requires the caller's current password as proof of possession and
+    a new password meeting the same length floor as register's password
+    field. All outstanding refresh tokens for the user are revoked when
+    the change succeeds.
+    """
+
+    current_password: str = Field(min_length=1)
+    new_password: str = Field(min_length=12, max_length=200)

--- a/packages/tulip-api/src/tulip_api/schemas/transaction.py
+++ b/packages/tulip-api/src/tulip_api/schemas/transaction.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from datetime import date as date_type
 from datetime import datetime
 from decimal import Decimal
+from typing import Self
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class PostingCreate(BaseModel):
@@ -96,6 +97,41 @@ class TransactionVoidResponse(BaseModel):
             "been auto-voided in the same atomic commit. Null otherwise."
         ),
     )
+
+
+class TransactionRectifyRequest(BaseModel):
+    """PATCH /v1/transactions/{id}/description body — GDPR Art. 16 rectification (#242).
+
+    Mutates ``description`` / ``reference`` / ``notes`` on a POSTED or
+    RECONCILED transaction in place. Postings, status, and date are out of
+    scope — those still require void-and-recreate. ``notes`` follows
+    PATCH semantics: omitting the key leaves the column unchanged; sending
+    ``null`` clears it. ``description`` is non-nullable on the underlying
+    row, so it cannot be set to ``null``. At least one of the three keys
+    must be present.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: str | None = Field(default=None, min_length=1, max_length=500)
+    reference: str | None = Field(default=None, max_length=200)
+    notes: str | None = Field(
+        default=None,
+        description=(
+            "Free-text transaction-level annotation. Omit to leave "
+            "unchanged; send ``null`` to clear."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate(self) -> Self:
+        if not (self.model_fields_set & {"description", "reference", "notes"}):
+            raise ValueError(
+                "At least one of 'description', 'reference', or 'notes' must be provided."
+            )
+        if "description" in self.model_fields_set and self.description is None:
+            raise ValueError("'description' cannot be null; omit the key to leave it unchanged.")
+        return self
 
 
 class TransactionUpdate(BaseModel):

--- a/packages/tulip-api/src/tulip_api/schemas/user.py
+++ b/packages/tulip-api/src/tulip_api/schemas/user.py
@@ -10,10 +10,10 @@ uploader, plus their own user record (with ``password_hash`` masked).
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Any
+from typing import Any, Self
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
 
 class UserRecordExport(BaseModel):
@@ -117,6 +117,42 @@ class TransactionExport(BaseModel):
     reference: str | None
     status: str
     created_at: datetime
+
+
+class UserProfilePatchRequest(BaseModel):
+    """PATCH /v1/users/me body — GDPR Art. 16 profile rectification (#242).
+
+    Updates ``display_name`` and/or ``email`` on the caller's own row.
+    Changing ``email`` is gated on re-auth: the caller must include
+    ``current_password`` in the same request body. ``current_password``
+    alone (with no email/display_name change) is ignored. At least one of
+    ``display_name`` / ``email`` must be present.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str | None = Field(default=None, min_length=1, max_length=200)
+    email: EmailStr | None = None
+    current_password: str | None = None
+
+    @model_validator(mode="after")
+    def _require_at_least_one_mutation(self) -> Self:
+        if not (self.model_fields_set & {"display_name", "email"}):
+            raise ValueError("At least one of 'display_name' or 'email' must be provided.")
+        return self
+
+
+class UserMeRead(BaseModel):
+    """Response shape for ``PATCH /v1/users/me`` (#242).
+
+    A trimmed user record — no password hash, no MFA enrollment timestamps.
+    Anything richer goes through ``GET /v1/users/me/export``.
+    """
+
+    id: UUID
+    email: str
+    display_name: str
+    role: str
 
 
 class UserDataExport(BaseModel):

--- a/packages/tulip-api/tests/test_auth_password_change.py
+++ b/packages/tulip-api/tests/test_auth_password_change.py
@@ -1,0 +1,218 @@
+"""Tests for POST /v1/auth/password/change (issue #242 part C).
+
+Verifies the caller's current password, updates the hash, and revokes all
+of the user's outstanding refresh tokens — a stolen access token + a
+forgotten refresh token shouldn't outlive the rotation. Audit row
+``password_changed`` records the revocation count; password material
+never enters the audit row.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def registered(client: TestClient) -> dict[str, str]:
+    body = {
+        "email": "alice@example.com",
+        "password": "correct horse battery staple",
+        "display_name": "Alice",
+        "household_name": "Smith Family",
+    }
+    r = client.post("/v1/auth/register", json=body)
+    assert r.status_code == 201, r.text
+    return body
+
+
+def _login(client: TestClient, body: dict[str, str]) -> dict:
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": body["email"], "password": body["password"]},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+@pytest.fixture
+def access(client: TestClient, registered: dict[str, str]) -> str:
+    return _login(client, registered)["access_token"]
+
+
+@pytest.fixture
+def auth_h(access: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {access}"}
+
+
+class TestPasswordChangeHappyPath:
+    def test_password_change_returns_204(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        registered: dict[str, str],
+    ) -> None:
+        r = client.post(
+            "/v1/auth/password/change",
+            headers=auth_h,
+            json={
+                "current_password": registered["password"],
+                "new_password": "another good password please",
+            },
+        )
+        assert r.status_code == 204, r.text
+        assert r.content == b""
+
+    def test_password_change_actually_rotates(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        registered: dict[str, str],
+    ) -> None:
+        client.post(
+            "/v1/auth/password/change",
+            headers=auth_h,
+            json={
+                "current_password": registered["password"],
+                "new_password": "another good password please",
+            },
+        )
+
+        # Login with the new password works.
+        ok = client.post(
+            "/v1/auth/login",
+            json={"email": registered["email"], "password": "another good password please"},
+        )
+        assert ok.status_code == 200
+
+        # Login with the old password fails.
+        bad = client.post(
+            "/v1/auth/login",
+            json={"email": registered["email"], "password": registered["password"]},
+        )
+        assert_problem(bad, code="auth.invalid_credentials", status=401)
+
+
+class TestPasswordChangeRevokesSessions:
+    def test_password_change_revokes_existing_refresh_tokens(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+    ) -> None:
+        """Two prior login refresh tokens should both fail to refresh after a
+        password change executed from a third login.
+        """
+        # Three logins ⇒ three refresh tokens.
+        a = _login(client, registered)
+        b = _login(client, registered)
+        c = _login(client, registered)
+
+        # Change password from session c.
+        client.post(
+            "/v1/auth/password/change",
+            headers={"Authorization": f"Bearer {c['access_token']}"},
+            json={
+                "current_password": registered["password"],
+                "new_password": "another good password please",
+            },
+        )
+
+        # All three pre-change refresh tokens should be revoked.
+        for tokens in (a, b, c):
+            r = client.post(
+                "/v1/auth/refresh",
+                json={"refresh_token": tokens["refresh_token"]},
+            )
+            assert_problem(r, code="auth.invalid_refresh_token", status=401)
+
+
+class TestPasswordChangeAudit:
+    def test_password_change_writes_audit_row_with_no_password_material(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        registered: dict[str, str],
+        session_maker,
+    ) -> None:
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        # Add another active session so sessions_revoked > 1.
+        _login(client, registered)
+
+        client.post(
+            "/v1/auth/password/change",
+            headers=auth_h,
+            json={
+                "current_password": registered["password"],
+                "new_password": "another good password please",
+            },
+        )
+
+        with session_maker() as s:
+            rows = list(
+                s.execute(select(AuditLog).where(AuditLog.action == "password_changed"))
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.entity_type == "user"
+        # Password material never enters the audit row.
+        for blob in (row.before_snapshot, row.after_snapshot, row.metadata_):
+            blob_str = str(blob) if blob is not None else ""
+            assert registered["password"] not in blob_str
+            assert "another good password please" not in blob_str
+        # metadata records the revoke count.
+        assert row.metadata_ is not None
+        assert int(row.metadata_["sessions_revoked"]) >= 2
+
+
+class TestPasswordChangeErrorPaths:
+    def test_password_change_wrong_current_password_returns_401(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ) -> None:
+        r = client.post(
+            "/v1/auth/password/change",
+            headers=auth_h,
+            json={
+                "current_password": "wrong",
+                "new_password": "another good password please",
+            },
+        )
+        assert_problem(r, code="auth.invalid_credentials", status=401)
+
+    def test_password_change_new_too_short_returns_422(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        registered: dict[str, str],
+    ) -> None:
+        r = client.post(
+            "/v1/auth/password/change",
+            headers=auth_h,
+            json={
+                "current_password": registered["password"],
+                "new_password": "short",
+            },
+        )
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_password_change_unauthenticated_returns_401(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+    ) -> None:
+        r = client.post(
+            "/v1/auth/password/change",
+            json={
+                "current_password": registered["password"],
+                "new_password": "another good password please",
+            },
+        )
+        assert_problem(r, code="auth.unauthorized", status=401)

--- a/packages/tulip-api/tests/test_openapi_contract.py
+++ b/packages/tulip-api/tests/test_openapi_contract.py
@@ -169,12 +169,18 @@ def test_api_conforms_to_schema(case: schemathesis.Case) -> None:
     #     (`multi-account` is a valid {batch_id}) → 401 on auth, not 405.
     #   - DELETE /v1/ai/proposals/kinds → routes to DELETE
     #     /v1/ai/proposals/{proposal_id} (#240) → 422 (bad UUID), not 405.
+    #   - DELETE /v1/users/me → routes to DELETE /v1/users/{user_id} (#242)
+    #     → 401, not 405.
     # Each collision is harmless. Map every shadowed static path to the one
-    # method it actually documents; skip schemathesis probes of the rest.
+    # method it actually documents; skip schemathesis cases targeting the
+    # other methods, and (for the documented method's own case) exclude
+    # the unsupported-method check so the probe-driven 405 expectation
+    # doesn't false-positive on the parametric sibling's response.
     _SHADOWED_STATIC_PATHS = {
         "/v1/imports/profiles/import": "POST",
         "/v1/imports/multi-account": "POST",
         "/v1/ai/proposals/kinds": "GET",
+        "/v1/users/me": "PATCH",
     }
     documented_method = _SHADOWED_STATIC_PATHS.get(str(case.path))
     if documented_method is not None and case.method.upper() != documented_method:
@@ -182,4 +188,8 @@ def test_api_conforms_to_schema(case: schemathesis.Case) -> None:
             "path-collision: an undocumented method on a static path routes to "
             "a parameterised sibling; harmless — see comment."
         )
-    case.call_and_validate()
+
+    from schemathesis.specs.openapi.checks import unsupported_method
+
+    excluded = [unsupported_method] if documented_method is not None else None
+    case.call_and_validate(excluded_checks=excluded)

--- a/packages/tulip-api/tests/test_transactions_rectify_endpoint.py
+++ b/packages/tulip-api/tests/test_transactions_rectify_endpoint.py
@@ -1,0 +1,549 @@
+"""Tests for PATCH /v1/transactions/{id}/description — GDPR Art. 16 (issue #242).
+
+Rectification mutates a POSTED / RECONCILED transaction's description /
+reference / notes in place. Postings are untouched. The audit row captures
+the old values verbatim under the Art. 17(3)(e) integrity carve-out (the
+user-erasure path then nulls them when the user is deleted, per #235).
+
+When the source has been voided, the reversal sibling's description was
+constructed as ``f"Reversal of {old}: {reason}"`` — quoting the very PII
+the user is now rectifying. The handler rewrites the reversal's
+description in place, substituting ``[redacted]`` for the original quote
+when the canonical prefix matches.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r.json()["access_token"]
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+@pytest.fixture
+def cash_and_food(client: TestClient, auth_h: dict[str, str]) -> tuple[str, str]:
+    cash = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Cash", "type": "asset", "currency": "USD", "code": "1110"},
+    ).json()
+    food = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Food", "type": "expense", "currency": "USD", "code": "5100"},
+    ).json()
+    return cash["id"], food["id"]
+
+
+def _post_lunch(
+    client: TestClient,
+    auth_h: dict[str, str],
+    cash: str,
+    food: str,
+    *,
+    description: str = "Lunch with John Doe",
+    reference: str | None = "INV-001",
+    notes: str | None = "private note",
+) -> dict:
+    body: dict[str, object] = {
+        "date": date.today().isoformat(),
+        "description": description,
+        "postings": [
+            {"account_id": food, "amount": "12.50", "currency": "USD"},
+            {"account_id": cash, "amount": "-12.50", "currency": "USD"},
+        ],
+    }
+    if reference is not None:
+        body["reference"] = reference
+    if notes is not None:
+        body["notes"] = notes
+    r = client.post("/v1/transactions", headers=auth_h, json=body)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestRectifyHappyPath:
+    def test_rectify_posted_updates_description(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ) -> None:
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"description": "Lunch with [redacted]"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["description"] == "Lunch with [redacted]"
+        # Postings, status, reference, notes untouched.
+        assert body["status"] == "posted"
+        assert body["reference"] == "INV-001"
+        assert body["notes"] == "private note"
+        amounts = sorted(float(p["amount"]) for p in body["postings"])
+        assert amounts == [-12.5, 12.5]
+
+    def test_rectify_updates_reference_and_notes(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ) -> None:
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"reference": "INV-CORRECTED", "notes": "updated note"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        # Description untouched (omitted from body).
+        assert body["description"] == "Lunch with John Doe"
+        assert body["reference"] == "INV-CORRECTED"
+        assert body["notes"] == "updated note"
+
+    def test_rectify_clears_notes_with_null(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ) -> None:
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"notes": None},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["notes"] is None
+
+    def test_rectify_reconciled_transaction_succeeds(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        session_maker,
+    ) -> None:
+        """Rectification is allowed on RECONCILED transactions too.
+
+        The status check accepts POSTED + RECONCILED; only PENDING is
+        rejected (which has its own PATCH).
+        """
+        from sqlalchemy import update
+
+        from tulip_storage.models import Transaction, TransactionStatus
+
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        # Force-flip the row to RECONCILED so the handler can be exercised
+        # without dragging in a full reconciliation flow.
+        with session_maker() as s:
+            s.execute(
+                update(Transaction)
+                .where(Transaction.id == UUID(tx["id"]))
+                .values(status=TransactionStatus.RECONCILED)
+            )
+            s.commit()
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"description": "Corrected"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "reconciled"
+
+
+class TestRectifyAudit:
+    def test_rectify_writes_description_rectified_audit_row(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        session_maker,
+    ) -> None:
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"description": "Corrected description"},
+        )
+        assert r.status_code == 200, r.text
+
+        with session_maker() as s:
+            rows = list(
+                s.execute(select(AuditLog).where(AuditLog.action == "description_rectified"))
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.entity_type == "transaction"
+        assert str(row.entity_id) == tx["id"]
+        assert row.before_snapshot is not None
+        assert row.before_snapshot["description"] == "Lunch with John Doe"
+        assert row.after_snapshot is not None
+        assert row.after_snapshot["description"] == "Corrected description"
+
+    def test_rectify_notes_audit_uses_presence_only(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        session_maker,
+    ) -> None:
+        """Notes plaintext must not appear in audit snapshots."""
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food, notes="SSN: 123-45-6789")
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"notes": "SSN: REDACTED"},
+        )
+        assert r.status_code == 200, r.text
+
+        with session_maker() as s:
+            row = s.execute(
+                select(AuditLog).where(AuditLog.action == "description_rectified")
+            ).scalar_one()
+        assert row.before_snapshot["notes_present"] is True
+        assert row.after_snapshot["notes_present"] is True
+        # Neither plaintext appears anywhere in the snapshots.
+        before_str = str(row.before_snapshot)
+        after_str = str(row.after_snapshot)
+        assert "123-45-6789" not in before_str
+        assert "REDACTED" not in after_str
+
+    def test_rectify_audit_omits_keys_not_in_body(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        session_maker,
+    ) -> None:
+        """If the body only changes ``description``, the audit row should
+        not record reference / notes in its snapshots.
+        """
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"description": "Only this changes"},
+        )
+
+        with session_maker() as s:
+            row = s.execute(
+                select(AuditLog).where(AuditLog.action == "description_rectified")
+            ).scalar_one()
+        assert "description" in row.before_snapshot
+        assert "reference" not in row.before_snapshot
+        assert "notes_present" not in row.before_snapshot
+        assert "description" in row.after_snapshot
+        assert "reference" not in row.after_snapshot
+
+
+class TestRectifyReversalRewrite:
+    def test_rectify_rewrites_reversal_description_in_place(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ) -> None:
+        """When the source has been voided, the reversal's description quotes
+        the source's old description. Rectification rewrites it in place so
+        the PII actually leaves the row at rest.
+        """
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food, description="Pay John Doe")
+
+        # Void → reversal's description is "Reversal of Pay John Doe: typo"
+        void_r = client.post(
+            f"/v1/transactions/{tx['id']}/void",
+            headers=auth_h,
+            json={"reason": "typo"},
+        )
+        assert void_r.status_code == 201
+        reversal_id = void_r.json()["reversal_id"]
+
+        rev_before = client.get(f"/v1/transactions/{reversal_id}", headers=auth_h).json()
+        assert "Pay John Doe" in rev_before["description"]
+
+        # Rectify the source — the reversal sibling should be rewritten too.
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"description": "Pay [redacted]"},
+        )
+        assert r.status_code == 200, r.text
+
+        rev_after = client.get(f"/v1/transactions/{reversal_id}", headers=auth_h).json()
+        assert "John Doe" not in rev_after["description"]
+        assert "[redacted]" in rev_after["description"]
+        # The reason ("typo") is preserved.
+        assert "typo" in rev_after["description"]
+
+    def test_rectify_audit_metadata_carries_reversal_id_when_rewritten(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        session_maker,
+    ) -> None:
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food, description="Pay John Doe")
+        void_r = client.post(
+            f"/v1/transactions/{tx['id']}/void",
+            headers=auth_h,
+            json={"reason": "typo"},
+        )
+        reversal_id = void_r.json()["reversal_id"]
+
+        client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"description": "Pay [redacted]"},
+        )
+
+        with session_maker() as s:
+            row = s.execute(
+                select(AuditLog).where(AuditLog.action == "description_rectified")
+            ).scalar_one()
+        assert row.metadata_ is not None
+        assert row.metadata_["reversal_id_rewritten"] == reversal_id
+
+    def test_rectify_leaves_reversal_alone_when_prefix_doesnt_match(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        session_maker,
+    ) -> None:
+        """If an operator has manually rewritten the reversal's description so
+        it no longer starts with the canonical ``Reversal of {old}: ``
+        prefix, rectifying the source must leave the reversal untouched.
+        """
+        from sqlalchemy import select, update
+
+        from tulip_storage.models import Transaction
+
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food, description="Pay John Doe")
+        void_r = client.post(
+            f"/v1/transactions/{tx['id']}/void",
+            headers=auth_h,
+            json={"reason": "typo"},
+        )
+        reversal_id = void_r.json()["reversal_id"]
+
+        # Hand-edit the reversal description out-of-band so the prefix no
+        # longer matches.
+        with session_maker() as s:
+            s.execute(
+                update(Transaction)
+                .where(Transaction.id == UUID(reversal_id))
+                .values(description="Unrelated note about the reversal")
+            )
+            s.commit()
+
+        client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"description": "Pay [redacted]"},
+        )
+
+        rev = client.get(f"/v1/transactions/{reversal_id}", headers=auth_h).json()
+        assert rev["description"] == "Unrelated note about the reversal"
+
+        # And the audit row's metadata reports no rewrite happened.
+        from tulip_storage.models import AuditLog
+
+        with session_maker() as s:
+            row = s.execute(
+                select(AuditLog).where(AuditLog.action == "description_rectified")
+            ).scalar_one()
+        if row.metadata_ is not None:
+            assert "reversal_id_rewritten" not in row.metadata_
+
+
+class TestRectifyErrorPaths:
+    def test_rectify_pending_returns_409(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        session_maker,
+    ) -> None:
+        """Rectification is for POSTED+ rows; PENDING uses the regular PATCH."""
+        from sqlalchemy import update
+
+        from tulip_storage.models import Transaction, TransactionStatus
+
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+        with session_maker() as s:
+            s.execute(
+                update(Transaction)
+                .where(Transaction.id == UUID(tx["id"]))
+                .values(status=TransactionStatus.PENDING)
+            )
+            s.commit()
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={"description": "x"},
+        )
+        assert_problem(r, code="transaction.not_rectifiable", status=409)
+
+    def test_rectify_unknown_id_returns_404(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ) -> None:
+        from uuid import uuid4
+
+        r = client.patch(
+            f"/v1/transactions/{uuid4()}/description",
+            headers=auth_h,
+            json={"description": "x"},
+        )
+        assert_problem(r, code="transaction.not_found", status=404)
+
+    def test_rectify_other_household_returns_404(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ) -> None:
+        """A second household's user cannot reach this household's tx."""
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        client.post(
+            "/v1/auth/register",
+            json={
+                "email": "other@example.com",
+                "password": "another good password please",
+                "display_name": "Other",
+                "household_name": "Other Family",
+            },
+        )
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": "other@example.com", "password": "another good password please"},
+        )
+        other_h = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=other_h,
+            json={"description": "x"},
+        )
+        assert_problem(r, code="transaction.not_found", status=404)
+
+    def test_rectify_empty_body_returns_422(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ) -> None:
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={},
+        )
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_rectify_extra_fields_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+    ) -> None:
+        """``postings`` / ``date`` in the body — out of scope for this endpoint."""
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            headers=auth_h,
+            json={
+                "description": "ok",
+                "postings": [{"account_id": food, "amount": "1.00", "currency": "USD"}],
+            },
+        )
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_rectify_unauthenticated_returns_401(
+        self,
+        client: TestClient,
+        cash_and_food: tuple[str, str],
+        auth_h: dict[str, str],
+    ) -> None:
+        cash, food = cash_and_food
+        tx = _post_lunch(client, auth_h, cash, food)
+
+        r = client.patch(
+            f"/v1/transactions/{tx['id']}/description",
+            json={"description": "x"},
+        )
+        assert_problem(r, code="auth.unauthorized", status=401)

--- a/packages/tulip-api/tests/test_users_me_patch.py
+++ b/packages/tulip-api/tests/test_users_me_patch.py
@@ -1,0 +1,263 @@
+"""Tests for PATCH /v1/users/me — GDPR Art. 16 profile rectification (issue #242).
+
+Mutations:
+* ``display_name`` may be updated without re-auth.
+* ``email`` is the login identifier, so changing it requires the caller
+  to re-submit their ``current_password`` in the body.
+
+Audit row: ``profile_updated`` with ``before_snapshot`` / ``after_snapshot``
+recording only the keys actually changed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def registered(client: TestClient) -> dict[str, str]:
+    body = {
+        "email": "alice@example.com",
+        "password": "correct horse battery staple",
+        "display_name": "Alice",
+        "household_name": "Smith Family",
+    }
+    r = client.post("/v1/auth/register", json=body)
+    assert r.status_code == 201, r.text
+    return body
+
+
+@pytest.fixture
+def auth_h(client: TestClient, registered: dict[str, str]) -> dict[str, str]:
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": registered["email"], "password": registered["password"]},
+    )
+    assert r.status_code == 200
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+class TestPatchProfileHappyPath:
+    def test_patch_display_name_without_reauth(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ) -> None:
+        r = client.patch(
+            "/v1/users/me",
+            headers=auth_h,
+            json={"display_name": "Alice Smith"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["display_name"] == "Alice Smith"
+        # Email round-trips unchanged.
+        assert body["email"] == "alice@example.com"
+
+    def test_patch_email_with_correct_password_updates(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        registered: dict[str, str],
+    ) -> None:
+        r = client.patch(
+            "/v1/users/me",
+            headers=auth_h,
+            json={
+                "email": "alice2@example.com",
+                "current_password": registered["password"],
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["email"] == "alice2@example.com"
+
+        # New email works for login.
+        ok = client.post(
+            "/v1/auth/login",
+            json={"email": "alice2@example.com", "password": registered["password"]},
+        )
+        assert ok.status_code == 200
+
+        # Old email fails.
+        bad = client.post(
+            "/v1/auth/login",
+            json={"email": "alice@example.com", "password": registered["password"]},
+        )
+        assert_problem(bad, code="auth.invalid_credentials", status=401)
+
+    def test_patch_email_and_display_name_in_one_request(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        registered: dict[str, str],
+    ) -> None:
+        r = client.patch(
+            "/v1/users/me",
+            headers=auth_h,
+            json={
+                "display_name": "Renamed",
+                "email": "renamed@example.com",
+                "current_password": registered["password"],
+            },
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["email"] == "renamed@example.com"
+        assert body["display_name"] == "Renamed"
+
+
+class TestPatchProfileAudit:
+    def test_patch_writes_profile_updated_audit_row(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        registered: dict[str, str],
+        session_maker,
+    ) -> None:
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        client.patch(
+            "/v1/users/me",
+            headers=auth_h,
+            json={
+                "display_name": "Renamed",
+                "email": "renamed@example.com",
+                "current_password": registered["password"],
+            },
+        )
+
+        with session_maker() as s:
+            rows = list(
+                s.execute(select(AuditLog).where(AuditLog.action == "profile_updated"))
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.entity_type == "user"
+        assert row.before_snapshot is not None
+        assert row.before_snapshot["display_name"] == "Alice"
+        assert row.before_snapshot["email"] == "alice@example.com"
+        assert row.after_snapshot is not None
+        assert row.after_snapshot["display_name"] == "Renamed"
+        assert row.after_snapshot["email"] == "renamed@example.com"
+
+    def test_patch_display_name_only_omits_email_from_snapshots(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        client.patch(
+            "/v1/users/me",
+            headers=auth_h,
+            json={"display_name": "Renamed"},
+        )
+
+        with session_maker() as s:
+            row = s.execute(
+                select(AuditLog).where(AuditLog.action == "profile_updated")
+            ).scalar_one()
+        assert "display_name" in row.before_snapshot
+        assert "email" not in row.before_snapshot
+        assert "display_name" in row.after_snapshot
+        assert "email" not in row.after_snapshot
+
+
+class TestPatchProfileErrorPaths:
+    def test_patch_email_without_current_password_returns_401(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ) -> None:
+        r = client.patch(
+            "/v1/users/me",
+            headers=auth_h,
+            json={"email": "alice2@example.com"},
+        )
+        assert_problem(r, code="auth.reauth_required", status=401)
+
+    def test_patch_email_with_wrong_password_returns_401(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ) -> None:
+        r = client.patch(
+            "/v1/users/me",
+            headers=auth_h,
+            json={"email": "alice2@example.com", "current_password": "wrong"},
+        )
+        assert_problem(r, code="auth.invalid_credentials", status=401)
+
+    def test_patch_email_duplicate_within_household_returns_409(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        registered: dict[str, str],
+        session_maker,
+    ) -> None:
+        """Two users in the same household with the same email is forbidden
+        by the (household_id, email) unique constraint."""
+        from uuid import uuid4
+
+        from tulip_api.auth.passwords import hash_password
+        from tulip_storage.models import User, UserRole
+
+        # Create a sibling user in the same household via the DB.
+        with session_maker() as s:
+            from sqlalchemy import select
+
+            existing = s.execute(select(User).where(User.email == registered["email"])).scalar_one()
+            sibling = User(
+                household_id=existing.household_id,
+                id=uuid4(),
+                email="sibling@example.com",
+                password_hash=hash_password("anyother goodpass"),
+                display_name="Sibling",
+                role=UserRole.MEMBER,
+            )
+            s.add(sibling)
+            s.commit()
+
+        r = client.patch(
+            "/v1/users/me",
+            headers=auth_h,
+            json={
+                "email": "sibling@example.com",
+                "current_password": registered["password"],
+            },
+        )
+        assert_problem(r, code="auth.duplicate_email", status=409)
+
+    def test_patch_empty_body_returns_422(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ) -> None:
+        r = client.patch("/v1/users/me", headers=auth_h, json={})
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_patch_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.patch("/v1/users/me", json={"display_name": "x"})
+        assert_problem(r, code="auth.unauthorized", status=401)
+
+    def test_patch_display_name_too_long_returns_422(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+    ) -> None:
+        r = client.patch(
+            "/v1/users/me",
+            headers=auth_h,
+            json={"display_name": "x" * 201},
+        )
+        assert_problem(r, code="validation.failed", status=422)

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
@@ -66,6 +66,10 @@ class TransactionNotEditableError(ValueError):
     """Raised when PATCH is attempted on a non-PENDING transaction."""
 
 
+class TransactionNotRectifiableError(ValueError):
+    """Raised when rectification is attempted on a non-ledger transaction (#242)."""
+
+
 class TransactionNotDeletableError(ValueError):
     """Raised when hard-delete is attempted on a non-PENDING transaction."""
 
@@ -587,6 +591,94 @@ class TransactionRepository:
         refreshed = self._session.get(Transaction, (self._household_id, tx_id))
         assert refreshed is not None  # noqa: S101 - existence verified above
         return refreshed
+
+    def rectify_posted(
+        self,
+        tx_id: UUID,
+        *,
+        description: str | _Unset = UNSET,
+        reference: str | None | _Unset = UNSET,
+        notes: str | None | _Unset = UNSET,
+    ) -> tuple[Transaction, UUID | None]:
+        """Rectify a POSTED / RECONCILED transaction's header fields (#242).
+
+        Mutates ``description`` / ``reference`` / ``notes_encrypted`` on the
+        row in place — postings, status, and date are untouched. Each field
+        follows PATCH semantics via the ``UNSET`` sentinel.
+
+        When the source has a paired reversal (``voided_by_transaction_id``)
+        and the reversal's description still matches the canonical
+        ``f"Reversal of {old_description}: "`` prefix the void route writes,
+        the reversal's description is rewritten in place so the old
+        description doesn't survive at rest in the reversal row. The
+        returned UUID is the reversal that was rewritten (or ``None`` when
+        no rewrite was applicable).
+
+        Raises:
+            LookupError: ``tx_id`` does not exist in this household.
+            TransactionNotRectifiableError: row is PENDING.
+            MasterKeyRequiredError: notes is a non-None string but no master_key.
+
+        """
+        existing = self.get(tx_id)
+        if existing is None:
+            raise LookupError(f"transaction {tx_id} not found in household {self._household_id}")
+        if existing.status not in _LEDGER_STATUSES:
+            raise TransactionNotRectifiableError(
+                f"transaction {tx_id} is {existing.status.value}; "
+                "only POSTED / RECONCILED transactions can be rectified"
+            )
+
+        old_description = existing.description
+        header_values: dict[str, object] = {}
+        if not isinstance(description, _Unset):
+            header_values["description"] = description
+        if not isinstance(reference, _Unset):
+            header_values["reference"] = reference
+        if not isinstance(notes, _Unset):
+            if notes is None:
+                header_values["notes_encrypted"] = None
+            else:
+                key = self._require_master_key()
+                header_values["notes_encrypted"] = encrypt_field(notes.encode("utf-8"), key)
+
+        if header_values:
+            self._session.execute(
+                update(Transaction)
+                .where(
+                    Transaction.household_id == self._household_id,
+                    Transaction.id == tx_id,
+                )
+                .values(**header_values)
+            )
+
+        reversal_id_rewritten: UUID | None = None
+        if not isinstance(description, _Unset) and existing.voided_by_transaction_id is not None:
+            # The void route at transactions.py:353 builds the reversal
+            # description as ``f"Reversal of {source.description}: {reason}"``.
+            # If that prefix still matches, rewrite it so the source's
+            # pre-rectification description doesn't survive at rest.
+            reversal_id = existing.voided_by_transaction_id
+            reversal = self._session.get(Transaction, (self._household_id, reversal_id))
+            if reversal is not None:
+                prefix = f"Reversal of {old_description}: "
+                if reversal.description.startswith(prefix):
+                    suffix = reversal.description[len(prefix) :]
+                    new_reversal_description = f"Reversal of [redacted]: {suffix}"
+                    self._session.execute(
+                        update(Transaction)
+                        .where(
+                            Transaction.household_id == self._household_id,
+                            Transaction.id == reversal_id,
+                        )
+                        .values(description=new_reversal_description)
+                    )
+                    reversal_id_rewritten = reversal_id
+
+        self._session.flush()
+        refreshed = self._session.get(Transaction, (self._household_id, tx_id))
+        assert refreshed is not None  # noqa: S101 - existence verified above
+        return refreshed, reversal_id_rewritten
 
     def _force_post_unbalanced_for_test(self, domain_tx: DomainTransaction) -> Transaction:
         """Force-post a (potentially unbalanced) Domain Transaction.


### PR DESCRIPTION
## Summary

Closes #242. Three new mutation endpoints close H-14 from the deep privacy audit:

- `PATCH /v1/transactions/{id}/description` rewrites `description` / `reference` / `notes` on a POSTED or RECONCILED transaction in place (postings, status, and date untouched). When the source has been voided, the reversal sibling's `f"Reversal of {old}: {reason}"` quote is rewritten to `f"Reversal of [redacted]: {reason}"` so the pre-rectification description doesn't survive at rest. New audit action `description_rectified` with before/after snapshots.
- `PATCH /v1/users/me` mutates `display_name` (no re-auth) and `email` (re-auth via `current_password` in body). New audit action `profile_updated`.
- `POST /v1/auth/password/change` rotates the Argon2id hash and revokes every outstanding (non-revoked) refresh token. New audit action `password_changed` (carries `sessions_revoked` count, no password material).

Audit retention: OLD descriptions / emails go into `audit_log.before_snapshot` verbatim under Art. 17(3)(e) integrity carve-out — they are scrubbed when the user is later erased via the existing #235 audit-PII redaction path.

Also extends the schemathesis `_SHADOWED_STATIC_PATHS` map with `/v1/users/me` and excludes the `unsupported_method` check for shadowed paths (`DELETE /v1/users/me` routes to the parametric `/v1/users/{user_id}` sibling rather than returning 405).

## Test plan
- [x] `just lint` — clean
- [x] `just typecheck` — clean
- [x] `just test` — 1912 passed, 4 expected skips (shadowed-path collisions)
- [x] `just coverage` — 89.95% (gate 85%)
- [x] Manual smoke test, three flows below
- [ ] CI green on this PR

### Manual smoke test

Bring up the API on the default port, then run the three flows below in one shell session.

\`\`\`bash
just dev &
DEV_PID=\$!
sleep 2
API=http://127.0.0.1:8000

curl -sS -X POST \$API/v1/auth/register \
  -H 'content-type: application/json' \
  -d '{\"email\":\"alice@example.com\",\"password\":\"correct horse battery staple\",\"display_name\":\"Alice\",\"household_name\":\"Smith\"}'

ACCESS=\$(curl -sS -X POST \$API/v1/auth/login \
  -H 'content-type: application/json' \
  -d '{\"email\":\"alice@example.com\",\"password\":\"correct horse battery staple\"}' | jq -r .access_token)
H=\"Authorization: Bearer \$ACCESS\"

# Build a balanced transaction.
CASH=\$(curl -sS -X POST \$API/v1/accounts -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"name\":\"Cash\",\"type\":\"asset\",\"currency\":\"USD\",\"code\":\"1110\"}' | jq -r .id)
FOOD=\$(curl -sS -X POST \$API/v1/accounts -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"name\":\"Food\",\"type\":\"expense\",\"currency\":\"USD\",\"code\":\"5100\"}' | jq -r .id)
TX=\$(curl -sS -X POST \$API/v1/transactions -H \"\$H\" -H 'content-type: application/json' \
  -d \"{\\\"date\\\":\\\"\$(date -u +%Y-%m-%d)\\\",\\\"description\\\":\\\"Pay John Doe\\\",\\\"postings\\\":[{\\\"account_id\\\":\\\"\$FOOD\\\",\\\"amount\\\":\\\"12.50\\\",\\\"currency\\\":\\\"USD\\\"},{\\\"account_id\\\":\\\"\$CASH\\\",\\\"amount\\\":\\\"-12.50\\\",\\\"currency\\\":\\\"USD\\\"}]}\" | jq -r .id)

# --- Flow 1: void the source then rectify; reversal description must be rewritten ---
REV=\$(curl -sS -X POST \$API/v1/transactions/\$TX/void -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"reason\":\"typo\"}' | jq -r .reversal_id)
echo \"Reversal BEFORE rectify:\"; curl -sS \$API/v1/transactions/\$REV -H \"\$H\" | jq -r .description
# expect: 'Reversal of Pay John Doe: typo'

curl -sS -X PATCH \$API/v1/transactions/\$TX/description -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"description\":\"Pay [redacted]\"}' | jq '{description, reference, notes, status}'

echo \"Reversal AFTER rectify:\"; curl -sS \$API/v1/transactions/\$REV -H \"\$H\" | jq -r .description
# expect: 'Reversal of [redacted]: typo'

# --- Flow 2: PATCH /v1/users/me — display_name w/o re-auth, email with re-auth ---
curl -sS -X PATCH \$API/v1/users/me -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"display_name\":\"Alice Smith\"}' | jq '{id, email, display_name, role}'

curl -sS -o /dev/null -w '%{http_code}\\n' -X PATCH \$API/v1/users/me -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"email\":\"alice2@example.com\"}'
# expect: 401  (auth.reauth_required)

curl -sS -X PATCH \$API/v1/users/me -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"email\":\"alice2@example.com\",\"current_password\":\"correct horse battery staple\"}' | jq '{id, email, display_name, role}'

# --- Flow 3: password change revokes outstanding refresh tokens ---
RT=\$(curl -sS -X POST \$API/v1/auth/login -H 'content-type: application/json' \
  -d '{\"email\":\"alice2@example.com\",\"password\":\"correct horse battery staple\"}' | jq -r .refresh_token)

curl -sS -o /dev/null -w '%{http_code}\\n' -X POST \$API/v1/auth/password/change -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"current_password\":\"correct horse battery staple\",\"new_password\":\"another good password please\"}'
# expect: 204

curl -sS -o /dev/null -w '%{http_code}\\n' -X POST \$API/v1/auth/refresh -H 'content-type: application/json' \
  -d \"{\\\"refresh_token\\\":\\\"\$RT\\\"}\"
# expect: 401  (auth.invalid_refresh_token)

curl -sS -o /dev/null -w '%{http_code}\\n' -X POST \$API/v1/auth/login -H 'content-type: application/json' \
  -d '{\"email\":\"alice2@example.com\",\"password\":\"another good password please\"}'
# expect: 200

kill \$DEV_PID
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)