### PR TITLE
security: audit_log SQLite immutability triggers + carve-out helpers (closes #333)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/households.py
+++ b/packages/tulip-api/src/tulip_api/routers/households.py
@@ -185,8 +185,17 @@ def erase_household(
     # shadow_postings, csv_profiles, import_batches, reconciliations,
     # attachments, ai_invocations, notifications, pending_proposals,
     # scheduled_jobs, pending_household_erasures.
-    session.execute(sa_delete(Household).where(Household.id == claims.household_id))
-    session.commit()
+    #
+    # The audit_log BEFORE DELETE trigger (#333 / M-22) blocks every
+    # row-delete; it has to come down for the FK cascade to clear the
+    # household's audit_log rows. The context manager drops + recreates
+    # the trigger; the try/finally on its exit guarantees the trigger
+    # is reinstated even if the DELETE fails.
+    from tulip_storage.audit_log_helpers import audit_log_deletion_allowed
+
+    with audit_log_deletion_allowed(session):
+        session.execute(sa_delete(Household).where(Household.id == claims.household_id))
+        session.commit()
 
     # Unlink orphaned attachment ciphertext. A blob is orphaned iff no
     # other household still references its content_hash (within-household

--- a/packages/tulip-api/src/tulip_api/routers/users.py
+++ b/packages/tulip-api/src/tulip_api/routers/users.py
@@ -112,17 +112,23 @@ def delete_user(
         if admin_count <= 1:
             raise LastAdminDeletionError()
 
-    # Redact historic audit-log PII for rows referencing this user (either as
-    # actor or as the entity being acted on). Tombstone row is written
-    # afterward so it isn't caught by the same UPDATE.
-    session.execute(
-        update(AuditLog)
-        .where(
-            AuditLog.household_id == claims.household_id,
-            or_(AuditLog.actor_user_id == user_id, AuditLog.entity_id == user_id),
+    # Redact historic audit-log PII for rows referencing this user (either
+    # as actor or as the entity being acted on). The BEFORE UPDATE trigger
+    # (#333 / M-22) blocks audit_log UPDATEs by default; the
+    # ``audit_log_pii_redaction_allowed`` context manager carves out this
+    # one legitimate site. The tombstone row below is written *after* the
+    # context exits so it isn't caught by the scrub.
+    from tulip_storage.audit_log_helpers import audit_log_pii_redaction_allowed
+
+    with audit_log_pii_redaction_allowed(session):
+        session.execute(
+            update(AuditLog)
+            .where(
+                AuditLog.household_id == claims.household_id,
+                or_(AuditLog.actor_user_id == user_id, AuditLog.entity_id == user_id),
+            )
+            .values(before_snapshot=None, after_snapshot=None, metadata_=None)
         )
-        .values(before_snapshot=None, after_snapshot=None, metadata_=None)
-    )
 
     # Tombstone: structural only — role + caller-id, no email or display name.
     AuditLogWriter(session, claims.household_id).write(

--- a/packages/tulip-storage/src/tulip_storage/audit_log_helpers.py
+++ b/packages/tulip-storage/src/tulip_storage/audit_log_helpers.py
@@ -1,0 +1,96 @@
+"""Helpers for the audit_log BEFORE DELETE trigger carve-out (#333).
+
+The migration that installs ``trg_audit_log_no_delete`` raises ABORT on
+every DELETE — but two code paths legitimately need to remove rows:
+
+- Household-erasure cascade (right-to-erasure, #235)
+- Tiered retention prune (audit-retention handler, #245)
+
+SQLite has a documented limit that triggers cannot reference TEMP
+objects, so the temp-marker pattern used elsewhere isn't available.
+Drop-and-recreate is the documented fallback. ``audit_log_deletion_allowed``
+brackets a session-scoped block where audit_log DELETEs are permitted;
+the trigger is dropped on enter and recreated on exit.
+
+Usage::
+
+    with audit_log_deletion_allowed(session):
+        session.execute(sa_delete(Household).where(...))
+        session.commit()
+
+The context manager is sync — SQLAlchemy's Session is sync — and
+guarantees the trigger is recreated even on exception, so a partial
+delete never leaves the database with no protection.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Final
+
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy.orm import Session
+
+
+#: DDL for the audit_log BEFORE DELETE / BEFORE UPDATE triggers.
+#: Duplicated from the migration in
+#: ``migrations/versions/20260517_1200_a6f1c9b3d8e4_*.py`` because
+#: migration modules have non-identifier filenames (leading digits)
+#: and can't be cleanly imported here. If the SQL changes, bump both;
+#: the migration test asserts behavioural equivalence.
+_TRIGGER_NO_DELETE_SQL: Final[str] = """
+CREATE TRIGGER trg_audit_log_no_delete
+BEFORE DELETE ON audit_log
+BEGIN
+  SELECT RAISE(ABORT, 'audit_log is append-only (M-22)');
+END;
+"""
+
+_TRIGGER_NO_UPDATE_SQL: Final[str] = """
+CREATE TRIGGER trg_audit_log_no_update
+BEFORE UPDATE ON audit_log
+BEGIN
+  SELECT RAISE(ABORT, 'audit_log is append-only (M-22)');
+END;
+"""
+
+
+@contextmanager
+def audit_log_deletion_allowed(session: Session) -> Iterator[None]:
+    """Yield with the audit_log DELETE trigger dropped; recreate on exit.
+
+    Use ONLY at the two legitimate cascade-delete sites:
+    - household-erasure (``routers/households.py``).
+    - audit-retention prune (``runner/handlers/audit_retention.py``).
+
+    Anywhere else, the trigger should fire — that's the point.
+    """
+    session.execute(text("DROP TRIGGER IF EXISTS trg_audit_log_no_delete"))
+    try:
+        yield
+    finally:
+        session.execute(text(_TRIGGER_NO_DELETE_SQL))
+
+
+@contextmanager
+def audit_log_pii_redaction_allowed(session: Session) -> Iterator[None]:
+    """Yield with the audit_log UPDATE trigger dropped; recreate on exit.
+
+    Use ONLY at the legitimate PII-scrub site:
+    - user-erasure GDPR Art. 17 redaction (``routers/users.py``).
+
+    The scrub is the documented carve-out from "audit_log is append-only":
+    the row stays but its ``before_snapshot`` / ``after_snapshot`` /
+    ``metadata_`` JSON blobs are nulled so the deleted user's PII doesn't
+    survive in historic rows. The audit log keeps the structural fact of
+    each event; the snapshot bodies are what carry PII.
+    """
+    session.execute(text("DROP TRIGGER IF EXISTS trg_audit_log_no_update"))
+    try:
+        yield
+    finally:
+        session.execute(text(_TRIGGER_NO_UPDATE_SQL))

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260517_1200_a6f1c9b3d8e4_audit_log_immutability_triggers.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260517_1200_a6f1c9b3d8e4_audit_log_immutability_triggers.py
@@ -1,0 +1,75 @@
+"""Add SQLite immutability triggers for ``audit_log`` (#333).
+
+Per security audit M-22: the ``audit_log`` model docstring notes that
+DB-level immutability is deferred to the Postgres phase. App-level
+enforcement (no UPDATE / DELETE statement against the table exists
+anywhere in the writer or callers) is correct today — but an attacker
+with shell access to ``tulip.db`` can run
+``sqlite3 tulip.db "DELETE FROM audit_log WHERE …"`` undetectably.
+
+Two triggers ship here:
+
+- ``trg_audit_log_no_update`` — BEFORE UPDATE, unconditional ABORT.
+  audit_log is true append-only; the writer only INSERTs.
+
+- ``trg_audit_log_no_delete`` — BEFORE DELETE, unconditional ABORT.
+  Legitimate cascade-delete sites (household-erasure, audit-retention
+  prune) drop the trigger via the
+  :func:`tulip_storage.audit_log_helpers.audit_log_deletion_allowed`
+  context manager and recreate it after. SQLite has a documented
+  limitation that triggers cannot reference TEMP objects, so the
+  temp-marker pattern used elsewhere isn't available; drop-and-
+  recreate is the documented fallback.
+
+The trigger is defense-in-depth against application-layer regressions
+and accidental ``sqlite3`` shell DELETEs, not a hardened ACL. An
+attacker with raw shell access can drop the trigger themselves; the
+point is to make the bypass visible.
+
+Revision ID: a6f1c9b3d8e4
+Revises: d9e2c8b5a3f7
+Create Date: 2026-05-17 12:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Final
+
+from alembic import op
+
+revision: str = "a6f1c9b3d8e4"
+down_revision: str | None = "d9e2c8b5a3f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Trigger DDL — exported so the runtime helper can recreate after the
+#: legitimate cascade-delete sites finish.
+TRIGGER_NO_UPDATE_SQL: Final[str] = """
+CREATE TRIGGER trg_audit_log_no_update
+BEFORE UPDATE ON audit_log
+BEGIN
+  SELECT RAISE(ABORT, 'audit_log is append-only (M-22)');
+END;
+"""
+
+TRIGGER_NO_DELETE_SQL: Final[str] = """
+CREATE TRIGGER trg_audit_log_no_delete
+BEFORE DELETE ON audit_log
+BEGIN
+  SELECT RAISE(ABORT, 'audit_log is append-only (M-22)');
+END;
+"""
+
+
+def upgrade() -> None:
+    """Install the BEFORE UPDATE + BEFORE DELETE immutability triggers."""
+    op.execute(TRIGGER_NO_UPDATE_SQL)
+    op.execute(TRIGGER_NO_DELETE_SQL)
+
+
+def downgrade() -> None:
+    """Drop both triggers."""
+    op.execute("DROP TRIGGER IF EXISTS trg_audit_log_no_update")
+    op.execute("DROP TRIGGER IF EXISTS trg_audit_log_no_delete")

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/audit_retention.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/audit_retention.py
@@ -173,59 +173,77 @@ def run_audit_retention(
     """
     summary: dict[UUID, dict[str, int]] = {}
     with session_maker() as session:
-        targets = (
-            session.execute(select(Household)).scalars().all()
-            if household_id is None
-            else [h for h in [session.get(Household, household_id)] if h is not None]
-        )
-        for household in targets:
-            policy = household.audit_retention_policy or {}
-            per_tier: dict[str, int] = {}
-            for tier_key in _TIER_DEFAULTS:
-                actions = tuple(
-                    action
-                    for action, mapped_tier in _RETENTION_TIER_BY_ACTION.items()
-                    if mapped_tier == tier_key
-                )
-                cutoff = now - timedelta(days=_resolve_tier_days(policy, tier_key))
-                if tier_key == "default_days":
-                    # Fall-through bucket: any action not in the static map
-                    # ages at default_days. We can't enumerate "anything
-                    # except the mapped ones" cheaply in SQL, so build a
-                    # NOT-IN against every mapped action.
-                    all_mapped = tuple(_RETENTION_TIER_BY_ACTION.keys())
-                    where_clauses = [
-                        AuditLog.household_id == household.id,
-                        AuditLog.occurred_at < cutoff,
-                        AuditLog.action.not_in(all_mapped),
-                    ]
-                elif actions:
-                    where_clauses = [
-                        AuditLog.household_id == household.id,
-                        AuditLog.occurred_at < cutoff,
-                        AuditLog.action.in_(actions),
-                    ]
-                else:
-                    per_tier[tier_key] = 0
-                    continue
-                result = session.execute(delete(AuditLog).where(*where_clauses))
-                per_tier[tier_key] = cast("CursorResult[Any]", result).rowcount or 0
+        # M-22 (#333): the audit_log BEFORE DELETE trigger blocks every
+        # row delete; this is one of the two legitimate carve-out sites
+        # (the other is household-erasure). The context manager drops +
+        # recreates the trigger; the try/finally on its exit guarantees
+        # the trigger is reinstated even if pruning fails partway.
+        from tulip_storage.audit_log_helpers import audit_log_deletion_allowed
 
-            total = sum(per_tier.values())
-            if total > 0:
-                # Summary row mirrors the ai.prompt_log_scrubbed pattern (#243).
-                # actor_user_id is None — this is system GC, not a user action.
-                # Routes through AuditLogWriter per the chokepoint invariant
-                # enforced by test_architecture_audit_log_writer_only (#331).
-                AuditLogWriter(session, household.id).write(
-                    action="audit.pruned",
-                    actor_kind="system",
-                    entity_type="household",
-                    entity_id=household.id,
-                    metadata={"deleted_per_tier": per_tier},
-                )
-            summary[household.id] = per_tier
-        session.commit()
+        with audit_log_deletion_allowed(session):
+            return _run_audit_retention_inner(session, now, household_id, summary)
+
+
+def _run_audit_retention_inner(
+    session: Session,
+    now: datetime,
+    household_id: UUID | None,
+    summary: dict[UUID, dict[str, int]],
+) -> dict[UUID, dict[str, int]]:
+    """The retention-prune body — extracted so the temp-marker bracket above stays tight."""
+    targets = (
+        session.execute(select(Household)).scalars().all()
+        if household_id is None
+        else [h for h in [session.get(Household, household_id)] if h is not None]
+    )
+    for household in targets:
+        policy = household.audit_retention_policy or {}
+        per_tier: dict[str, int] = {}
+        for tier_key in _TIER_DEFAULTS:
+            actions = tuple(
+                action
+                for action, mapped_tier in _RETENTION_TIER_BY_ACTION.items()
+                if mapped_tier == tier_key
+            )
+            cutoff = now - timedelta(days=_resolve_tier_days(policy, tier_key))
+            if tier_key == "default_days":
+                # Fall-through bucket: any action not in the static map
+                # ages at default_days. We can't enumerate "anything
+                # except the mapped ones" cheaply in SQL, so build a
+                # NOT-IN against every mapped action.
+                all_mapped = tuple(_RETENTION_TIER_BY_ACTION.keys())
+                where_clauses = [
+                    AuditLog.household_id == household.id,
+                    AuditLog.occurred_at < cutoff,
+                    AuditLog.action.not_in(all_mapped),
+                ]
+            elif actions:
+                where_clauses = [
+                    AuditLog.household_id == household.id,
+                    AuditLog.occurred_at < cutoff,
+                    AuditLog.action.in_(actions),
+                ]
+            else:
+                per_tier[tier_key] = 0
+                continue
+            result = session.execute(delete(AuditLog).where(*where_clauses))
+            per_tier[tier_key] = cast("CursorResult[Any]", result).rowcount or 0
+
+        total = sum(per_tier.values())
+        if total > 0:
+            # Summary row mirrors the ai.prompt_log_scrubbed pattern (#243).
+            # actor_user_id is None — this is system GC, not a user action.
+            # Routes through AuditLogWriter per the chokepoint invariant
+            # enforced by test_architecture_audit_log_writer_only (#331).
+            AuditLogWriter(session, household.id).write(
+                action="audit.pruned",
+                actor_kind="system",
+                entity_type="household",
+                entity_id=household.id,
+                metadata={"deleted_per_tier": per_tier},
+            )
+        summary[household.id] = per_tier
+    session.commit()
     if summary:
         log.info(
             "audit_retention.summary",

--- a/packages/tulip-storage/tests/test_migrations.py
+++ b/packages/tulip-storage/tests/test_migrations.py
@@ -391,3 +391,89 @@ class TestDeprecatedViewerRole:
                 assert row[0] == "MEMBER"
         finally:
             eng.dispose()
+
+
+class TestAuditLogImmutabilityTrigger:
+    """#333 / security audit M-22: SQLite triggers reject UPDATE / DELETE
+    on ``audit_log`` to defend against application-layer regressions and
+    accidental ``sqlite3`` shell DELETEs. The household-erasure cascade
+    is carved out via a connection-scoped temp marker.
+    """
+
+    def _seed_audit_row(self, session: Session) -> tuple[Household, object]:
+        """Insert one household + one audit_log row; return both."""
+        from datetime import UTC, datetime
+
+        from tulip_storage.models import AuditLog as _AuditLog
+        from tulip_storage.repositories.audit_log import AuditLogWriter
+
+        h = Household(id=uuid4(), name="Audit", base_currency="USD")
+        session.add(h)
+        session.flush()
+        row = AuditLogWriter(session, h.id).write(
+            action="test",
+            actor_kind="user",
+            actor_user_id=None,
+            entity_type="household",
+            entity_id=h.id,
+        )
+        session.commit()
+        _ = datetime.now(tz=UTC), _AuditLog  # silence unused imports
+        return h, row
+
+    def test_direct_update_is_rejected(self, migrated_db):
+        from sqlalchemy import text
+
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            self._seed_audit_row(s)
+        with Smaker() as s, pytest.raises((IntegrityError, OperationalError), match="append-only"):
+            s.execute(text("UPDATE audit_log SET action = 'tampered'"))
+            s.commit()
+
+    def test_direct_delete_is_rejected(self, migrated_db):
+        from sqlalchemy import text
+
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            self._seed_audit_row(s)
+        with Smaker() as s, pytest.raises((IntegrityError, OperationalError), match="append-only"):
+            s.execute(text("DELETE FROM audit_log"))
+            s.commit()
+
+    def test_household_cascade_delete_succeeds_inside_carveout_helper(self, migrated_db):
+        """The right-to-erasure flow brackets its ``DELETE FROM households``
+        with the ``audit_log_deletion_allowed`` context manager; the
+        cascade then clears audit_log rows. After the block exits the
+        trigger is reinstated.
+        """
+        from sqlalchemy import delete as sa_delete
+        from sqlalchemy import text
+
+        from tulip_storage.audit_log_helpers import audit_log_deletion_allowed
+
+        _, Smaker = migrated_db
+        with Smaker() as s:
+            h, _ = self._seed_audit_row(s)
+            household_id = h.id
+
+        with Smaker() as s, audit_log_deletion_allowed(s):
+            s.execute(sa_delete(Household).where(Household.id == household_id))
+            s.commit()
+
+        with Smaker() as s:
+            remaining = s.execute(
+                text("SELECT COUNT(*) FROM audit_log WHERE household_id = :h"),
+                {"h": str(household_id)},
+            ).scalar_one()
+            assert remaining == 0
+
+        # After the context exits, the trigger is reinstated — a direct
+        # delete attempt still fails.
+        with Smaker() as s:
+            h2, _ = self._seed_audit_row(s)
+        with Smaker() as s, pytest.raises((IntegrityError, OperationalError), match="append-only"):
+            s.execute(text("DELETE FROM audit_log"))
+            s.commit()
+        # Silence the unused-var warning — h2 created intentionally.
+        _ = h2


### PR DESCRIPTION
## Summary
Security audit M-22: \`audit_log\` had app-level append-only discipline but no DB-level immutability — a shell user running \`sqlite3 tulip.db "DELETE FROM audit_log WHERE …"\` could tamper undetectably.

- New migration \`a6f1c9b3d8e4\` adds two BEFORE triggers: \`trg_audit_log_no_update\` (unconditional ABORT on UPDATE) + \`trg_audit_log_no_delete\` (unconditional ABORT on DELETE).
- SQLite limitation: triggers cannot reference TEMP objects, so the temp-marker pattern used elsewhere isn't available. Drop-and-recreate is the documented fallback.
- New \`tulip_storage.audit_log_helpers\` module: two context managers (\`audit_log_deletion_allowed\`, \`audit_log_pii_redaction_allowed\`) wrap the three legitimate carve-out sites — household-erasure cascade, audit-retention prune, and the GDPR Art. 17 PII scrub on user-erasure. Each drops the relevant trigger on enter and recreates it on exit; \`try/finally\` guarantees reinstatement even on exception.

## Test plan
- [x] \`just lint\` / \`just typecheck\` clean.
- [x] 3 new \`TestAuditLogImmutabilityTrigger\` tests: direct UPDATE rejected, direct DELETE rejected, household cascade succeeds inside the carve-out + trigger reinstated after.
- [x] All 26 affected tests pass (trigger + audit-retention + erasure-endpoints).
- [ ] CI green.

## Threat-model framing
The trigger is defense-in-depth against application-layer regressions and accidental shell DELETEs, not a hardened ACL — a shell user can drop the trigger themselves. The point is to make the bypass *visible* and force any future "skip audit for this special case" patch through CI.