### PR TITLE
feat: per-user AI policy + per-user AI keys (closes #239)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-14 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landing (#242 GDPR Art. 16 rectification merged), plus a CLI/importers usability bundle
+**Last updated:** 2026-05-15 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification merged), plus a CLI/importers usability bundle
 
 ---
 
@@ -622,6 +622,18 @@ Every Wave-1 security follow-up shipped, one PR per issue:
   redaction), two-step `DELETE /v1/households/me` (token-confirmed),
   `AttachmentRepository.delete()` with refcount, and an `attachment_gc`
   scheduler handler. New `pending_household_erasures` table.
+- **#239 (H-11 + M-16)** — per-user AI policy + per-user AI keys:
+  `users.ai_policy` JSON column (nullable = inherit household);
+  `HouseholdContext.acting_user_id` plumbed through all five
+  `resolve_policy` callsites (categorize / nl_query / proposals /
+  forecast / `routers/ai.py` × 3) so members can ratchet up severity
+  from the household floor; `PUT /v1/users/{me,user_id}/ai-policy`
+  endpoints; per-user key precedence in `routers/ai.py`
+  (`_resolve_provider_key` helper); six new key endpoints under
+  `/v1/ai/keys/{me,users/{user_id}}/{provider}`. New audit actions:
+  `user.ai_policy_set` / `user.ai_key_set` / `user.ai_key_forgotten`
+  (no key bytes in audit rows). `users.ai_policy` exposed in
+  `UserRecordExport` for #241 Art. 15 completeness.
 - **#242 (H-14)** — GDPR Art. 16 rectification:
   `PATCH /v1/transactions/{id}/description` rewrites a POSTED /
   RECONCILED transaction's `description` / `reference` / `notes` in
@@ -635,8 +647,7 @@ Every Wave-1 security follow-up shipped, one PR per issue:
   `description_rectified` / `profile_updated` / `password_changed`.
 
 Remaining privacy Wave-1: #237 (cross-user-within-household visibility
-filter, gated on multi-user invite) and #239 (per-user AI policy +
-per-user AI keys, finishing the half-wired `resolve_policy`). All other
+filter) — dormant, gated on multi-user invite landing first. All other
 issues in the #236–#243 range have closed.
 
 ### Post-audit CLI + importers usability bundle — ✅

--- a/packages/tulip-ai/src/tulip_ai/categorize.py
+++ b/packages/tulip-ai/src/tulip_ai/categorize.py
@@ -41,7 +41,7 @@ from tulip_ai.redaction import (
 )
 from tulip_core.reconciliation.categorizer import CategorizationResult
 from tulip_storage.encryption import decrypt_field
-from tulip_storage.models import Account, AccountType, Household
+from tulip_storage.models import Account, AccountType, Household, User
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -63,6 +63,7 @@ class _PromptInputs:
     """What we gathered from the DB to build the prompt + audit the call."""
 
     household: Household
+    user_policy: dict[str, object] | None
     api_key: str | None
     chart: list[ChartEntry]
 
@@ -145,12 +146,16 @@ class AICategorizer:
     ) -> CategorizationResult:
         """Inner categorize body — caller wraps in a broad exception guard."""
         with use_session_or_make_one(session, self._session_maker) as (session, should_commit):
-            inputs = self._load_inputs(session, household_context.household_id)
+            inputs = self._load_inputs(
+                session,
+                household_context.household_id,
+                household_context.acting_user_id,
+            )
             if inputs is None:
                 # Household vanished mid-call (shouldn't happen) — fall back silently.
                 return _FALLBACK_RESULT
 
-            policy = resolve_policy(inputs.household.ai_policy, None, "categorize")
+            policy = resolve_policy(inputs.household.ai_policy, inputs.user_policy, "categorize")
             writer = AIInvocationWriter(session)
 
             if policy.level == "disabled":
@@ -209,7 +214,7 @@ class AICategorizer:
             gate = enforce_pre_call(
                 session,
                 household_id=household_context.household_id,
-                user_id=None,  # importer-driven; no acting user surfaced yet
+                user_id=household_context.acting_user_id,
                 rate_limit_per_hour=policy.rate_limit_per_hour,
                 monthly_cost_cap_usd=policy.monthly_cost_cap_usd,
                 cost_cap_behaviour=policy.cost_cap_behaviour,
@@ -290,17 +295,27 @@ class AICategorizer:
                 session.commit()
             return result
 
-    def _load_inputs(self, session: Session, household_id: UUID) -> _PromptInputs | None:
+    def _load_inputs(
+        self,
+        session: Session,
+        household_id: UUID,
+        acting_user_id: UUID | None,
+    ) -> _PromptInputs | None:
         household = session.get(Household, household_id)
         if household is None:
             return None
 
-        # Resolve API key: per-user override > household. P6.1 doesn't yet
-        # have an "acting user" passed in via HouseholdContext, so we use
-        # the household-level key. The user-level override surface lands
-        # when HouseholdContext grows an ``acting_user_id`` field — tracked
-        # as a Phase 6 follow-up.
-        api_key = self._decrypt_key(household.ai_keys_encrypted, household.ai_policy)
+        user: User | None = None
+        if acting_user_id is not None:
+            user = session.get(User, (household_id, acting_user_id))
+
+        # Resolve API key (#239): per-user override > household for the
+        # resolved provider. Use the user's key when set for the provider;
+        # otherwise fall back to the household's. Note we look up the
+        # provider from the household policy here (categorize doesn't yet
+        # let users override provider — only severity); a Phase 9 follow-up
+        # might revisit if per-user provider routing becomes a thing.
+        api_key = self._resolve_api_key(household, user)
 
         # Chart of expense + income accounts — categorize doesn't propose
         # asset / liability codes per ADR-0005 §Q3.
@@ -320,19 +335,28 @@ class AICategorizer:
             for a in rows
             if a.code is not None
         ]
-        return _PromptInputs(household=household, api_key=api_key, chart=chart)
+        return _PromptInputs(
+            household=household,
+            user_policy=user.ai_policy if user is not None else None,
+            api_key=api_key,
+            chart=chart,
+        )
 
-    def _decrypt_key(self, blob: bytes | None, ai_policy: dict[str, object]) -> str | None:
-        """Extract the API key for the resolved provider from an encrypted JSON blob.
-
-        ``ai_keys_encrypted`` is JSON ``{provider: api_key}``, encrypted with
-        the master key. Returns ``None`` if no blob or no key for this provider.
-        """
-        if not blob:
-            return None
-        provider = ai_policy.get("default_provider")
+    def _resolve_api_key(self, household: Household, user: User | None) -> str | None:
+        """Per-user key overrides household key for the resolved provider (#239)."""
+        provider = household.ai_policy.get("default_provider")
         if not isinstance(provider, str):
             return None
+        if user is not None and user.ai_keys_encrypted:
+            user_key = self._extract_provider_key(user.ai_keys_encrypted, provider)
+            if user_key is not None:
+                return user_key
+        if household.ai_keys_encrypted:
+            return self._extract_provider_key(household.ai_keys_encrypted, provider)
+        return None
+
+    def _extract_provider_key(self, blob: bytes, provider: str) -> str | None:
+        """Decrypt + extract a single provider's key from a ``{provider: key}`` blob."""
         try:
             decrypted = decrypt_field(blob, master_key=self._master_key).decode("utf-8")
             keys_dict = json.loads(decrypted)

--- a/packages/tulip-ai/src/tulip_ai/forecast.py
+++ b/packages/tulip-ai/src/tulip_ai/forecast.py
@@ -227,13 +227,18 @@ class AIForecastCapability:
         target_date: date | None,
         recent_inflow_average: Decimal | None,
     ) -> ForecastResult:
-        from tulip_storage.models import Household
+        from tulip_storage.models import Household, User
 
         with self._session_maker() as session:
             household = session.get(Household, household_id)
             if household is None:
                 return ForecastResult(text="", error="household not found")
-            policy = resolve_policy(household.ai_policy, None, "forecast")
+            user_policy: dict[str, object] | None = None
+            if actor_user_id is not None:
+                user = session.get(User, (household_id, actor_user_id))
+                if user is not None:
+                    user_policy = user.ai_policy
+            policy = resolve_policy(household.ai_policy, user_policy, "forecast")
 
             if policy.level == "disabled":
                 self._audit(

--- a/packages/tulip-ai/src/tulip_ai/nl_query.py
+++ b/packages/tulip-ai/src/tulip_ai/nl_query.py
@@ -225,13 +225,18 @@ class AINLQueryCapability:
         actor_user_id: UUID | None,
         api_key: str | None,
     ) -> NLAnswer:
-        from tulip_storage.models import Household
+        from tulip_storage.models import Household, User
 
         with self._session_maker() as session:
             household = session.get(Household, household_id)
             if household is None:
                 return NLAnswer(summary="", rows=[], sql=None, error="household not found")
-            policy = resolve_policy(household.ai_policy, None, "nl_query")
+            user_policy: dict[str, object] | None = None
+            if actor_user_id is not None:
+                user = session.get(User, (household_id, actor_user_id))
+                if user is not None:
+                    user_policy = user.ai_policy
+            policy = resolve_policy(household.ai_policy, user_policy, "nl_query")
             writer = AIInvocationWriter(session)
 
             if policy.level == "disabled":

--- a/packages/tulip-ai/src/tulip_ai/proposals.py
+++ b/packages/tulip-ai/src/tulip_ai/proposals.py
@@ -124,13 +124,18 @@ class AIProposalCapability:
         current_budget: Decimal | None,
         recent_spend_series: list[tuple[date, Decimal]],
     ) -> SuggestionResult:
-        from tulip_storage.models import Household
+        from tulip_storage.models import Household, User
 
         with self._session_maker() as session:
             household = session.get(Household, household_id)
             if household is None:
                 return SuggestionResult(proposal=None, error="household not found")
-            policy = resolve_policy(household.ai_policy, None, "agentic")
+            user_policy: dict[str, object] | None = None
+            if actor_user_id is not None:
+                user = session.get(User, (household_id, actor_user_id))
+                if user is not None:
+                    user_policy = user.ai_policy
+            policy = resolve_policy(household.ai_policy, user_policy, "agentic")
 
             if policy.level == "disabled":
                 self._audit(

--- a/packages/tulip-ai/tests/test_categorize.py
+++ b/packages/tulip-ai/tests/test_categorize.py
@@ -119,6 +119,128 @@ async def test_categorize_happy_path_returns_model_choice(
         assert rows[0].capability == "categorize"
 
 
+class _KeyCapturingAdapter(RecordingAdapter):
+    """Test-only adapter that records the actual ``api_key`` value passed (#239).
+
+    The shared ``RecordingAdapter`` deliberately only records a boolean
+    ``api_key_was_passed`` for privacy; this subclass stores the cleartext
+    so per-user-key-precedence tests can assert which key got through.
+    """
+
+    api_keys_seen: list[str | None]
+
+    def __init__(self, *, canned_reply: str) -> None:
+        super().__init__(canned_reply=canned_reply)
+        self.api_keys_seen = []
+
+    async def chat(self, **kwargs):  # type: ignore[no-untyped-def]
+        self.api_keys_seen.append(kwargs.get("api_key"))
+        return await super().chat(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_categorize_uses_user_key_over_household_when_set(
+    session_maker: sessionmaker[Session], household_and_user, master_key: bytes
+) -> None:
+    """#239: per-user ai_keys_encrypted overrides household for the resolved provider."""
+    household, user = household_and_user
+    _seed_chart(
+        session_maker,
+        household.id,
+        codes=[("5100", "Groceries", AccountType.EXPENSE)],
+    )
+    # Household key + user key, both for anthropic but different values.
+    _set_ai_keys(
+        session_maker, household.id, keys={"anthropic": "sk-household"}, master_key=master_key
+    )
+    from tulip_storage.encryption import encrypt_field
+
+    with session_maker() as s:
+        u = s.get(type(user), (household.id, user.id))
+        assert u is not None
+        u.ai_keys_encrypted = encrypt_field(b'{"anthropic": "sk-user-only"}', master_key=master_key)
+        s.commit()
+
+    adapter = _KeyCapturingAdapter(canned_reply='{"account_code": "5100", "confidence": 0.9}')
+    categorizer = AICategorizer(session_maker=session_maker, master_key=master_key, adapter=adapter)
+    await categorizer.categorize(
+        _make_statement_line(description="WHOLE FOODS", amount="-12.00"),
+        HouseholdContext(
+            household_id=household.id,
+            account_whitelist=frozenset(),
+            acting_user_id=user.id,
+        ),
+    )
+    assert adapter.api_keys_seen == ["sk-user-only"]
+
+
+@pytest.mark.asyncio
+async def test_categorize_falls_back_to_household_key_when_user_has_none(
+    session_maker: sessionmaker[Session], household_and_user, master_key: bytes
+) -> None:
+    """#239: if user has no key for the provider, the household's is used."""
+    household, user = household_and_user
+    _seed_chart(
+        session_maker,
+        household.id,
+        codes=[("5100", "Groceries", AccountType.EXPENSE)],
+    )
+    _set_ai_keys(
+        session_maker, household.id, keys={"anthropic": "sk-household"}, master_key=master_key
+    )
+    # Note: NOT setting user.ai_keys_encrypted.
+
+    adapter = _KeyCapturingAdapter(canned_reply='{"account_code": "5100", "confidence": 0.9}')
+    categorizer = AICategorizer(session_maker=session_maker, master_key=master_key, adapter=adapter)
+    await categorizer.categorize(
+        _make_statement_line(description="WHOLE FOODS", amount="-12.00"),
+        HouseholdContext(
+            household_id=household.id,
+            account_whitelist=frozenset(),
+            acting_user_id=user.id,
+        ),
+    )
+    assert adapter.api_keys_seen == ["sk-household"]
+
+
+@pytest.mark.asyncio
+async def test_categorize_threads_user_policy_via_acting_user_id(
+    session_maker: sessionmaker[Session], household_and_user, master_key: bytes
+) -> None:
+    """#239: user-level ai_policy disables categorize when household is permissive."""
+    household, user = household_and_user
+    _seed_chart(
+        session_maker,
+        household.id,
+        codes=[("5100", "Groceries", AccountType.EXPENSE)],
+    )
+    _set_ai_keys(session_maker, household.id, keys={"anthropic": "sk-test"}, master_key=master_key)
+    with session_maker() as s:
+        u = s.get(type(user), (household.id, user.id))
+        assert u is not None
+        u.ai_policy = {"capabilities": {"categorize": {"policy": "disabled"}}}
+        s.commit()
+
+    adapter = RecordingAdapter(canned_reply='{"account_code": "5100"}')
+    categorizer = AICategorizer(session_maker=session_maker, master_key=master_key, adapter=adapter)
+    result = await categorizer.categorize(
+        _make_statement_line(description="WHOLE FOODS", amount="-12.00"),
+        HouseholdContext(
+            household_id=household.id,
+            account_whitelist=frozenset(),
+            acting_user_id=user.id,
+        ),
+    )
+    # Categorize falls back; adapter not called.
+    assert result.account_code == "Imbalance:Unknown"
+    assert adapter.calls == []
+    with session_maker() as s:
+        rows = s.execute(select(AIInvocation)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].outcome == "policy_disabled"
+        assert rows[0].policy_resolved == "disabled"
+
+
 @pytest.mark.asyncio
 async def test_categorize_falls_back_when_policy_disabled(
     session_maker: sessionmaker[Session], household_and_user, master_key: bytes

--- a/packages/tulip-ai/tests/test_nl_query.py
+++ b/packages/tulip-ai/tests/test_nl_query.py
@@ -190,6 +190,46 @@ async def test_ask_happy_path(
 
 
 @pytest.mark.asyncio
+async def test_ask_threads_user_policy_disabled_blocks_call(
+    session_maker: sessionmaker[Session],
+    configured_household: Household,
+    household_and_user: tuple[Household, object],
+) -> None:
+    """#239: when the user's ai_policy disables nl_query but household is
+    permissive, the resolved policy is disabled and no provider call fires.
+    """
+    _, user = household_and_user
+    with session_maker() as s:
+        u = s.get(type(user), (configured_household.id, user.id))  # type: ignore[arg-type]
+        assert u is not None
+        u.ai_policy = {"capabilities": {"nl_query": {"policy": "disabled"}}}
+        s.commit()
+
+    adapter = _two_turn_adapter(turn1_sql="unused", turn2_summary="unused")
+    capability = AINLQueryCapability(session_maker=session_maker, adapter=adapter)
+    answer = await capability.ask(
+        "How much did I spend on groceries?",
+        household_id=configured_household.id,
+        actor_user_id=user.id,  # type: ignore[attr-defined]
+        api_key="sk-test",
+    )
+
+    assert answer.error == "NL query is disabled for this household."
+    assert answer.sql is None
+    assert answer.rows == []
+    assert adapter.calls == [], "no provider call should fire when disabled"
+    with session_maker() as s:
+        rows = (
+            s.execute(select(AIInvocation).where(AIInvocation.capability == "nl_query"))
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].outcome == "policy_disabled"
+        assert rows[0].policy_resolved == "disabled"
+
+
+@pytest.mark.asyncio
 async def test_ask_rejects_unsafe_emitted_sql(
     session_maker: sessionmaker[Session],
     configured_household: Household,

--- a/packages/tulip-api/src/tulip_api/routers/ai.py
+++ b/packages/tulip-api/src/tulip_api/routers/ai.py
@@ -18,10 +18,10 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import structlog
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
 
 from tulip_ai.categorize import build_categorize_prompt
 from tulip_ai.policy import resolve_policy
@@ -29,7 +29,7 @@ from tulip_ai.redaction import ChartEntry, PromptRedactor
 from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.config import Settings, get_settings
 from tulip_api.deps import get_session
-from tulip_api.errors import problem_response
+from tulip_api.errors import UserNotFoundError, problem_response
 from tulip_api.schemas.ai import (
     CLEAR_SENTINEL,
     AIAskRequest,
@@ -47,7 +47,7 @@ from tulip_api.schemas.ai import (
 from tulip_core.money import Money
 from tulip_core.reconciliation.statement_line import StatementLine
 from tulip_storage.encryption import decrypt_field, encrypt_field
-from tulip_storage.models import Account, AccountType, Household
+from tulip_storage.models import Account, AccountType, Household, User
 from tulip_storage.repositories import AIInvocationRepository, AuditLogWriter
 from tulip_storage.runner.handlers import AI_INVOCATION_RETENTION_DAYS
 
@@ -62,27 +62,69 @@ router = APIRouter(prefix="/v1/ai", tags=["ai"])
 log = structlog.get_logger("tulip_api.ai")
 
 
-def _load_household_keys(household: Household, master_key: bytes) -> dict[str, str]:
-    """Decrypt ``households.ai_keys_encrypted`` to a ``{provider: key}`` dict."""
-    if not household.ai_keys_encrypted:
+def _decrypt_keys_blob(blob: bytes | None, master_key: bytes) -> dict[str, str]:
+    """Decrypt an ``ai_keys_encrypted`` blob to a ``{provider: key}`` dict.
+
+    Returns ``{}`` for ``None`` / malformed / non-dict ciphertexts. Used
+    by both the household helpers below and the per-user helpers (#239).
+    """
+    if not blob:
         return {}
     try:
-        decrypted = decrypt_field(household.ai_keys_encrypted, master_key=master_key).decode(
-            "utf-8"
-        )
+        decrypted = decrypt_field(blob, master_key=master_key).decode("utf-8")
         parsed = json.loads(decrypted)
         return parsed if isinstance(parsed, dict) else {}
     except (ValueError, json.JSONDecodeError):
         return {}
 
 
+def _encrypt_keys_blob(keys: dict[str, str], master_key: bytes) -> bytes | None:
+    """Encrypt a ``{provider: key}`` dict; ``None`` when empty."""
+    if not keys:
+        return None
+    return encrypt_field(json.dumps(keys).encode("utf-8"), master_key=master_key)
+
+
+def _load_household_keys(household: Household, master_key: bytes) -> dict[str, str]:
+    """Decrypt ``households.ai_keys_encrypted`` to a ``{provider: key}`` dict."""
+    return _decrypt_keys_blob(household.ai_keys_encrypted, master_key)
+
+
 def _store_household_keys(household: Household, keys: dict[str, str], master_key: bytes) -> None:
     """Re-encrypt the ``{provider: key}`` dict back onto the household row."""
-    if not keys:
-        household.ai_keys_encrypted = None
-        return
-    blob = encrypt_field(json.dumps(keys).encode("utf-8"), master_key=master_key)
-    household.ai_keys_encrypted = blob
+    household.ai_keys_encrypted = _encrypt_keys_blob(keys, master_key)
+
+
+def _load_user_keys(user: User, master_key: bytes) -> dict[str, str]:
+    """Decrypt ``users.ai_keys_encrypted`` to a ``{provider: key}`` dict (#239)."""
+    return _decrypt_keys_blob(user.ai_keys_encrypted, master_key)
+
+
+def _store_user_keys(user: User, keys: dict[str, str], master_key: bytes) -> None:
+    """Re-encrypt the ``{provider: key}`` dict back onto the user row (#239)."""
+    user.ai_keys_encrypted = _encrypt_keys_blob(keys, master_key)
+
+
+def _resolve_provider_key(
+    *,
+    household: Household,
+    user: User | None,
+    provider: str,
+    master_key: bytes,
+) -> str | None:
+    """Per-user > per-household key precedence for ``provider`` (#239).
+
+    Mirrors the precedence in :class:`tulip_ai.categorize.AICategorizer`:
+    if the acting user has set a key for this provider, use it; otherwise
+    fall back to the household-level key.
+    """
+    if user is not None and user.ai_keys_encrypted:
+        user_keys = _load_user_keys(user, master_key)
+        if provider in user_keys:
+            return user_keys[provider]
+    if household.ai_keys_encrypted:
+        return _load_household_keys(household, master_key).get(provider)
+    return None
 
 
 @router.post(
@@ -153,6 +195,238 @@ def list_ai_keys(
     return AIKeysList(providers=sorted(keys.keys()))
 
 
+def _set_user_key(
+    *,
+    session: Session,
+    actor_claims: Claims,
+    target_user: User,
+    provider: str,
+    api_key: str,
+    master_key: bytes,
+    request: Request,
+) -> None:
+    """Upload or replace ``target_user``'s key for ``provider`` (#239)."""
+    keys = _load_user_keys(target_user, master_key)
+    keys[provider] = api_key
+    _store_user_keys(target_user, keys, master_key)
+    AuditLogWriter(session, actor_claims.household_id).write(
+        action="user.ai_key_set",
+        actor_kind="user",
+        actor_user_id=actor_claims.user_id,
+        entity_type="user",
+        entity_id=target_user.id,
+        metadata={"provider": provider},
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    log.info(
+        "ai.user_key_set",
+        provider=provider,
+        user_id=str(target_user.id),
+        household_id=str(actor_claims.household_id),
+    )
+
+
+def _forget_user_key(
+    *,
+    session: Session,
+    actor_claims: Claims,
+    target_user: User,
+    provider: str,
+    master_key: bytes,
+    request: Request,
+) -> None:
+    """Remove ``target_user``'s key for ``provider``. Idempotent (#239)."""
+    keys = _load_user_keys(target_user, master_key)
+    keys.pop(provider, None)
+    _store_user_keys(target_user, keys, master_key)
+    AuditLogWriter(session, actor_claims.household_id).write(
+        action="user.ai_key_forgotten",
+        actor_kind="user",
+        actor_user_id=actor_claims.user_id,
+        entity_type="user",
+        entity_id=target_user.id,
+        metadata={"provider": provider},
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    log.info(
+        "ai.user_key_forgotten",
+        provider=provider,
+        user_id=str(target_user.id),
+        household_id=str(actor_claims.household_id),
+    )
+
+
+@router.post(
+    "/keys/me/{provider}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        400: problem_response("request.body_invalid"),
+        401: problem_response("auth.unauthorized"),
+        422: problem_response("validation.failed"),
+    },
+)
+def set_own_ai_key(
+    provider: str,
+    body: AIKeyCreate,
+    request: Request,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+) -> None:
+    """Upload or replace the caller's own per-user key for ``provider`` (#239)."""
+    user = session.get(User, (claims.household_id, claims.user_id))
+    if user is None:
+        raise UserNotFoundError()
+    _set_user_key(
+        session=session,
+        actor_claims=claims,
+        target_user=user,
+        provider=provider,
+        api_key=body.api_key,
+        master_key=settings.master_key,
+        request=request,
+    )
+
+
+@router.delete(
+    "/keys/me/{provider}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={401: problem_response("auth.unauthorized")},
+)
+def forget_own_ai_key(
+    provider: str,
+    request: Request,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+) -> None:
+    """Remove the caller's own per-user key for ``provider``. Idempotent (#239)."""
+    user = session.get(User, (claims.household_id, claims.user_id))
+    if user is None:
+        raise UserNotFoundError()
+    _forget_user_key(
+        session=session,
+        actor_claims=claims,
+        target_user=user,
+        provider=provider,
+        master_key=settings.master_key,
+        request=request,
+    )
+
+
+@router.get(
+    "/keys/me",
+    response_model=AIKeysList,
+    responses={401: problem_response("auth.unauthorized")},
+)
+def list_own_ai_keys(
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+) -> AIKeysList:
+    """List providers for which the caller has a per-user key (#239). No key values."""
+    user = session.get(User, (claims.household_id, claims.user_id))
+    if user is None:
+        raise UserNotFoundError()
+    keys = _load_user_keys(user, settings.master_key)
+    return AIKeysList(providers=sorted(keys.keys()))
+
+
+@router.post(
+    "/keys/users/{user_id}/{provider}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        400: problem_response("request.body_invalid"),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("user.not_found"),
+        422: problem_response("validation.failed"),
+    },
+)
+def set_user_ai_key(
+    user_id: UUID,
+    provider: str,
+    body: AIKeyCreate,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+) -> None:
+    """Admin: upload or replace another user's per-user key (#239)."""
+    user = session.get(User, (claims.household_id, user_id))
+    if user is None:
+        raise UserNotFoundError()
+    _set_user_key(
+        session=session,
+        actor_claims=claims,
+        target_user=user,
+        provider=provider,
+        api_key=body.api_key,
+        master_key=settings.master_key,
+        request=request,
+    )
+
+
+@router.delete(
+    "/keys/users/{user_id}/{provider}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("user.not_found"),
+    },
+)
+def forget_user_ai_key(
+    user_id: UUID,
+    provider: str,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+) -> None:
+    """Admin: remove another user's per-user key. Idempotent (#239)."""
+    user = session.get(User, (claims.household_id, user_id))
+    if user is None:
+        raise UserNotFoundError()
+    _forget_user_key(
+        session=session,
+        actor_claims=claims,
+        target_user=user,
+        provider=provider,
+        master_key=settings.master_key,
+        request=request,
+    )
+
+
+@router.get(
+    "/keys/users/{user_id}",
+    response_model=AIKeysList,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("user.not_found"),
+    },
+)
+def list_user_ai_keys(
+    user_id: UUID,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+    settings: Settings = Depends(get_settings),  # noqa: B008
+) -> AIKeysList:
+    """Admin: list providers for which a user has a per-user key (#239)."""
+    user = session.get(User, (claims.household_id, user_id))
+    if user is None:
+        raise UserNotFoundError()
+    keys = _load_user_keys(user, settings.master_key)
+    return AIKeysList(providers=sorted(keys.keys()))
+
+
 @router.get(
     "/status",
     response_model=AIStatusRead,
@@ -176,17 +450,19 @@ def get_ai_status(
 
     household = session.get(Household, claims.household_id)
     assert household is not None  # noqa: S101
+    user = session.get(User, (claims.household_id, claims.user_id))
+    user_policy = user.ai_policy if user is not None else None
     keys = _load_household_keys(household, settings.master_key)
     capabilities: dict[str, dict[str, str | None]] = {}
     for cap in ("categorize", "nl_query", "forecast", "agentic"):
-        resolved = resolve_policy(household.ai_policy, None, cap)
+        resolved = resolve_policy(household.ai_policy, user_policy, cap)
         capabilities[cap] = {
             "level": resolved.level,
             "provider": resolved.provider,
             "model": resolved.model,
             "profile": resolved.profile,
         }
-    cat_policy = resolve_policy(household.ai_policy, None, "categorize")
+    cat_policy = resolve_policy(household.ai_policy, user_policy, "categorize")
 
     mtd: Decimal | None = None
     if cat_policy.monthly_cost_cap_usd is not None:
@@ -265,7 +541,9 @@ def preview_categorize_prompt(
         ChartEntry(code=a.code, name=a.name, type=a.type.value) for a in rows if a.code is not None
     )
 
-    policy = resolve_policy(household.ai_policy, None, "categorize")
+    user = session.get(User, (claims.household_id, claims.user_id))
+    user_policy = user.ai_policy if user is not None else None
+    policy = resolve_policy(household.ai_policy, user_policy, "categorize")
     payload = build_categorize_prompt(line, chart)
     redactor = PromptRedactor(policy.profile)
     body_dict = redactor.to_message_body(payload)
@@ -306,15 +584,19 @@ async def ask_nl_query(
     from tulip_ai import AINLQueryCapability as _AINLQueryCapability
     from tulip_ai import LitellmAdapter
 
-    # Resolve the API key (per-household; user override deferred to a follow-up).
+    # Resolve the API key — per-user override > household (#239).
     household = session.get(Household, claims.household_id)
     assert household is not None  # noqa: S101
+    user = session.get(User, (claims.household_id, claims.user_id))
     api_key: str | None = None
-    if household.ai_keys_encrypted:
-        keys = _load_household_keys(household, settings.master_key)
-        provider = household.ai_policy.get("default_provider")
-        if isinstance(provider, str):
-            api_key = keys.get(provider)
+    provider = household.ai_policy.get("default_provider")
+    if isinstance(provider, str):
+        api_key = _resolve_provider_key(
+            household=household,
+            user=user,
+            provider=provider,
+            master_key=settings.master_key,
+        )
 
     if capability is None:
         bind = session.get_bind()
@@ -615,6 +897,20 @@ def put_ai_capability_config(
         capability=capability,
     )
     return get_ai_config(claims=claims, session=session)
+
+
+def _request_uuid(request: Request) -> UUID | None:
+    rid = request.headers.get("x-request-id")
+    if rid:
+        try:
+            return UUID(rid)
+        except ValueError:
+            return None
+    return None
+
+
+def _client_ip(request: Request) -> str | None:
+    return request.client.host if request.client else None
 
 
 __all__ = ["router"]

--- a/packages/tulip-api/src/tulip_api/routers/proposals.py
+++ b/packages/tulip-api/src/tulip_api/routers/proposals.py
@@ -403,7 +403,7 @@ async def suggest_envelope_budget(
 
     from tulip_ai import AIProposalCapability, LitellmAdapter
     from tulip_api.config import get_settings
-    from tulip_storage.models import Household
+    from tulip_storage.models import Household, User
     from tulip_storage.repositories import EnvelopeRepository, ShadowTransactionRepository
 
     found = EnvelopeRepository(session, claims.household_id).get(body.envelope_id)
@@ -429,14 +429,18 @@ async def suggest_envelope_budget(
     settings = get_settings()
     household = session.get(Household, claims.household_id)
     assert household is not None  # noqa: S101
+    user = session.get(User, (claims.household_id, claims.user_id))
     api_key: str | None = None
-    if household.ai_keys_encrypted:
-        from tulip_api.routers.ai import _load_household_keys
+    provider = household.ai_policy.get("default_provider")
+    if isinstance(provider, str):
+        from tulip_api.routers.ai import _resolve_provider_key
 
-        keys = _load_household_keys(household, settings.master_key)
-        provider = household.ai_policy.get("default_provider")
-        if isinstance(provider, str):
-            api_key = keys.get(provider)
+        api_key = _resolve_provider_key(
+            household=household,
+            user=user,
+            provider=provider,
+            master_key=settings.master_key,
+        )
 
     bind = session.get_bind()
     cap_session_maker = _sessionmaker(bind, expire_on_commit=False)

--- a/packages/tulip-api/src/tulip_api/routers/users.py
+++ b/packages/tulip-api/src/tulip_api/routers/users.py
@@ -16,7 +16,7 @@ Admin-only; refuses when the target is the last admin in the household.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Request, status
@@ -42,6 +42,8 @@ from tulip_api.schemas.user import (
     RecoveryCodesStatusExport,
     SessionExport,
     TransactionExport,
+    UserAIPolicyPatchRequest,
+    UserAIPolicyRead,
     UserDataExport,
     UserMeRead,
     UserProfilePatchRequest,
@@ -215,6 +217,109 @@ def patch_own_profile(
     )
 
 
+def _apply_ai_policy(
+    *,
+    session: Session,
+    request: Request,
+    actor_claims: Claims,
+    target_user: User,
+    body: UserAIPolicyPatchRequest,
+) -> UserAIPolicyRead:
+    """Replace the target user's ``ai_policy`` and emit an audit row (#239).
+
+    Empty body clears the override (NULL = inherit household). Otherwise
+    we store the validated JSON shape verbatim. Returns the new policy
+    shape; the audit row carries before/after snapshots.
+    """
+    before = target_user.ai_policy
+    new_policy: dict[str, Any] | None
+    if body.capabilities is None:
+        new_policy = None
+    else:
+        # Dump via Pydantic so Literals coerce to plain strings and any
+        # explicit ``None`` capability keys drop out cleanly.
+        dumped = body.model_dump(exclude_none=True)
+        new_policy = dumped if dumped else None
+    target_user.ai_policy = new_policy
+
+    AuditLogWriter(session, actor_claims.household_id).write(
+        action="user.ai_policy_set",
+        actor_kind="user",
+        actor_user_id=actor_claims.user_id,
+        entity_type="user",
+        entity_id=target_user.id,
+        before=before,
+        after=new_policy,
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    return UserAIPolicyRead(user_id=target_user.id, ai_policy=new_policy)
+
+
+@router.put(
+    "/me/ai-policy",
+    response_model=UserAIPolicyRead,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        422: problem_response("validation.failed"),
+    },
+)
+def put_own_ai_policy(
+    body: UserAIPolicyPatchRequest,
+    request: Request,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> UserAIPolicyRead:
+    """Set the caller's own per-user AI policy override (#239).
+
+    Members can ratchet the household's policy *up* (stricter). The merge
+    happens at read time in ``tulip_ai.policy.resolve_policy``; this
+    endpoint just stores the override JSON.
+    """
+    user = session.get(User, (claims.household_id, claims.user_id))
+    if user is None:
+        raise UserNotFoundError()
+    return _apply_ai_policy(
+        session=session,
+        request=request,
+        actor_claims=claims,
+        target_user=user,
+        body=body,
+    )
+
+
+@router.put(
+    "/{user_id}/ai-policy",
+    response_model=UserAIPolicyRead,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("user.not_found"),
+        422: problem_response("validation.failed"),
+    },
+)
+def put_user_ai_policy(
+    user_id: UUID,
+    body: UserAIPolicyPatchRequest,
+    request: Request,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> UserAIPolicyRead:
+    """Admin: set the AI policy override for any user in the caller's household (#239)."""
+    user = session.get(User, (claims.household_id, user_id))
+    if user is None:
+        raise UserNotFoundError()
+    return _apply_ai_policy(
+        session=session,
+        request=request,
+        actor_claims=claims,
+        target_user=user,
+        body=body,
+    )
+
+
 def _build_user_export(session: Session, user: User) -> UserDataExport:
     """Assemble the full data-subject-access envelope for ``user`` (#241).
 
@@ -363,6 +468,7 @@ def _build_user_export(session: Session, user: User) -> UserDataExport:
             last_login_at=user.last_login_at,
             created_at=user.created_at,
             updated_at=user.updated_at,
+            ai_policy=user.ai_policy,
         ),
         sessions=sessions,
         audit_log_where_actor=audit,

--- a/packages/tulip-api/src/tulip_api/schemas/user.py
+++ b/packages/tulip-api/src/tulip_api/schemas/user.py
@@ -10,14 +10,18 @@ uploader, plus their own user record (with ``password_hash`` masked).
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Any, Self
+from typing import Any, Literal, Self
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
 
 class UserRecordExport(BaseModel):
-    """The ``users`` row itself. ``password_hash`` is always masked."""
+    """The ``users`` row itself. ``password_hash`` is always masked.
+
+    ``ai_policy`` (#239) is included so the Art. 15 export reflects any
+    per-user policy override the system holds about the subject.
+    """
 
     id: UUID
     email: str
@@ -28,6 +32,7 @@ class UserRecordExport(BaseModel):
     last_login_at: datetime | None
     created_at: datetime
     updated_at: datetime
+    ai_policy: dict[str, Any] | None = None
 
 
 class SessionExport(BaseModel):
@@ -140,6 +145,48 @@ class UserProfilePatchRequest(BaseModel):
         if not (self.model_fields_set & {"display_name", "email"}):
             raise ValueError("At least one of 'display_name' or 'email' must be provided.")
         return self
+
+
+class UserAIPolicyCapability(BaseModel):
+    """Per-capability ratchet — only severity and redaction-profile (#239).
+
+    Provider / cost-cap / rate-limit remain household-scope per ADR-0005 §Q5.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    policy: Literal["permissive", "requires_approval", "disabled"] | None = None
+    profile: Literal["default", "strict", "local_only"] | None = None
+
+
+class UserAIPolicyPatchRequest(BaseModel):
+    """Body for ``PUT /v1/users/{me,user_id}/ai-policy`` (#239).
+
+    An empty body clears the per-user override (resets to "inherit
+    household"). When ``capabilities`` is present, each known capability
+    can carry a ``policy`` (severity ratchet) and ``profile`` (redaction
+    ratchet); both are optional.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    capabilities: (
+        dict[
+            Literal["categorize", "nl_query", "forecast", "agentic"],
+            UserAIPolicyCapability,
+        ]
+        | None
+    ) = None
+
+
+class UserAIPolicyRead(BaseModel):
+    """Response for ``PUT /v1/users/{me,user_id}/ai-policy`` (#239).
+
+    ``ai_policy`` is the raw stored JSON (or ``None`` when no override).
+    """
+
+    user_id: UUID
+    ai_policy: dict[str, Any] | None
 
 
 class UserMeRead(BaseModel):

--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -207,7 +207,11 @@ async def promote_statement_line(
         domain_line = _to_domain_line(line)
         suggestion = await categorizer.categorize(
             domain_line,
-            HouseholdContext(household_id=household_id, account_whitelist=frozenset()),
+            HouseholdContext(
+                household_id=household_id,
+                account_whitelist=frozenset(),
+                acting_user_id=actor_user_id,
+            ),
             session=session,
         )
         resolved = accounts.get_by_code(suggestion.account_code)

--- a/packages/tulip-api/tests/test_openapi_contract.py
+++ b/packages/tulip-api/tests/test_openapi_contract.py
@@ -171,6 +171,8 @@ def test_api_conforms_to_schema(case: schemathesis.Case) -> None:
     #     /v1/ai/proposals/{proposal_id} (#240) → 422 (bad UUID), not 405.
     #   - DELETE /v1/users/me → routes to DELETE /v1/users/{user_id} (#242)
     #     → 401, not 405.
+    #   - POST /v1/ai/keys/me → routes to POST /v1/ai/keys/{provider} (#239)
+    #     where ``me`` is a valid {provider} → 401, not 405.
     # Each collision is harmless. Map every shadowed static path to the one
     # method it actually documents; skip schemathesis cases targeting the
     # other methods, and (for the documented method's own case) exclude
@@ -181,6 +183,7 @@ def test_api_conforms_to_schema(case: schemathesis.Case) -> None:
         "/v1/imports/multi-account": "POST",
         "/v1/ai/proposals/kinds": "GET",
         "/v1/users/me": "PATCH",
+        "/v1/ai/keys/me": "GET",
     }
     documented_method = _SHADOWED_STATIC_PATHS.get(str(case.path))
     if documented_method is not None and case.method.upper() != documented_method:

--- a/packages/tulip-api/tests/test_per_user_ai_policy_e2e.py
+++ b/packages/tulip-api/tests/test_per_user_ai_policy_e2e.py
@@ -1,0 +1,253 @@
+"""End-to-end tests for #239 (per-user AI policy + per-user keys).
+
+The three acceptance cases from the issue body, exercised against the
+running app:
+
+1. Member-stricter: household = permissive, user = disabled → user's
+   nl_query call is blocked.
+2. Admin-overrides-member: admin uses PUT /v1/users/{member_id}/ai-policy
+   to re-enable the member's capabilities; the household floor still
+   bounds the resolved level.
+3. Member-with-own-key: user uploads their own key for the resolved
+   provider; the categorize call uses that key, not the household's.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_h(client: TestClient) -> dict[str, str]:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith Family",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+@pytest.fixture
+def admin_user_id(client: TestClient, admin_h: dict[str, str]) -> UUID:
+    return UUID(client.get("/v1/users/me/export", headers=admin_h).json()["user"]["id"])
+
+
+class TestMemberStricter:
+    def test_member_disables_own_nl_query_household_permissive(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        """Household is permissive by default; member ratchets nl_query disabled.
+
+        AI status for the member reflects the merged (disabled) level.
+        """
+        client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"nl_query": {"policy": "disabled"}}},
+        )
+        r = client.get("/v1/ai/status", headers=admin_h)
+        assert r.json()["capabilities"]["nl_query"]["level"] == "disabled"
+
+    def test_member_cannot_ratchet_down_below_household_floor(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        """Household sets requires_approval; member tries permissive → still requires_approval.
+
+        Max-severity wins. The user's stored override is ``permissive`` but
+        the resolver clamps to the household floor.
+        """
+        client.put(
+            "/v1/ai/config/capabilities/forecast",
+            headers=admin_h,
+            json={"policy": "requires_approval"},
+        )
+        client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"forecast": {"policy": "permissive"}}},
+        )
+        r = client.get("/v1/ai/status", headers=admin_h)
+        assert r.json()["capabilities"]["forecast"]["level"] == "requires_approval"
+
+
+class TestAdminOverridesMember:
+    def test_admin_can_set_member_policy_via_admin_endpoint(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        """Admin uses PUT /v1/users/{member_id}/ai-policy to change a member."""
+        from uuid import uuid4
+
+        from sqlalchemy import select
+
+        from tulip_api.auth.passwords import hash_password
+        from tulip_storage.models import Household, User, UserRole
+
+        with session_maker() as s:
+            household = s.execute(select(Household)).scalar_one()
+            member_id = uuid4()
+            s.add(
+                User(
+                    household_id=household.id,
+                    id=member_id,
+                    email="member@example.com",
+                    password_hash=hash_password("memberpassword123"),
+                    display_name="Member",
+                    role=UserRole.MEMBER,
+                )
+            )
+            s.commit()
+
+        r = client.put(
+            f"/v1/users/{member_id}/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"agentic": {"policy": "disabled"}}},
+        )
+        assert r.status_code == 200, r.text
+
+        # Verify by logging in as the member.
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": "member@example.com", "password": "memberpassword123"},
+        )
+        member_h = {"Authorization": f"Bearer {login.json()['access_token']}"}
+        status_body = client.get("/v1/ai/status", headers=member_h).json()
+        assert status_body["capabilities"]["agentic"]["level"] == "disabled"
+
+
+class TestMemberKey:
+    def test_member_key_appears_in_status_providers_list(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        """Setting a per-user key is visible via /v1/ai/keys/me (no key bytes)."""
+        client.post(
+            "/v1/ai/keys/me/anthropic",
+            headers=admin_h,
+            json={"api_key": "sk-mine"},
+        )
+        r = client.get("/v1/ai/keys/me", headers=admin_h).json()
+        assert r["providers"] == ["anthropic"]
+        # Household-key list and per-user-key list are independent surfaces.
+        admin_keys = client.get("/v1/ai/keys", headers=admin_h).json()
+        assert "anthropic" not in admin_keys["providers"]
+
+    def test_member_can_set_own_key_without_admin(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        """A non-admin member can still call POST /v1/ai/keys/me/{provider}."""
+        from uuid import uuid4
+
+        from sqlalchemy import select
+
+        from tulip_api.auth.passwords import hash_password
+        from tulip_storage.models import Household, User, UserRole
+
+        with session_maker() as s:
+            household = s.execute(select(Household)).scalar_one()
+            s.add(
+                User(
+                    household_id=household.id,
+                    id=uuid4(),
+                    email="member@example.com",
+                    password_hash=hash_password("memberpassword123"),
+                    display_name="Member",
+                    role=UserRole.MEMBER,
+                )
+            )
+            s.commit()
+
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": "member@example.com", "password": "memberpassword123"},
+        )
+        member_h = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+        r = client.post(
+            "/v1/ai/keys/me/anthropic",
+            headers=member_h,
+            json={"api_key": "sk-member"},
+        )
+        assert r.status_code == 204, r.text
+
+
+class TestAdminRestrictions:
+    def test_member_cannot_set_household_key_admin_only(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        """The household-key endpoint stays admin-only (existing #229 behavior)."""
+        from uuid import uuid4
+
+        from sqlalchemy import select
+
+        from tulip_api.auth.passwords import hash_password
+        from tulip_storage.models import Household, User, UserRole
+
+        with session_maker() as s:
+            household = s.execute(select(Household)).scalar_one()
+            s.add(
+                User(
+                    household_id=household.id,
+                    id=uuid4(),
+                    email="member@example.com",
+                    password_hash=hash_password("memberpassword123"),
+                    display_name="Member",
+                    role=UserRole.MEMBER,
+                )
+            )
+            s.commit()
+
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": "member@example.com", "password": "memberpassword123"},
+        )
+        member_h = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+        r = client.post(
+            "/v1/ai/keys/anthropic",
+            headers=member_h,
+            json={"api_key": "sk-evil"},
+        )
+        assert_problem(r, code="auth.forbidden", status=403)
+
+
+class TestExportIncludesUserAIPolicy:
+    def test_user_export_carries_ai_policy(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        """GDPR Art. 15 (#241): the export reflects the per-user policy override."""
+        client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"nl_query": {"policy": "disabled"}}},
+        )
+        export = client.get("/v1/users/me/export", headers=admin_h).json()
+        assert export["user"]["ai_policy"] == {"capabilities": {"nl_query": {"policy": "disabled"}}}

--- a/packages/tulip-api/tests/test_user_ai_keys_endpoint.py
+++ b/packages/tulip-api/tests/test_user_ai_keys_endpoint.py
@@ -1,0 +1,219 @@
+"""Tests for the per-user AI key endpoints (#239).
+
+Per ADR-0005 §Q2: a user can upload their own provider key that takes
+precedence over the household's for that user's AI calls. Endpoints are
+``POST/DELETE/GET /v1/ai/keys/me/{provider}`` (self) and
+``POST/DELETE/GET /v1/ai/keys/users/{user_id}/{provider}`` (admin-on-other).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_h(client: TestClient) -> dict[str, str]:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith Family",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+class TestOwnKeyCrud:
+    def test_set_then_list_then_delete_round_trips(
+        self, client: TestClient, admin_h: dict[str, str]
+    ) -> None:
+        # Empty to start.
+        r = client.get("/v1/ai/keys/me", headers=admin_h)
+        assert r.status_code == 200
+        assert r.json()["providers"] == []
+
+        # Set anthropic key → 204.
+        r = client.post(
+            "/v1/ai/keys/me/anthropic",
+            headers=admin_h,
+            json={"api_key": "sk-user"},
+        )
+        assert r.status_code == 204, r.text
+
+        # GET reflects it (but never returns the key value).
+        r = client.get("/v1/ai/keys/me", headers=admin_h)
+        assert r.json()["providers"] == ["anthropic"]
+        assert "sk-user" not in r.text
+
+        # Delete it → 204.
+        r = client.delete("/v1/ai/keys/me/anthropic", headers=admin_h)
+        assert r.status_code == 204
+
+        # Empty again.
+        assert client.get("/v1/ai/keys/me", headers=admin_h).json()["providers"] == []
+
+    def test_set_audit_emits_provider_only_no_key_material(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        client.post(
+            "/v1/ai/keys/me/anthropic",
+            headers=admin_h,
+            json={"api_key": "sk-secret-do-not-leak"},
+        )
+
+        with session_maker() as s:
+            row = s.execute(
+                select(AuditLog).where(AuditLog.action == "user.ai_key_set")
+            ).scalar_one()
+        assert row.metadata_ == {"provider": "anthropic"}
+        # Key bytes never appear anywhere in the audit row.
+        for blob in (row.before_snapshot, row.after_snapshot, row.metadata_):
+            assert "sk-secret-do-not-leak" not in str(blob)
+
+    def test_delete_is_idempotent(self, client: TestClient, admin_h: dict[str, str]) -> None:
+        # Never set; delete returns 204 anyway.
+        r = client.delete("/v1/ai/keys/me/anthropic", headers=admin_h)
+        assert r.status_code == 204
+
+
+class TestAdminKeyCrud:
+    def test_admin_can_set_other_users_key(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        from sqlalchemy import select
+
+        from tulip_api.auth.passwords import hash_password
+        from tulip_storage.models import Household, User, UserRole
+
+        with session_maker() as s:
+            household = s.execute(select(Household)).scalar_one()
+            member_id = uuid4()
+            s.add(
+                User(
+                    household_id=household.id,
+                    id=member_id,
+                    email="member@example.com",
+                    password_hash=hash_password("memberpassword123"),
+                    display_name="Member",
+                    role=UserRole.MEMBER,
+                )
+            )
+            s.commit()
+
+        r = client.post(
+            f"/v1/ai/keys/users/{member_id}/anthropic",
+            headers=admin_h,
+            json={"api_key": "sk-by-admin"},
+        )
+        assert r.status_code == 204, r.text
+
+        r = client.get(f"/v1/ai/keys/users/{member_id}", headers=admin_h)
+        assert r.json()["providers"] == ["anthropic"]
+
+    def test_non_admin_cannot_set_others_key(
+        self,
+        client: TestClient,
+        session_maker,
+        admin_h: dict[str, str],  # ensures household is registered first
+    ) -> None:
+        from sqlalchemy import select
+
+        from tulip_api.auth.passwords import hash_password
+        from tulip_storage.models import Household, User, UserRole
+
+        with session_maker() as s:
+            household = s.execute(select(Household)).scalar_one()
+            target_id = uuid4()
+            s.add_all(
+                [
+                    User(
+                        household_id=household.id,
+                        id=uuid4(),
+                        email="member@example.com",
+                        password_hash=hash_password("memberpassword123"),
+                        display_name="Member",
+                        role=UserRole.MEMBER,
+                    ),
+                    User(
+                        household_id=household.id,
+                        id=target_id,
+                        email="target@example.com",
+                        password_hash=hash_password("targetpassword123"),
+                        display_name="Target",
+                        role=UserRole.MEMBER,
+                    ),
+                ]
+            )
+            s.commit()
+
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": "member@example.com", "password": "memberpassword123"},
+        )
+        member_h = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+        r = client.post(
+            f"/v1/ai/keys/users/{target_id}/anthropic",
+            headers=member_h,
+            json={"api_key": "sk-evil"},
+        )
+        assert_problem(r, code="auth.forbidden", status=403)
+
+    def test_admin_cannot_reach_other_household(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        client.post(
+            "/v1/auth/register",
+            json={
+                "email": "other@example.com",
+                "password": "other good password please",
+                "display_name": "Other",
+                "household_name": "Other Family",
+            },
+        )
+        other_login = client.post(
+            "/v1/auth/login",
+            json={"email": "other@example.com", "password": "other good password please"},
+        )
+        other_h = {"Authorization": f"Bearer {other_login.json()['access_token']}"}
+        other_id = client.get("/v1/users/me/export", headers=other_h).json()["user"]["id"]
+
+        r = client.post(
+            f"/v1/ai/keys/users/{other_id}/anthropic",
+            headers=admin_h,
+            json={"api_key": "x"},
+        )
+        assert_problem(r, code="user.not_found", status=404)
+
+
+class TestKeyAuth:
+    def test_set_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.post("/v1/ai/keys/me/anthropic", json={"api_key": "x"})
+        assert_problem(r, code="auth.unauthorized", status=401)
+
+    def test_list_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.get("/v1/ai/keys/me")
+        assert_problem(r, code="auth.unauthorized", status=401)

--- a/packages/tulip-api/tests/test_users_ai_policy_endpoint.py
+++ b/packages/tulip-api/tests/test_users_ai_policy_endpoint.py
@@ -1,0 +1,280 @@
+"""Tests for PUT /v1/users/{me,user_id}/ai-policy — per-user AI policy (#239).
+
+GDPR Art. 18(1)(a)/(d) restriction-of-processing. Members can ratchet up
+the strictness of their own AI policy (the household sets the floor).
+Admins can set policy on any user in their household. The endpoint only
+accepts ``capabilities[<cap>].{policy,profile}`` — provider / cost-cap /
+rate-limit remain household-scope per ADR-0005 §Q5.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+def _register_household_admin(client: TestClient) -> dict[str, str]:
+    body = {
+        "email": "admin@example.com",
+        "password": "correct horse battery staple",
+        "display_name": "Admin",
+        "household_name": "Smith Family",
+    }
+    r = client.post("/v1/auth/register", json=body)
+    assert r.status_code == 201, r.text
+    return body
+
+
+@pytest.fixture
+def admin_h(client: TestClient) -> dict[str, str]:
+    body = _register_household_admin(client)
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": body["email"], "password": body["password"]},
+    )
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+@pytest.fixture
+def admin_user_id(client: TestClient, admin_h: dict[str, str]) -> str:
+    """Resolve the admin's own user_id via the export endpoint."""
+    r = client.get("/v1/users/me/export", headers=admin_h)
+    assert r.status_code == 200
+    return r.json()["user"]["id"]
+
+
+class TestPutOwnAIPolicy:
+    def test_member_can_ratchet_up_own_policy(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        r = client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"nl_query": {"policy": "disabled"}}},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ai_policy"]["capabilities"]["nl_query"]["policy"] == "disabled"
+
+    def test_put_reflected_in_ai_status(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        """The /v1/ai/status response should reflect the user's stricter policy."""
+        client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"nl_query": {"policy": "disabled"}}},
+        )
+        r = client.get("/v1/ai/status", headers=admin_h)
+        assert r.json()["capabilities"]["nl_query"]["level"] == "disabled"
+
+    def test_clear_resets_to_inherit(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        # Set, then clear by sending an empty body.
+        client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"nl_query": {"policy": "disabled"}}},
+        )
+        r = client.put("/v1/users/me/ai-policy", headers=admin_h, json={})
+        assert r.status_code == 200, r.text
+        assert r.json()["ai_policy"] is None
+
+    def test_put_writes_audit_row(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        admin_user_id: str,
+        session_maker,
+    ) -> None:
+        from sqlalchemy import select
+
+        from tulip_storage.models import AuditLog
+
+        client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"nl_query": {"policy": "disabled"}}},
+        )
+        with session_maker() as s:
+            row = s.execute(
+                select(AuditLog).where(AuditLog.action == "user.ai_policy_set")
+            ).scalar_one()
+        assert row.entity_type == "user"
+        assert str(row.entity_id) == admin_user_id
+        assert row.before_snapshot is None or row.before_snapshot == {}
+        assert row.after_snapshot is not None
+        assert row.after_snapshot["capabilities"]["nl_query"]["policy"] == "disabled"
+
+
+class TestPutOtherAIPolicy:
+    def test_admin_can_set_other_users_policy(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        """Admin sets policy on a sibling member in the same household."""
+        from sqlalchemy import select
+
+        from tulip_api.auth.passwords import hash_password
+        from tulip_storage.models import Household, User, UserRole
+
+        # Create a sibling member in the admin's household.
+        with session_maker() as s:
+            household = s.execute(select(Household)).scalar_one()
+            member_id = uuid4()
+            s.add(
+                User(
+                    household_id=household.id,
+                    id=member_id,
+                    email="member@example.com",
+                    password_hash=hash_password("memberpassword123"),
+                    display_name="Member",
+                    role=UserRole.MEMBER,
+                )
+            )
+            s.commit()
+
+        r = client.put(
+            f"/v1/users/{member_id}/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"forecast": {"policy": "disabled"}}},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["ai_policy"]["capabilities"]["forecast"]["policy"] == "disabled"
+
+    def test_non_admin_cannot_set_others_policy(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        """Member calls PUT /v1/users/{other_id}/ai-policy → 403."""
+        from sqlalchemy import select
+
+        from tulip_api.auth.passwords import hash_password
+        from tulip_storage.models import Household, User, UserRole
+
+        # Seed a member and a target.
+        with session_maker() as s:
+            household = s.execute(select(Household)).scalar_one()
+            target_id = uuid4()
+            s.add_all(
+                [
+                    User(
+                        household_id=household.id,
+                        id=uuid4(),
+                        email="member@example.com",
+                        password_hash=hash_password("memberpassword123"),
+                        display_name="Member",
+                        role=UserRole.MEMBER,
+                    ),
+                    User(
+                        household_id=household.id,
+                        id=target_id,
+                        email="target@example.com",
+                        password_hash=hash_password("targetpassword123"),
+                        display_name="Target",
+                        role=UserRole.MEMBER,
+                    ),
+                ]
+            )
+            s.commit()
+
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": "member@example.com", "password": "memberpassword123"},
+        )
+        member_h = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+        r = client.put(
+            f"/v1/users/{target_id}/ai-policy",
+            headers=member_h,
+            json={"capabilities": {"forecast": {"policy": "disabled"}}},
+        )
+        assert_problem(r, code="auth.forbidden", status=403)
+
+    def test_admin_cannot_reach_other_household(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        """user_id from another household → 404 (tenant scoping)."""
+        # Register a second household; capture its admin's user id.
+        client.post(
+            "/v1/auth/register",
+            json={
+                "email": "other@example.com",
+                "password": "other good password please",
+                "display_name": "Other",
+                "household_name": "Other Family",
+            },
+        )
+        other_login = client.post(
+            "/v1/auth/login",
+            json={"email": "other@example.com", "password": "other good password please"},
+        )
+        other_h = {"Authorization": f"Bearer {other_login.json()['access_token']}"}
+        other_id = client.get("/v1/users/me/export", headers=other_h).json()["user"]["id"]
+
+        r = client.put(
+            f"/v1/users/{other_id}/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"forecast": {"policy": "disabled"}}},
+        )
+        assert_problem(r, code="user.not_found", status=404)
+
+
+class TestPutAIPolicyValidation:
+    def test_invalid_policy_value_returns_422(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        r = client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"nl_query": {"policy": "nonsense"}}},
+        )
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_unknown_capability_rejected(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        r = client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"capabilities": {"made_up": {"policy": "disabled"}}},
+        )
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_extra_fields_rejected(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+    ) -> None:
+        """Provider / cost-cap belong on the household policy, not per-user."""
+        r = client.put(
+            "/v1/users/me/ai-policy",
+            headers=admin_h,
+            json={"default_provider": "openai"},
+        )
+        assert_problem(r, code="validation.failed", status=422)
+
+    def test_unauthenticated_returns_401(self, client: TestClient) -> None:
+        r = client.put("/v1/users/me/ai-policy", json={})
+        assert_problem(r, code="auth.unauthorized", status=401)

--- a/packages/tulip-core/src/tulip_core/reconciliation/categorizer.py
+++ b/packages/tulip-core/src/tulip_core/reconciliation/categorizer.py
@@ -52,11 +52,17 @@ class HouseholdContext:
     inputs (recent transactions, learned rules, account preferences),
     and that's where ``HouseholdContext`` will grow. Adding fields with
     defaults won't break existing callers.
+
+    ``acting_user_id`` (#239) is the optional id of the user on whose
+    behalf the categorization runs. When set, downstream AI capabilities
+    read that user's ``ai_policy`` and per-user keys; when ``None`` the
+    household-level policy is dispositive.
     """
 
     household_id: UUID
     account_whitelist: frozenset[UUID]
     existing_rules: tuple[object, ...] = field(default=())
+    acting_user_id: UUID | None = None
 
 
 @runtime_checkable

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260515_1000_f3b8e1a5c2d7_add_users_ai_policy.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260515_1000_f3b8e1a5c2d7_add_users_ai_policy.py
@@ -1,0 +1,40 @@
+"""Add users.ai_policy JSON column for per-user AI policy ratchet-up (#239).
+
+Per ADR-0005 §Q5 the policy shape is household-floor + per-user-ratchet-up.
+The merge logic in ``tulip_ai.policy.resolve_policy`` already accepts a
+``user_policy`` argument and is tested for "max-severity wins"; this
+column gives it storage to draw from.
+
+Nullable, defaults NULL → the resolver's existing ``if user_policy: ...``
+guard interprets NULL as "no per-user override; inherit household". This
+is unlike ``households.ai_policy`` which is NOT NULL with default ``{}``
+— for users, "no override" is the common case.
+
+Revision ID: f3b8e1a5c2d7
+Revises: a2e9c4f1d8b3
+Create Date: 2026-05-15 10:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f3b8e1a5c2d7"
+down_revision: str | None = "a2e9c4f1d8b3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable JSON ``ai_policy`` column to ``users``."""
+    with op.batch_alter_table("users", schema=None) as batch:
+        batch.add_column(sa.Column("ai_policy", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the ``ai_policy`` column from ``users``."""
+    with op.batch_alter_table("users", schema=None) as batch:
+        batch.drop_column("ai_policy")

--- a/packages/tulip-storage/src/tulip_storage/models/user.py
+++ b/packages/tulip-storage/src/tulip_storage/models/user.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
+    JSON,
     DateTime,
     ForeignKey,
     LargeBinary,
@@ -51,6 +53,11 @@ class User(Base):
     # Encrypted ``{provider: api_key}``; overrides the household's keys
     # for this user. See ADR-0005 §Q2.
     ai_keys_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    # Per-user AI policy override (#239). NULL = inherit household. The
+    # resolver merges this with ``households.ai_policy`` using max-severity
+    # wins per ADR-0005 §Q5 — a user can ratchet *up* (stricter) but not
+    # ratchet down below the household's floor.
+    ai_policy: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True, default=None)
     totp_enrolled_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/packages/tulip-storage/tests/test_models.py
+++ b/packages/tulip-storage/tests/test_models.py
@@ -135,6 +135,45 @@ class TestUserCrud:
         with pytest.raises(IntegrityError):
             session.commit()
 
+    def test_ai_policy_defaults_null(self, session: Session):
+        """New users have no per-user AI policy (#239) — inherit household."""
+        h = Household(id=uuid4(), name="Smith", base_currency="USD")
+        session.add(h)
+        u = User(
+            household_id=h.id,
+            id=uuid4(),
+            email="carol@example.com",
+            password_hash="argon2id$dummy",
+            display_name="Carol",
+            role=UserRole.MEMBER,
+        )
+        session.add(u)
+        session.commit()
+        loaded = session.execute(select(User).where(User.email == "carol@example.com")).scalar_one()
+        assert loaded.ai_policy is None
+
+    def test_ai_policy_round_trips_dict(self, session: Session):
+        """Per-user ai_policy JSON column persists and reloads a dict (#239)."""
+        h = Household(id=uuid4(), name="Smith", base_currency="USD")
+        session.add(h)
+        u = User(
+            household_id=h.id,
+            id=uuid4(),
+            email="dave@example.com",
+            password_hash="argon2id$dummy",
+            display_name="Dave",
+            role=UserRole.MEMBER,
+            ai_policy={
+                "capabilities": {"categorize": {"policy": "disabled"}},
+            },
+        )
+        session.add(u)
+        session.commit()
+        loaded = session.execute(select(User).where(User.email == "dave@example.com")).scalar_one()
+        assert loaded.ai_policy == {
+            "capabilities": {"categorize": {"policy": "disabled"}},
+        }
+
     def test_totp_enrolled_at_defaults_null_and_round_trips(self, session: Session):
         h = Household(id=uuid4(), name="Smith", base_currency="USD")
         session.add(h)


### PR DESCRIPTION
## Summary

Closes #239. ADR-0005 §Q5's household-floor + per-user-ratchet-up shape lands end-to-end:

- New nullable JSON column `users.ai_policy` (NULL = inherit household). The resolver's existing falsy check already treats NULL as "no override," so existing rows behave unchanged.
- `HouseholdContext.acting_user_id` (tulip-core) threads through the five `resolve_policy` callsites — categorize / nl_query / proposals / forecast capabilities + `routers/ai.py` (status, preview). The previous `user_policy=None` passthroughs flagged in the privacy audit are all gone.
- `PUT /v1/users/me/ai-policy` (self) and `PUT /v1/users/{user_id}/ai-policy` (admin) write the JSON override; empty body resets to NULL. Body shape is `capabilities[*].{policy,profile}` only — provider / cost-cap / rate-limit remain household-scope.
- `POST/DELETE/GET /v1/ai/keys/me/{provider}` (self) and `/users/{user_id}/` (admin) for per-user provider keys. New `_resolve_provider_key` helper applies user-precedence in categorize + nl_query + proposals key resolution.
- Three new audit actions: `user.ai_policy_set` / `user.ai_key_set` / `user.ai_key_forgotten`. Key actions carry only the provider name in metadata; key bytes never enter the audit row.
- `UserRecordExport` (GDPR Art. 15, #241) now carries `ai_policy` so the data-subject-access dump reflects the per-user override.
- `/v1/ai/keys/me` joins `_SHADOWED_STATIC_PATHS` in the schemathesis contract test — same path-collision pattern as `/v1/users/me`.

## Test plan
- [x] `just lint` / `just typecheck` — clean
- [x] `just coverage` — 1951 passed, 5 expected shadowed-path skips; 90.02% coverage (gate 85%)
- [x] Manual smoke test, below
- [ ] CI green on this PR

### Manual smoke test

\`\`\`bash
just dev &
DEV_PID=\$!
sleep 2
API=http://127.0.0.1:8000

curl -sS -X POST \$API/v1/auth/register -H 'content-type: application/json' \
  -d '{\"email\":\"admin@example.com\",\"password\":\"correct horse battery staple\",\"display_name\":\"Admin\",\"household_name\":\"Smith\"}'

ACCESS=\$(curl -sS -X POST \$API/v1/auth/login -H 'content-type: application/json' \
  -d '{\"email\":\"admin@example.com\",\"password\":\"correct horse battery staple\"}' | jq -r .access_token)
H=\"Authorization: Bearer \$ACCESS\"

# Flow 1: set + read own AI policy (member-stricter case)
curl -sS -X PUT \$API/v1/users/me/ai-policy -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"capabilities\":{\"nl_query\":{\"policy\":\"disabled\"}}}'

curl -sS \$API/v1/ai/status -H \"\$H\" | jq '.capabilities.nl_query.level'
# expected: \"disabled\"

# Flow 2: clear it (reset to inherit)
curl -sS -X PUT \$API/v1/users/me/ai-policy -H \"\$H\" -H 'content-type: application/json' -d '{}'

curl -sS \$API/v1/ai/status -H \"\$H\" | jq '.capabilities.nl_query.level'
# expected: \"permissive\"

# Flow 3: per-user key surfaces
curl -sS -o /dev/null -w '%{http_code}\\n' -X POST \$API/v1/ai/keys/me/anthropic -H \"\$H\" -H 'content-type: application/json' \
  -d '{\"api_key\":\"sk-mine\"}'
# expected: 204

curl -sS \$API/v1/ai/keys/me -H \"\$H\" | jq -r '.providers[]'
# expected: anthropic

# household keys list is independent of per-user keys
curl -sS \$API/v1/ai/keys -H \"\$H\" | jq -r '.providers[]'
# expected: (empty)

curl -sS -o /dev/null -w '%{http_code}\\n' -X DELETE \$API/v1/ai/keys/me/anthropic -H \"\$H\"
# expected: 204

kill \$DEV_PID
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)