### PR TITLE
docs: refresh THREAT_MODEL.md §2 classification + add §2.1/§2.2 (closes #244)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-15 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle
+**Last updated:** 2026-05-15 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle
 
 ---
 
@@ -622,6 +622,19 @@ Every Wave-1 security follow-up shipped, one PR per issue:
   redaction), two-step `DELETE /v1/households/me` (token-confirmed),
   `AttachmentRepository.delete()` with refcount, and an `attachment_gc`
   scheduler handler. New `pending_household_erasures` table.
+- **#244 (H-17 + M-3 / M-4 / M-5)** — `THREAT_MODEL.md §2` data
+  classification refreshed against the deep privacy audit's §11
+  recommendations: email moved Medium → High; IP/UA online identifiers
+  added; AI body vs. hash split into Critical-when-populated vs
+  High-pseudonymous; free-text inference risk under GDPR Art. 9(1)
+  given its own Critical-free-text tier with all 12 fields enumerated;
+  `audit_log.before_snapshot` / `after_snapshot` flagged as
+  integrity-High but confidentiality-inherits-content; new
+  Multi-presence column tracks the deletion-cascade footprint. New
+  §2.1 "Explicitly absent categories" enumerates the structure-not-
+  collected categories (DOB, phone, address, government IDs, special
+  categories) so future audits don't reconfirm. New §2.2 documents
+  the multi-presence column's role in right-to-erasure planning.
 - **#249 (M-28)** — new operator-facing
   [`docs/USER_RIGHTS.md`](USER_RIGHTS.md) maps GDPR/CCPA data-subject
   rights (Art. 15 access / 16 rectification / 17 erasure / 18

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -32,17 +32,82 @@ Today's deployment is single-tenant, single-machine, no network exposure beyond 
 
 ## 2. Data classification
 
-Five tiers, highest to lowest confidentiality:
+Refreshed against the deep privacy audit (2026-05-13) findings H-17 +
+M-3..M-5. Confidentiality tiers, highest to lowest:
 
-| Tier | Data | Where it lives today | Notes |
-|---|---|---|---|
-| **Critical** | Master key, password hashes, TOTP secrets, recovery codes, JWT secret | env / process memory; `users.password_hash`; `users.totp_secret_encrypted`; `mfa_recovery_codes.code_hash`; `Settings.jwt_secret` | TOTP secrets are the only field-level-encrypted item today. Passwords + recovery codes are argon2id-hashed (one-way, not encrypted). Master key + JWT secret are in process memory only. |
-| **High** | Account balances, transaction descriptions, transaction references, account codes/names, audit log entries | unencrypted SQLite columns | This is "the ledger" — the actual financial data. Nothing about it is encrypted at rest today (Layer 1 SQLCipher deferred). Whoever can read the DB file reads the ledger. |
-| **High (integrity)** | `audit_log` rows | unencrypted SQLite | Append-only via `AuditLogWriter` (single chokepoint). Confidentiality is medium; integrity is high — a tampered audit log invalidates forensics. No DB-level immutability yet (deferred to the Postgres phase per ARCHITECTURE.md §1.1). |
-| **Medium** | Email addresses, household / display names, periods, account hierarchy structure | unencrypted SQLite | PII-ish but largely user-chosen labels. Logging redaction list (`logging_config.py`) keeps emails out of logs by default. |
-| **Highest (Phase 6)** | AI prompt bodies (proposed transactions, NL queries, household financial context fed to LLMs) | `ai_invocations.prompt_json` (NULL by default) + `prompt_hash` always populated | Phase 6 shipped 2026-05-11. Prompts never persisted by default; metadata + SHA-256 hash give forensics-light. Full prompt logging is opt-in via `tulip ai config log-prompts on` (warns the operator) — see §5.3. |
+| Tier | Data | Where it lives today | Multi-presence (count of surfaces) | Notes |
+|---|---|---|---|---|
+| **Critical** | Master key, password hashes, TOTP secrets, recovery codes, JWT secret | env / process memory; `users.password_hash`; `users.totp_secret_encrypted`; `mfa_recovery_codes.code_hash`; `Settings.jwt_secret` | 1 each | TOTP secrets are field-level-encrypted. Passwords + recovery codes are argon2id-hashed (one-way). Master key + JWT secret are in process memory only. |
+| **Critical (free-text content)** | User-typed free text: `transactions.description`, `.reference`, `.notes_encrypted`; `postings.memo`; `accounts.notes_encrypted`; `allocation_pools.name`; `pending_proposals.decision_note` / `.rationale`; `notifications.body`; `shadow_transactions.description`; `shadow_postings.memo`; `statement_lines.description` / `.counterparty` | unencrypted SQLite columns (except `*_encrypted` fields under master-key AES-256-GCM) | 12 columns across 8 tables | **Inference risk under GDPR Art. 9(1).** A user typing `"Payment to Planned Parenthood — $40"` introduces special-category data (health) by inference; `"Tithe to <church>"` does the same for religion. No content classifier today; minimisation is the only mitigation. Free-text fields *cannot* be tier-classified ahead of time — they take whatever tier the user's input pushes them to. |
+| **Critical (when populated)** | AI prompt bodies + response text | `ai_invocations.prompt_json` (NULL unless `households.ai_policy.log_prompts=true`); `ai_invocations.response_text` (same gate) | 1 column each | Per ADR-0005, opt-in retention only; default is NULL. Withdrawing consent atomically scrubs every existing row in the same commit as the policy flip (#243); consent-changed audit row (#247) records the toggle. |
+| **High** | Account balances, account codes/names, period dates, account hierarchy structure, audit log entries (confidentiality) | unencrypted SQLite columns | derived from postings | This is "the ledger." Nothing encrypted at rest today (Layer 1 SQLCipher deferred). Whoever reads the DB file reads the ledger. |
+| **High (pseudonymous)** | `ai_invocations.prompt_hash` (SHA-256 over redacted prompt); `audit_log.actor_user_id` + `entity_id` for deleted users (Art. 17(3)(e) carve-out) | unencrypted SQLite | always populated | Different retention curve from the prompt bodies — the hashes survive consent withdrawal so "was the same prompt sent twice" stays answerable. The 90-day `AI_INVOCATION_RETENTION_DAYS` TTL bounds long-term accumulation. |
+| **High (PII identifiers)** | Email addresses | `users.email`; embedded in `audit_log.metadata_` rows (`login_failed`, `register`) | 2 surfaces | GDPR Art. 4(1) — "an identified or identifiable natural person." Redacted in structlog by default (#220). Scrubbed from `audit_log` on user erasure (#235). **Previously misclassified as Medium.** |
+| **High (online identifiers)** | IP address, user agent | `sessions.ip_address`, `sessions.user_agent`; `audit_log.ip_address`, `audit_log.user_agent` | 2 tables × 2 columns | GDPR Recital 30 names IP as a personal identifier. Captured on every auth event (nine sites in `routers/auth.py`). Redacted in structlog (#246). At-rest in DB stays full precision; scrubbed from `audit_log` on user erasure (#235). **Previously missing from the table.** |
+| **High (integrity, mixed confidentiality)** | `audit_log.before_snapshot` / `audit_log.after_snapshot` | unencrypted SQLite (JSON) | 2 columns | **Integrity is High** (single `AuditLogWriter` chokepoint, no other mutator). **Confidentiality inherits the highest field tier of the snapshot's content** — `description_rectified` rows embed Critical free-text, `profile_updated` rows embed High-PII emails, etc. Treat as Critical-when-populated. Nulled on user erasure via the redaction pass (#235). |
+| **Medium** | Household / display names | `households.name`, `users.display_name` | 1 each | User-chosen labels, low inference risk on their own, but flow through into `audit_log` snapshots which then inherit. |
 
-Classification informs constraints in [§5](#5-constraints-for-phase-46-work).
+### 2.1 Explicitly absent categories
+
+Tulip does **not** structure-collect any of the following. A future audit
+that flags their absence is wasting cycles — minimisation is the design.
+
+- **Date of birth, age, age range.** Not collected at registration or
+  during use. The user's `created_at` is platform-side metadata, not
+  birth-related.
+- **Phone numbers, postal addresses.** Not collected. Statement-line
+  imports may contain merchant addresses but that's *merchant* data,
+  not subject data.
+- **Government IDs** (SSN, tax ID, passport, driver's licence). Not
+  collected. Operators who want to record one are doing it in
+  free-text fields and inherit the Critical (free-text) tier.
+- **Gender, sexual orientation, racial or ethnic origin.** Not
+  collected. GDPR Art. 9(1) special category; absent by design.
+- **Biometric or genetic data.** Not collected. Art. 9(1) special
+  category; absent by design.
+- **Health data.** Not collected. Art. 9(1) special category; the
+  Critical (free-text) tier acknowledges the *inference* risk a user
+  could introduce by typing it, which is qualitatively different from
+  structure-collecting it.
+- **Children's data (under-13 / under-16 depending on jurisdiction).**
+  Tulip has no minor-targeted features; the registration flow assumes
+  an adult operator. There is no age-verification gate.
+- **Geolocation beyond IP.** GPS, cell-tower triangulation, etc. not
+  collected. IP is the only location-adjacent signal (see High (online
+  identifiers) above).
+- **Behavioural advertising profiles.** Not collected, not derived,
+  not transmitted to advertising third parties. The AI provider call
+  is the only outbound — see §5.3 + ADR-0005.
+
+If any of these become relevant for a future capability, the
+classification table is updated *before* the migration that introduces
+the column lands.
+
+### 2.2 Multi-presence and the deletion-cascade chain
+
+The Multi-presence column is load-bearing for the right-to-erasure
+implementation (Wave-1 #235): a field that lives in eight surfaces
+needs eight cascade rules. Today the load-bearing footprints are:
+
+- `transactions.description` and the rectified copies it produces:
+  the source row, the void reversal's quoted copy (rewritten to
+  `[redacted]` on rectification per #242), the user's exported JSON
+  (#241), the audit-log before/after snapshots for both create and
+  rectify, and the journal export. Eight surfaces total when all are
+  populated; the rectification + erasure paths together drain the
+  ones the controller controls.
+- `users.email` flows into `audit_log.metadata_` for `register` and
+  `login_failed`; the user-erasure path nulls those snapshots in the
+  same commit as the row delete.
+- `ai_invocations.prompt_json` is opt-in; the consent-withdrawal scrub
+  (#243) is its erasure path.
+
+The audit `2026-05-13-deep-privacy-audit.md §6` "Data-subject rights
+gap analysis" is the canonical map; this section just calls out the
+cascade dimension classification doesn't otherwise expose.
+
+Classification informs constraints in [§5](#5-constraints-for-phase-46-work)
+and the operator-facing commands map in [USER_RIGHTS.md](USER_RIGHTS.md).
 
 ## 3. Threat actors and attack surface (current)
 


### PR DESCRIPTION
## Summary

Closes #244. The deep privacy audit's §11 flagged six revisions for the data classification table; this PR lands all six and adds the two subsections the audit asked for.

**§2 revisions:**
- Email moves Medium → High (GDPR Art. 4(1)). The old "logging-redacted by default" footnote was code/doc drift closed by #220.
- IP + user-agent get their own row (High, online identifiers per Recital 30); captured on every auth event in `sessions` + `audit_log`.
- Old "Highest (Phase 6)" splits: `prompt_json` + `response_text` → Critical-when-populated; `prompt_hash` + provider metadata → High-pseudonymous (different retention curves).
- Free-text user content gets its own Critical-free-text tier with all 12 columns enumerated and the Art. 9(1) inference risk noted explicitly.
- `audit_log.before_snapshot` / `after_snapshot` flagged as integrity-High but confidentiality-inherits-content (a `description_rectified` row embeds Critical free-text).
- New Multi-presence column tracks the deletion-cascade footprint.

**§2.1 Explicitly absent categories** lists what Tulip structurally does not collect (DOB, phone, address, government IDs, GDPR Art. 9 special categories, children's data, behavioural advertising) so future audits don't reconfirm.

**§2.2** documents the multi-presence column's role in right-to-erasure cascade planning, with `transactions.description` (8 surfaces) as the worked example.

## Test plan
- [x] `just lint` — clean
- [x] Manual: rendered the doc + verified the table aligns
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)