### PR TITLE
fix(runner): redact handler exception messages from scheduled_job_runs.last_error (closes #343)

### DIFF
--- a/packages/tulip-storage/src/tulip_storage/runner/runner.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/runner.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import traceback
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
@@ -48,6 +49,24 @@ DEFAULT_POLL_INTERVAL_SECONDS: float = 30.0
 
 
 HandlerCallback = Callable[[ScheduledJob, Clock], Awaitable[None]]
+
+
+def _redact_exception(exc: BaseException) -> str:
+    """Return ``<ClassName> at <file>:<lineno>`` — drops the exception message.
+
+    Privacy audit M-13 (#343): Python exception messages routinely embed
+    user-supplied values via DB constraint text, parse-error excerpts,
+    Pydantic validation echoes, etc. The runner persists this string on
+    ``scheduled_job_runs.last_error`` where it survives daily-fire
+    rotation and lands in ``audit_log`` snapshots — a long-tail PII leak.
+
+    The class name + raise-site file:line identifies the failure mode
+    for operators without echoing user content. Stack traces are still
+    captured via ``log.exception`` for diagnosis.
+    """
+    tb = traceback.extract_tb(exc.__traceback__)
+    location = f"{tb[-1].filename}:{tb[-1].lineno}" if tb else "unknown"
+    return f"{type(exc).__name__} at {location}"
 
 
 class IdempotencyKeyConflictError(ValueError):
@@ -314,7 +333,7 @@ class Runner:
                 "runner.handler_failed",
                 extra={"job_id": str(job.id), "kind": job.kind},
             )
-            self._on_failure(job, run_id=run_id, started_at=start, error=str(exc))
+            self._on_failure(job, run_id=run_id, started_at=start, error=_redact_exception(exc))
             return
 
         completed = self._clock()

--- a/packages/tulip-storage/tests/test_runner.py
+++ b/packages/tulip-storage/tests/test_runner.py
@@ -428,3 +428,43 @@ async def test_start_stop_lifecycle(
     await runner.stop()
 
     assert fired == [job_id]
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_last_error_does_not_leak_exception_message(
+    session_maker: sessionmaker[Session],
+    session: Session,
+    household: Household,
+) -> None:
+    """#343 / privacy audit M-13: handler-raised exception messages do
+    NOT land in ``scheduled_job_runs.last_error``. Class name + raise-
+    site file:line is recorded instead, so operators still get a
+    diagnosable signal without persisting PII-bearing exception text.
+    """
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(now=t0)
+    runner = _runner(session_maker, clock=clock)
+
+    pii_secret = "alice@example.com is the leaked email"
+
+    async def leaky_handler(job: ScheduledJob, _clock):
+        raise RuntimeError(pii_secret)
+
+    runner.register_handler("leaky", leaky_handler)
+    job_id = runner.schedule_one(
+        household_id=household.id,
+        kind="leaky",
+        payload={},
+        fire_at=t0,
+    )
+
+    await runner.run_once()
+    runs = _runs(session, household.id, job_id)
+    assert len(runs) == 1
+    last_error = runs[0].last_error or ""
+
+    # The PII string must not survive into the persisted last_error.
+    assert pii_secret not in last_error
+    # The class name + a file:line marker should be present.
+    assert "RuntimeError" in last_error
+    assert "at " in last_error


### PR DESCRIPTION
## Summary
- Privacy audit M-13: runner.py wrote \`str(exc)\` into \`scheduled_job_runs.last_error\` on handler failure. Python exception messages routinely embed user content via DB constraint text, parse-error excerpts, Pydantic validation echoes — long-tail PII leak that survived daily-fire rotation and landed in audit_log snapshots.
- New \`_redact_exception(exc)\` helper returns \`"<ClassName> at <file>:<lineno>"\`. Class + raise-site identifies the failure mode for operators without echoing exception text.
- Wired at \`runner.py:_dispatch\` handler-failure path. The other \`last_error\` write (no-handler-registered) already uses a static template.
- Full stack traces still flow through \`log.exception\` under the structlog context for diagnosis — only the persisted string changes.
- New test exercises the leaky-handler path with a PII-bearing exception message; asserts the message does not survive and class+location markers do.

## Test plan
- [x] \`just lint\` / \`just typecheck\` clean.
- [x] Three relevant runner tests pass (new leak test + existing retry test + no-handler test).
- [ ] CI green.

## GDPR framing
Art. 5(1)(c) data minimisation: operators get the diagnostic signal they need (class name + file:line) without persisting user content.