### PR TITLE
P9.0 — tulip-tui workspace skeleton + Textual app shell (#309)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,10 @@
   - changed-files:
       - any-glob-to-any-file: 'packages/tulip-cli/**'
 
+"area:tui":
+  - changed-files:
+      - any-glob-to-any-file: 'packages/tulip-tui/**'
+
 "area:ai":
   - changed-files:
       - any-glob-to-any-file: 'packages/tulip-ai/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
           - tulip-storage
           - tulip-api
           - tulip-cli
+          - tulip-tui
           - tulip-ai
           - tulip-importers
           # tulip-reports has 0 tests today; exclude rather than run a

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) cross-cutting design questions resolved (#318): bill data-model in ADR-0008; other four in TUI_WIREFRAMES.md cross-cutting decisions.
+**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + P9.0 tulip-tui skeleton shipped** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell + pilot-mode smoke test landed; P9.1+ queued per #309.
 
 ---
 
@@ -30,7 +30,7 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **CLI + importers usability bundle (post-audit):** ✅ shipped — transaction id-prefix display + prefix resolution (#207/#211), interactive reconciliation wizard (#205), `tulip imports show`/`list` (#203/#272), QIF split-posting fidelity (#270) + non-transaction-section skipping (#198) + multi-account import with transfer pairing (#195a/#195b), paper-statement reconciliation (#275), `tulip imports apply --posted` (#210), currency-natural amount precision (#213), account names in `transactions list`/`show` (#214), transaction-level notes (#271), account resolution by name / hierarchical path (#197), interactive UUID picker (#273), `--pending` balance toggle (#274), Rich `Console` honouring `COLUMNS` (#285), right-aligned numeric columns (#289), `/reject` OpenAPI 400 (#194).
 
-- **Phase 9 (terminal UI):** ⏳ design pass complete (2026-05-17), implementation not yet started — per [ADR-0007](adrs/0007-terminal-ui.md), a Textual TUI as an additive client (CLI stays the scriptable surface). v1 scope is read/browse only. Cross-cutting design questions resolved: bill data-model in [ADR-0008](adrs/0008-bills-data-model.md), other four in [TUI_WIREFRAMES.md § Cross-cutting decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17). Implementation slices P9.0–P9.4 tracked in [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). Sits after Phase 8 wraps; pre-cloud preparation renumbers to **Phase 10**.
+- **Phase 9 (terminal UI):** 🔄 design pass complete (2026-05-17) + P9.0 skeleton shipped (2026-05-17) — per [ADR-0007](adrs/0007-terminal-ui.md), a Textual TUI as an additive client (CLI stays the scriptable surface). v1 scope is read/browse only. Cross-cutting design questions resolved: bill data-model in [ADR-0008](adrs/0008-bills-data-model.md), other four in [TUI_WIREFRAMES.md § Cross-cutting decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17). `packages/tulip-tui/` workspace package + pilot-mode smoke test now in tree; P9.1–P9.4 (account browser, transaction register, reports viewer, reconciliation/import status) queued per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). Sits after Phase 8 wraps; pre-cloud preparation renumbers to **Phase 10**.
 
 **Tests:** 1828 passing · **CI:** green on `main`
 
@@ -1475,7 +1475,7 @@ No code changes; design-only slice. Implementation begins with P6.1.
 
 ---
 
-## Phase 9 — Terminal UI (TUI) — design pass complete, implementation queued
+## Phase 9 — Terminal UI (TUI) — P9.0 shipped, P9.1+ queued
 
 Per [ADR-0007](adrs/0007-terminal-ui.md). A Textual TUI as an **additive
 client** (CLI stays the scriptable surface; the TUI is the comfortable
@@ -1510,14 +1510,46 @@ re-litigate them.
 No code changes; doc-only slice. Implementation slices land in the order
 below from [#309](https://github.com/rmwarriner/tulip-accounting/issues/309).
 
-### P9.0 — `tulip-tui` workspace skeleton — 🔜 next
+### P9.0 — `tulip-tui` workspace skeleton — ✅ *(2026-05-17)*
 
-Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). New workspace package `packages/tulip-tui/`: Textual
-app shell, API-client layer (reuse `tulip-cli`'s `TulipClient` /
-token-store patterns), architecture-boundary test extended to
-`tulip-tui` (no server / storage imports — same rule as `tulip-cli`),
-new `Test (tulip-tui)` CI shard with a pilot-mode boot-and-quit smoke
-test. No screens yet — just the shell that subsequent slices fill.
+Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). New workspace package `packages/tulip-tui/` lands the
+shell that the rest of Phase 9 fills in.
+
+- **Package shape** — `packages/tulip-tui/` with `src/tulip_tui/` +
+  `tests/`, hatchling build, src layout. Console script `tulip-tui`
+  invokes `tulip_tui.main:run`. Auto-discovered by the existing
+  `[tool.uv.workspace] members = ["packages/*"]` glob.
+- **App shell** — `TulipTuiApp(App[None])` (Textual) with a single `q`
+  quit binding, a placeholder Header / Static welcome / Footer compose
+  tree. No screens beyond the shell — by design.
+- **API-client reuse** — package depends on `tulip-cli` (workspace
+  source). `TulipClient`, `TokenStore`, and `Config` are reusable from
+  `tulip_cli.http` / `tulip_cli.auth.tokens` / `tulip_cli.config`
+  without duplication. (Extracting a dedicated `tulip-client` package
+  is a candidate post-v1 refactor; not worth the churn now.)
+- **Architecture-boundary test** — `tests/test_architecture.py` AST-scans
+  `tulip_tui/` source and asserts no top-level imports of
+  `tulip_storage`, `tulip_api`, `tulip_ai`, `tulip_importers`,
+  `tulip_reports`, `sqlalchemy`, `alembic`, `fastapi`, `starlette`, or
+  `uvicorn`. `tulip_cli` is allowed (per the reuse decision above);
+  mirrors the rule `tulip-cli` itself lives under.
+- **Pilot-mode smoke test** — `tests/test_app_boot.py` uses Textual's
+  headless `App.run_test()` harness: boots `TulipTuiApp`, asserts
+  `is_running`, sends `q`, asserts `return_code == 0`. Runs in ~0.2s.
+  `pytest-asyncio` already in dev deps; `@pytest.mark.asyncio` per test
+  (strict mode).
+- **CI** — new `tulip-tui` row in the `.github/workflows/ci.yml` test
+  matrix; `area:tui` label rule added to `.github/labeler.yml` (and the
+  label created on the repo). The path-conditional `changes` job
+  already catches `packages/tulip-tui/**/*.py` via the existing
+  `packages/**/*.py` glob.
+- **Root config touches** — `pyproject.toml`: `testpaths`, mypy
+  `files` + `mypy_path`, and ruff `known-first-party` all gain
+  `tulip-tui` / `tulip_tui` entries.
+
+3 tests in the new package; lint / format / mypy --strict all clean.
+The next slice (P9.1 — account browser) is the first to introduce a
+real screen and the first real API call.
 
 ### P9.1 — Account browser — ⏳ queued
 

--- a/packages/tulip-tui/pyproject.toml
+++ b/packages/tulip-tui/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "tulip-tui"
+version = "0.0.0"
+description = "Terminal UI (Textual) for the Tulip Accounting API."
+requires-python = ">=3.12"
+dependencies = [
+    "textual>=0.80",
+    "tulip-cli",
+]
+
+[project.scripts]
+tulip-tui = "tulip_tui.main:run"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tulip_tui"]
+
+[tool.uv.sources]
+tulip-cli = { workspace = true }

--- a/packages/tulip-tui/src/tulip_tui/__init__.py
+++ b/packages/tulip-tui/src/tulip_tui/__init__.py
@@ -1,0 +1,8 @@
+"""Textual terminal UI client for the Tulip Accounting API.
+
+Per ADR-0007 and ADR-0001 architecture boundary: this package is an HTTP
+client of `tulip-api`, the same way `tulip-cli` is. It must not import
+storage, server, or domain internals; the only allowed channel to the
+running tulip server is the HTTP API. See
+``tests/test_architecture.py`` for the enforced import set.
+"""

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -1,0 +1,32 @@
+"""The top-level Textual ``App`` for tulip-tui.
+
+P9.0 ships only the shell - a mounted app that reaches a runnable state
+and quits cleanly on ``q``. Real screens (account browser, transaction
+register, reports, reconciliation/import status) arrive in P9.1-P9.4 per
+[#309](https://github.com/rmwarriner/tulip-accounting/issues/309).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding, BindingType
+from textual.widgets import Footer, Header, Static
+
+
+class TulipTuiApp(App[None]):
+    """Tulip TUI shell - placeholder until P9.1 lands the first real screen."""
+
+    TITLE = "tulip"
+    SUB_TITLE = "terminal UI"
+    BINDINGS: ClassVar[list[BindingType]] = [Binding("q", "quit", "quit", show=True)]
+
+    def compose(self) -> ComposeResult:
+        """Yield the static placeholder layout for the P9.0 shell."""
+        yield Header()
+        yield Static(
+            "tulip-tui - Phase 9 shell.\nScreens land in subsequent slices (see #309).",
+            id="welcome",
+        )
+        yield Footer()

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -1,0 +1,10 @@
+"""Entry point for the ``tulip-tui`` console script."""
+
+from __future__ import annotations
+
+from tulip_tui.app import TulipTuiApp
+
+
+def run() -> None:
+    """Launch the Tulip TUI under the user's terminal."""
+    TulipTuiApp().run()

--- a/packages/tulip-tui/tests/test_app_boot.py
+++ b/packages/tulip-tui/tests/test_app_boot.py
@@ -1,0 +1,23 @@
+"""Pilot-mode boot-and-quit smoke test for the Tulip TUI app shell.
+
+The first slice (P9.0 of [#309](https://github.com/rmwarriner/tulip-accounting/issues/309))
+ships a non-functional app shell — no screens yet, no API calls — but
+asserting boot-and-quit under Textual's headless ``run_test`` harness
+proves the package is wired correctly and gives subsequent slices a
+test scaffold to build on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+
+
+@pytest.mark.asyncio
+async def test_app_boots_and_quits_cleanly() -> None:
+    app = TulipTuiApp()
+    async with app.run_test() as pilot:
+        assert app.is_running
+        await pilot.press("q")
+    assert app.return_code == 0

--- a/packages/tulip-tui/tests/test_architecture.py
+++ b/packages/tulip-tui/tests/test_architecture.py
@@ -1,0 +1,61 @@
+"""Architecture boundary tests for tulip-tui.
+
+ARCHITECTURE.md §9 + ADR-0007: the TUI is a network client of the API.
+It must not import server-side or storage internals — talking to the API
+is the only allowed channel, identical to the rule ``tulip-cli`` lives
+under. Reuse of ``tulip-cli``'s HTTP client and token store (per
+[#309](https://github.com/rmwarriner/tulip-accounting/issues/309))
+is permitted; ``tulip_cli`` is therefore not in the forbidden set.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+_FORBIDDEN_TOP_LEVEL: Final[frozenset[str]] = frozenset(
+    {
+        "tulip_api",
+        "tulip_storage",
+        "tulip_ai",
+        "tulip_importers",
+        "tulip_reports",
+        "sqlalchemy",
+        "alembic",
+        "fastapi",
+        "starlette",
+        "uvicorn",
+    }
+)
+
+TUI_SRC: Final[Path] = Path(__file__).resolve().parents[1] / "src" / "tulip_tui"
+
+
+def _iter_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                found.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            found.add(node.module.split(".")[0])
+    return found
+
+
+def test_tulip_tui_has_no_forbidden_imports() -> None:
+    violations: dict[Path, set[str]] = {}
+    for py_file in TUI_SRC.rglob("*.py"):
+        bad = _iter_imports(py_file) & _FORBIDDEN_TOP_LEVEL
+        if bad:
+            violations[py_file] = bad
+    assert not violations, (
+        "tulip-tui leaked imports across an architectural boundary: "
+        f"{ {str(p): sorted(v) for p, v in violations.items()} }"
+    )
+
+
+def test_tui_src_directory_exists() -> None:
+    assert TUI_SRC.is_dir()
+    assert any(TUI_SRC.rglob("*.py"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ known-first-party = [
     "tulip_importers",
     "tulip_reports",
     "tulip_cli",
+    "tulip_tui",
 ]
 
 # ---------------------------------------------------------------------------
@@ -94,6 +95,7 @@ files = [
     "packages/tulip-importers/src",
     "packages/tulip-reports/src",
     "packages/tulip-cli/src",
+    "packages/tulip-tui/src",
 ]
 # Tests are intentionally excluded from mypy: pytest doesn't enforce return
 # annotations on test methods, and conftest.py files at sibling-package
@@ -109,6 +111,7 @@ mypy_path = [
     "packages/tulip-importers/src",
     "packages/tulip-reports/src",
     "packages/tulip-cli/src",
+    "packages/tulip-tui/src",
 ]
 explicit_package_bases = true
 
@@ -116,7 +119,7 @@ explicit_package_bases = true
 # Pytest
 # ---------------------------------------------------------------------------
 [tool.pytest.ini_options]
-testpaths = ["packages/tulip-core/tests", "packages/tulip-storage/tests", "packages/tulip-api/tests", "packages/tulip-ai/tests", "packages/tulip-importers/tests", "packages/tulip-reports/tests", "packages/tulip-cli/tests"]
+testpaths = ["packages/tulip-core/tests", "packages/tulip-storage/tests", "packages/tulip-api/tests", "packages/tulip-ai/tests", "packages/tulip-importers/tests", "packages/tulip-reports/tests", "packages/tulip-cli/tests", "packages/tulip-tui/tests"]
 # importlib import mode lets each package's tests/ have an __init__.py
 # without colliding with sibling packages' tests/ (mypy module-pattern
 # overrides need the __init__.py; pytest's default 'prepend' mode would

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ members = [
     "tulip-importers",
     "tulip-reports",
     "tulip-storage",
+    "tulip-tui",
 ]
 
 [[package]]
@@ -3558,6 +3559,21 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "tulip-core", editable = "packages/tulip-core" },
     { name = "types-python-dateutil", specifier = ">=2.9" },
+]
+
+[[package]]
+name = "tulip-tui"
+version = "0.0.0"
+source = { editable = "packages/tulip-tui" }
+dependencies = [
+    { name = "textual" },
+    { name = "tulip-cli" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "textual", specifier = ">=0.80" },
+    { name = "tulip-cli", editable = "packages/tulip-cli" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First implementation slice of Phase 9 per [ADR-0007](docs/adrs/0007-terminal-ui.md). Adds a new `tulip-tui` workspace package alongside the existing seven. Ships only the shell; real screens (account browser, transaction register, reports, reconciliation/import status) land in P9.1–P9.4 per #309.

- **Package** — `packages/tulip-tui/` with `src/tulip_tui/` + `tests/`, hatchling + src layout, console script `tulip-tui = "tulip_tui.main:run"`. Deps: \`textual>=0.80\` + \`tulip-cli\` (workspace) for \`TulipClient\` / \`TokenStore\` / \`Config\` reuse — no duplication of the HTTP client. Extracting a shared \`tulip-client\` package is a candidate post-v1 refactor; not worth the churn now.
- **App shell** — \`TulipTuiApp(App[None])\` with a \`q\` quit binding and a placeholder Header / Static welcome / Footer compose tree. Real screens land in P9.1+.
- **Architecture boundary test** — \`tests/test_architecture.py\` AST-scans \`tulip_tui/\` source and asserts no top-level imports of \`tulip_storage\`, \`tulip_api\`, \`tulip_ai\`, \`tulip_importers\`, \`tulip_reports\`, \`sqlalchemy\`, \`alembic\`, \`fastapi\`, \`starlette\`, or \`uvicorn\`. \`tulip_cli\` is allowed per the reuse decision; mirrors the rule tulip-cli itself lives under.
- **Pilot-mode smoke test** — \`tests/test_app_boot.py\` uses Textual's headless \`App.run_test()\` harness: boot, assert \`is_running\`, send \`q\`, assert \`return_code == 0\`. ~0.2s; \`pytest-asyncio\` already in dev deps (strict mode → \`@pytest.mark.asyncio\` per test).
- **CI + labeler** — \`.github/workflows/ci.yml\` test matrix gains \`tulip-tui\`; \`.github/labeler.yml\` gains \`area:tui\` (label created on the repo). The path-conditional \`changes\` job already catches \`packages/tulip-tui/**/*.py\` via the existing \`packages/**/*.py\` glob — no edit needed.
- **Root config** — \`pyproject.toml\`: \`testpaths\`, mypy \`files\` + \`mypy_path\`, and ruff \`known-first-party\` all gain \`tulip-tui\` / \`tulip_tui\`.

3 tests in the new package pass locally; lint / format / mypy --strict clean; 17 cross-package architecture tests + tulip-tui tests run serially in 4.5s.

## Test plan

- [x] \`uv run pytest packages/tulip-tui/tests/ -v\` → 3 passed in 0.20s
- [x] \`uv run ruff check packages/tulip-tui/\` → All checks passed!
- [x] \`uv run ruff format --check packages/tulip-tui/\` → clean
- [x] \`uv run mypy packages/tulip-tui/src\` → Success
- [x] \`just lint\` (whole tree) → clean
- [x] \`just format-check\` (whole tree) → clean
- [x] \`just typecheck\` (whole tree) → 262 source files, no issues
- [x] All 9 cross-package architecture tests in \`tulip-storage/tests/test_architecture_*.py\` + the per-package boundary tests in \`tulip-{tui,cli,core}/tests/\` + \`tulip-api/tests/test_architecture_no_http_exception.py\` → 17 passed in 4.47s
- [ ] CI green on this PR (\`Test (tulip-tui)\` shard is the new one)

### Manual smoke (optional — launches a real terminal)

\`\`\`bash
uv sync --all-packages --dev
uv run tulip-tui
# Expect: Header "tulip · terminal UI", static welcome line, Footer showing "q quit".
# Press q → app exits with code 0.
\`\`\`