### PR TITLE
fix: clear promoted_transaction_id back-ref + IntegrityError → 409 not 500 (closes #301 #302)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -622,6 +622,21 @@ Every Wave-1 security follow-up shipped, one PR per issue:
   redaction), two-step `DELETE /v1/households/me` (token-confirmed),
   `AttachmentRepository.delete()` with refcount, and an `attachment_gc`
   scheduler handler. New `pending_household_erasures` table.
+- **#301 + #302 (bugs)** — fixed two coupled bugs surfaced by the
+  Banktivity migration. **#301**: `TransactionRepository.delete_pending`
+  now NULLs the back-reference in `statement_lines.promoted_transaction_id`
+  before the DELETE — the RESTRICT FK `fk_statement_lines_promoted_tx`
+  previously blocked deletion of any PENDING tx that came from an
+  imports-apply flow, surfacing as a generic 500. The line is left in
+  the unmatched pool (re-promotable). **#302**: new
+  `DataIntegrityConstraintError` (409, `data.integrity_constraint`) +
+  a `sqlalchemy.exc.IntegrityError` handler in
+  `install_problem_handlers` so unhandled DB constraint violations
+  return a typed Problem Detail instead of the generic 500
+  catch-all. Five exception handlers now (TulipProblem,
+  RequestValidationError, IntegrityError, StarletteHTTPException,
+  Exception); the IntegrityError-specific handler outranks the bare
+  Exception catch-all by Starlette's MRO dispatch.
 - **#297 (bug)** — QIF split records now import as **one
   ParsedStatementLine with a structured splits tuple** instead of
   fanning out into N siblings. The `_finalize_split_record` rewrite +

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -1848,20 +1848,58 @@ class InternalServerError(TulipProblem):
         )
 
 
+class DataIntegrityConstraintError(TulipProblem):
+    """A database constraint blocked the request (#302).
+
+    Caught by the global ``sqlalchemy.exc.IntegrityError`` handler in
+    :func:`install_problem_handlers`. The detail is intentionally
+    generic — the specific constraint (UNIQUE / FOREIGN KEY / CHECK /
+    NOT NULL) is in the server logs; the client gets a classified 409
+    rather than a generic 500. Endpoint code that *foresees* a specific
+    IntegrityError condition should raise its own more-actionable
+    ``TulipProblem`` subclass instead of relying on this catch-all (the
+    transaction-delete path is the motivating example — its FK issue
+    is fixed at the source in #301 so this catch-all is the long-tail
+    safety net, not the user's normal path).
+    """
+
+    def __init__(self) -> None:
+        """Build the data.integrity_constraint problem (no SQL leaked)."""
+        super().__init__(
+            code="data.integrity_constraint",
+            title="Database constraint violation",
+            status=409,
+            detail=(
+                "The request violated a database constraint (foreign key, "
+                "unique, check, or not-null). The request_id below identifies "
+                "the specific row + constraint in the server logs. If this "
+                "looks like a user-facing error rather than a server bug, "
+                "please file a bug — the endpoint should be raising a typed "
+                "Problem Detail instead of falling through to this catch-all."
+            ),
+        )
+
+
 def install_problem_handlers(app: FastAPI) -> None:
     """Register the :class:`TulipProblem` handler on ``app``.
 
-    Wires up four handlers, in order of specificity (Starlette dispatches
+    Wires up five handlers, in order of specificity (Starlette dispatches
     by MRO, picking the most specific match):
 
     * :class:`TulipProblem` — typed domain errors raised by route code.
     * :class:`fastapi.exceptions.RequestValidationError` — Pydantic 422.
+    * :class:`sqlalchemy.exc.IntegrityError` (#302) — DB constraint
+      violations (FK, UNIQUE, CHECK, NOT NULL) get a typed 409 rather
+      than the generic 500 the bare ``Exception`` handler would emit.
+      Endpoint code that *foresees* a specific IntegrityError should
+      catch it locally and raise a more-actionable ``TulipProblem``;
+      this handler is the long-tail safety net.
     * :class:`starlette.exceptions.HTTPException` — framework-level
       400 (malformed body), 404 (no route), 405 (wrong method), 415, etc.
     * :class:`Exception` — last-resort catch-all so an unhandled
       exception never escapes as the default ``text/plain`` 500.
 
-    With all four registered, every non-2xx response is RFC 9457
+    With all five registered, every non-2xx response is RFC 9457
     ``application/problem+json``. Schemathesis's contract test asserts
     this for documented endpoints; the catch-all closes the
     "unhandled-exception" gap that schemathesis can't see (production
@@ -1870,6 +1908,7 @@ def install_problem_handlers(app: FastAPI) -> None:
     """
     import structlog
     from fastapi.exceptions import RequestValidationError
+    from sqlalchemy.exc import IntegrityError
     from starlette.exceptions import HTTPException as StarletteHTTPException
 
     log = structlog.get_logger("tulip_api.errors")
@@ -1885,6 +1924,21 @@ def install_problem_handlers(app: FastAPI) -> None:
         # JSONResponse can't serialize. Coerce them to strings recursively.
         sanitized = [_sanitize_for_json(e) for e in exc.errors()]
         return _render(request, ValidationFailedError(errors=sanitized))
+
+    @app.exception_handler(IntegrityError)
+    def _handle_integrity_error(request: Request, exc: IntegrityError) -> JSONResponse:
+        # #302: DB constraint violations are a classified failure, not
+        # the "we don't know what happened" 500 the bare Exception
+        # handler would emit. We log the full SQL exception server-side
+        # for diagnosis (same shape as _handle_unhandled below) but the
+        # client sees a stable 409 ``data.integrity_constraint`` code.
+        log.exception(
+            "integrity_error",
+            exc_info=exc,
+            exc_type=type(exc).__name__,
+            path=request.url.path,
+        )
+        return _render(request, DataIntegrityConstraintError())
 
     @app.exception_handler(Exception)
     def _handle_unhandled(request: Request, exc: Exception) -> JSONResponse:

--- a/packages/tulip-api/tests/test_internal_error_handler.py
+++ b/packages/tulip-api/tests/test_internal_error_handler.py
@@ -86,6 +86,60 @@ def test_internal_error_carries_request_id_when_supplied_by_client(
     assert response.json().get("request_id") == "00000000-0000-0000-0000-000000000abc"
 
 
+def test_integrity_error_renders_data_integrity_constraint_409() -> None:
+    """#302: sqlalchemy.exc.IntegrityError is a classified failure, not a 500.
+
+    The catch-all maps it to a typed 409 ``data.integrity_constraint`` so
+    a client gets a structured response rather than the generic "we don't
+    know what happened" wrapper. The full SQL exception still lands in
+    server logs at error level for diagnosis.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    app = FastAPI()
+    install_problem_handlers(app)
+
+    @app.get("/boom-integrity")
+    def _boom_integrity() -> None:
+        # Synthesize the shape SQLAlchemy raises in production. Constructor
+        # is (statement, params, orig); ``orig`` is the DBAPI exception.
+        raise IntegrityError("DELETE FROM x", {}, Exception("FK constraint failed"))
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/boom-integrity")
+
+    assert response.status_code == 409
+    assert response.headers["content-type"] == PROBLEM_CONTENT_TYPE
+    body = response.json()
+    assert body["code"] == "data.integrity_constraint"
+    assert body["status"] == 409
+    # SQL text must not leak.
+    assert "DELETE FROM" not in response.text
+    assert "FK constraint" not in response.text
+
+
+def test_integrity_error_does_not_fall_through_to_internal_server_error() -> None:
+    """The IntegrityError-specific handler must outrank the bare ``Exception`` catch-all.
+
+    Starlette dispatches by MRO; this asserts the registration order +
+    specificity actually wins, not by accident.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    app = FastAPI()
+    install_problem_handlers(app)
+
+    @app.get("/boom")
+    def _boom() -> None:
+        raise IntegrityError("UPDATE x", {}, Exception("uniqueness violation"))
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/boom")
+    assert response.json()["code"] == "data.integrity_constraint"
+    # Specifically NOT the 500 catch-all code.
+    assert response.json()["code"] != "server.internal_error"
+
+
 def test_typed_problem_handler_still_wins_over_catchall(panic_client: TestClient) -> None:
     """Registering an Exception handler must not shadow the TulipProblem handler.
 

--- a/packages/tulip-api/tests/test_transactions_patch_delete_endpoint.py
+++ b/packages/tulip-api/tests/test_transactions_patch_delete_endpoint.py
@@ -245,3 +245,61 @@ class TestDelete:
         bogus = "11111111-1111-1111-1111-111111111111"
         r = client.delete(f"/v1/transactions/{bogus}", headers=auth_h)
         assert_problem(r, code="transaction.not_found", status=404)
+
+    def test_delete_pending_promoted_from_import_unpromotes_statement_line(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        session_maker,
+    ):
+        """#301 + #302: a PENDING tx created via the imports-apply flow can
+        be deleted via the API. The source statement line is un-promoted
+        (re-promotable). Without the fix this returned 500 from an
+        unhandled IntegrityError; with the fix it's 204.
+        """
+        from uuid import UUID
+
+        from sqlalchemy import select
+
+        from tulip_storage.models import StatementLine
+
+        cash, _food = cash_and_food
+
+        # Upload a minimal QIF that auto-categorizes to Imbalance:Unknown
+        # via the register-time seeded chart entry (so the apply flow
+        # succeeds without seeding extra category accounts).
+        qif_body = b"!Type:Bank\nD1/2/26\nT-12.50\nPCoffee\n^\n"
+        r = client.post(
+            "/v1/imports",
+            headers=auth_h,
+            files={"file": ("coffee.qif", qif_body, "application/qif")},
+            data={
+                "account_id": cash,
+                "source_format": "qif",
+                "no_categorize": "true",
+            },
+        )
+        assert r.status_code == 201, r.text
+        batch_id = r.json()["id"]
+
+        # Apply → one PENDING tx promoted from the single statement line.
+        ap = client.post(f"/v1/imports/{batch_id}/apply", headers=auth_h)
+        assert ap.status_code == 200, ap.text
+        tx_ids = ap.json()["transaction_ids"]
+        assert len(tx_ids) == 1
+        tx_id = tx_ids[0]
+
+        # Confirm the back-reference exists pre-delete.
+        with session_maker() as s:
+            line = s.execute(select(StatementLine)).scalar_one()
+            assert line.promoted_transaction_id == UUID(tx_id)
+
+        # The reproduction case from #301: DELETE on a promoted PENDING tx.
+        r = client.delete(f"/v1/transactions/{tx_id}", headers=auth_h)
+        assert r.status_code == 204, r.text
+
+        # Post-delete: tx gone, line still here but un-promoted.
+        with session_maker() as s:
+            line = s.execute(select(StatementLine)).scalar_one()
+            assert line.promoted_transaction_id is None

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction.py
@@ -20,7 +20,7 @@ from uuid import UUID
 from sqlalchemy import String, case, cast, delete, func, select, update
 
 from tulip_storage.encryption import decrypt_field, encrypt_field
-from tulip_storage.models import Posting, Transaction, TransactionStatus
+from tulip_storage.models import Posting, StatementLine, Transaction, TransactionStatus
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -487,6 +487,19 @@ class TransactionRepository:
     def delete_pending(self, tx_id: UUID) -> None:
         """Hard-delete a PENDING transaction and its postings.
 
+        When the transaction was created via ``imports apply`` (i.e. there
+        is a ``statement_lines.promoted_transaction_id`` row referencing
+        it), the back-reference is NULLed before the transaction delete
+        (#301). Semantically this **un-promotes** the source line — it
+        returns to the unmatched pool so the operator can re-promote or
+        exclude it. Without this NULLing the composite RESTRICT FK
+        ``fk_statement_lines_promoted_tx`` would block the delete with
+        an IntegrityError. Other FKs into ``transactions`` for PENDING
+        rows are unreachable by construction: ``reconciliation_matches``
+        only references POSTED/RECONCILED transactions (the matcher
+        rejects PENDING), and ``transactions.voided_by_transaction_id``
+        likewise only links from POSTED rows (void requires POSTED).
+
         Raises:
             LookupError: ``tx_id`` does not exist in this household.
             TransactionNotDeletableError: transaction is not PENDING.
@@ -500,6 +513,17 @@ class TransactionRepository:
                 f"transaction {tx_id} is {existing.status.value}; "
                 "only PENDING transactions may be hard-deleted (use void otherwise)"
             )
+        # Un-promote any statement line that points at this transaction
+        # (#301). The FK is RESTRICT; without this, the DELETE below
+        # raises sqlite3.IntegrityError.
+        self._session.execute(
+            update(StatementLine)
+            .where(
+                StatementLine.household_id == self._household_id,
+                StatementLine.promoted_transaction_id == tx_id,
+            )
+            .values(promoted_transaction_id=None)
+        )
         self._session.execute(
             delete(Posting).where(
                 Posting.household_id == self._household_id,

--- a/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
@@ -89,6 +89,16 @@ _ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
         # select is household-scoped; it never writes — same read-only
         # justification as households.py.
         "tulip-api/src/tulip_api/routers/users.py",
+        # Transaction repo's delete_pending (#301) needs to NULL
+        # statement_lines.promoted_transaction_id before the DELETE FROM
+        # transactions, otherwise the RESTRICT FK
+        # fk_statement_lines_promoted_tx blocks the delete. The mutation
+        # is a targeted column-clear, not a row write — the line itself
+        # stays in place (un-promoted, ready for re-promotion). Routing
+        # this through StatementLineRepository.mark_unpromoted would
+        # introduce a circular-import between TransactionRepository and
+        # StatementLineRepository.
+        "tulip-storage/src/tulip_storage/repositories/transaction.py",
     }
 )
 

--- a/packages/tulip-storage/tests/test_transaction_repository_void.py
+++ b/packages/tulip-storage/tests/test_transaction_repository_void.py
@@ -238,6 +238,94 @@ class TestDeletePending:
         with pytest.raises(LookupError):
             repo.delete_pending(uuid4())
 
+    def test_promoted_pending_tx_unpromotes_source_line(
+        self, session: Session, household: Household
+    ):
+        """#301: deleting a promoted PENDING tx must NULL the back-reference
+        on ``statement_lines.promoted_transaction_id`` before the DELETE,
+        otherwise the RESTRICT FK ``fk_statement_lines_promoted_tx`` blocks
+        with sqlite3.IntegrityError.
+
+        The line is left in the unmatched pool so the operator can
+        re-promote or exclude it.
+        """
+        from datetime import datetime as _dt
+
+        from sqlalchemy import text
+
+        from tulip_storage.models import (
+            ImportBatch as ImportBatchModel,
+        )
+        from tulip_storage.models import (
+            ImportBatchStatus,
+            SourceFormat,
+            StatementLine,
+        )
+
+        cash, food = _seed_accounts(session, household)
+        source = _post_pending_lunch(session, household, food, cash)
+
+        # Seed an import batch (and the attachment FK target via raw SQL,
+        # mirroring the test_import_apply fixture pattern — easier than
+        # threading the full encryption pipeline through a repo test).
+        att_id = uuid4()
+        session.execute(
+            text(
+                "INSERT INTO attachments (household_id, id, filename, "
+                "content_type, size_bytes, content_hash, storage_uri, "
+                "uploaded_at) VALUES "
+                "(:h, :i, 'x.qif', 'application/qif', 1, :hash, 's3://x', :now)"
+            ),
+            {
+                "h": str(household.id),
+                "i": str(att_id),
+                "hash": "x" * 64,
+                "now": _dt.now(UTC).isoformat(),
+            },
+        )
+        batch = ImportBatchModel(
+            household_id=household.id,
+            id=uuid4(),
+            account_id=cash.id,
+            source_format=SourceFormat.QIF,
+            source_filename="x.qif",
+            source_file_attachment_id=att_id,
+            status=ImportBatchStatus.APPLIED,
+            imported_count=1,
+            skipped_count=0,
+            error_count=0,
+            created_at=_dt.now(UTC),
+        )
+        session.add(batch)
+        session.flush()
+
+        # Seed a statement line pointing at the source transaction.
+        line = StatementLine(
+            household_id=household.id,
+            id=uuid4(),
+            import_batch_id=batch.id,
+            line_number=1,
+            posted_date=date(2026, 6, 1),
+            amount=Decimal("-12.50"),
+            currency="USD",
+            description="Lunch",
+            raw_json="{}",
+            promoted_transaction_id=source.id,
+        )
+        session.add(line)
+        session.commit()
+
+        # Delete the promoted PENDING tx — must succeed.
+        repo = TransactionRepository(session, household.id)
+        repo.delete_pending(source.id)
+        session.commit()
+
+        # Transaction + postings gone.
+        assert session.query(TxModel).filter_by(id=source.id).one_or_none() is None
+        # Statement line still exists, but its back-reference is cleared.
+        loaded = session.query(StatementLine).filter_by(id=line.id).one()
+        assert loaded.promoted_transaction_id is None
+
 
 class TestUpdatePending:
     def test_updates_header_fields_and_replaces_postings(


### PR DESCRIPTION
## Summary

Closes #301 and #302. Two coupled bugs surfaced by a Banktivity → Tulip migration: deleting a PENDING transaction that was promoted from an import statement line returned a 500 from an unhandled `IntegrityError`. The functional bug (#301) and the error-handling guarantee (#302) ship together because they share a test surface.

### #301 — Functional fix

The composite FK `fk_statement_lines_promoted_tx` is RESTRICT (migration `d5c8e7a91f2b` had no `ON DELETE` clause), so `DELETE FROM transactions` was blocked while `statement_lines.promoted_transaction_id` still pointed at the row. `TransactionRepository.delete_pending` now NULLs the back-reference before the delete — the source line is left in the unmatched pool (re-promotable). The other FKs into `transactions` are audited inline: `reconciliation_matches.ledger_transaction_id` only references POSTED/RECONCILED, and `transactions.voided_by_transaction_id` likewise only links from POSTED rows. Neither is reachable for PENDING.

### #302 — Error-handling contract

New `DataIntegrityConstraintError` (409, `data.integrity_constraint`) + a fifth handler registered in `install_problem_handlers` for `sqlalchemy.exc.IntegrityError`. Any unhandled DB constraint violation now returns a typed Problem Detail rather than the generic 500 catch-all, while the full SQL exception still lands in server logs at `error` level for diagnosis. The IntegrityError handler outranks the bare `Exception` catch-all by Starlette MRO dispatch.

With #301, the original reproduction case no longer raises IntegrityError, but #302 is the long-tail safety net — endpoints that legitimately raise IntegrityError get classified responses, not 500s.

### Test plan
- [x] `just lint` / `just typecheck` — clean
- [x] `just test` — 2006 passed, 5 expected skips
- [x] Storage: `delete_pending` on a promoted PENDING tx un-promotes the line.
- [x] API: end-to-end upload → apply → DELETE returns 204 (was 500); statement line back in the unmatched pool.
- [x] Catch-all: synthetic `IntegrityError` returns 409 `data.integrity_constraint`; verified it outranks the bare `Exception` handler.
- [x] Manual smoke test (Banktivity reproduction), below.
- [ ] CI green on this PR

### Manual smoke test

```bash
just dev > /tmp/tulip-dev.log 2>&1 &
DEV_PID=$!
sleep 2
API=http://127.0.0.1:8000

curl -sS -X POST $API/v1/auth/register -H 'content-type: application/json' \
  -d '{"email":"admin@example.com","password":"correct horse battery staple","display_name":"Admin","household_name":"Smith"}' > /dev/null
ACCESS=$(curl -sS -X POST $API/v1/auth/login -H 'content-type: application/json' \
  -d '{"email":"admin@example.com","password":"correct horse battery staple"}' | jq -r .access_token)
H="Authorization: Bearer $ACCESS"
CHK=$(curl -sS -X POST $API/v1/accounts -H "$H" -H 'content-type: application/json' \
  -d '{"name":"Checking","type":"asset","currency":"USD","code":"1010"}' | jq -r .id)

# Upload + apply a minimal QIF — produces one PENDING tx via the import flow.
printf '!Type:Bank\nD1/2/26\nT-12.50\nPCoffee\n^\n' > /tmp/coffee.qif
BATCH=$(curl -sS -X POST $API/v1/imports -H "$H" \
  -F "file=@/tmp/coffee.qif;type=application/qif" \
  -F "account_id=$CHK" -F "source_format=qif" -F "no_categorize=true" | jq -r .id)
TX=$(curl -sS -X POST $API/v1/imports/$BATCH/apply -H "$H" | jq -r '.transaction_ids[0]')

# The original repro: DELETE the promoted PENDING tx. Pre-fix: 500.
curl -sS -o /dev/null -w '%{http_code}\n' -X DELETE $API/v1/transactions/$TX -H "$H"
# expected: 204

# Line is back in the unmatched pool (re-promotable).
curl -sS $API/v1/imports/$BATCH -H "$H" | jq '.lines[0].promoted_transaction_id'
# expected: null

kill $DEV_PID
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)