### PR TITLE
docs+test: pin daily_insights handler deferral, surface in ai status (closes #340)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -1084,12 +1084,18 @@ envelopes; sinking funds — which actually *want* a target-relative
 - All 4 prior P6.3 / P6.3.b handler tests updated to the new
   callback signature and still pass.
 
-**Out of scope** (deploy-time concern, not a code slice):
+**Out of scope** (deploy-time concern, not a code slice — see also #340 Phase 8 Wave-2):
 - Wiring `AIForecastCapability` into the runner's handler registration
   as the production `forecaster` callback. The slot is in place; what
   remains is one line of glue at deployment to construct the
   capability + adapter + session factory and pass it to
-  `make_daily_insights_handler(..., forecaster=...)`.
+  `make_daily_insights_handler(..., forecaster=...)`. Privacy audit M-17
+  flagged this as a doc/code drift; closed in #340 (Phase 8 Wave-2) by
+  (a) documenting the deferral in ADR-0005 §"Daily-insights handler
+  registration", (b) surfacing "background daily fire: not scheduled" in
+  `tulip ai status` output, and (c) adding a regression test
+  (`tests/test_main_lifespan.py`) that pins the invariant so a future
+  silent wiring patch fails CI.
 
 ### P6.5.b — `tulip ai config` editor + `log_prompts` toggle + status polish — ✅ *(2026-05-11)*
 

--- a/docs/adrs/0005-ai-integration.md
+++ b/docs/adrs/0005-ai-integration.md
@@ -368,6 +368,24 @@ The combination — pending-by-default + byte-faithful preview + explicit-approv
 
 Art. 21(1) "right to object to profiling" is a related but separable concern (a *persistent* "I objected" state, not just a one-shot reject) and is not satisfied by this design alone. The privacy audit's M-24 tracks the Art. 21 framing separately; the gap is documentation-acknowledged rather than wired today, since the household admin already controls the AI policy.
 
+### Daily-insights handler registration — deferred (added #340, deep privacy audit M-17)
+
+`make_daily_insights_handler` is exported from `tulip-storage`'s runner-handler registry and fully tested end-to-end (envelope + sinking-fund forecast paths under P6.3 / P6.5.c). It is **deliberately not registered** with the runner in `tulip_api.main.lifespan` for v1.
+
+What this means in practice:
+
+- The `forecast` capability is exposed for **synchronous** use: any caller can hit the proposal / categorise paths and exercise `AIForecastCapability` directly. That path runs only on explicit request.
+- The **scheduled daily fire** — what `make_daily_insights_handler` is for — does not fire. No background egress happens unless an operator explicitly registers the handler at deploy time.
+- `tulip ai status` notes the `forecast` capability's policy resolution honestly but adds a "background daily fire: not scheduled" hint, so an operator reading the output doesn't conclude that enabling `forecast=permissive` automatically means scheduled provider traffic.
+
+Why deferred:
+
+- **Scheduling is operational.** Daily cadence (which time? which user-of-household for multi-user?) is a deploy-time decision that's premature without operational mileage.
+- **Feature-flagging is cleaner at the registration site.** A future `runner.register_handler("daily_insights", make_daily_insights_handler(session_maker, forecaster=…))` is one-line glue; gating that line on `TULIP_AI_FORECAST_ENABLED` or `households.ai_policy.capabilities.forecast.scheduled=true` is the natural extension when the use case lands.
+- **Honest-by-default.** Surface honesty (the status hint) plus a regression test (`tests/test_main_lifespan.py::test_daily_insights_handler_is_not_registered_by_default`) preserve the invariant: nothing changes silently.
+
+When the wiring lands, the deletion of this subsection + the status hint + the regression test is part of the same PR.
+
 ## Alternatives considered
 
 ### Q1 — `tulip-ai` lives inside `tulip-api`

--- a/packages/tulip-api/src/tulip_api/main.py
+++ b/packages/tulip-api/src/tulip_api/main.py
@@ -154,6 +154,15 @@ def create_app(*, enable_runner: bool = True) -> FastAPI:
                 "audit_retention",
                 make_audit_retention_handler(session_maker),
             )
+            # M-17 (#340) — deep privacy audit: ``daily_insights`` is
+            # deliberately NOT registered here. The handler is exported
+            # from ``tulip_storage.runner.handlers`` and tested end-to-end,
+            # but daily cadence + per-household-user scheduling decisions
+            # are deferred (ADR-0005 §"Daily-insights handler registration").
+            # The ``forecast`` capability remains available for synchronous
+            # use; only the background daily fire is gated. When the
+            # wiring lands, register here + delete the ADR subsection +
+            # delete the regression test.
             app.state.runner = runner
             _register_ai_categorizer(session_maker)
             await runner.start()

--- a/packages/tulip-api/tests/test_main_lifespan.py
+++ b/packages/tulip-api/tests/test_main_lifespan.py
@@ -1,0 +1,71 @@
+"""Regression tests for the FastAPI lifespan / runner handler registration.
+
+Privacy audit M-17 (#340): the ``daily_insights`` handler is exported
+from ``tulip_storage.runner.handlers`` but deliberately not registered
+with the runner in ``create_app``'s lifespan. The deferral is
+documented in ADR-0005 §"Daily-insights handler registration"; this
+test pins the invariant so a future "we should just wire it" patch
+doesn't silently fire background AI egress.
+
+When the wiring lands, delete this test in the same PR.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tulip_api.main import create_app
+
+
+@pytest.mark.integration
+def test_daily_insights_handler_is_not_registered_by_default(monkeypatch, tmp_path):
+    """``daily_insights`` is gated behind explicit operator wiring (M-17 / #340).
+
+    The lifespan should NOT register a handler named ``daily_insights``;
+    the three handlers expected today are ``attachment_gc``,
+    ``ai_retention``, ``audit_retention``.
+    """
+    # Point the app at an isolated SQLite file + attachment root so the
+    # default-runner lifespan boots cleanly.
+    db_path = tmp_path / "tulip.db"
+    attach_root = tmp_path / "attachments"
+    attach_root.mkdir()
+    monkeypatch.setenv("TULIP_DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("TULIP_ATTACHMENT_ROOT", str(attach_root))
+    monkeypatch.setenv(
+        "TULIP_MASTER_KEY",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",  # base64 of 32 zero bytes
+    )
+    monkeypatch.setenv("TULIP_JWT_SECRET", "test-secret-for-lifespan-only")
+    # Stamp the DB head so the runner can boot cleanly.
+    from pathlib import Path
+
+    from alembic.command import upgrade
+    from alembic.config import Config
+
+    cfg = Config(str(Path(__file__).resolve().parents[2] / "tulip-storage" / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    cfg.set_main_option(
+        "script_location",
+        str(
+            Path(__file__).resolve().parents[2]
+            / "tulip-storage"
+            / "src"
+            / "tulip_storage"
+            / "migrations"
+        ),
+    )
+    upgrade(cfg, "head")
+
+    app = create_app(enable_runner=True)
+    with TestClient(app) as _:
+        runner = app.state.runner
+        assert runner is not None, "lifespan should set app.state.runner"
+        registered = set(runner._handlers.keys())
+        assert "daily_insights" not in registered, (
+            "daily_insights handler must NOT be registered by default — see "
+            "ADR-0005 §'Daily-insights handler registration' / privacy audit M-17"
+        )
+        # Positive control — the three handlers we do register.
+        assert {"attachment_gc", "ai_retention", "audit_retention"} <= registered

--- a/packages/tulip-cli/src/tulip_cli/commands/ai.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/ai.py
@@ -186,6 +186,11 @@ def status(ctx: typer.Context) -> None:
             f"    {name:14s} level={cfg.get('level')} profile={cfg.get('profile')} "
             f"provider={cfg.get('provider') or '(inherit)'}"
         )
+        if name == "forecast":
+            typer.echo(
+                "      background daily fire: not scheduled "
+                "(synchronous use only; ADR-0005 §Daily-insights handler registration)"
+            )
 
 
 @ai_app.command("ask")

--- a/packages/tulip-cli/tests/test_ai.py
+++ b/packages/tulip-cli/tests/test_ai.py
@@ -118,6 +118,20 @@ def test_ai_status_renders_defaults(authed: str) -> None:
 
 
 @pytest.mark.integration
+def test_ai_status_forecast_capability_notes_unscheduled_daily_fire(
+    authed: str,
+) -> None:
+    """#340 / privacy audit M-17: the ``forecast`` line carries a
+    "background daily fire: not scheduled" hint so operators don't read
+    ``forecast=permissive`` and assume background egress will fire.
+    """
+    result = _run_cli("ai", "status", api_url=authed)
+    assert result.returncode == 0, result.stderr
+    assert "forecast" in result.stdout
+    assert "background daily fire: not scheduled" in result.stdout
+
+
+@pytest.mark.integration
 def test_ai_preview_renders_payload(authed: str) -> None:
     # Seed two expense accounts so the chart isn't empty.
     httpx.post(


### PR DESCRIPTION
## Summary
- Privacy audit M-17 doc/code drift closed via Option B (document the deferral) — \`make_daily_insights_handler\` stays unregistered for v1, but the absence is now visible and CI-enforced.
- ADR-0005 gains a "Daily-insights handler registration" subsection.
- \`create_app\` lifespan carries a comment documenting the intentional absence alongside the three handlers that ARE registered.
- \`tulip ai status\` appends "background daily fire: not scheduled" under the \`forecast\` capability so operators don't read \`permissive\` as "scheduled".
- New \`tests/test_main_lifespan.py\` exercises the real lifespan boot and asserts \`daily_insights\` is NOT in the registered handler set.
- New CLI integration test asserts the status hint shows up.

## Test plan
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (262 source files)
- [x] \`test_main_lifespan.py\` + new \`test_ai_status_forecast_capability_notes_unscheduled_daily_fire\` pass.
- [ ] CI green.