### PR TITLE
test(api): regression guard against SQLite write-lock leak (closes #200)

### DIFF
--- a/packages/tulip-api/src/tulip_api/deps.py
+++ b/packages/tulip-api/src/tulip_api/deps.py
@@ -36,7 +36,26 @@ def _session_factory_for(url: str) -> sessionmaker[Session]:
 
 
 def get_session() -> Iterator[Session]:
-    """Yield a Session bound to the configured database URL."""
+    """Yield a Session bound to the configured database URL.
+
+    Lifecycle invariant (defends #200, the SQLite write-lock leak):
+    when an exception bubbles up from inside the request handler, the
+    ``with factory() as s:`` context exit + the explicit ``s.close()``
+    in the ``finally`` clause guarantee the underlying connection is
+    returned to the pool with any open transaction rolled back. The
+    next request can acquire a fresh connection without contending on
+    a stale write lock.
+
+    The other half of the same invariant is in
+    :func:`tulip_ai._sessions.use_session_or_make_one` — AI capabilities
+    invoked mid-transaction (the import-apply flow's categorizer call)
+    must share the caller's session rather than open a second connection
+    that would deadlock on the caller's write lock.
+
+    Regression test:
+    ``packages/tulip-api/tests/test_apply_promote_endpoints.py
+    ::TestApplyExceptionDoesNotLeakLock``.
+    """
     settings = get_settings()
     factory = _session_factory_for(settings.database_url)
     with factory() as s:

--- a/packages/tulip-api/tests/test_apply_promote_endpoints.py
+++ b/packages/tulip-api/tests/test_apply_promote_endpoints.py
@@ -268,3 +268,54 @@ class TestPromoteLineErrors:
 
         r = client.post(f"/v1/imports/{parsed_batch}/lines/{uuid4()}/promote", headers=auth_h)
         assert_problem(r, status=404, code="import.line.not_found")
+
+
+class TestApplyExceptionDoesNotLeakLock:
+    """#200: an exception bubbling from apply must not leave the SQLite
+    write lock held — subsequent requests must continue to work without
+    a process restart. The bug surfaced during a Banktivity migration
+    where ai.categorize failures wedged the API until docker compose
+    restart.
+
+    This test monkey-patches ``promote_statement_line`` to raise
+    mid-batch, fires the apply endpoint (expects 500), then immediately
+    fires a follow-up request that must NOT see "database is locked".
+    """
+
+    def test_subsequent_request_succeeds_after_apply_5xx(
+        self,
+        app,
+        auth_h: dict[str, str],
+        parsed_batch: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from tulip_api.services import import_apply as svc
+
+        async def _raise(*args, **kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError("simulated mid-apply failure (#200 regression)")
+
+        monkeypatch.setattr(svc, "promote_statement_line", _raise)
+
+        # raise_server_exceptions=False so the catch-all 500 handler
+        # emits the typed Problem-Details body rather than re-raising
+        # into pytest.
+        leak_client = TestClient(app, raise_server_exceptions=False)
+
+        # First request: apply raises mid-flight → 500 with the typed
+        # server.internal_error body (catch-all handler).
+        r1 = leak_client.post(f"/v1/imports/{parsed_batch}/apply", headers=auth_h)
+        assert r1.status_code == 500, r1.text
+        assert "internal_error" in r1.text.lower() or "server" in r1.text.lower()
+
+        # Second request: must not block. Before the fix, this returned
+        # 500 "database is locked"; the lock leaked across the request
+        # boundary.
+        r2 = leak_client.get("/v1/accounts", headers=auth_h)
+        assert r2.status_code == 200, r2.text
+        # And a write request must also work.
+        r3 = leak_client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Post-failure", "type": "expense", "currency": "USD", "code": "5200"},
+        )
+        assert r3.status_code == 201, r3.text


### PR DESCRIPTION
## Summary
#200 surfaced during a Banktivity migration: a mid-apply failure (\`ai.categorize\` raised — see #199) left the API process wedged with a stale SQLite write lock; subsequent requests returned "database is locked" until \`docker compose restart api\`.

The lock leak was already mitigated by:

- The session-sharing helper \`use_session_or_make_one\` (added in #199's earlier slice) — AI capabilities invoked mid-transaction now share the caller's session rather than opening a second connection that would deadlock on the caller's write lock.
- FastAPI's dependency unwinding: \`get_session\` uses \`with factory() as s: yield s; finally: s.close()\`, so the connection is returned to the pool with any open transaction rolled back when an exception bubbles up.

What this PR adds:
1. A regression test pinning the invariant. Monkey-patches \`promote_statement_line\` to raise mid-apply, fires the apply endpoint (expects 500), then immediately fires both a read and a write follow-up that must NOT see "database is locked". Before the fix this test failed; now it passes.
2. A doc comment in \`get_session\` cross-linking #200, the session-sharing helper, and the regression test so the next developer to touch the session machinery doesn't accidentally undo the invariant.

## Test plan
- [x] \`just lint\` clean.
- [x] New \`TestApplyExceptionDoesNotLeakLock::test_subsequent_request_succeeds_after_apply_5xx\` passes.
- [x] All 15 \`test_apply_promote_endpoints.py\` tests pass.
- [ ] CI green.