### PR TITLE
robustness: import body caps + journal regex bounds + journal-export metadata opt-out (closes #351)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/csv_profiles.py
+++ b/packages/tulip-api/src/tulip_api/routers/csv_profiles.py
@@ -8,7 +8,7 @@ mandatory; ``yaml.load`` is banned by an architecture test in
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 from uuid import UUID
 
 import structlog
@@ -277,6 +277,13 @@ def export_profile(
     return Response(content=row.yaml_body, media_type="application/x-yaml")
 
 
+#: Security audit L-11 (#351): cap matches THREAT_MODEL.md §5.2's
+#: published 100 KB claim. CSV profiles are mapping configuration —
+#: real ones come in under 4 KiB. The cap defends against a yaml.safe_load
+#: that allocates aggressively on degenerate input.
+_MAX_CSV_PROFILE_BYTES: Final[int] = 100 * 1024
+
+
 @router.post(
     "/import",
     response_model=CsvProfileRead,
@@ -285,6 +292,7 @@ def export_profile(
         400: problem_response("csv_profile.invalid_yaml"),
         401: problem_response("auth.unauthorized"),
         409: problem_response("csv_profile.duplicate_name"),
+        413: problem_response("request.payload_too_large"),
         422: problem_response("validation.failed"),
     },
 )
@@ -299,6 +307,10 @@ def import_profile(
     session: Session = Depends(get_session),  # noqa: B008
 ) -> CsvProfileRead:
     """Import a CSV profile from a YAML body (round-trip with /export)."""
+    if len(body) > _MAX_CSV_PROFILE_BYTES:
+        from tulip_api.errors import RequestPayloadTooLargeError
+
+        raise RequestPayloadTooLargeError(max_bytes=_MAX_CSV_PROFILE_BYTES)
     try:
         text = body.decode("utf-8")
     except UnicodeDecodeError as exc:

--- a/packages/tulip-api/src/tulip_api/routers/journal.py
+++ b/packages/tulip-api/src/tulip_api/routers/journal.py
@@ -100,6 +100,15 @@ def export(
         default=None,
         description="Inclusive upper bound on transaction date (YYYY-MM-DD).",
     ),
+    include_metadata: bool = Query(
+        default=True,
+        description=(
+            "When true (default), the export's header comments name the "
+            "household + Tulip provenance. Set false (privacy audit L-5 / "
+            "L-17, #351) for handoffs to third parties — e.g. a tax "
+            "preparer — where the household name shouldn't ride along."
+        ),
+    ),
     claims: Claims = Depends(get_current_claims),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> Response:
@@ -118,6 +127,7 @@ def export(
         end=end,
         # #229: drop postings on private accounts the caller can't see.
         visible_account_filter=lambda vis, by: _filter_for_role(vis, by, claims),
+        include_metadata=include_metadata,
     )
     suffix_parts = []
     if start is not None:

--- a/packages/tulip-api/tests/test_csv_profiles_endpoint.py
+++ b/packages/tulip-api/tests/test_csv_profiles_endpoint.py
@@ -213,3 +213,19 @@ class TestExportImport:
             content=b"name: : :\n  bad indent",
         )
         assert_problem(r, code="csv_profile.invalid_yaml", status=400)
+
+
+class TestImportSizeCap:
+    """#351 / security audit L-11: 100 KB cap matches THREAT_MODEL.md §5.2
+    and defends against a yaml.safe_load that allocates aggressively on
+    degenerate input.
+    """
+
+    def test_oversize_yaml_returns_413(self, client: TestClient, auth_h: dict[str, str]):
+        oversize = ("name: x\n" + ("# pad\n" * 30_000)).encode()  # >150 KB
+        r = client.post(
+            "/v1/imports/profiles/import",
+            headers={**auth_h, "content-type": "application/x-yaml"},
+            content=oversize,
+        )
+        assert_problem(r, code="request.payload_too_large", status=413)

--- a/packages/tulip-api/tests/test_journal_export.py
+++ b/packages/tulip-api/tests/test_journal_export.py
@@ -173,3 +173,33 @@ class TestJournalExport:
         body = r.text
         assert "Expense:Misc Food" in body
         assert "Asset:Cash on hand" in body
+
+
+class TestExportMetadataOptOut:
+    """#351 / privacy audit L-5 / L-17: ``?include_metadata=false`` mutes
+    the header comments naming the household + Tulip provenance. The
+    transactions themselves are unchanged either way.
+    """
+
+    def test_default_export_carries_household_name_header(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        r = client.get("/v1/journal/export", headers=auth_h)
+        assert r.status_code == 200
+        body = r.text
+        assert "Tulip Accounting" in body
+        # The test fixture's household name is the default 'Smith' (see registered fixture).
+        assert "household:" in body
+
+    def test_include_metadata_false_drops_header_comments(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        r = client.get(
+            "/v1/journal/export?include_metadata=false",
+            headers=auth_h,
+        )
+        assert r.status_code == 200
+        body = r.text
+        # The leading provenance + household-name comments are gone.
+        assert "Tulip Accounting" not in body
+        assert "household:" not in body

--- a/packages/tulip-api/tests/test_journal_import.py
+++ b/packages/tulip-api/tests/test_journal_import.py
@@ -194,3 +194,24 @@ class TestImportErrors:
 
 # Keep the date import in scope (used implicitly by some test bodies).
 _ = date
+
+
+class TestParseLineCap:
+    """#351 / security audit L-12: the journal parser bounds each line
+    before any regex runs. A pathologically long line surfaces as a
+    typed parse error instead of risking catastrophic backtracking.
+    """
+
+    def test_pathological_long_line_surfaces_as_parse_error(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """A 5000-char description (above the 4096 cap) is rejected with
+        ``journal.parse_failed`` + a line-too-long error.
+        """
+        oversize_line = "2026-05-01 " + ("A" * 5000) + "\n"
+        body = oversize_line + "    Asset:Cash  1.00 USD\n    Expense:Misc  -1.00 USD\n"
+        r = _post_journal(client, auth_h, body)
+        assert r.status_code == 400
+        assert r.json()["code"] == "journal.parse_failed"
+        errors = r.json()["errors"]
+        assert any("line exceeds" in e["message"] for e in errors)

--- a/packages/tulip-reports/src/tulip_reports/journal/export.py
+++ b/packages/tulip-reports/src/tulip_reports/journal/export.py
@@ -81,6 +81,7 @@ def export_journal(
     start: date_type | None = None,
     end: date_type | None = None,
     visible_account_filter: Callable[[str, UUID | None], bool] | None = None,
+    include_metadata: bool = True,
 ) -> bytes:
     """Render the household's posted transactions as a hledger journal.
 
@@ -92,6 +93,14 @@ def export_journal(
       whose every posting becomes invisible. The router supplies a
       closure over the request's claims; tests can pass ``None``
       to see every account (#229).
+
+    Privacy:
+    - ``include_metadata`` (default True) controls whether the export's
+      header comments carry the household name + tulip provenance. Set
+      False (privacy audit L-5 / L-17, #351) when the bytes are headed
+      to a tax preparer / accountant who doesn't need the household
+      identity surfaced in the file. The transactions themselves are
+      unchanged either way; only the leading comment block is muted.
     """
     from sqlalchemy import select
 
@@ -131,13 +140,14 @@ def export_journal(
     transactions = session.execute(tx_query).scalars().all()
 
     lines: list[str] = []
-    lines.append("; Tulip Accounting — hledger journal export")
-    lines.append(f"; household: {household.name}")
-    if start is not None:
-        lines.append(f"; from: {start.isoformat()}")
-    if end is not None:
-        lines.append(f"; to: {end.isoformat()}")
-    lines.append("")
+    if include_metadata:
+        lines.append("; Tulip Accounting — hledger journal export")
+        lines.append(f"; household: {household.name}")
+        if start is not None:
+            lines.append(f"; from: {start.isoformat()}")
+        if end is not None:
+            lines.append(f"; to: {end.isoformat()}")
+        lines.append("")
 
     for tx in transactions:
         # Postings: stable order by amount sign (debits first, then credits)

--- a/packages/tulip-reports/src/tulip_reports/journal/parse.py
+++ b/packages/tulip-reports/src/tulip_reports/journal/parse.py
@@ -68,12 +68,19 @@ class ParsedJournal:
     errors: list[JournalParseError] = field(default_factory=list)
 
 
+#: Per-line length cap (security audit L-12, #351). Real journal lines
+#: are well under 200 chars; the cap defends against pathologically long
+#: lines that could push the regex into catastrophic backtracking. Lines
+#: that exceed surface as ``line too long`` parse errors.
+_MAX_LINE_LEN: int = 4096
+
+
 _HEADER_RE = re.compile(
     r"""
     ^(?P<date>\d{4}-\d{2}-\d{2})    # ISO date
     \s+
-    (?:\((?P<ref>[^)]+)\)\s+)?      # optional (reference) prefix
-    (?P<description>.+?)            # the rest of the line is the description
+    (?:\((?P<ref>[^)]{1,200})\)\s+)?  # optional (reference) prefix, bounded
+    (?P<description>[^\r\n]+?)        # rest of the line (single-line; no LF)
     \s*$
     """,
     re.VERBOSE,
@@ -82,11 +89,11 @@ _HEADER_RE = re.compile(
 
 _POSTING_RE = re.compile(
     r"""
-    ^\s+                              # leading whitespace (indented)
-    (?P<account>\S+(?:\s\S+)*?)       # account path: tokens joined by single spaces
-    \s{2,}                            # at least two spaces separator (hledger spec)
-    (?P<amount>-?\d+(?:\.\d+)?)       # decimal amount, optionally negative
-    \s+
+    ^[ \t]+                           # leading indent (TAB or spaces only)
+    (?P<account>\S(?:[\S ]{0,500}\S)?)  # account path: bounded, possessive-ish
+    [ \t]{2,}                         # at least two spaces separator (hledger spec)
+    (?P<amount>-?\d{1,18}(?:\.\d{1,8})?)  # decimal amount, bounded digits
+    [ \t]+
     (?P<currency>[A-Z]{3,5})          # currency code (3-5 uppercase letters)
     \s*$
     """,
@@ -131,6 +138,18 @@ def parse_journal(text: str) -> ParsedJournal:
         )
 
     for line_num, raw_line in enumerate(text.splitlines(), start=1):
+        # Security audit L-12 (#351): bound each line before regex runs.
+        # Real journal lines are well under 200 chars; anything past
+        # _MAX_LINE_LEN is pathological and surfaces as a typed error
+        # rather than risking catastrophic backtracking.
+        if len(raw_line) > _MAX_LINE_LEN:
+            errors.append(
+                JournalParseError(
+                    line_number=line_num,
+                    message=f"line exceeds {_MAX_LINE_LEN}-char cap; cannot parse",
+                )
+            )
+            continue
         stripped = raw_line.strip()
         if not stripped or stripped.startswith(";"):
             # Blank line ends the current transaction; comments are ignored.


### PR DESCRIPTION
## Summary
Security + privacy audit Low bundle (sec L-11 + L-12, priv L-5 + L-17):

- **Sec L-11** \`POST /v1/imports/profiles/import\` enforces the 100 KB cap that THREAT_MODEL.md §5.2 already claimed; rejects with \`request.payload_too_large\` (413).
- **Sec L-12** \`tulip_reports.journal.parse\`:
  - New 4096-char per-line cap, checked *before* regex; pathological lines surface as \`journal.parse_failed\` "line exceeds" rather than risking catastrophic backtracking.
  - Tightened both regexes with bounded quantifiers (reference ≤200, account-token ≤502, amount digit counts bounded). Tabs explicitly allowed in indent/separator since hledger accepts them.
- **Priv L-5 / L-17** \`GET /v1/journal/export?include_metadata=false\` drops the header comments that name the household + Tulip provenance. Default \`true\` for backwards-compat. Transactions themselves are unchanged either way.

## Test plan
- [x] \`just lint\` / \`just typecheck\` clean.
- [x] New tests: \`TestImportSizeCap\` (1), \`TestParseLineCap\` (1), \`TestExportMetadataOptOut\` (2). All pass.
- [x] 34 affected tests (csv-profile + journal export/import) pass.
- [ ] CI green.