### PR TITLE
fix(api): HTTP defense-in-depth + custom-query admin-gate (closes #349)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/reports.py
+++ b/packages/tulip-api/src/tulip_api/routers/reports.py
@@ -212,6 +212,23 @@ def _to_jsonable(obj: object) -> object:
     return obj
 
 
+#: Security headers applied to every HTML report response. Defense-in-
+#: depth against a hypothetical template-escaping bug (security audit
+#: L-22). Tulip's report templates pull no remote resources and use only
+#: inline ``<style>`` (no inline script), so the policy below is the
+#: tightest one that still renders correctly. Adjust ``style-src`` if a
+#: report ever needs an external stylesheet.
+_HTML_REPORT_SECURITY_HEADERS = {
+    "Content-Security-Policy": (
+        "default-src 'none'; style-src 'unsafe-inline'; "
+        "img-src 'self' data:; base-uri 'none'; form-action 'none'; "
+        "frame-ancestors 'none'"
+    ),
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+}
+
+
 def _report_response(
     data: object,
     render_html: Callable[..., str],
@@ -224,7 +241,10 @@ def _report_response(
 ) -> Response:
     """Common JSON / HTML / PDF / CSV branch used by the report endpoints."""
     if format == "html":
-        return HTMLResponse(content=render_html(data))
+        return HTMLResponse(
+            content=render_html(data),
+            headers=_HTML_REPORT_SECURITY_HEADERS,
+        )
     if format == "pdf":
         if render_pdf is None:
 
@@ -550,12 +570,13 @@ class CustomQueryUnsafeError(TulipProblem):
         200: {"description": "Custom-query report (JSON or HTML)."},
         400: problem_response("report.unsafe_query"),
         401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
     },
 )
 def custom_query(
     sql: str = Query(..., description="Read-only SELECT against AI views (P6.2)."),
     format: Literal["json", "html", "pdf", "csv"] = Query(default="json"),
-    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008 — #349 / audit L-7
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
     """Run a read-only SELECT against the AI views; render as a table.
@@ -563,6 +584,13 @@ def custom_query(
     Queries are validated by ``tulip_ai.sql_safety.validate_and_rewrite``
     — writes, non-AI-view reads, and joins outside the allowlist raise
     ``UnsafeSQLError`` which we surface as a 400 Problem Details.
+
+    Admin-only per security audit L-7 (#349). The SQL-safety pass
+    constrains *which* SQL runs, not which tenant rows are visible —
+    a member running custom-query would observe private-pool data the
+    visibility filter would otherwise hide. Restricting to admin
+    sidesteps the cross-user-within-household concern; the broader
+    visibility-filter bundle stays gated on multi-user invite (#237).
     """
     from tulip_ai.sql_safety import UnsafeSQLError
     from tulip_reports.reports import custom_query as report_module

--- a/packages/tulip-api/src/tulip_api/routers/system.py
+++ b/packages/tulip-api/src/tulip_api/routers/system.py
@@ -14,7 +14,7 @@ import secrets
 import uuid
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 from sqlalchemy import text
 
 from tulip_api.config import Settings, get_settings
@@ -61,10 +61,16 @@ def _probe_attachment_root_writable(settings: Settings) -> bool:
     response_model=SystemDiagnosticsRead,
 )
 def get_system_diagnostics(
+    response: Response,
     session: Session = Depends(get_session),  # noqa: B008
     settings: Settings = Depends(get_settings),  # noqa: B008
 ) -> SystemDiagnosticsRead:
     """Aggregate environment + storage probes consumed by ``tulip doctor``."""
+    # Security audit L-23 (#349): the writability-probe answer + alembic
+    # head can change between calls; intermediaries / browsers must not
+    # cache. ``no-store`` is the strongest no-cache directive (also
+    # forbids transformation by caching proxies).
+    response.headers["Cache-Control"] = "no-store"
     head_in_db = _read_alembic_head_in_db(session)
     head_expected = expected_alembic_head()
     return SystemDiagnosticsRead(

--- a/packages/tulip-api/tests/test_reports_endpoints.py
+++ b/packages/tulip-api/tests/test_reports_endpoints.py
@@ -242,3 +242,87 @@ class TestDateRangeReports:
 
 # Use the date import so linters don't flag it as unused after parametrization.
 _ = date
+
+
+class TestHtmlReportSecurityHeaders:
+    """#349 / security audit L-22: HTML report responses carry a strict
+    ``Content-Security-Policy`` + ``X-Content-Type-Options: nosniff``.
+    Defense-in-depth against a hypothetical template-escaping bug.
+    """
+
+    def test_html_format_carries_csp_header(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        r = client.get(
+            "/v1/reports/trial-balance",
+            headers=auth_h,
+            params={"format": "html"},
+        )
+        assert r.status_code == 200
+        assert "Content-Security-Policy" in r.headers
+        # The policy locks down default-src; no remote loads.
+        assert "default-src 'none'" in r.headers["Content-Security-Policy"]
+
+    def test_html_format_carries_nosniff(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        r = client.get(
+            "/v1/reports/trial-balance",
+            headers=auth_h,
+            params={"format": "html"},
+        )
+        assert r.headers.get("X-Content-Type-Options") == "nosniff"
+
+    def test_json_format_does_not_carry_csp_header(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """CSP is only meaningful on browser-rendered HTML — JSON consumers
+        don't need it and it would be noise on every API response.
+        """
+        r = client.get(
+            "/v1/reports/trial-balance",
+            headers=auth_h,
+            params={"format": "json"},
+        )
+        assert "Content-Security-Policy" not in r.headers
+
+
+class TestCustomQueryAdminGate:
+    """#349 / security audit L-7: ``/custom-query`` requires admin. The
+    SQL-safety pass constrains *which* SQL runs, not which tenant rows
+    are visible — a member could observe private-pool data the
+    visibility filter would otherwise hide.
+    """
+
+    def test_member_caller_rejected_with_403(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        """Demote the registered user to MEMBER, then assert 403 on custom-query.
+
+        ``auth_h`` registers an admin user (creating the household) — that
+        login fixture is the prerequisite for the demote step below.
+        """
+        from sqlalchemy import select, update
+
+        from tulip_storage.models import User, UserRole
+
+        _ = auth_h  # trigger the admin-register fixture
+
+        with session_maker() as s:
+            s.execute(update(User).values(role=UserRole.MEMBER))
+            s.commit()
+
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": "admin@example.com", "password": "correct horse battery staple"},
+        )
+        member_h = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+        r = client.get(
+            "/v1/reports/custom-query",
+            headers=member_h,
+            params={"sql": "SELECT 1"},
+        )
+        assert_problem(r, code="auth.forbidden", status=403)
+        _ = select  # silence ruff if unused after the inline update

--- a/packages/tulip-api/tests/test_system_diagnostics_endpoint.py
+++ b/packages/tulip-api/tests/test_system_diagnostics_endpoint.py
@@ -133,3 +133,27 @@ class TestDegradedStates:
         assert body["alembic_head_match"] is False
         assert body["alembic_head_expected"] == "deadbeef0000"
         assert body["alembic_head_in_db"] != "deadbeef0000"
+
+
+class TestCacheControl:
+    """#349 / security audit L-23: ``/v1/system/diagnostics`` answers can
+    change between calls (alembic head bumps, attachment-root writability
+    flips), so intermediaries / browsers must not cache the response.
+    """
+
+    def test_no_store_cache_control_header(
+        self, app: FastAPI, client: TestClient, tmp_path: Path
+    ) -> None:
+        _override_settings(
+            app,
+            Settings(
+                database_url="sqlite:///:memory:",
+                jwt_secret="test-secret-32bytes-test-secret!!",
+                master_key=b"\x42" * 32,
+                master_key_source="env",
+                attachment_root=tmp_path / "attachments",
+            ),
+        )
+        r = client.get("/v1/system/diagnostics")
+        assert r.status_code == 200
+        assert r.headers.get("Cache-Control") == "no-store"


### PR DESCRIPTION
## Summary
Security audit Low bundle (L-7 + L-22 + L-23):

- **L-22** HTML report responses (every \`/v1/reports/*?format=html\`) gain a strict CSP (\`default-src 'none'\`; \`style-src 'unsafe-inline'\`; \`img-src 'self' data:\`; \`base-uri\`/\`form-action\`/\`frame-ancestors 'none'\`) + \`X-Content-Type-Options: nosniff\` + \`Referrer-Policy: no-referrer\`. Defense-in-depth against a hypothetical template-escaping bug. JSON responses unaffected.
- **L-23** \`/v1/system/diagnostics\` sets \`Cache-Control: no-store\` — answer can change between calls (alembic head bumps, writability flips).
- **L-7** \`/v1/reports/custom-query\` restricted to \`require_role("admin")\`. SQL-safety constrains *which* SQL runs, not which tenant rows are visible — admin gate sidesteps the cross-user-within-household concern.

## Test plan
- [x] \`just lint\` / \`just typecheck\` clean.
- [x] 5 new tests pass (CSP on HTML; nosniff on HTML; no-CSP on JSON; member 403 on custom-query; no-store on diagnostics).
- [x] 45 non-PDF tests in test_reports_endpoints.py + test_system_diagnostics_endpoint.py pass locally. (7 PDF tests fail on macOS due to missing libpango — pre-existing env issue, not this PR.)
- [ ] CI green (Linux runner has libpango).