### PR TITLE
feat: redact ip_address + user_agent in structlog + stdlib (closes #246)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-15 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #247 ai.consent_changed audit merged), plus a CLI/importers usability bundle
+**Last updated:** 2026-05-15 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit merged), plus a CLI/importers usability bundle
 
 ---
 
@@ -622,6 +622,15 @@ Every Wave-1 security follow-up shipped, one PR per issue:
   redaction), two-step `DELETE /v1/households/me` (token-confirmed),
   `AttachmentRepository.delete()` with refcount, and an `attachment_gc`
   scheduler handler. New `pending_household_erasures` table.
+- **#246 (M-2)** — `ip_address` + `user_agent` join the
+  `_SENSITIVE_FIELDS` whitelist in `logging_config.py`. Both the
+  structlog pipeline and the stdlib `Logger.makeRecord` redactor scrub
+  these values in any structlog event or `extra={...}` payload. The
+  `sessions.ip_address` and `audit_log.ip_address` rows stay
+  full-precision at rest — the existing `#235` user-erasure scrub is
+  the long-term redaction path. No IP truncation: full-precision DB +
+  redacted logs preserves per-host forensic depth while closing the
+  log-leak hazard.
 - **#247 (M-7)** — consent provenance: every mutation to
   `households.ai_policy` (PUT `/v1/ai/config` and PUT
   `/v1/ai/config/capabilities/{capability}`) now writes an

--- a/packages/tulip-api/src/tulip_api/logging_config.py
+++ b/packages/tulip-api/src/tulip_api/logging_config.py
@@ -51,6 +51,14 @@ _SENSITIVE_FIELDS: Final[frozenset[str]] = frozenset(
         # promise it's redacted-by-default. #220 (H-5).
         "email",
         "user_email",
+        # IP + user-agent are personal data per GDPR Recital 30 / Art. 4(1).
+        # They're captured on every auth event (register / login / MFA /
+        # refresh / logout / recovery) into ``sessions.ip_address`` /
+        # ``audit_log.ip_address`` — that's the at-rest fate. This whitelist
+        # entry keeps the same values from leaking into structlog files in
+        # the clear. #246 (M-2).
+        "ip_address",
+        "user_agent",
     }
 )
 

--- a/packages/tulip-api/tests/test_logging.py
+++ b/packages/tulip-api/tests/test_logging.py
@@ -55,6 +55,9 @@ class TestPIIRedaction:
             # H-5 (#220): emails are personal data per GDPR.
             "email",
             "user_email",
+            # M-2 (#246): IP + user-agent are personal data (Recital 30).
+            "ip_address",
+            "user_agent",
         ],
     )
     def test_redact_replaces_known_sensitive_fields(self, field: str):
@@ -118,6 +121,26 @@ class TestStdlibFilter:
         log.info("login.failed", extra={"email": "alice@example.com"})
         record = caplog.records[-1]
         assert record.email == "<redacted>"
+
+    def test_filter_redacts_extra_ip_address(self, configured_logging, caplog):
+        """#246 (M-2): GDPR Recital 30 — IPs are personal data."""
+        import logging as _logging
+
+        caplog.set_level(_logging.INFO)
+        log = _logging.getLogger("tulip_api.test_filter")
+        log.info("login.attempt", extra={"ip_address": "203.0.113.7"})
+        record = caplog.records[-1]
+        assert record.ip_address == "<redacted>"
+
+    def test_filter_redacts_extra_user_agent(self, configured_logging, caplog):
+        """#246 (M-2): user-agent fingerprints the caller and is personal data."""
+        import logging as _logging
+
+        caplog.set_level(_logging.INFO)
+        log = _logging.getLogger("tulip_api.test_filter")
+        log.info("login.attempt", extra={"user_agent": "Mozilla/5.0 ..."})
+        record = caplog.records[-1]
+        assert record.user_agent == "<redacted>"
 
     def test_filter_leaves_unknown_fields_alone(self, configured_logging, caplog):
         import logging as _logging


### PR DESCRIPTION
## Summary

Closes #246. GDPR Recital 30 / Art. 4(1) classifies IP as personal data. Both fields are already captured on every auth event (nine sites in `routers/auth.py`) into `sessions.ip_address` and `audit_log.ip_address` — that's their at-rest fate. The structlog redaction whitelist did not include them, so any log call passing them through landed in JSON log files in the clear.

- `ip_address` + `user_agent` join `_SENSITIVE_FIELDS` in `tulip_api.logging_config`.
- Both pipelines covered: the structlog `redact_pii` processor scrubs them in any structlog event; the stdlib `Logger.makeRecord` redactor scrubs `extra={...}` payloads from any caller that uses `logging.getLogger(...).info(...)` directly.
- Tests extended: the existing parametrize over `_SENSITIVE_FIELDS` adds both fields; two new stdlib tests verify the `extra={"ip_address": ...}` / `extra={"user_agent": ...}` paths.

**No IP truncation at write time** — sessions and audit_log keep full-precision IPs at rest so per-host forensic queries stay possible; the #235 user-erasure scrub path is the long-term redaction story for the DB columns themselves.

## Test plan
- [x] `just lint` / `just typecheck` — clean
- [x] `uv run pytest packages/tulip-api/tests/test_logging.py` — 25 passed (was 21)
- [x] Manual smoke test, below
- [ ] CI green on this PR

### Manual smoke test

```bash
just dev > /tmp/tulip-dev.log 2>&1 &
DEV_PID=$!
sleep 2
API=http://127.0.0.1:8000

curl -sS -X POST $API/v1/auth/register -H 'content-type: application/json' \
  -d '{"email":"admin@example.com","password":"correct horse battery staple","display_name":"Admin","household_name":"Smith"}' > /dev/null

# Trigger one failed login so the ip_address/user_agent get logged
curl -sS -X POST $API/v1/auth/login -H 'content-type: application/json' \
  -d '{"email":"admin@example.com","password":"wrong"}' > /dev/null

# Inspect what landed in the structlog output
grep -E 'login|ip_address|user_agent' /tmp/tulip-dev.log | head -5
# expected: any ip_address / user_agent key reads "<redacted>" in the JSON

kill $DEV_PID
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)