### PR TITLE
feat(api): auth hardening lows — TOTP enroll rate limit, extra=forbid, Settings repr redaction (closes #350)

### DIFF
--- a/packages/tulip-api/src/tulip_api/auth/rate_limit.py
+++ b/packages/tulip-api/src/tulip_api/auth/rate_limit.py
@@ -50,6 +50,37 @@ AUTH_LOGIN_MFA_LIMIT = "10/minute"
 AUTH_LOGIN_RECOVER_LIMIT = "10/minute"
 AUTH_REFRESH_LIMIT = "30/minute"
 
+#: Per-user quota on ``/v1/auth/mfa/enroll`` (security audit L-3, #350).
+#: The endpoint generates a fresh TOTP secret + provisioning URI on every
+#: call, rotating any unverified secret. A token-stealer with brief access
+#: to a valid access token could spam enroll to deny the user re-enrollment
+#: of their own MFA. 5 per 15 minutes leaves room for a confused user
+#: who didn't scan the first QR code, blocks an automated attacker.
+AUTH_MFA_ENROLL_LIMIT = "5/15minutes"
+
+
+def get_user_id_from_jwt(request: Request) -> str:
+    """Extract the user_id from the bearer token for per-user rate keying.
+
+    Used as a slowapi ``key_func`` for endpoints already behind auth — the
+    JWT's ``sub`` claim is the natural per-user discriminator. Falls back
+    to the client IP when the header is missing/malformed/invalid; the
+    endpoint's own auth dependency will then reject with 401, but slowapi
+    has already accounted the attempt.
+    """
+    from tulip_api.auth.tokens import InvalidTokenError, verify_access_token
+    from tulip_api.config import get_settings
+
+    authorization = request.headers.get("Authorization")
+    if not authorization or not authorization.lower().startswith("bearer "):
+        return get_remote_address(request)
+    token = authorization.split(" ", 1)[1].strip()
+    try:
+        claims = verify_access_token(token, secret=get_settings().jwt_secret)
+    except InvalidTokenError:
+        return get_remote_address(request)
+    return f"user:{claims.user_id}"
+
 
 class AuthRateLimitedError(TulipProblem):
     """The caller exceeded the per-IP auth rate limit (H-4, #219)."""

--- a/packages/tulip-api/src/tulip_api/config.py
+++ b/packages/tulip-api/src/tulip_api/config.py
@@ -161,6 +161,11 @@ class Settings:
     back to ephemeral values. In ``prod`` mode (``TULIP_ENV=prod``) the
     constructor refuses to materialise a Settings instance if either the
     master key or the JWT secret is ephemeral — see #223 (M-2 + M-3).
+
+    ``__repr__`` redacts the secret-bearing fields (security audit L-14,
+    #350) so a traceback / debug-print can't leak the master key, the
+    JWT secret, or a DB URL that may carry inline credentials. Access
+    the actual values through attribute access, not ``repr(settings)``.
     """
 
     database_url: str = field(default_factory=_default_db_url)
@@ -185,6 +190,20 @@ class Settings:
                 "TULIP_ENV=prod: refusing to boot with an ephemeral JWT secret. "
                 "Set TULIP_JWT_SECRET before starting the API.",
             )
+
+    def __repr__(self) -> str:
+        """Return a debug representation with secret fields redacted (L-14, #350)."""
+        return (
+            "Settings("
+            "database_url='<redacted>', "
+            "jwt_secret='<redacted>', "
+            f"jwt_secret_source={self.jwt_secret_source!r}, "
+            "master_key=<redacted bytes>, "
+            f"master_key_source={self.master_key_source!r}, "
+            f"attachment_root={self.attachment_root!r}, "
+            f"deployment_mode={self.deployment_mode!r}"
+            ")"
+        )
 
 
 _SINGLETON: Settings | None = None

--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -30,7 +30,9 @@ from tulip_api.auth.rate_limit import (
     AUTH_LOGIN_LIMIT,
     AUTH_LOGIN_MFA_LIMIT,
     AUTH_LOGIN_RECOVER_LIMIT,
+    AUTH_MFA_ENROLL_LIMIT,
     AUTH_REFRESH_LIMIT,
+    get_user_id_from_jwt,
     limiter,
 )
 from tulip_api.auth.recovery_codes import (
@@ -538,8 +540,10 @@ def change_password(
     responses={
         401: problem_response("auth.unauthorized"),
         409: problem_response("auth.mfa_already_enrolled"),
+        429: problem_response("auth.rate_limited"),
     },
 )
+@limiter.limit(AUTH_MFA_ENROLL_LIMIT, key_func=get_user_id_from_jwt)
 def mfa_enroll(
     request: Request,
     claims: Claims = Depends(get_current_claims),  # noqa: B008

--- a/packages/tulip-api/src/tulip_api/schemas/ai.py
+++ b/packages/tulip-api/src/tulip_api/schemas/ai.py
@@ -6,11 +6,18 @@ from datetime import date
 from decimal import Decimal
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+# Security audit L-13 (#350): request schemas use extra="forbid". The
+# two AIConfig*Patch schemas below already had it from the original
+# P6.5.b implementation — those are kept; this PR brings the rest of
+# the request bodies in this file into line.
 
 
 class AIKeyCreate(BaseModel):
     """Body for ``POST /v1/ai/keys/{provider}``."""
+
+    model_config = ConfigDict(extra="forbid")
 
     api_key: str = Field(
         min_length=1,
@@ -48,6 +55,8 @@ class AIStatusRead(BaseModel):
 class AIPreviewRequest(BaseModel):
     """Body for ``POST /v1/ai/preview`` — synthetic statement line for the categorize prompt."""
 
+    model_config = ConfigDict(extra="forbid")
+
     description: str = Field(min_length=1, max_length=500)
     amount: Decimal
     currency: str = Field(min_length=3, max_length=3)
@@ -65,6 +74,8 @@ class AIPreviewResponse(BaseModel):
 
 class AIAskRequest(BaseModel):
     """Body for ``POST /v1/ai/ask`` — one user question over the AI views (P6.2)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     question: str = Field(
         min_length=1,

--- a/packages/tulip-api/src/tulip_api/schemas/auth.py
+++ b/packages/tulip-api/src/tulip_api/schemas/auth.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+# Security audit L-13 (#350): every request schema in this file uses
+# ``extra="forbid"`` so undeclared fields surface as 422 instead of being
+# silently ignored. Response schemas can keep the default since clients
+# never construct them; mass-assignment is the input-side concern.
 
 
 class RegisterRequest(BaseModel):
     """Body for POST /v1/auth/register."""
+
+    model_config = ConfigDict(extra="forbid")
 
     email: EmailStr
     password: str = Field(min_length=12, max_length=200)
@@ -27,6 +34,8 @@ class RegisterResponse(BaseModel):
 class LoginRequest(BaseModel):
     """Body for POST /v1/auth/login."""
 
+    model_config = ConfigDict(extra="forbid")
+
     email: EmailStr
     password: str
 
@@ -43,11 +52,15 @@ class TokenResponse(BaseModel):
 class RefreshRequest(BaseModel):
     """Body for POST /v1/auth/refresh."""
 
+    model_config = ConfigDict(extra="forbid")
+
     refresh_token: str
 
 
 class LogoutRequest(BaseModel):
     """Body for POST /v1/auth/logout."""
+
+    model_config = ConfigDict(extra="forbid")
 
     refresh_token: str
 
@@ -68,11 +81,15 @@ class MfaEnrollResponse(BaseModel):
 class MfaVerifyRequest(BaseModel):
     """Body for POST /v1/auth/mfa/verify."""
 
+    model_config = ConfigDict(extra="forbid")
+
     code: str = Field(min_length=1, max_length=12)
 
 
 class MfaLoginRequest(BaseModel):
     """Body for POST /v1/auth/login/mfa (the step-2 challenge response)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     mfa_token: str = Field(min_length=1)
     code: str = Field(min_length=1, max_length=12)
@@ -80,6 +97,8 @@ class MfaLoginRequest(BaseModel):
 
 class MfaRecoveryLoginRequest(BaseModel):
     """Body for POST /v1/auth/login/recover (alternative step-2 path)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     mfa_token: str = Field(min_length=1)
     recovery_code: str = Field(min_length=1, max_length=64)
@@ -91,6 +110,8 @@ class MfaRegenerateRequest(BaseModel):
     Requires a current TOTP code as the "MFA-fresh" gate — bare access
     tokens are not enough for this sensitive operation.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     code: str = Field(min_length=1, max_length=12)
 
@@ -122,6 +143,8 @@ class PasswordChangeRequest(BaseModel):
     field. All outstanding refresh tokens for the user are revoked when
     the change succeeds.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     current_password: str = Field(min_length=1)
     new_password: str = Field(min_length=12, max_length=200)

--- a/packages/tulip-api/src/tulip_api/schemas/pool.py
+++ b/packages/tulip-api/src/tulip_api/schemas/pool.py
@@ -11,7 +11,9 @@ from datetime import date as date_type
 from decimal import Decimal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+# Security audit L-13 (#350): request schemas use extra="forbid".
 
 
 class PoolBalanceRead(BaseModel):
@@ -45,6 +47,8 @@ class PoolBalancesRequest(BaseModel):
     per-pool balance endpoint. Empty ``pool_ids`` returns an empty list.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     pool_ids: list[UUID] = Field(
         max_length=500,
         description=(
@@ -62,6 +66,8 @@ class TransferRequest(BaseModel):
     be user pools (envelope or sinking_fund), active, in the same household,
     and share a currency.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     dest_pool_id: UUID
     amount: Decimal = Field(
@@ -85,6 +91,8 @@ class BudgetInflowRequest(BaseModel):
     Lazy-creates the household's ``Inflow`` and ``Unallocated`` system pools
     for the currency if they don't already exist.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     amount: Decimal = Field(gt=0)
     currency: str = Field(min_length=3, max_length=3)

--- a/packages/tulip-api/src/tulip_api/schemas/reconciliation.py
+++ b/packages/tulip-api/src/tulip_api/schemas/reconciliation.py
@@ -14,7 +14,9 @@ from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+# Security audit L-13 (#350): request schemas use extra="forbid".
 
 
 class ReconciliationCreate(BaseModel):
@@ -24,6 +26,8 @@ class ReconciliationCreate(BaseModel):
     reconciliation (#275) where the user ticks off ledger transactions
     against a physical statement, with no imported batch to match against.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     account_id: UUID
     statement_period_start: date_type
@@ -129,6 +133,8 @@ class CompleteResponse(BaseModel):
 class ManualMatchCreate(BaseModel):
     """Request body for ``POST /v1/reconciliations/{id}/matches`` (manual match)."""
 
+    model_config = ConfigDict(extra="forbid")
+
     statement_line_id: UUID
     ledger_transaction_id: UUID
     match_amount: Decimal
@@ -144,6 +150,8 @@ class PaperMatchCreate(BaseModel):
     derived server-side from the bank-side posting on the recon's
     account; the client need only identify the transaction.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     ledger_transaction_id: UUID
 

--- a/packages/tulip-api/src/tulip_api/schemas/refill_schedule.py
+++ b/packages/tulip-api/src/tulip_api/schemas/refill_schedule.py
@@ -11,11 +11,15 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+# Security audit L-13 (#350): request schemas use extra="forbid".
 
 
 class RefillScheduleCreate(BaseModel):
     """Body for ``POST /v1/envelopes/{id}/refill-schedule``."""
+
+    model_config = ConfigDict(extra="forbid")
 
     rrule: str = Field(
         min_length=1,

--- a/packages/tulip-api/tests/test_config.py
+++ b/packages/tulip-api/tests/test_config.py
@@ -248,3 +248,43 @@ class TestDeploymentModeProdRefusal:
         with patch("tulip_api.config.log"):
             s = Settings()
         assert s.deployment_mode == "dev"
+
+
+class TestSettingsReprRedacts:
+    """#350 / security audit L-14: ``repr(Settings)`` must not leak the
+    master key, the JWT secret, or a DB URL that may carry inline
+    credentials. A traceback or debug print is the failure scenario.
+    """
+
+    def test_repr_does_not_contain_master_key_bytes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sentinel = b"\xab\xcd" * 16  # 32 bytes
+        monkeypatch.setenv(
+            "TULIP_MASTER_KEY",
+            base64.b64encode(sentinel).decode("ascii"),
+        )
+        monkeypatch.setenv("TULIP_JWT_SECRET", "totally-secret-jwt-value-not-for-print")
+        monkeypatch.setenv("TULIP_DATABASE_URL", "postgresql://user:supersecretpw@host/db")
+        with patch("tulip_api.config.log"):
+            s = Settings()
+        r = repr(s)
+        assert "redacted" in r
+        # The actual secret-bearing values must not appear anywhere.
+        assert "supersecretpw" not in r
+        assert "totally-secret-jwt-value-not-for-print" not in r
+        # Bytes literal of the master key in any common rendering.
+        assert "\\xab\\xcd" not in r.lower()
+        # Source / mode metadata is fine and useful for debug.
+        assert "deployment_mode" in r
+        assert "jwt_secret_source" in r
+
+    def test_attribute_access_still_returns_real_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Redaction is repr-only — attribute reads return the actual values."""
+        sentinel = b"\xef" * 32
+        monkeypatch.setenv("TULIP_MASTER_KEY", base64.b64encode(sentinel).decode("ascii"))
+        monkeypatch.setenv("TULIP_JWT_SECRET", "the-real-secret")
+        with patch("tulip_api.config.log"):
+            s = Settings()
+        assert s.master_key == sentinel
+        assert s.jwt_secret == "the-real-secret"

--- a/packages/tulip-api/tests/test_mfa_endpoints.py
+++ b/packages/tulip-api/tests/test_mfa_endpoints.py
@@ -175,3 +175,26 @@ class TestVerify:
                 for row in s.execute(select(AuditLog).order_by(AuditLog.occurred_at)).scalars()
             ]
         assert "mfa.verify" in actions
+
+
+class TestEnrollRateLimit:
+    """#350 / security audit L-3: ``/v1/auth/mfa/enroll`` is rate-limited
+    per-authenticated-user (5 / 15min) to defeat denial-of-enrollment by
+    a token-stealer who repeatedly hits enroll to rotate the secret.
+    """
+
+    def test_returns_429_after_burst(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        from tulip_api.auth.rate_limit import limiter as _auth_limiter
+
+        # conftest resets per-test; re-arm to be explicit.
+        _auth_limiter.reset()
+        # Quota is 5/15min — drive 6 calls and check the 6th trips.
+        last = None
+        for _ in range(6):
+            last = client.post("/v1/auth/mfa/enroll", headers=auth_headers)
+        assert last is not None
+        assert_problem(last, code="auth.rate_limited", status=429)


### PR DESCRIPTION
## Summary
Security audit Low bundle (L-3 + L-13 + L-14):

- **L-3** \`/v1/auth/mfa/enroll\` is per-user rate-limited at \`5/15minutes\` via a new \`AUTH_MFA_ENROLL_LIMIT\` + custom slowapi \`key_func\` (\`get_user_id_from_jwt\`) that pulls user_id from the bearer token. Defeats denial-of-enrollment by a token-stealer who spams the rotate-secret endpoint.
- **L-13** Every request-side pydantic schema now declares \`model_config = ConfigDict(extra="forbid")\`. Covers \`auth.py\` (9 classes), \`reconciliation.py\` (3), \`ai.py\` (3 — two AIConfig*Patch already had it), \`refill_schedule.py\` (1), \`pool.py\` (3). Response schemas unaffected.
- **L-14** \`Settings.__repr__\` redacts \`master_key\`, \`jwt_secret\`, and \`database_url\`. Settings is a stdlib \`@dataclass\` so custom \`__repr__\` is the natural fit; attribute access continues to return real values.

## Test plan
- [x] \`just lint\` / \`just typecheck\` clean.
- [x] New tests: \`TestEnrollRateLimit\` (1) + \`TestSettingsReprRedacts\` (2) pass.
- [x] 346 affected tests pass; 1 macOS-libpango PDF test fails locally (pre-existing env issue, CI has libpango).
- [ ] CI green.