### PR TITLE
fix: QIF split records import as one multi-posting transaction (closes #297)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -622,6 +622,21 @@ Every Wave-1 security follow-up shipped, one PR per issue:
   redaction), two-step `DELETE /v1/households/me` (token-confirmed),
   `AttachmentRepository.delete()` with refcount, and an `attachment_gc`
   scheduler handler. New `pending_household_erasures` table.
+- **#297 (bug)** — QIF split records now import as **one
+  ParsedStatementLine with a structured splits tuple** instead of
+  fanning out into N siblings. The `_finalize_split_record` rewrite +
+  new `ParsedSplit` value object in tulip-core + a multi-posting
+  branch in `promote_statement_line` together produce
+  `1 + len(splits)` postings (one bank-side at the parent total + one
+  per split, balanced per currency) — restoring "one external event
+  = one transaction" for users migrating from Banktivity / Quicken /
+  Moneydance whose checking exports are full of multi-category bills
+  and paychecks. The new splits envelope lives in
+  `statement_lines.raw_json` under a reserved `__splits__` key;
+  legacy `str(dict)`-format rows fall through to the existing
+  two-posting path. Per-split categories resolve against the
+  household's chart of accounts (`accounts.get_by_code`) with
+  fallback to `Imbalance:Unknown` for unknown codes.
 - **#245 (M-1 + M-22 + M-23)** — audit-log tiered retention + backup-leak
   warning. New `households.audit_retention_policy` JSON column + daily
   `audit_retention` scheduled handler that ages out `audit_log` rows by

--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -73,6 +73,7 @@ from tulip_api.services.import_apply import (
     LineExcludedError,
     apply_batch,
     promote_statement_line,
+    serialize_parsed_line_raw_json,
 )
 from tulip_api.services.qif_multi_account import pair_transfers
 from tulip_core.reconciliation.categorizer import get_categorizer
@@ -375,7 +376,7 @@ async def upload_import(
                 "counterparty": parsed.counterparty,
                 "reference": parsed.reference,
                 "fitid": parsed.fitid,
-                "raw_json": str(dict(parsed.raw)),
+                "raw_json": serialize_parsed_line_raw_json(parsed),
             }
             for parsed in parsed_lines
         ],
@@ -592,7 +593,7 @@ async def upload_multi_account_qif(
                     "counterparty": p.counterparty,
                     "reference": p.reference,
                     "fitid": p.fitid,
-                    "raw_json": str(dict(p.raw)),
+                    "raw_json": serialize_parsed_line_raw_json(p),
                 }
                 for p in parsed
             ],

--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -26,14 +26,22 @@ log row + the promoted-tx rows land atomically.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from decimal import Decimal
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 from tulip_core.money import Money
 from tulip_core.reconciliation.categorizer import HouseholdContext
-from tulip_core.reconciliation.statement_line import StatementLine as DomainStatementLine
+from tulip_core.reconciliation.statement_line import (
+    ParsedSplit,
+    ParsedStatementLine,
+)
+from tulip_core.reconciliation.statement_line import (
+    StatementLine as DomainStatementLine,
+)
 from tulip_core.transactions import (
     Posting as DomainPosting,
 )
@@ -63,6 +71,84 @@ if TYPE_CHECKING:
 # so journal export → external tool → re-import round-trips cleanly.
 _IMBALANCE_NAME = "Imbalance:Unknown"
 _IMBALANCE_CODE_PREFIX = "9999"  # 9999.<CURRENCY>, e.g. 9999.USD
+
+# Key under which the structured splits envelope lives inside the
+# statement-line ``raw_json`` blob (#297). The full shape on disk is::
+#
+#   {"raw": {"<QIF-key>": "<value>", ...},
+#    "__splits__": [
+#        {"amount": "-45.27", "currency": "USD",
+#         "category": "Needs:Utilities:...", "memo": "Current gas charges"},
+#        ...
+#    ]}
+#
+# Lines with no splits omit the ``__splits__`` key. The choice of a
+# reserved double-underscore prefix avoids collision with any
+# format-native field name on the ``raw`` side.
+_RAW_JSON_SPLITS_KEY = "__splits__"
+
+
+def serialize_parsed_line_raw_json(parsed: ParsedStatementLine) -> str:
+    """Serialize a parsed line's ``raw`` + ``splits`` for ``statement_lines.raw_json`` (#297).
+
+    Single chokepoint so the QIF, OFX, CSV upload paths all use the
+    same envelope. Lines with no splits get a minimal ``{"raw": {...}}``
+    blob (proper JSON, not the legacy ``str(dict)`` repr — old format
+    was never parsed back, see #297).
+    """
+    payload: dict[str, object] = {"raw": dict(parsed.raw)}
+    if parsed.splits:
+        payload[_RAW_JSON_SPLITS_KEY] = [
+            {
+                "amount": str(s.amount.amount),
+                "currency": s.amount.currency,
+                "category": s.category,
+                "memo": s.memo,
+            }
+            for s in parsed.splits
+        ]
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _extract_splits_from_raw_json(raw_json: str, *, currency: str) -> tuple[ParsedSplit, ...]:
+    """Read the splits tuple back out of a persisted ``raw_json`` blob (#297).
+
+    Returns an empty tuple for lines with no splits, malformed JSON
+    (legacy ``str(dict)`` repr from before #297 — already-applied
+    rows that won't re-enter the promotion path), or any missing /
+    invalid field. ``currency`` is the statement line's currency; we
+    use it as a safety check that every split's currency matches the
+    parent line (the parser already enforces this at parse time, but
+    a hand-edited DB row could violate it).
+    """
+    try:
+        payload = json.loads(raw_json)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return ()
+    if not isinstance(payload, dict):
+        return ()
+    raw_splits = payload.get(_RAW_JSON_SPLITS_KEY)
+    if not isinstance(raw_splits, list) or not raw_splits:
+        return ()
+    out: list[ParsedSplit] = []
+    for entry in raw_splits:
+        if not isinstance(entry, dict):
+            return ()
+        try:
+            amount_str = entry["amount"]
+            split_currency = entry["currency"]
+            category = entry["category"]
+        except KeyError:
+            return ()
+        memo = entry.get("memo")
+        if split_currency != currency:
+            return ()
+        try:
+            amount = Money(Decimal(str(amount_str)), split_currency)
+        except (ValueError, TypeError):
+            return ()
+        out.append(ParsedSplit(amount=amount, category=category, memo=memo))
+    return tuple(out)
 
 
 def _get_or_create_imbalance_account(
@@ -196,6 +282,59 @@ async def promote_statement_line(
     if bank_account is None:  # pragma: no cover - bank account is FK-enforced
         raise LookupError(f"batch.account_id {batch.account_id} not found")
 
+    splits = _extract_splits_from_raw_json(line.raw_json, currency=line.currency)
+    tx_status = DomainTxStatus.POSTED if as_posted else DomainTxStatus.PENDING
+
+    if splits:
+        # #297: split-bearing line promotes to one transaction with
+        # ``1 + len(splits)`` postings — one bank-side at the parent
+        # total + one per split. Per-split categories come from the
+        # QIF ``S`` field (encoded in ``ParsedSplit.category``); we
+        # try ``accounts.get_by_code`` first and fall back to the
+        # Imbalance account for unknown categories so a missing chart
+        # entry doesn't block the whole batch. ``no_categorize`` is
+        # not honoured for splits — the source format already
+        # categorized them, the operator's "skip categorization" toggle
+        # is moot.
+        postings: list[DomainPosting] = [
+            DomainPosting(
+                id=uuid4(),
+                account_id=bank_account.id,
+                amount=Money(line.amount, line.currency),
+            )
+        ]
+        for split in splits:
+            split_account = accounts.get_by_code(split.category)
+            if split_account is None:
+                split_account = _get_or_create_imbalance_account(
+                    session=session,
+                    household_id=household_id,
+                    currency=line.currency,
+                    actor_user_id=actor_user_id,
+                )
+            postings.append(
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=split_account.id,
+                    amount=Money(-split.amount.amount, line.currency),
+                    memo=split.memo,
+                )
+            )
+        domain_tx = DomainTransaction(
+            id=uuid4(),
+            household_id=household_id,
+            date=line.posted_date,
+            description=line.description,
+            postings=tuple(postings),
+            status=tx_status,
+            created_by_user_id=actor_user_id,
+        )
+        tx = TransactionRepository(session, household_id).save_balanced(
+            domain_tx, imported_from_id=batch.id
+        )
+        StatementLineRepository(session, household_id).mark_promoted(line.id, tx.id)
+        return tx
+
     if no_categorize:
         other_account = _get_or_create_imbalance_account(
             session=session,
@@ -221,7 +360,6 @@ async def promote_statement_line(
 
     bank_amount = Money(line.amount, line.currency)
     other_amount = Money(-line.amount, line.currency)
-    tx_status = DomainTxStatus.POSTED if as_posted else DomainTxStatus.PENDING
     domain_tx = DomainTransaction(
         id=uuid4(),
         household_id=household_id,

--- a/packages/tulip-api/tests/services/test_import_apply.py
+++ b/packages/tulip-api/tests/services/test_import_apply.py
@@ -367,6 +367,256 @@ class TestPromoteStatementLine:
             assert tx.status == TransactionStatus.PENDING
 
 
+# ---- promote_statement_line: split-bearing lines (#297) ----------------
+
+
+class TestPromoteSplitLine:
+    """Per #297: a split-bearing statement line promotes to ONE transaction
+    with ``1 + len(splits)`` postings (one bank-side + one per split).
+
+    The split detail lives in ``statement_lines.raw_json`` under a
+    reserved ``__splits__`` key (encoded by
+    ``serialize_parsed_line_raw_json`` on import). The apply path
+    reads it back, resolves each split's category via
+    ``AccountRepository.get_by_code``, and falls back to
+    ``Imbalance:Unknown`` for unknown categories. ``no_categorize``
+    is moot for splits — the source format already categorized them.
+    """
+
+    def _seed_split_line(
+        self,
+        session_maker,
+        setup,
+        *,
+        total: str,
+        splits: list[dict],
+    ) -> UUID:
+        """Insert one new split-bearing statement line; return its id."""
+        line_id = uuid4()
+        with session_maker() as s:
+            line = StatementLine(
+                household_id=setup["household_id"],
+                id=line_id,
+                import_batch_id=setup["batch_id"],
+                line_number=99,  # fresh number, no collision with seeded 1/2/3.
+                posted_date=date(2026, 1, 2),
+                amount=Decimal(total),
+                currency="USD",
+                description="CenterPoint Energy",
+                raw_json=(
+                    '{"raw": {"P": "CenterPoint Energy", "T": "' + total + '"}, '
+                    '"__splits__": ' + str(splits).replace("'", '"').replace("None", "null") + "}"
+                ),
+            )
+            s.add(line)
+            s.commit()
+        return line_id
+
+    @pytest.mark.asyncio
+    async def test_split_gas_bill_promotes_one_tx_with_three_postings(self, session_maker, setup):
+        """Banktivity-style 2-split gas bill: -58.99 total = -45.27 + -13.72."""
+        gas_code = "Needs:Utilities:Natural Gas/TulipDrive"
+        warranty_code = "Needs:Insurance:Home Warranty/TulipDrive"
+        # Seed accounts so the split categories resolve.
+        with session_maker() as s:
+            AccountRepository(s, setup["household_id"]).create(
+                code=gas_code, name="Natural Gas", type=AccountType.EXPENSE, currency="USD"
+            )
+            AccountRepository(s, setup["household_id"]).create(
+                code=warranty_code,
+                name="Home Warranty",
+                type=AccountType.EXPENSE,
+                currency="USD",
+            )
+            s.commit()
+
+        line_id = self._seed_split_line(
+            session_maker,
+            setup,
+            total="-58.99",
+            splits=[
+                {
+                    "amount": "-45.27",
+                    "currency": "USD",
+                    "category": gas_code,
+                    "memo": "Current gas charges",
+                },
+                {
+                    "amount": "-13.72",
+                    "currency": "USD",
+                    "category": warranty_code,
+                    "memo": "Current home service charges",
+                },
+            ],
+        )
+
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], line_id)
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+
+            assert tx.status == TransactionStatus.PENDING
+            postings = list(s.query(Posting).filter_by(transaction_id=tx.id).all())
+            # One bank-side + two splits = three postings.
+            assert len(postings) == 3
+            # Postings sum to zero per currency.
+            assert sum(p.amount for p in postings) == Decimal("0")
+            # Bank-side carries the parent total.
+            bank = next(p for p in postings if p.account_id == setup["cash_id"])
+            assert bank.amount == Decimal("-58.99")
+            # Two split-side postings, negated.
+            split_amounts = sorted(p.amount for p in postings if p.account_id != setup["cash_id"])
+            assert split_amounts == [Decimal("13.72"), Decimal("45.27")]
+            # Per-split memo round-trips into Posting.memo.
+            split_memos = {p.memo for p in postings if p.memo is not None}
+            assert split_memos == {"Current gas charges", "Current home service charges"}
+
+    @pytest.mark.asyncio
+    async def test_split_paycheck_promotes_one_tx_with_five_postings(self, session_maker, setup):
+        """4-split paycheck: +2814.50 = +3500.00 - 420 - 150 - 115.50."""
+        wages = "Income:Wages/BNSF"
+        fed = "Expenses:Taxes:Federal/BNSF"
+        state = "Expenses:Taxes:State/BNSF"
+        fica = "Expenses:Taxes:FICA/BNSF"
+        with session_maker() as s:
+            for code, account_type in [
+                (wages, AccountType.INCOME),
+                (fed, AccountType.EXPENSE),
+                (state, AccountType.EXPENSE),
+                (fica, AccountType.EXPENSE),
+            ]:
+                AccountRepository(s, setup["household_id"]).create(
+                    code=code, name=code, type=account_type, currency="USD"
+                )
+            s.commit()
+
+        line_id = self._seed_split_line(
+            session_maker,
+            setup,
+            total="2814.50",
+            splits=[
+                {"amount": "3500.00", "currency": "USD", "category": wages, "memo": "Gross"},
+                {"amount": "-420.00", "currency": "USD", "category": fed, "memo": "Federal"},
+                {"amount": "-150.00", "currency": "USD", "category": state, "memo": "State"},
+                {"amount": "-115.50", "currency": "USD", "category": fica, "memo": "FICA"},
+            ],
+        )
+
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], line_id)
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+
+            postings = list(s.query(Posting).filter_by(transaction_id=tx.id).all())
+            assert len(postings) == 5
+            assert sum(p.amount for p in postings) == Decimal("0")
+            # Bank-side carries the net deposited amount.
+            bank = next(p for p in postings if p.account_id == setup["cash_id"])
+            assert bank.amount == Decimal("2814.50")
+
+    @pytest.mark.asyncio
+    async def test_unknown_split_category_falls_back_to_imbalance(self, session_maker, setup):
+        """A split whose category doesn't exist routes to Imbalance:Unknown."""
+        line_id = self._seed_split_line(
+            session_maker,
+            setup,
+            total="-58.99",
+            splits=[
+                {
+                    "amount": "-45.27",
+                    "currency": "USD",
+                    "category": "Account:Does:Not:Exist",
+                    "memo": None,
+                },
+                {
+                    "amount": "-13.72",
+                    "currency": "USD",
+                    "category": "Another:Missing:Code",
+                    "memo": None,
+                },
+            ],
+        )
+
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], line_id)
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            postings = list(s.query(Posting).filter_by(transaction_id=tx.id).all())
+            # 3 postings: bank + 2 splits → both unknown splits route to
+            # the auto-created Imbalance:Unknown (code 9999.USD).
+            assert len(postings) == 3
+            imbalance = AccountRepository(s, setup["household_id"]).get_by_code("9999.USD")
+            assert imbalance is not None
+            # Both non-bank postings land on the auto-created Imbalance account.
+            other = [p for p in postings if p.account_id != setup["cash_id"]]
+            assert len(other) == 2
+            assert all(p.account_id == imbalance.id for p in other)
+            assert sum(p.amount for p in postings) == Decimal("0")
+
+    @pytest.mark.asyncio
+    async def test_links_promoted_transaction_id_on_split_line(self, session_maker, setup):
+        """Split lines link to their promoted tx the same way non-split lines do."""
+        gas_code = "Needs:Utilities:Natural Gas/TulipDrive"
+        with session_maker() as s:
+            AccountRepository(s, setup["household_id"]).create(
+                code=gas_code, name="Gas", type=AccountType.EXPENSE, currency="USD"
+            )
+            s.commit()
+
+        line_id = self._seed_split_line(
+            session_maker,
+            setup,
+            total="-58.99",
+            splits=[
+                {
+                    "amount": "-58.99",
+                    "currency": "USD",
+                    "category": gas_code,
+                    "memo": None,
+                },
+            ],
+        )
+
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], line_id)
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            reloaded = _reload(s, StatementLine, setup["household_id"], line.id)
+            assert reloaded.promoted_transaction_id == tx.id
+
+
 # ---- apply_batch ----------------------------------------------------------
 
 

--- a/packages/tulip-api/tests/test_imports_endpoint.py
+++ b/packages/tulip-api/tests/test_imports_endpoint.py
@@ -271,6 +271,46 @@ class TestUploadQif:
         # Currency on every line picks up the account's USD; QIF carries none.
         assert all(line["currency"] == "USD" for line in full["lines"])
 
+    def test_split_qif_persists_one_line_with_consolidated_total(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        checking_account: str,
+        session_maker,
+    ):
+        """#297: a 2-split QIF record produces ONE statement_line with the parent total
+        + structured ``__splits__`` envelope in raw_json.
+        """
+        import json as _json
+        from decimal import Decimal as _Decimal
+
+        from sqlalchemy import select
+
+        from tulip_storage.models import StatementLine
+
+        body_bytes = (_OFX_FIXTURES.parent / "qif" / "split_gas_bill.qif").read_bytes()
+        r = client.post(
+            "/v1/imports",
+            headers=auth_h,
+            files={"file": ("gas.qif", body_bytes, "application/qif")},
+            data={"account_id": checking_account, "source_format": "qif"},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["statement_line_count"] == 1
+
+        # The GET endpoint doesn't expose raw_json (internal detail);
+        # read the DB row directly for the split envelope check.
+        with session_maker() as s:
+            line = s.execute(select(StatementLine)).scalar_one()
+        assert _Decimal(line.amount) == _Decimal("-58.99")
+        assert line.currency == "USD"
+        raw = _json.loads(line.raw_json)
+        assert "__splits__" in raw
+        assert len(raw["__splits__"]) == 2
+        amounts = sorted(_Decimal(s["amount"]) for s in raw["__splits__"])
+        assert amounts == [_Decimal("-45.27"), _Decimal("-13.72")]
+
     def test_qif_garbage_returns_parse_error(
         self,
         client: TestClient,

--- a/packages/tulip-core/src/tulip_core/reconciliation/__init__.py
+++ b/packages/tulip-core/src/tulip_core/reconciliation/__init__.py
@@ -26,6 +26,7 @@ from tulip_core.reconciliation.categorizer import (
 from tulip_core.reconciliation.match_confidence import MatchConfidence
 from tulip_core.reconciliation.matcher import find_candidates
 from tulip_core.reconciliation.statement_line import (
+    ParsedSplit,
     ParsedStatementLine,
     StatementLine,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "HouseholdContext",
     "MatchConfidence",
     "NullCategorizer",
+    "ParsedSplit",
     "ParsedStatementLine",
     "StatementLine",
     "find_candidates",

--- a/packages/tulip-core/src/tulip_core/reconciliation/statement_line.py
+++ b/packages/tulip-core/src/tulip_core/reconciliation/statement_line.py
@@ -56,6 +56,41 @@ def _validate_common(
 
 
 @dataclass(frozen=True, slots=True)
+class ParsedSplit:
+    """One leg of a multi-category statement-line (#297).
+
+    A QIF split-record like::
+
+        T-58.99            (parent total)
+        SNeeds:Utilities   (split 1 category)
+        $-45.27            (split 1 amount)
+        SNeeds:Insurance   (split 2 category)
+        $-13.72            (split 2 amount)
+
+    produces one :class:`ParsedStatementLine` whose ``amount`` is the
+    parent total and whose ``splits`` tuple holds one ``ParsedSplit``
+    per category. Promoting the line builds a single transaction with
+    one bank-side posting (the total) + one posting per split.
+
+    ``category`` is the format-native category string (e.g. the QIF
+    ``L:`` value). The apply path resolves it against the household's
+    chart of accounts at promotion time — there's no per-split account
+    lookup here.
+    """
+
+    amount: Money
+    category: str
+    memo: str | None = None
+
+    def __post_init__(self) -> None:
+        """Reject empty category strings."""
+        if not isinstance(self.amount, Money):
+            raise TypeError(f"split amount must be Money (got {type(self.amount).__name__})")
+        if not self.category or not self.category.strip():
+            raise ValueError("split.category must be non-empty after strip()")
+
+
+@dataclass(frozen=True, slots=True)
 class ParsedStatementLine:
     """A bank-statement row as produced by an importer (pre-persistence).
 
@@ -63,6 +98,13 @@ class ParsedStatementLine:
     return ``list[ParsedStatementLine]``. The API handler creates the
     ``ImportBatch`` row first, then converts each parsed line into a
     :class:`StatementLine` via :meth:`with_persistence_ids`.
+
+    ``splits`` (#297) is empty for ordinary two-posting lines. When
+    non-empty, ``amount`` is the consolidated parent total and the
+    sum of ``splits[i].amount`` must equal ``amount`` (the parser
+    enforces this with a ``QifParseError`` on mismatch). The apply
+    path promotes a split-bearing line to a single transaction with
+    ``1 + len(splits)`` postings (one bank-side, one per split).
     """
 
     line_number: int
@@ -73,6 +115,7 @@ class ParsedStatementLine:
     counterparty: str | None = field(default=None)
     reference: str | None = field(default=None)
     fitid: str | None = field(default=None)
+    splits: tuple[ParsedSplit, ...] = field(default=())
 
     def __post_init__(self) -> None:
         """Validate invariants and freeze the ``raw`` dict against later mutation."""
@@ -85,6 +128,15 @@ class ParsedStatementLine:
         # mutate it post-construction. Idempotent on existing proxies.
         if not isinstance(self.raw, MappingProxyType):
             object.__setattr__(self, "raw", MappingProxyType(dict(self.raw)))
+        if self.splits:
+            # Every split must share the parent line's currency — otherwise
+            # promotion can't produce a per-currency balanced transaction.
+            for split in self.splits:
+                if split.amount.currency != self.amount.currency:
+                    raise ValueError(
+                        f"split currency {split.amount.currency!r} does not "
+                        f"match parent line currency {self.amount.currency!r}"
+                    )
 
     def with_persistence_ids(
         self,

--- a/packages/tulip-importers/src/tulip_importers/qif/parser.py
+++ b/packages/tulip-importers/src/tulip_importers/qif/parser.py
@@ -25,8 +25,8 @@ Date parsing handles three common dialects:
 - US 2-digit: ``5/12/26`` (rolls to 20YY — no QIF-emitting bank issues
   19xx files in 2026+).
 
-Split records (#270)
---------------------
+Split records (#270, #297)
+--------------------------
 
 Banktivity and most legacy desktop apps (Quicken, Moneydance, …) encode
 a multi-category transaction as one record carrying:
@@ -35,18 +35,21 @@ a multi-category transaction as one record carrying:
 - N ``S<category>`` / ``$<amount>`` / ``E<memo>`` triples — one per
   category. The ``$``-amounts must sum to ``T``.
 
-We emit **one ``ParsedStatementLine`` per split** rather than one line
-with the consolidated total. Each split inherits the parent record's
-date, payee, and reference; ``raw["L"]`` carries the split category for
-the categorizer; the per-split ``E`` memo is folded into ``description``
-so operator-facing renders surface the split's own purpose, not the
-parent record's generic memo. Splits whose amounts don't sum to ``T``
-are rejected with :class:`QifParseError` — silently dropping or
-rebalancing would lose money in either direction.
+Per #297, we emit **one ``ParsedStatementLine`` per split-bearing
+record** with the consolidated parent total in ``amount`` and the
+per-category breakdown in a ``splits`` tuple of :class:`ParsedSplit`.
+Each ``ParsedSplit`` carries its category (the ``S`` line) + amount
+(the ``$`` line) + optional memo (the ``E`` line). Promoting the line
+later yields a single transaction with ``1 + len(splits)`` postings:
+one bank-side at ``T`` and one per split — preserving double-entry's
+"one external event = one transaction" invariant and keeping the bank
+statement reconciliation 1:1.
 
-A non-split record (no ``S``/``$`` lines) still emits exactly one
-``ParsedStatementLine``, preserving the existing two-posting promotion
-shape.
+Splits whose amounts don't sum to ``T`` are rejected with
+:class:`QifParseError` — silently dropping or rebalancing would lose
+money in either direction. A non-split record (no ``S``/``$`` lines)
+still emits exactly one ``ParsedStatementLine`` with an empty
+``splits`` tuple, preserving the existing two-posting promotion shape.
 
 Section skipping (#198)
 -----------------------
@@ -80,7 +83,7 @@ from datetime import date as date_type
 from decimal import Decimal, InvalidOperation
 
 from tulip_core.money import Money
-from tulip_core.reconciliation import ParsedStatementLine
+from tulip_core.reconciliation import ParsedSplit, ParsedStatementLine
 
 #: Each transaction record ends with this single-character line.
 _RECORD_TERMINATOR = "^"
@@ -216,13 +219,16 @@ def _finalize_split_record(
     posted_date: date_type,
     total: Decimal,
 ) -> list[ParsedStatementLine]:
-    """Expand a split record into one ParsedStatementLine per S/$/E triple.
+    """Emit a single ParsedStatementLine carrying every split in ``splits`` (#297).
 
-    Each split inherits the parent's date, payee, and reference. The
-    split's category lives in ``raw["L"]`` (where downstream's
-    categorizer already looks for category hints); the split memo is
-    folded into the per-line description so operator-facing renders
-    surface the split's own purpose.
+    Per #297 the parser no longer fans a split record out into N lines —
+    that broke "one external event = one transaction" and produced N
+    statement-line rows for a single bank-cleared payment. Instead, one
+    :class:`ParsedStatementLine` is emitted with ``amount`` equal to the
+    parent total (the ``T`` line) and a ``splits`` tuple holding one
+    :class:`ParsedSplit` per ``S``/``$``/``E`` triple. The apply path
+    promotes this to a transaction with ``1 + len(splits)`` postings:
+    one bank-side at the total + one per split.
 
     Raises:
         QifParseError: a split is missing its ``$`` amount, or the
@@ -233,15 +239,15 @@ def _finalize_split_record(
     if account_type:
         base_raw["TYPE"] = account_type
     # Strip the running ``$``/``S``/``E`` last-write-wins residue from the
-    # parent ``raw`` — each emitted line carries its own per-split values
-    # via the loop below, so leaving the parent's noise would confuse
-    # downstream consumers reading ``raw``.
+    # parent ``raw`` — the per-split values live in the ``splits`` tuple
+    # below, so leaving the parent's noise would confuse downstream
+    # consumers reading ``raw``.
     for stale in ("$", "S", "E"):
         base_raw.pop(stale, None)
 
-    out: list[ParsedStatementLine] = []
+    parsed_splits: list[ParsedSplit] = []
     running = Decimal("0")
-    for idx, split in enumerate(rec.splits, start=0):
+    for split in rec.splits:
         if split.amount_str is None:
             raise QifParseError(
                 f"line {split.opened_at}: split for category {split.category!r} "
@@ -249,29 +255,11 @@ def _finalize_split_record(
             )
         split_amount = _parse_amount(split.amount_str, source_line=split.opened_at)
         running += split_amount
-
-        split_raw = dict(base_raw)
-        # ``L`` is the conventional QIF category field on a non-split
-        # record; reusing it here means the categorizer doesn't need a
-        # split-aware code path to read the per-split category.
-        split_raw["L"] = split.category
-        if split.memo is not None:
-            split_raw["E"] = split.memo
-
-        description = _compose_description(
-            rec.payee,
-            split.memo if split.memo is not None else rec.memo,
-        )
-
-        out.append(
-            ParsedStatementLine(
-                line_number=start_line_number + idx,
-                posted_date=posted_date,
+        parsed_splits.append(
+            ParsedSplit(
                 amount=Money(split_amount, currency),
-                description=description,
-                counterparty=(rec.payee or None) if rec.payee else None,
-                reference=rec.reference,
-                raw=split_raw,
+                category=split.category,
+                memo=split.memo,
             )
         )
 
@@ -282,7 +270,20 @@ def _finalize_split_record(
             "splits don't reconcile (one or more $ lines were dropped, or "
             "the file was hand-edited)"
         )
-    return out
+
+    description = _compose_description(rec.payee, rec.memo)
+    return [
+        ParsedStatementLine(
+            line_number=start_line_number,
+            posted_date=posted_date,
+            amount=Money(total, currency),
+            description=description,
+            counterparty=(rec.payee or None) if rec.payee else None,
+            reference=rec.reference,
+            raw=base_raw,
+            splits=tuple(parsed_splits),
+        )
+    ]
 
 
 def _finalize_record(

--- a/packages/tulip-importers/tests/test_qif_parser.py
+++ b/packages/tulip-importers/tests/test_qif_parser.py
@@ -73,80 +73,83 @@ class TestParseHappy:
 
 
 class TestParseSplits:
-    """Per #270: each S/$/E triple emits its own ParsedStatementLine.
+    """Per #297: one ParsedStatementLine with consolidated total + structured splits.
 
     QIF encodes a multi-category transaction as a single record with
     ``S`` (split category), ``$`` (split amount), and ``E`` (split memo)
-    field-triples. Banktivity's gas-bill export from the issue body is
-    the canonical 2-split debit case; the BNSF paycheck shape is the
+    field-triples. Banktivity's gas-bill export from #270 is the
+    canonical 2-split debit case; the BNSF paycheck shape is the
     multi-split credit case (a positive gross + negative withholdings
     netting to the deposited total).
 
-    We model splits as N statement lines — one per split — rather than
-    one transaction with N+1 postings because ``ParsedStatementLine`` is
-    the parser surface and downstream (``import_apply``) already turns
-    each statement line into a 2-posting PENDING transaction. This
-    preserves per-category fidelity (the issue's headline requirement)
-    without a schema change across packages.
+    #270's original shape (N lines per N-way split) broke "one external
+    event = one transaction" — a single bank-cleared payment showed up
+    as N separate PENDING transactions, and bank-statement reconciliation
+    couldn't pair one statement line against N ledger transactions.
+    #297 fixes this: the parser emits ONE line with ``amount = T``, and
+    the per-category breakdown lives in the new ``splits`` tuple.
+    Apply-side promotes this to one transaction with ``1 + len(splits)``
+    postings (one bank-side + one per split).
     """
 
-    def test_split_gas_bill_two_lines(self):
-        # The exact snippet from #270: -45.27 + -13.72 = -58.99.
+    def test_split_gas_bill_one_line_with_two_splits(self):
+        # The exact snippet from #270 / #297: -45.27 + -13.72 = -58.99.
         lines = parse(_read("split_gas_bill.qif"), currency="USD")
-        assert len(lines) == 2
+        assert len(lines) == 1
 
-        gas, warranty = lines
-        # Per-split amounts replace the consolidated T-total.
+        (line,) = lines
+        # Consolidated parent total — what hit the bank.
+        assert line.amount.amount == Decimal("-58.99")
+        # The two splits sit on the line, not as siblings.
+        assert len(line.splits) == 2
+        gas, warranty = line.splits
         assert gas.amount.amount == Decimal("-45.27")
         assert warranty.amount.amount == Decimal("-13.72")
-        # Sum reconciles to the row's T-total (cross-check, not asserted
-        # by the parser at the file level — but it must, per #270).
-        assert gas.amount.amount + warranty.amount.amount == Decimal("-58.99")
+        # Sanity: parser-enforced sum check.
+        assert sum(s.amount.amount for s in line.splits) == line.amount.amount
 
     def test_split_gas_bill_carries_per_split_category_and_memo(self):
-        lines = parse(_read("split_gas_bill.qif"), currency="USD")
-        gas, warranty = lines
+        ((line,)) = parse(_read("split_gas_bill.qif"), currency="USD")
+        gas, warranty = line.splits
 
-        # QIF S-field (split category) lives in raw["L"] (categorizer's
-        # input). Per-split memo lives in raw["E"] and is folded into
-        # description so the operator-facing renderer surfaces it.
-        assert gas.raw["L"] == "Needs:Utilities:Natural Gas/TulipDrive"
-        assert warranty.raw["L"] == "Needs:Insurance:Home Warranty/TulipDrive"
-        assert "Current gas charges" in gas.description
-        assert "Current home service charges" in warranty.description
+        # Per-split QIF S-field on the structured ParsedSplit.
+        assert gas.category == "Needs:Utilities:Natural Gas/TulipDrive"
+        assert warranty.category == "Needs:Insurance:Home Warranty/TulipDrive"
+        # Per-split memo (the QIF ``E`` line right before each ``S``).
+        assert gas.memo == "Current gas charges"
+        assert warranty.memo == "Current home service charges"
 
-    def test_split_gas_bill_shares_payee_and_date(self):
-        lines = parse(_read("split_gas_bill.qif"), currency="USD")
-        gas, warranty = lines
+    def test_split_gas_bill_inherits_parent_payee_and_date(self):
+        ((line,)) = parse(_read("split_gas_bill.qif"), currency="USD")
+        # The parent record's date + payee survive on the consolidated line.
+        assert line.posted_date == date(2026, 1, 2)
+        assert line.counterparty == "CenterPoint Energy"
+        # One line, one line_number.
+        assert line.line_number == 1
+        # The line's currency matches every split's currency (enforced
+        # in ParsedStatementLine.__post_init__).
+        for split in line.splits:
+            assert split.amount.currency == line.amount.currency
 
-        # All splits share the parent record's date + payee — they're
-        # the same bank transaction split across categories.
-        assert gas.posted_date == date(2026, 1, 2)
-        assert warranty.posted_date == date(2026, 1, 2)
-        assert gas.counterparty == "CenterPoint Energy"
-        assert warranty.counterparty == "CenterPoint Energy"
-        # Each split gets its own 1-based line_number so downstream
-        # idempotency (UNIQUE (batch_id, line_number)) still holds.
-        assert gas.line_number == 1
-        assert warranty.line_number == 2
-
-    def test_split_paycheck_emits_one_line_per_split(self):
+    def test_split_paycheck_emits_one_line_with_four_splits(self):
         # BNSF gross-paycheck shape: +3500 wages, -420 fed, -150 state,
         # -115.50 FICA, netting to +2814.50 deposited.
         lines = parse(_read("split_paycheck.qif"), currency="USD")
-        assert len(lines) == 4
+        assert len(lines) == 1
 
-        amounts = [line.amount.amount for line in lines]
+        (line,) = lines
+        assert line.amount.amount == Decimal("2814.50")
+        assert len(line.splits) == 4
+
+        amounts = [s.amount.amount for s in line.splits]
         assert amounts == [
             Decimal("3500.00"),
             Decimal("-420.00"),
             Decimal("-150.00"),
             Decimal("-115.50"),
         ]
-        assert sum(amounts) == Decimal("2814.50")
-
         # Per-split category survives parsing.
-        categories = [line.raw["L"] for line in lines]
+        categories = [s.category for s in line.splits]
         assert categories == [
             "Income:Wages/BNSF",
             "Expenses:Taxes:Federal/BNSF",
@@ -155,19 +158,20 @@ class TestParseSplits:
         ]
 
     def test_split_sum_mismatch_raises(self):
-        # Per #270: "If split amounts don't sum to T, the row is
+        # Per #270 + #297: "If split amounts don't sum to T, the row is
         # rejected with an import error rather than silently dropped."
         with pytest.raises(QifParseError, match="split"):
             parse(_read("split_sum_mismatch.qif"), currency="USD")
 
-    def test_single_line_unsplit_still_one_statement_line(self):
+    def test_single_line_unsplit_has_empty_splits_tuple(self):
         # Regression: non-split QIF entries continue to produce exactly
-        # one ParsedStatementLine (which downstream turns into a
-        # two-posting transaction, per #270's regression requirement).
+        # one ParsedStatementLine each, with an empty ``splits`` tuple
+        # — preserving the two-posting promotion shape.
         lines = parse(_read("minimal.qif"), currency="USD")
         assert len(lines) == 3  # three records, no splits, three lines.
         for line in lines:
-            # Non-split lines carry no S-field; raw["L"] is absent.
+            # Non-split lines carry no S-field; splits is empty.
+            assert line.splits == ()
             assert "L" not in line.raw
 
 


### PR DESCRIPTION
## Summary

Closes #297. A QIF transaction with split categories (one `T<total>` + N `S`/`$`/`E` triples) previously imported as N separate statement lines → N separate PENDING transactions on apply. That broke "one external event = one transaction" — a single bank-cleared payment showed up as N distinct ledger rows, bank statement reconciliation couldn't pair one statement line against N ledger txns, and spend reports double-counted.

This change consolidates: one QIF split-record → one `ParsedStatementLine` with a structured `splits` tuple → one PENDING ledger transaction with `1 + len(splits)` postings (one bank-side at the parent total + one per split, balanced per currency).

**Domain (tulip-core):** new `ParsedSplit` frozen dataclass (amount + category + memo); `ParsedStatementLine` gains an optional `splits: tuple[ParsedSplit, ...] = ()` field. Non-split callers unchanged. Currency invariant enforced at construction.

**Parser:** `_finalize_split_record` emits one line with `amount = T` and `splits = tuple(ParsedSplit(...))` per category. The parser-level sum check (`$`-amounts must equal `T`, `QifParseError` on mismatch) is preserved verbatim.

**Persistence:** new `serialize_parsed_line_raw_json` helper writes `statement_lines.raw_json` as a proper JSON envelope `{"raw": {...}, "__splits__": [...]}`. The legacy `str(dict)` repr the QIF / OFX / CSV upload paths used is replaced — old format was never parsed back, so no migration risk.

**Apply path:** `promote_statement_line` branches on split presence. Per-split account resolves via `accounts.get_by_code(split.category)` with fallback to `Imbalance:Unknown` for unknown codes (a missing chart entry doesn't block the whole batch). Per-split memos round-trip into `Posting.memo`. `no_categorize` is moot for splits — the source format already categorized them.

## Test plan
- [x] `just lint` / `just typecheck` — clean
- [x] `just test` — 2003 passed, 5 expected shadowed-path skips
- [x] Manual smoke test (Banktivity split fixture), below
- [ ] CI green on this PR

### Manual smoke test (Banktivity gas-bill case from #297)

```bash
just dev > /tmp/tulip-dev.log 2>&1 &
DEV_PID=$!
sleep 2
API=http://127.0.0.1:8000

curl -sS -X POST $API/v1/auth/register -H 'content-type: application/json' \
  -d '{"email":"admin@example.com","password":"correct horse battery staple","display_name":"Admin","household_name":"Smith"}' > /dev/null
ACCESS=$(curl -sS -X POST $API/v1/auth/login -H 'content-type: application/json' \
  -d '{"email":"admin@example.com","password":"correct horse battery staple"}' | jq -r .access_token)
H="Authorization: Bearer $ACCESS"

# Seed bank + the two split categories.
CHK=$(curl -sS -X POST $API/v1/accounts -H "$H" -H 'content-type: application/json' \
  -d '{"name":"Checking","type":"asset","currency":"USD","code":"1110"}' | jq -r .id)
curl -sS -X POST $API/v1/accounts -H "$H" -H 'content-type: application/json' \
  -d '{"name":"Gas","type":"expense","currency":"USD","code":"Needs:Utilities:Natural Gas/TulipDrive"}' > /dev/null
curl -sS -X POST $API/v1/accounts -H "$H" -H 'content-type: application/json' \
  -d '{"name":"Warranty","type":"expense","currency":"USD","code":"Needs:Insurance:Home Warranty/TulipDrive"}' > /dev/null

# Upload the split fixture from the issue body.
curl -sS -X POST $API/v1/imports -H "$H" \
  -F "file=@packages/tulip-importers/tests/fixtures/qif/split_gas_bill.qif;type=application/qif" \
  -F "account_id=$CHK" \
  -F "source_format=qif" > /tmp/batch.json
BATCH=$(jq -r .id /tmp/batch.json)

# Verify: exactly one statement line, total = -58.99
jq '.statement_line_count' /tmp/batch.json
# expected: 1
curl -sS $API/v1/imports/$BATCH -H "$H" | jq '.lines[0].amount'
# expected: "-58.99000000" (i.e. -58.99)

# Apply → one transaction with 3 postings, balanced per currency.
curl -sS -X POST $API/v1/imports/$BATCH/apply -H "$H" > /tmp/apply.json
TX=$(jq -r '.transaction_ids[0]' /tmp/apply.json)
curl -sS $API/v1/transactions/$TX -H "$H" | jq '{postings: (.postings | length), amounts: (.postings | map(.amount))}'
# expected: postings: 3, amounts sum to 0

kill $DEV_PID
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)