### PR TITLE
fix(api): strip errors[].input from 422 Problem-Details (closes #342)

### DIFF
--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -1922,7 +1922,14 @@ def install_problem_handlers(app: FastAPI) -> None:
         # Pydantic's error structure can contain Decimal values (e.g. inside
         # ``ctx`` for ``ge`` / ``gt`` / ``le`` / ``lt`` constraints) that
         # JSONResponse can't serialize. Coerce them to strings recursively.
-        sanitized = [_sanitize_for_json(e) for e in exc.errors()]
+        # Privacy audit M-14 (#342): also strip the per-error ``input`` field
+        # — Pydantic echoes the rejected value back, but request bodies can
+        # carry PII or accidentally-misposted secrets. The ``loc`` + ``msg``
+        # + ``type`` triple identifies the failure without re-emitting the
+        # value.
+        sanitized = [
+            _sanitize_for_json({k: v for k, v in e.items() if k != "input"}) for e in exc.errors()
+        ]
         return _render(request, ValidationFailedError(errors=sanitized))
 
     @app.exception_handler(IntegrityError)

--- a/packages/tulip-api/tests/test_problem_details.py
+++ b/packages/tulip-api/tests/test_problem_details.py
@@ -85,3 +85,56 @@ class TestTulipProblem:
         assert r.headers["www-authenticate"] == "Bearer"
         # Content-Type for the body must still be application/problem+json.
         assert r.headers["content-type"].startswith("application/problem+json")
+
+
+class TestValidationErrorInputStripped:
+    """#342 / privacy audit M-14: ``errors[N].input`` is removed from 422
+    Problem Details responses to avoid echoing rejected request-body
+    values (which may carry PII, secrets sent to the wrong endpoint, or
+    arbitrary user input). The ``loc`` + ``msg`` + ``type`` triple
+    identifies the failing field without re-emitting its value.
+    """
+
+    @staticmethod
+    def _app_with_validated_body():
+        from pydantic import BaseModel, Field
+
+        class _Body(BaseModel):
+            description: str = Field(max_length=10)
+
+        app = FastAPI()
+        install_problem_handlers(app)
+
+        @app.post("/echo")
+        def echo(body: _Body) -> dict[str, str]:
+            return {"description": body.description}
+
+        return TestClient(app)
+
+    def test_long_string_input_is_not_echoed_in_response(self):
+        client = self._app_with_validated_body()
+        rejected = "A" * 500
+        r = client.post("/echo", json={"description": rejected})
+        assert r.status_code == 422
+        body = r.json()
+        # The rejected value must not appear anywhere in the response body.
+        assert rejected not in r.text, "rejected request-body value must not echo"
+        # The structured loc / msg / type triple is preserved.
+        first_error = body["errors"][0]
+        assert "loc" in first_error
+        assert "msg" in first_error
+        assert "type" in first_error
+        # The ``input`` field must be stripped.
+        assert "input" not in first_error
+
+    def test_email_secret_value_is_not_echoed(self):
+        """Scenario: a client accidentally posts a password where an email
+        is expected. The rejected ``input`` value must not survive into
+        the 422 response (it might land in proxy logs, browser dev-tools,
+        etc.).
+        """
+        client = self._app_with_validated_body()
+        secret = "this-is-not-a-description-it-is-a-secret"
+        r = client.post("/echo", json={"description": secret})
+        assert r.status_code == 422
+        assert secret not in r.text


### PR DESCRIPTION
## Summary
- Privacy audit M-14: \`RequestValidationError.errors()\` includes \`errors[N].input\` — Pydantic echoes the rejected request-body value back. Long descriptions, accidentally-misposted secrets, arbitrary user input all land in the 422 response body (and in any proxy log / dev-tools that records >=400 responses).
- Fix in \`install_problem_handlers._handle_validation\`: filter out the \`input\` key from each error dict before \`_sanitize_for_json\`. The \`loc\` + \`msg\` + \`type\` triple is preserved, so tooling that discriminates on the structured shape still works.
- Two new regression tests in \`TestValidationErrorInputStripped\`: 500-char rejected value not in response; accidentally-misposted secret not in response.

## Test plan
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean
- [x] New tests pass (\`TestValidationErrorInputStripped::*\`)
- [x] Existing \`test_problem_details.py\` + \`test_internal_error_handler.py\` still pass (14/14)
- [ ] CI green.

## Privacy framing
GDPR Art. 5(1)(c) — data minimisation. The structured triple identifies what failed; the rejected value isn't needed for the client to remediate.