### PR TITLE
feat: deprecate UserRole.VIEWER — never wired through require_role (closes #341)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,10 +130,10 @@ Same shape, with:
 ### 3.4 User & Permission Model
 
 - **Users** belong to exactly one household in v1 (multi-household membership deferred — schema-friendly to add).
-- **Roles** (per household): `admin`, `member`, `viewer`.
+- **Roles** (per household): `admin`, `member`.
   - `admin`: manage users, settings, scheduled tx, period close, see and edit all accounts including private ones, set tenant AI policy, set tenant MFA policy.
   - `member`: see and edit shared accounts, manage own private accounts/envelopes/sinking funds.
-  - `viewer`: read-only on shared accounts; no visibility into private accounts.
+  - *(A read-only `viewer` role was scaffolded in the initial schema but was never wired through `require_role` and was deprecated in #341 — see [docs/audits/2026-05-13-deep-privacy-audit.md §M-26](audits/2026-05-13-deep-privacy-audit.md). Re-introduce when a real read-only-audit-seat use case lands, with the per-endpoint authz matrix tested.)*
 - **Visibility** (per account / envelope / sinking fund): `shared` (default) or `private` (creator + admins only).
 - **Right to erasure** (GDPR Art. 17 / CCPA §1798.105 — shipped Phase 8 Wave-1):
   - `DELETE /v1/users/{user_id}` — erases one user; cascades their `sessions` + `mfa_recovery_codes` and redacts their PII from `audit_log` snapshots. Admin-only (or self).

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -77,7 +77,7 @@ Per [PHASE_0_CHECKLIST.md](PHASE_0_CHECKLIST.md). Completed 2026-04-29.
 | **P2.1** | `structlog` JSON logging + `RequestIdMiddleware` + PII-redaction processor (whitelist-based) |
 | **P2.2** | Repositories (`AccountRepository`, `PeriodRepository`, `TransactionRepository`) + `AuditLogWriter` |
 | **P2.3** | Auth: argon2id passwords, JWT access (15m) + opaque refresh (30d hashed), `Session` table + migration #2, `/v1/auth/{register,login,refresh,logout}` |
-| **P2.5** | `/v1/accounts` CRUD with role + visibility enforcement (admin / member / viewer; shared / private) |
+| **P2.5** | `/v1/accounts` CRUD with role + visibility enforcement (admin / member; shared / private — VIEWER role was scaffolded here but never wired; deprecated Phase 8 Wave-2 #341) |
 | **P2.6** | `/v1/transactions` CRUD routing through `post_transaction` with audit log on every mutation |
 
 ### Phase 2 deferred to Phase 2.x (see below)

--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -59,7 +59,7 @@ def _filter_for_role(account: Account, claims: Claims) -> bool:
     """Return True iff the caller may see this account."""
     if account.visibility == "shared":
         return True
-    # private — admin sees all; member/viewer must be the creator.
+    # private — admin sees all; member must be the creator.
     if claims.role == "admin":
         return True
     return account.created_by_user_id == claims.user_id

--- a/packages/tulip-api/src/tulip_api/routers/reports.py
+++ b/packages/tulip-api/src/tulip_api/routers/reports.py
@@ -12,7 +12,7 @@ remains JSON for backward compatibility.
 Pending transactions are excluded by default (they're workflow state,
 not ledger state); ``?include_pending=true`` (#274) folds them in.
 Role-based filtering matches ``GET /v1/accounts`` — admins see private
-accounts, members and viewers only see shared accounts and their own.
+accounts, members only see shared accounts and their own.
 """
 
 from __future__ import annotations

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260517_1000_d9e2c8b5a3f7_deprecate_viewer_role.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260517_1000_d9e2c8b5a3f7_deprecate_viewer_role.py
@@ -1,0 +1,57 @@
+"""Deprecate ``UserRole.VIEWER`` — never wired through ``require_role`` (#341).
+
+Per the deep privacy audit's M-26: ``UserRole.VIEWER`` exists in the
+enum but no router accepts it and ``_filter_for_role`` only
+special-cases ``"admin"``. A future read-only role cannot be safely
+built on top of the nominal-only scaffolding — re-introducing it
+cleanly once a real read-only-audit-seat use case lands is straight-
+forward, and the misleading current shape is worse than the absence.
+
+Defensive UPDATE handles any extant VIEWER rows (idempotent — zero on
+a fresh install) by demoting them to ``MEMBER``. ``batch_alter_table``
+then rewrites the ``users.role`` column without ``VIEWER`` in the
+CHECK constraint.
+
+Revision ID: d9e2c8b5a3f7
+Revises: b4c8e2d9a1f5
+Create Date: 2026-05-17 10:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d9e2c8b5a3f7"
+down_revision: str | None = "b4c8e2d9a1f5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_OLD_ENUM = sa.Enum("ADMIN", "MEMBER", "VIEWER", name="userrole", native_enum=False, length=20)
+_NEW_ENUM = sa.Enum("ADMIN", "MEMBER", name="userrole", native_enum=False, length=20)
+
+
+def upgrade() -> None:
+    """Demote VIEWER rows to MEMBER, then narrow the CHECK constraint."""
+    op.execute("UPDATE users SET role = 'MEMBER' WHERE role = 'VIEWER'")
+    with op.batch_alter_table("users", schema=None) as batch:
+        batch.alter_column(
+            "role",
+            existing_type=_OLD_ENUM,
+            type_=_NEW_ENUM,
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    """Re-widen the CHECK constraint to allow VIEWER again."""
+    with op.batch_alter_table("users", schema=None) as batch:
+        batch.alter_column(
+            "role",
+            existing_type=_NEW_ENUM,
+            type_=_OLD_ENUM,
+            existing_nullable=False,
+        )

--- a/packages/tulip-storage/src/tulip_storage/models/user.py
+++ b/packages/tulip-storage/src/tulip_storage/models/user.py
@@ -30,7 +30,6 @@ class UserRole(Enum):
 
     ADMIN = "admin"
     MEMBER = "member"
-    VIEWER = "viewer"
 
 
 class User(Base):

--- a/packages/tulip-storage/tests/test_migrations.py
+++ b/packages/tulip-storage/tests/test_migrations.py
@@ -297,3 +297,97 @@ class TestBalanceTrigger:
                 s2.add(bad)
                 with pytest.raises((IntegrityError, OperationalError), match="balance"):
                     s2.commit()
+
+
+class TestDeprecatedViewerRole:
+    """#341: ``UserRole.VIEWER`` is removed from the enum after the migration
+    runs. Defensive UPDATE in the migration demotes any pre-existing VIEWER
+    rows to MEMBER (audit M-26).
+
+    The DB column carries no CHECK constraint by design — the existing model
+    uses ``native_enum=False`` without ``create_constraint=True``. The Python
+    enum class is the enforcement boundary; any row written via raw SQL with
+    a value outside the enum fails to re-hydrate through the ORM.
+    """
+
+    def test_userrole_enum_does_not_contain_viewer(self):
+        from tulip_storage.models import UserRole
+
+        assert {r.name for r in UserRole} == {"ADMIN", "MEMBER"}
+        assert not hasattr(UserRole, "VIEWER")
+
+    def test_reading_raw_viewer_row_fails_via_orm(self, migrated_db):
+        from sqlalchemy import text
+
+        from tulip_storage.models import User
+
+        _, Smaker = migrated_db
+        h_id = uuid4()
+        u_id = uuid4()
+        with Smaker() as s:
+            h = Household(id=h_id, name="H", base_currency="USD")
+            s.add(h)
+            s.flush()
+            s.execute(
+                text(
+                    "INSERT INTO users "
+                    "(household_id, id, email, password_hash, display_name, role, "
+                    "created_at, updated_at) "
+                    "VALUES (:h, :u, 'v@example.com', 'x', 'V', 'VIEWER', "
+                    "'2026-01-01 00:00:00', '2026-01-01 00:00:00')"
+                ),
+                {"h": str(h_id), "u": str(u_id)},
+            )
+            s.commit()
+
+        with Smaker() as s, pytest.raises(LookupError):
+            s.get(User, (h_id, u_id))
+
+    def test_upgrade_demotes_existing_viewer_rows_to_member(self, tmp_path):
+        """downgrade → insert VIEWER → upgrade demotes the row to MEMBER."""
+        from sqlalchemy import create_engine, text
+
+        db_path = tmp_path / "tulip.db"
+        db_url = f"sqlite:///{db_path}"
+        cfg = _make_alembic_cfg(db_url)
+        # Go to the revision *just before* the deprecation lands so VIEWER
+        # is still in the CHECK constraint.
+        upgrade(cfg, "b4c8e2d9a1f5")
+
+        eng = create_engine(db_url, future=True)
+        try:
+            household_id = uuid4()
+            user_id = uuid4()
+            ts = "2026-01-01 00:00:00"
+            with eng.begin() as c:
+                c.execute(
+                    text(
+                        "INSERT INTO households "
+                        "(id, name, base_currency, created_at, updated_at, "
+                        "ai_policy, audit_retention_policy) "
+                        "VALUES (:i, 'H', 'USD', :ts, :ts, '{}', '{}')"
+                    ),
+                    {"i": str(household_id), "ts": ts},
+                )
+                c.execute(
+                    text(
+                        "INSERT INTO users "
+                        "(household_id, id, email, password_hash, display_name, "
+                        "role, created_at, updated_at) "
+                        "VALUES (:h, :u, 'v@example.com', 'x', 'V', "
+                        "'VIEWER', :ts, :ts)"
+                    ),
+                    {"h": str(household_id), "u": str(user_id), "ts": ts},
+                )
+
+            upgrade(cfg, "head")
+
+            with eng.connect() as c:
+                row = c.execute(
+                    text("SELECT role FROM users WHERE id = :u"),
+                    {"u": str(user_id)},
+                ).first()
+                assert row is not None
+                assert row[0] == "MEMBER"
+        finally:
+            eng.dispose()


### PR DESCRIPTION
## Summary
- Removes \`UserRole.VIEWER\` from the enum — was nominal-only (no router accepted it, \`_filter_for_role\` only special-cased \`"admin"\`).
- Alembic migration \`d9e2c8b5a3f7\` defensively demotes any pre-existing \`role='VIEWER'\` rows to \`'MEMBER'\` before narrowing the column via \`batch_alter_table\` (downgrade re-widens).
- Doc updates: ARCHITECTURE §3.4 role list, PHASE_STATUS P2.5 row, plus passing references in \`accounts.py\` / \`reports.py\` docstrings.
- The DB column carries no CHECK constraint by design (existing model uses \`native_enum=False\` without \`create_constraint=True\`); the Python enum class is the enforcement boundary.

## Test plan
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean
- [x] New migration tests pass: enum no longer has VIEWER; raw-SQL VIEWER row fails ORM re-hydration; downgrade → insert VIEWER → upgrade demotes to MEMBER.
- [x] Full migration round-trip test passes.
- [x] \`just test\` — 2009 passed locally (one schemathesis fuzz flake on an unrelated path, passes in isolation).
- [ ] CI green.

## Rationale (Option B from #341)
The audit recommended deprecation over wiring: there's no use case driving VIEWER today, the existing scaffolding is misleading, and re-introducing it cleanly post-Phase-9 (with proper read-only invariants tested per endpoint) is straightforward when a real read-only-audit-seat use case lands.