### PR TITLE
feat(auth): pin argon2id parameters explicitly (closes #328)

### DIFF
--- a/packages/tulip-api/src/tulip_api/auth/argon2_params.py
+++ b/packages/tulip-api/src/tulip_api/auth/argon2_params.py
@@ -1,0 +1,31 @@
+"""Pinned argon2id parameters for password + recovery-code hashing.
+
+Per the deep security audit's M-24: ``argon2-cffi`` library defaults
+exceed OWASP 2024 minimums, but they are not pinned, not surfaced via
+diagnostics, and not configurable. A future ``argon2-cffi`` default
+change would silently shift parameters across the fleet. Pin them
+explicitly here; tune by editing this file (and ``needs_rehash`` will
+flag stale hashes for upgrade-on-next-login per #224).
+
+Current values match the library defaults at the time of audit (2026-
+05) and exceed OWASP 2024 minimums (m=19 MiB, t=2, p=1) comfortably.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+#: Iterations.
+TIME_COST: Final[int] = 3
+
+#: Memory cost in KiB (65 536 KiB = 64 MiB).
+MEMORY_COST: Final[int] = 65_536
+
+#: Parallelism (lanes).
+PARALLELISM: Final[int] = 4
+
+#: Output length, bytes.
+HASH_LEN: Final[int] = 32
+
+#: Salt length, bytes.
+SALT_LEN: Final[int] = 16

--- a/packages/tulip-api/src/tulip_api/auth/passwords.py
+++ b/packages/tulip-api/src/tulip_api/auth/passwords.py
@@ -10,10 +10,26 @@ from __future__ import annotations
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHashError, VerifyMismatchError
 
-# OWASP 2024 minimum: m=19MiB, t=2, p=1. argon2-cffi defaults are stricter
-# than that already (m=64MiB, t=3, p=4) — keep them. If we re-tune later,
-# `needs_rehash` will flag old hashes for upgrade-on-next-login.
-_HASHER = PasswordHasher()
+from tulip_api.auth.argon2_params import (
+    HASH_LEN,
+    MEMORY_COST,
+    PARALLELISM,
+    SALT_LEN,
+    TIME_COST,
+)
+
+# Parameters pinned explicitly per security audit M-24 (#328). Current
+# values match the argon2-cffi defaults at audit time (m=64MiB, t=3, p=4)
+# and exceed OWASP 2024 minimums (m=19MiB, t=2, p=1). Tune by editing
+# ``argon2_params.py``; ``needs_rehash`` will flag stale hashes for
+# upgrade-on-next-login per #224.
+_HASHER = PasswordHasher(
+    time_cost=TIME_COST,
+    memory_cost=MEMORY_COST,
+    parallelism=PARALLELISM,
+    hash_len=HASH_LEN,
+    salt_len=SALT_LEN,
+)
 
 
 def hash_password(plain: str) -> str:

--- a/packages/tulip-api/src/tulip_api/auth/recovery_codes.py
+++ b/packages/tulip-api/src/tulip_api/auth/recovery_codes.py
@@ -27,6 +27,14 @@ from typing import Final
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHashError, VerifyMismatchError
 
+from tulip_api.auth.argon2_params import (
+    HASH_LEN,
+    MEMORY_COST,
+    PARALLELISM,
+    SALT_LEN,
+    TIME_COST,
+)
+
 #: RFC 4648 base32 alphabet (A-Z + 2-7), excluding 0/1/8/9 by construction.
 _ALPHABET: Final[str] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
 
@@ -38,9 +46,15 @@ _GROUP_LEN: Final[int] = 4
 _GROUP_COUNT: Final[int] = 4
 _CODE_CHARS: Final[int] = _GROUP_LEN * _GROUP_COUNT
 
-# Reuse argon2-cffi defaults — same parameters used for passwords. The
-# CPU cost during enrollment-verify (8 hashes) is bounded and acceptable.
-_HASHER = PasswordHasher()
+# Pinned parameters per security audit M-24 (#328). Same parameters as
+# password hashing — see ``argon2_params.py``.
+_HASHER = PasswordHasher(
+    time_cost=TIME_COST,
+    memory_cost=MEMORY_COST,
+    parallelism=PARALLELISM,
+    hash_len=HASH_LEN,
+    salt_len=SALT_LEN,
+)
 
 
 def generate_recovery_codes(count: int = DEFAULT_CODE_COUNT) -> list[str]:

--- a/packages/tulip-api/tests/test_passwords.py
+++ b/packages/tulip-api/tests/test_passwords.py
@@ -35,3 +35,55 @@ class TestNeedsRehash:
     def test_unknown_hash_format_raises(self):
         with pytest.raises(ValueError):
             verify_password("x", "not-a-hash")
+
+
+class TestArgon2ParamsArePinned:
+    """#328 / security audit M-24: argon2id parameters are pinned in
+    ``argon2_params.py`` and applied to both the password hasher and
+    the recovery-code hasher. A future ``argon2-cffi`` default-tune
+    cannot silently shift parameters across the fleet.
+    """
+
+    def test_password_hasher_uses_pinned_params(self):
+        from tulip_api.auth.argon2_params import (
+            HASH_LEN,
+            MEMORY_COST,
+            PARALLELISM,
+            SALT_LEN,
+            TIME_COST,
+        )
+        from tulip_api.auth.passwords import _HASHER
+
+        assert _HASHER.time_cost == TIME_COST
+        assert _HASHER.memory_cost == MEMORY_COST
+        assert _HASHER.parallelism == PARALLELISM
+        assert _HASHER.hash_len == HASH_LEN
+        assert _HASHER.salt_len == SALT_LEN
+
+    def test_recovery_code_hasher_uses_pinned_params(self):
+        from tulip_api.auth.argon2_params import (
+            HASH_LEN,
+            MEMORY_COST,
+            PARALLELISM,
+            SALT_LEN,
+            TIME_COST,
+        )
+        from tulip_api.auth.recovery_codes import _HASHER
+
+        assert _HASHER.time_cost == TIME_COST
+        assert _HASHER.memory_cost == MEMORY_COST
+        assert _HASHER.parallelism == PARALLELISM
+        assert _HASHER.hash_len == HASH_LEN
+        assert _HASHER.salt_len == SALT_LEN
+
+    def test_pinned_params_exceed_owasp_2024_minimums(self):
+        """OWASP 2024 minimum: m=19 MiB, t=2, p=1."""
+        from tulip_api.auth.argon2_params import (
+            MEMORY_COST,
+            PARALLELISM,
+            TIME_COST,
+        )
+
+        assert MEMORY_COST >= 19 * 1024
+        assert TIME_COST >= 2
+        assert PARALLELISM >= 1


### PR DESCRIPTION
## Summary
- Security audit M-24: \`PasswordHasher()\` ran on \`argon2-cffi\` library defaults. Defaults exceeded OWASP 2024 minimums, so today's strength is fine — but a future \`argon2-cffi\` default-tune would silently shift parameters across the fleet.
- New \`auth/argon2_params.py\` module exposes the five tuning knobs (\`TIME_COST\`, \`MEMORY_COST\`, \`PARALLELISM\`, \`HASH_LEN\`, \`SALT_LEN\`).
- Both \`auth/passwords.py\` and \`auth/recovery_codes.py\` now construct their \`PasswordHasher\` with the explicit pinned values.
- Current values match the audit-time defaults — no behaviour shift; future tuning is a one-line edit, and \`needs_rehash\` (wired #224) takes care of upgrading old hashes.
- Three regression tests assert both hashers carry the pinned params and the values exceed OWASP 2024 minimums.

## Test plan
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (264 source files)
- [x] All 49 password / recovery-code tests pass.
- [ ] CI green.