### PR TITLE
test: architecture test enforcing AuditLogWriter chokepoint (closes #331)

### DIFF
--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/audit_retention.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/audit_retention.py
@@ -32,11 +32,11 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
-from uuid import uuid4
 
 from sqlalchemy import delete, select
 
 from tulip_storage.models import AuditLog, Household
+from tulip_storage.repositories.audit_log import AuditLogWriter
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -215,18 +215,14 @@ def run_audit_retention(
             if total > 0:
                 # Summary row mirrors the ai.prompt_log_scrubbed pattern (#243).
                 # actor_user_id is None — this is system GC, not a user action.
-                session.add(
-                    AuditLog(
-                        id=uuid4(),
-                        household_id=household.id,
-                        occurred_at=now,
-                        actor_user_id=None,
-                        actor_kind="system",
-                        action="audit.pruned",
-                        entity_type="household",
-                        entity_id=household.id,
-                        metadata_={"deleted_per_tier": per_tier},
-                    )
+                # Routes through AuditLogWriter per the chokepoint invariant
+                # enforced by test_architecture_audit_log_writer_only (#331).
+                AuditLogWriter(session, household.id).write(
+                    action="audit.pruned",
+                    actor_kind="system",
+                    entity_type="household",
+                    entity_id=household.id,
+                    metadata={"deleted_per_tier": per_tier},
                 )
             summary[household.id] = per_tier
         session.commit()

--- a/packages/tulip-storage/tests/test_architecture_audit_log_writer_only.py
+++ b/packages/tulip-storage/tests/test_architecture_audit_log_writer_only.py
@@ -1,0 +1,88 @@
+"""Architecture test: ``AuditLog`` rows are written only via ``AuditLogWriter``.
+
+Per security audit M-18 (#331): the writer is the contract chokepoint for
+the audit_log table — it stamps ``request_id``, validates ``household_id``,
+and normalises ``occurred_at``. A future contributor (or an AI-generated
+patch) could instantiate ``AuditLog(...)`` directly to "skip the writer
+for a special case" and bypass those invariants. This test catches the
+regression.
+
+The check is constructor-call-based, not import-based: legitimate read
+paths (the audit-retention prune handler, the audit-log report) import
+``AuditLog`` for ``select`` / ``delete`` queries. Those are not flagged.
+Only ``AuditLog(...)`` calls — which can only mean "construct a new row" —
+are.
+
+Mirrors the eleven other ``test_architecture_no_direct_X_writes.py``
+tests in shape; replaces the missing ``audit_log`` entry in that family.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
+_PACKAGES: Final[Path] = _REPO_ROOT / "packages"
+
+#: Files allowed to construct ``AuditLog(...)`` directly.
+_ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
+    {
+        # The model file itself declares the class.
+        "tulip-storage/src/tulip_storage/models/audit_log.py",
+        # The single legitimate writer — the chokepoint this test
+        # defends.
+        "tulip-storage/src/tulip_storage/repositories/audit_log.py",
+    }
+)
+
+
+def _python_source_files() -> list[Path]:
+    out: list[Path] = []
+    for pkg in sorted(_PACKAGES.iterdir()):
+        src = pkg / "src"
+        if not src.is_dir():
+            continue
+        out.extend(sorted(src.rglob("*.py")))
+    return out
+
+
+def _audit_log_constructions(path: Path) -> list[int]:
+    """Return line numbers of ``AuditLog(...)`` constructor calls in ``path``.
+
+    Matches both ``AuditLog(...)`` (after ``from tulip_storage.models import
+    AuditLog``) and ``models.AuditLog(...)`` / ``tulip_storage.models.AuditLog(...)``.
+    Does not match ``AuditLog.foo``, ``AuditLog.action``, etc. — only Call nodes
+    where the callee resolves to ``AuditLog``.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "AuditLog":
+            hits.append(node.lineno)
+        elif isinstance(func, ast.Attribute) and func.attr == "AuditLog":
+            hits.append(node.lineno)
+    return hits
+
+
+def test_no_direct_audit_log_construction_outside_allowlist() -> None:
+    offenders: dict[str, list[int]] = {}
+    for path in _python_source_files():
+        rel = str(path.relative_to(_PACKAGES))
+        if rel in _ALLOWED_RELATIVE:
+            continue
+        hits = _audit_log_constructions(path)
+        if hits:
+            offenders[rel] = hits
+
+    assert not offenders, (
+        "Direct ``AuditLog(...)`` construction outside the AuditLogWriter "
+        "chokepoint — route writes through ``AuditLogWriter(session, "
+        "household_id).write(...)`` so request_id / household_id / "
+        "occurred_at invariants stay correct:\n"
+        + "\n".join(f"  {file}:{lines}" for file, lines in offenders.items())
+    )


### PR DESCRIPTION
## Summary
- Security audit M-18: ten other "no direct X writes" arch tests guard the chokepoint tables, but \`audit_log\` had no equivalent guard. A future contributor / AI patch could drop an \`AuditLog(...)\` to "skip the writer for a special case" and bypass \`request_id\` / \`household_id\` / \`occurred_at\` invariants without CI catching it.
- New \`test_architecture_audit_log_writer_only.py\` AST-scans every \`tulip-*/src/**/*.py\` for \`AuditLog(...)\` constructor calls. Allowlist is two files: the model itself + \`repositories/audit_log.py\`. Constructor-call-based (not import-based) — legitimate read paths (\`select(AuditLog)\` / \`delete(AuditLog)\`) are not flagged.
- Required fix to land the test: \`runner/handlers/audit_retention.py\` was constructing an \`AuditLog(...)\` directly for its \`audit.pruned\` summary row. Refactored to \`AuditLogWriter(session, household_id).write(...)\` — same behaviour, but stamped via the chokepoint with its UTC-now.

## Test plan
- [x] \`just lint\` / \`just typecheck\` clean.
- [x] New arch test passes (no offenders after the audit-retention refactor).
- [x] All 14 audit_retention handler / model tests pass.
- [ ] CI green.

## Pattern fidelity
Mirrors the eleven existing \`test_architecture_no_direct_X_writes.py\` tests in shape, fills the missing audit_log slot.