### PR TITLE
docs: TUI cross-cutting design decisions + ADR-0008 Bills (closes #318)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-15 · `main` @ **Phase 8 deep security audit complete** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle
+**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) cross-cutting design questions resolved (#318): bill data-model in ADR-0008; other four in TUI_WIREFRAMES.md cross-cutting decisions.
 
 ---
 
@@ -30,7 +30,7 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **CLI + importers usability bundle (post-audit):** ✅ shipped — transaction id-prefix display + prefix resolution (#207/#211), interactive reconciliation wizard (#205), `tulip imports show`/`list` (#203/#272), QIF split-posting fidelity (#270) + non-transaction-section skipping (#198) + multi-account import with transfer pairing (#195a/#195b), paper-statement reconciliation (#275), `tulip imports apply --posted` (#210), currency-natural amount precision (#213), account names in `transactions list`/`show` (#214), transaction-level notes (#271), account resolution by name / hierarchical path (#197), interactive UUID picker (#273), `--pending` balance toggle (#274), Rich `Console` honouring `COLUMNS` (#285), right-aligned numeric columns (#289), `/reject` OpenAPI 400 (#194).
 
-- **Phase 9 (terminal UI):** ⏳ scoped, not started — per [ADR-0007](adrs/0007-terminal-ui.md), a Textual TUI as an additive client (CLI stays the scriptable surface). v1 scope is read/browse only. Sits after Phase 8 wraps; pre-cloud preparation renumbers to **Phase 10**.
+- **Phase 9 (terminal UI):** ⏳ design pass complete (2026-05-17), implementation not yet started — per [ADR-0007](adrs/0007-terminal-ui.md), a Textual TUI as an additive client (CLI stays the scriptable surface). v1 scope is read/browse only. Cross-cutting design questions resolved: bill data-model in [ADR-0008](adrs/0008-bills-data-model.md), other four in [TUI_WIREFRAMES.md § Cross-cutting decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17). Implementation slices P9.0–P9.4 tracked in [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). Sits after Phase 8 wraps; pre-cloud preparation renumbers to **Phase 10**.
 
 **Tests:** 1828 passing · **CI:** green on `main`
 
@@ -1472,6 +1472,75 @@ Side effects of P6.0:
 - The Phase 6 bullet list in ARCHITECTURE.md §10 is replaced with the P6.0–P6.5 slice plan.
 
 No code changes; design-only slice. Implementation begins with P6.1.
+
+---
+
+## Phase 9 — Terminal UI (TUI) — design pass complete, implementation queued
+
+Per [ADR-0007](adrs/0007-terminal-ui.md). A Textual TUI as an **additive
+client** (CLI stays the scriptable surface; the TUI is the comfortable
+human surface). v1 scope is read/browse only — mutations land in later
+slices after the read surfaces prove out. Phase 9 sits after Phase 8
+wraps; pre-cloud preparation moved to Phase 10 when ADR-0007 was accepted.
+
+### P9.D — design pass — ✅ *(2026-05-17; closes [#318](https://github.com/rmwarriner/tulip-accounting/issues/318))*
+
+Resolves the five cross-cutting design questions raised in
+[#318](https://github.com/rmwarriner/tulip-accounting/issues/318) so the implementation slices that follow don't
+re-litigate them.
+
+- **Q1 — bill data model:** new ADR. [ADR-0008](adrs/0008-bills-data-model.md)
+  adopts `Bill` as a third entity alongside `Envelope` and `SinkingFund`,
+  with optional `charge_envelope_id` and `funded_by_sinking_fund_id`
+  cross-references. ADR-0001 (envelope shadow ledger) is unchanged.
+  Implementing `Bill` is **out of v1 TUI scope** — it lands on a separate
+  phase ticket (provisionally Phase 9.5 or new Phase 11) when prioritised.
+- **Q2–Q5 — real-liquid surfacing, stale thresholds, AI categorization,
+  recurring-bill matching:** captured in
+  [TUI_WIREFRAMES.md § Cross-cutting decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17).
+  Headline defaults pinned: account-sync stale = 24h, check stale = 14d,
+  card hold = 5d, ACH = 3 business days, bill past-due = 5d; bill-match
+  tolerance = payee fuzzy ≥ 0.85 + amount ±5% + date ±3d. AI categorize
+  is **always-confirm in v1** (no silent auto-accept).
+- **#318 acceptance:** ADR for Q1 opened (✓), Q2–Q5 decisions captured
+  (✓), unmocked mutation screens (AI-categorize, assign-unallocated,
+  reconcile-action) explicitly punted to post-v1 with rationale (✓),
+  Phase 9 placement reflected here (✓).
+
+No code changes; doc-only slice. Implementation slices land in the order
+below from [#309](https://github.com/rmwarriner/tulip-accounting/issues/309).
+
+### P9.0 — `tulip-tui` workspace skeleton — 🔜 next
+
+Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). New workspace package `packages/tulip-tui/`: Textual
+app shell, API-client layer (reuse `tulip-cli`'s `TulipClient` /
+token-store patterns), architecture-boundary test extended to
+`tulip-tui` (no server / storage imports — same rule as `tulip-cli`),
+new `Test (tulip-tui)` CI shard with a pilot-mode boot-and-quit smoke
+test. No screens yet — just the shell that subsequent slices fill.
+
+### P9.1 — Account browser — ⏳ queued
+
+Navigable tree/list of the chart of accounts with balances; drill into
+an account to see its transactions (reusing the P9.2 register).
+
+### P9.2 — Transaction register — ⏳ queued
+
+Scrollable, filterable transaction list with a posting detail pane;
+honors the same status / account / date filters that `tulip
+transactions list` exposes.
+
+### P9.3 — Reports viewer — ⏳ queued
+
+On-screen render of the nine Phase 7 reports. The HTML/PDF/CSV exporters
+stay on `tulip reports` (CLI); this slice is the in-TUI browse surface.
+
+### P9.4 — Reconciliation + import status (read-only) — ⏳ queued
+
+Browse reconciliation envelopes (4-section state) and import batches
+(parsed lines). **Read only** — *acting* on a reconciliation is a
+mutation flow punted to post-v1 (see TUI_WIREFRAMES.md "Screens not yet
+mocked").
 
 ---
 

--- a/docs/TUI_WIREFRAMES.md
+++ b/docs/TUI_WIREFRAMES.md
@@ -1,9 +1,13 @@
 # tulip TUI wireframes (design exploration)
 
-> **Status:** design exploration · 2026-05-15
-> **Scope:** wireframes only — not a committed spec, not scheduled, not gated.
-> Use as a starting point if/when a TUI surface is picked up. Open questions
-> below need decisions before any of this becomes implementable.
+> **Status:** wireframes 2026-05-15 · cross-cutting decisions 2026-05-17.
+> **Scope:** wireframes + the cross-cutting design decisions that gate
+> implementation. The data-model question is resolved in
+> [ADR-0008](adrs/0008-bills-data-model.md); the other four cross-cutting
+> decisions are captured below in [§ Cross-cutting decisions](#cross-cutting-decisions-2026-05-17).
+> Per-screen open questions are non-blocking and get resolved as each slice
+> lands. Phase 9 implementation slices are tracked in
+> [#309](https://github.com/rmwarriner/tulip-accounting/issues/309).
 
 This document captures wireframe sketches for a possible terminal UI on top of
 the tulip data model. The mockups assume monospace rendering (box-drawing
@@ -653,8 +657,10 @@ Multi-month savings goals and bill-paired accumulations, reachable via
 
 ## Cross-cutting open questions
 
-Decisions that affect multiple screens. These should land before any of
-this becomes implementable scope.
+> **Status:** resolved 2026-05-17. The five questions originally raised here
+> have all been answered. The data-model question is now [ADR-0008](adrs/0008-bills-data-model.md);
+> the other four are summarised in [§ Cross-cutting decisions](#cross-cutting-decisions-2026-05-17)
+> below. The original framings are retained for context.
 
 ### Bill ↔ envelope ↔ sinking-fund model
 
@@ -734,20 +740,187 @@ misses generate spurious past-due flags. The matching rules need to be:
 
 ---
 
+## Cross-cutting decisions (2026-05-17)
+
+Resolutions for the five questions above. Bill data model goes to its own
+ADR; the remaining four are captured here. The Phase 9 v1 TUI slices
+([#309](https://github.com/rmwarriner/tulip-accounting/issues/309) P9.0–P9.4) are read-only and do not implement the
+mutation/matching aspects of these decisions — those land in the dedicated
+Bills + AI follow-up slices that build on this baseline.
+
+### 1. Bill ↔ envelope ↔ sinking-fund model — see [ADR-0008](adrs/0008-bills-data-model.md)
+
+**Decision:** Three distinct entities. `Bill` is a new domain object alongside
+`Envelope` and `SinkingFund`, with optional `charge_envelope_id` and
+`funded_by_sinking_fund_id` cross-references. ADR-0008 captures the full
+rationale, alternatives considered, and field shape.
+
+### 2. "Real liquid" surfacing
+
+**Decision:** Pending screen only. Do not add a fourth figure to the vitals
+strip; do not duplicate to Accounts.
+
+**Rationale:**
+
+- The vitals strip is deliberately a three-item dashboard discipline (sync
+  state, unalloc, forecast). A fourth figure crowds it and dilutes the
+  "three things you never want to lose track of" framing.
+- "Real liquid" is a *reconciliation-flavoured* number — it answers "is the
+  cheque I wrote three weeks ago still uncashed?" Users who care are
+  thinking about pending items, in which case they're on the Pending
+  screen anyway. The number is wasted on a daily glance.
+- The Accounts screen *could* surface it as an aggregate row, but the
+  existing footer line ("Net worth: $X · Liquid: $Y · 4 accounts") is
+  already the canonical aggregate; adding a third figure muddies that
+  surface for the same crowding reason as the vitals strip.
+
+**Implication for v1:** the Pending screen's `"Real" liquid: $14,898 − $921 = $13,977`
+line is the only place this computation appears. No other screen needs it.
+
+### 3. Stale thresholds
+
+**Decision:** Global defaults table, with per-entity override capability as
+a follow-up (not gating v1). The defaults are pinned here so the Settings
+screen (when it lands) has a canonical starting point.
+
+| Concept                  | Default | Notes                                    |
+|--------------------------|---------|------------------------------------------|
+| Account sync             | 24h     | Aggregator/bank-feed last-poll age       |
+| Pending check            | 14d     | Most US banks honour 90–180d; warn early |
+| Card hold                | 5d      | Banks typically auto-expire at 7d        |
+| ACH (push or pull)       | 3 business days | Counts business days, not calendar  |
+| Bill past-due            | 5d      | Expected-pay date + tolerance            |
+
+**Rationale:**
+
+- One config table keeps the mental model simple ("stale = N days, where N
+  depends on type"). Per-type defaults beat one global number because the
+  underlying mechanics genuinely differ — a card hold and a paper cheque
+  decay on completely different timescales.
+- Per-entity override is a real need (a known-slow ACH endpoint, a cheque
+  the user has accepted will never clear) but it's a per-entity nullable
+  column on the relevant tables, not a v1 TUI affordance. The Settings
+  screen + per-row "override stale threshold" action can land after the
+  read-only browsers ship.
+
+**Implication for v1:** the read-only TUI screens render `⚠` against these
+default thresholds. The Settings screen and the override mechanism are
+post-v1.
+
+### 4. AI categorization integration
+
+**Decision:** v1 TUI surfaces AI proposals but **always requires
+confirmation**. No silent auto-categorize, no confidence-threshold
+auto-accept.
+
+- **`⏎` on a row with `⚡`** opens a proposal detail screen (option (a)
+  from the Transactions-screen per-screen open question) listing the
+  top-N proposals with confidence scores. The user picks one or
+  dismisses. Inline-accordion (option (b)) is deferred — simpler model
+  for v1.
+- **Batch flow** — `space`-select multiple rows with `⚡`, then `c`,
+  opens a confirm-list screen showing per-row top proposal + a "use top
+  for all" / "review each" toggle.
+- **Default `⏎` behaviour** in the proposal list is "preview the top
+  choice," not "accept the top choice." Acceptance requires a second
+  affirmative key (e.g. `a` or a second `⏎`). This is deliberately
+  slower; it matches the project's conservative AI posture established
+  by the `local_only` AI policy ([#233](https://github.com/rmwarriner/tulip-accounting/issues/233)) and audit logging.
+
+**Rationale:**
+
+- Categorization is a *write* the user has to live with in reports for
+  years. False auto-categorization is harder to spot and undo than
+  always-confirm friction.
+- Threshold-based auto-accept ("if confidence ≥ 0.95, just take it") is a
+  reasonable future feature, but it needs observed-accuracy data from
+  real households first. v1 collects that data via the confirm flow
+  before tuning a threshold.
+- The proposal-list-on-`⏎` UX is consistent with every other "drill in
+  to see detail" key in the design language. The accordion-inline
+  alternative would be a one-off interaction pattern.
+
+**Implication for v1:** the categorize flow is not part of the read-only
+P9.0–P9.4 slices. The wireframes in this doc reflect the post-categorize
+mutation flow; implementing it lands after the read-only baseline.
+
+### 5. Recurring-bill matching policy
+
+**Decision:** Conservative scoring with an explicit "pending matches" inbox
+the user confirms or rejects. Defaults pinned here; per-bill overrides
+live on the `Bill` row (see ADR-0008's `match_amount_tolerance_pct` and
+`match_date_tolerance_days` fields).
+
+**Defaults:**
+
+| Dimension          | Default tolerance                                    |
+|--------------------|------------------------------------------------------|
+| Payee match        | Normalised exact, OR fuzzy similarity ≥ 0.85        |
+| Amount             | Within ±5% of `Bill.expected_amount`                 |
+| Date               | Within ±3 calendar days of `Bill.next_due_on`        |
+| Account            | Posting on `Bill.pay_from_account_id` (if set)       |
+
+A candidate must satisfy all four to score as a match. If multiple bills
+match a single posted transaction, the highest-confidence match wins;
+the others stay in the inbox.
+
+**Inbox flow:**
+
+- A new screen ("Pending matches", reachable from the Bills detail strip
+  or via `m`) lists `(posted_transaction, candidate_bill, score)` rows.
+- One-key actions on each row: `a` accept (writes `Bill.last_paid_*`,
+  clears past-due, optionally proposes `posting.pool_id =
+  bill.charge_envelope_id`), `r` reject (records an exclusion so the
+  same pair won't auto-re-suggest), `s` snooze (defers without learning).
+- Reject feedback is per-bill (a per-bill exclusion list), not a global
+  ML model. No model training, no opaque scoring weights.
+
+**Rationale:**
+
+- Conservative-by-default fits the project's "false-miss > false-match"
+  preference: a nag is recoverable, a wrongly-marked-paid bill silently
+  hides a real problem.
+- The inbox flow keeps the matching engine **explicit** and **editable** —
+  both criteria the original open question called out.
+- Per-bill exclusions are interpretable (the user can read them) and
+  bounded (they don't accumulate across unrelated bills); a global
+  learning model would be a much heavier commitment for marginal benefit
+  at a single-household scale.
+
+**Implication for v1:** matching is not part of the read-only P9.0–P9.4
+slices. The matching engine + inbox screen land in the Bills
+implementation phase that follows ADR-0008.
+
+---
+
 ## Screens not yet mocked
 
-Surfaces referenced but not drafted in this round:
+Surfaces referenced but not drafted. Per the 2026-05-17 decision pass, the
+three flagged in [#318](https://github.com/rmwarriner/tulip-accounting/issues/318) acceptance criterion 3 are explicitly
+**punted to a later design iteration** — they are all *mutation* flows,
+and v1 TUI scope ([ADR-0007](adrs/0007-terminal-ui.md), [#309](https://github.com/rmwarriner/tulip-accounting/issues/309)) is
+read-only. Re-mocking them belongs with the slice that builds the
+corresponding mutation surface.
 
-- **AI-categorize flow** — what the user sees when they press `c` on a
-  transaction with `⚡` or on a multi-selection.
-- **Assign-unallocated flow** — what the user sees when they press `u` from
-  any screen, with `$408.78 ▸` in the vitals.
-- **Reconcile flow** — what happens when `r` is pressed on the Accounts
-  screen for an unreconciled account.
+- **AI-categorize flow** *(punted to post-v1)* — what the user sees when
+  they press `c` on a transaction with `⚡` or on a multi-selection. The
+  *policy* is decided ([§ Cross-cutting decisions #4](#4-ai-categorization-integration));
+  the screen design lands with the implementation slice.
+- **Assign-unallocated flow** *(punted to post-v1)* — what the user sees
+  when they press `u` from any screen, with `$408.78 ▸` in the vitals.
+- **Reconcile flow** *(punted to post-v1)* — what happens when `r` is
+  pressed on the Accounts screen for an unreconciled account. The
+  reconciliation **status** screen *is* in v1 scope (P9.4 in [#309](https://github.com/rmwarriner/tulip-accounting/issues/309));
+  *acting* on a reconciliation is the punted flow.
+
+Also referenced but not drafted, and not part of any current v1 acceptance:
+
 - **Add/edit forms** — new account, new envelope, new bill, new sinking
   fund, edit recurring schedule, edit goal target.
-- **Settings screen** — stale thresholds, sync policies, AI confidence
-  cutoffs, group definitions, household management.
+- **Settings screen** — stale thresholds (defaults pinned in
+  [§ Cross-cutting decisions #3](#3-stale-thresholds)), sync policies, AI
+  confidence cutoffs, group definitions, household management.
 - **Help overlay (`?`)** — full keybind reference per screen.
-
-Worth mocking when this design direction gets picked up.
+- **Pending matches inbox** (Bills) — referenced in
+  [§ Cross-cutting decisions #5](#5-recurring-bill-matching-policy); screen
+  design lands with the Bills implementation slice.

--- a/docs/adrs/0008-bills-data-model.md
+++ b/docs/adrs/0008-bills-data-model.md
@@ -1,0 +1,259 @@
+# ADR-0008: Bills as a third allocation entity, linked to envelopes and sinking funds
+
+**Status:** Accepted (2026-05-17). No code ships with this ADR; it locks the
+shape so the eventual implementation slice does not re-litigate it.
+
+**Phase:** Decision lands during Phase 9 (terminal UI) design. The
+*implementation* of `Bill` is out of v1 TUI scope and will land in a
+dedicated backend slice (post-[#309](https://github.com/rmwarriner/tulip-accounting/issues/309) P9.0–P9.4) before the Bills browser TUI screen is built.
+
+**Supersedes / extends:** [ADR-0001](0001-envelope-shadow-ledger.md) (envelope + sinking-fund shadow ledger).
+
+---
+
+## Context
+
+The Phase 9 wireframes ([docs/TUI_WIREFRAMES.md](../TUI_WIREFRAMES.md))
+introduce a `Bills` screen — recurring outflows grouped by frequency,
+with autopay matching, past-due flags, and a `⇄` linkage to sinking funds
+for annual bills. The bills screen is presented alongside the existing
+Envelopes screen (period budgets) and Sinking Funds screen (multi-month
+goals). [Issue #318](https://github.com/rmwarriner/tulip-accounting/issues/318) flagged
+that the relationship between these three concepts is not pinned down
+anywhere — and the wireframes deliberately stayed agnostic on it so the
+data-model question could be resolved before any of it became implementable.
+
+What's already shipped, and constrains this decision:
+
+- **ADR-0001** treats `Envelope` and `SinkingFund` as distinct `Pool`
+  subtypes in a parallel shadow ledger. Both have shipped (`tulip-core
+  allocation/`). Refills into either pool use the shared `RefillRule`
+  value object.
+- **No `Bill` entity exists** anywhere in the codebase as of 2026-05-17.
+  Recurring transactions are handled informally via the importer +
+  user-driven entry; there is no scheduled-payment object, no past-due
+  detection, no auto-match against the bank feed.
+
+Three model shapes were considered for where Bills should live:
+
+1. **Single entity (collapse)** — every recurring outflow is an envelope.
+   `Bill` is a property of certain envelopes ("category=bill"). Sinking
+   funds also collapse into envelopes-with-targets.
+2. **Three entities, explicit cross-refs** — `Bill`, `Envelope`,
+   `SinkingFund` stay distinct. Bills *link* to envelopes (which expense
+   bucket the post lands in) and optionally to sinking funds (which
+   accumulator funds the annual payment).
+3. **Bill as a property of Envelope or SinkingFund (hybrid)** —
+   `Envelope` gains an optional `payment_schedule` field. `SinkingFund`
+   already has `target_date`. The "Bills" screen is a filtered view over
+   both, not a separate entity.
+
+## Decision
+
+**Adopt (2) — three distinct entities, with optional cross-references.**
+
+`Bill` is a new first-class domain entity alongside `Envelope` and
+`SinkingFund`. All three are scoped per `household_id` and follow the
+same `tulip-core` / `tulip-storage` split that ADR-0001 established.
+
+### Shape (preliminary — final field set will be refined in the
+implementation slice)
+
+```
+Bill
+├─ household_id            (FK households.id; tenant scope)
+├─ id                      (UUID v4)
+├─ payee                   (str; normalized form used for matching)
+├─ display_name            (str; what the UI shows)
+├─ status                  (enum: active | paused | archived)
+├─ pay_from_account_id     (FK accounts.id; optional — null for "any")
+├─ payment_method          (enum: ach_pull | ach_push | card | check
+│                                | manual | unknown)
+├─ expected_amount_kind    (enum: fixed | statement | estimated)
+├─ expected_amount         (Money; null when kind=statement)
+├─ schedule                (RecurrenceSpec; see "Schedule shape" below)
+├─ next_due_on             (DATE; denormalised from schedule for
+│                          forecast/sort queries — like Pool balance)
+├─ charge_envelope_id      (FK allocation_pools.id; optional. The
+│                          envelope the spend lands in when posted.)
+├─ funded_by_sinking_fund_id  (FK allocation_pools.id; optional. The
+│                          sinking fund accumulating for this bill.
+│                          Surfaces the `⇄` marker in the wireframes.)
+├─ match_amount_tolerance_pct   (NUMERIC; null = use global default)
+├─ match_date_tolerance_days    (INTEGER; null = use global default)
+├─ past_due_tolerance_days      (INTEGER; null = use global default)
+├─ last_paid_transaction_id     (FK transactions.id; null until matched)
+├─ last_paid_on                 (DATE; null until matched)
+├─ created_by_user_id, created_at, updated_at
+```
+
+`RecurrenceSpec` is a structured value object — same posture as
+[`RefillRule`](../../packages/tulip-core/src/tulip_core/allocation/refill_rule.py): no
+expression eval, finite set of recurrence shapes (monthly-on-day,
+monthly-nth-weekday, fixed-interval-days, annual-on-date,
+quarterly-on-day). The exact discriminator set lands in the
+implementation slice and gets its own short ADR if it grows.
+
+### Cross-reference semantics
+
+- **`charge_envelope_id`** — purely informational at the `Bill` level.
+  It does not auto-tag the matched transaction's `posting.pool_id`; the
+  envelope linkage that drives the shadow ledger is on the *posting*,
+  not on the bill. The bill→envelope link is what the Bills screen uses
+  to show "Envelope: Utilities" in the detail strip and to power the
+  Envelopes-screen `▣` marker for "this envelope is scheduled."
+- **`funded_by_sinking_fund_id`** — drives the `⇄` marker on Sinking
+  Funds. When set, the bill participates in the annual-bill
+  accumulation pattern: the sinking fund refills over the year, the
+  bill draws it down when it pays. Both directions must be the same
+  household; both pools must be active.
+
+### What `RefillRule` is and is not
+
+`RefillRule` (existing, ADR-0001) governs **how money flows into an
+allocation pool on a schedule.** It belongs on the `SinkingFund` (or on
+an `Envelope`) — not on the `Bill`. A bill that's funded by a sinking
+fund inherits the accumulation cadence from `SinkingFund.refill_rule`,
+not from a separate field on `Bill`.
+
+`Bill.schedule` is the **payment schedule** — when the outflow is
+expected, not when accumulation happens. The two are different concepts
+that happen to both be "recurring."
+
+### What ships when
+
+This ADR pins the *shape*. It does not ship:
+
+- The `bills` table or migration.
+- The `Bill` domain type in `tulip-core`.
+- The `BillRepository`, API endpoints, or CLI commands.
+- The Bills TUI browser screen.
+- The autopay matching engine (matching policy lives in
+  [docs/TUI_WIREFRAMES.md §Cross-cutting decisions](../TUI_WIREFRAMES.md);
+  the rules engine is its own future slice).
+
+[#309](https://github.com/rmwarriner/tulip-accounting/issues/309) explicitly slices Phase 9 v1 as P9.0–P9.4 covering accounts,
+transactions, reports, and reconciliation/import status — **not** bills.
+The Bills implementation lands after that, on a separate phase ticket
+(provisionally Phase 9.5 or a new Phase 11 depending on what's prioritised
+when v1 ships).
+
+## Why this shape
+
+- **Symmetry with the existing model.** ADR-0001 already chose distinct
+  pool types (Envelope, SinkingFund) over collapse. A third distinct
+  entity is the consistent continuation. The "fewer concepts is better"
+  argument was made and lost in ADR-0001; replaying it for Bills would
+  reopen that decision.
+- **The cross-refs are real, not imagined.** The wireframes show a
+  `⇄` marker tying annual bills to sinking funds. That linkage *exists*
+  in user mental models — "I save monthly into the auto-insurance fund,
+  then the insurance bill draws it down once a year." Collapsing them
+  loses the relationship; explicit cross-refs preserve it.
+- **Bills carry state nothing else does.** Past-due tolerance, match
+  policy, last-paid linkage, statement-based vs estimated amount —
+  these are not envelope concepts and not sinking-fund concepts. Bolting
+  them onto Envelope inflates a working, tested domain object with
+  optional fields that mean something only for the "this envelope is
+  also a bill" subset.
+- **Implementation cost is contained.** The shadow ledger does not
+  change. Bills are a sibling table that *references* allocation_pools
+  but does not extend it. No ADR-0001 invariants are touched.
+
+## Alternatives considered
+
+### (1) Single entity (every recurring outflow is an envelope)
+
+Rejected. Would require unwinding ADR-0001's Envelope-vs-SinkingFund
+distinction (they have different semantics — period-bounded vs
+goal-bounded — that don't degrade gracefully into one shape). Also
+loses the bill ↔ sinking-fund linkage entirely: you can't have
+"my Vacation envelope is funded by my Vacation envelope" coherently.
+
+### (3) Bill as a property of Envelope (hybrid)
+
+Rejected, but more narrowly than (1). The objection isn't structural —
+you *could* hang a `payment_schedule` off Envelope and call it done.
+The objection is:
+
+- It conflates two lifecycles (envelope-period vs payment-schedule)
+  that have independent cadences. A monthly envelope can be funded by a
+  bi-weekly refill and drained by a weekly schedule of small bills; one
+  shape doesn't model that well.
+- The `⇄` linkage to sinking funds gets awkward. A sinking fund linked
+  to an "envelope-that-is-actually-a-bill" reads weirdly in the model
+  and in the docs.
+- The Bills screen would still have to filter envelopes by "has a
+  schedule," producing the same UI surface as having a distinct entity,
+  for no domain-modelling saving.
+
+## Consequences
+
+### Positive
+
+1. **Wireframes become implementable** without ambiguity. The Bills
+   screen has a domain backing; the Envelopes `▣` marker has a
+   referent; the Sinking Funds `⇄` marker has a referent.
+2. **No churn on ADR-0001.** Shadow ledger, pool taxonomy, refill rule
+   — all unchanged. The new entity sits next to them.
+3. **Matching engine has a clean place to live.** A future
+   `BillMatcher` runs per-tenant over the bank feed, scoring against
+   active bills using each bill's tolerance fields (falling back to
+   global defaults from settings). One concern, one module.
+4. **Past-due, skip, pause are first-class operations on `Bill`.**
+   They're not properties of envelopes-with-schedules retroactively.
+
+### Negative
+
+1. **Yet another table to migrate, query, scope-by-household,
+   tenant-test, audit-log, and cover.** The "three pool types plus a
+   bill table" surface is bigger than option (3)'s "envelope-with-
+   schedule." The trade is paid in code volume and test count.
+2. **Two ways to express "I always pay $200/mo for X."** Option A: an
+   envelope with a $200 monthly budget. Option B: a $200 monthly bill
+   charging that envelope. The Bills screen and Envelopes screen
+   together must teach the user when each shape is right (bill = a
+   *specific recurring payment*; envelope = a *budget bucket*, possibly
+   funded by multiple bills or by ad-hoc spending). The wireframes
+   already lean into this distinction; docs will need to reinforce it.
+3. **Bill ↔ Envelope cross-ref is informational, not enforcing.** A
+   matched transaction's `posting.pool_id` is still authoritative for
+   the shadow ledger. If a user fat-fingers the envelope on a manual
+   txn that the matcher links to the bill, the bill says
+   "charge_envelope=Utilities" but the shadow ledger says
+   "Miscellaneous." This is by design (the posting is the truth) but
+   surfaces as "wait, why didn't this hit my Utilities envelope?"
+   surprises until a UI affordance ("apply bill's envelope to matched
+   txn?") lands.
+
+### Neutral
+
+1. **The `RecurrenceSpec` shape is left to the implementation slice.**
+   It will mirror `RefillRule`'s structured-value-object style. If the
+   discriminator set grows past ~5 cases or needs cron-style flexibility,
+   that's a new ADR.
+2. **Match policy defaults live in settings, not in `Bill`.** Per-bill
+   overrides are nullable columns. The system-wide defaults
+   (`match_amount_tolerance_pct=5`, `match_date_tolerance_days=3`,
+   `past_due_tolerance_days=5`) are captured in
+   [TUI_WIREFRAMES.md §Cross-cutting decisions](../TUI_WIREFRAMES.md).
+
+## References
+
+- [TUI_WIREFRAMES.md](../TUI_WIREFRAMES.md) — Bills screen and the
+  `⇄`/`▣` markers this decision underpins.
+- [ADR-0001](0001-envelope-shadow-ledger.md) — envelope + sinking-fund
+  shadow ledger (the model this extends).
+- [ADR-0007](0007-terminal-ui.md) — Phase 9 TUI scope (v1 is read-only;
+  Bills implementation is post-v1).
+- [#318](https://github.com/rmwarriner/tulip-accounting/issues/318) — the design issue this ADR resolves.
+- [#309](https://github.com/rmwarriner/tulip-accounting/issues/309) — Phase 9 kickoff and its P9.0–P9.4 slice plan
+  (Bills implementation explicitly out of scope).
+
+## Decision log
+
+| Date       | Decision                                                                                  | By                  |
+|------------|-------------------------------------------------------------------------------------------|---------------------|
+| 2026-05-17 | `Bill` adopted as a third distinct entity with optional `charge_envelope_id` + `funded_by_sinking_fund_id`. | #318 design slice |
+| 2026-05-17 | `RecurrenceSpec` shape deferred to implementation slice (structured value object, no eval). | #318 design slice |
+| 2026-05-17 | Bills implementation explicitly out of #309's P9.0–P9.4 scope; lands on a separate phase ticket. | #318 design slice |


### PR DESCRIPTION
## Summary

Resolves all five cross-cutting design questions raised in #318 so Phase 9 implementation slices (P9.0–P9.4 per #309) don't re-litigate them. Doc-only slice; no code changes.

- **ADR-0008** *(new)* — `Bill` adopted as a third allocation entity alongside `Envelope` and `SinkingFund`, with optional `charge_envelope_id` + `funded_by_sinking_fund_id` cross-references. ADR-0001's shadow ledger is unchanged. Implementation explicitly deferred to a post-#309 phase ticket — v1 TUI is read-only.
- **TUI_WIREFRAMES.md** gains a `Cross-cutting decisions (2026-05-17)` section answering Q2–Q5:
  - "Real liquid" stays on the Pending screen only (vitals strip stays 3-item).
  - Stale thresholds pinned: account sync 24h, check 14d, card hold 5d, ACH 3 business days, bill past-due 5d (per-entity overrides post-v1).
  - AI categorize is **always-confirm in v1** — `⏎` opens the proposal list; batch via `space`-select + `c`; no silent auto-accept until real-data accuracy is observed.
  - Bill matching defaults to conservative scoring (payee fuzzy ≥ 0.85 + amount ±5% + date ±3d) with a pending-matches inbox; per-bill exclusions instead of a global learning model.
- **"Screens not yet mocked"** updated to explicitly punt the three #318-acceptance flows (AI-categorize, assign-unallocated, reconcile-action) to post-v1 mutation slices, with rationale (all are write paths; v1 is read-only).
- **PHASE_STATUS.md** gains a new `Phase 9` section with the P9.D design pass marked shipped and P9.0–P9.4 listed from #309; top-line bullet + last-updated date refreshed.

#318 acceptance is satisfied: ADR for Q1 opened ✓; Q2–Q5 captured in TUI_WIREFRAMES.md ✓; unmocked mutation screens explicitly punted ✓; Phase 9 placement reflected in PHASE_STATUS.md ✓.

## Test plan

- [x] `git diff --stat` — three files changed, no code paths touched
- [x] pre-commit hooks pass (no Python source in scope; ruff/format skipped, secrets scan green)
- [ ] CI green on this PR (path-conditional `changes` job should skip type-check / test / benchmarks / dependency-audit; only lint + secrets-scan run)