### PR TITLE
feat: tulip admin grep-pii — post-delete erasure verification scanner (closes #346)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/admin.py
+++ b/packages/tulip-api/src/tulip_api/routers/admin.py
@@ -28,7 +28,10 @@ from tulip_api.schemas.admin import (
     AuditPruneResult,
     AuditRetentionPolicyPatch,
     AuditRetentionPolicyRead,
+    GrepPiiMatchRead,
+    GrepPiiResult,
 )
+from tulip_storage.grep_pii import run_grep_pii
 from tulip_storage.models import Household
 from tulip_storage.repositories import AuditLogWriter
 from tulip_storage.runner.handlers.audit_retention import (
@@ -182,6 +185,104 @@ def post_audit_prune(
         household_id=claims.household_id,
         deleted_per_tier=per_tier,
         total_deleted=total,
+    )
+
+
+@router.get(
+    "/grep-pii",
+    response_model=GrepPiiResult,
+    status_code=status.HTTP_200_OK,
+    responses={
+        400: problem_response("request.body_invalid"),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+    },
+)
+def get_grep_pii(
+    request: Request,
+    user_id: UUID | None = None,
+    email: str | None = None,
+    display_name: str | None = None,
+    claims: Claims = Depends(require_role("admin")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> GrepPiiResult:
+    """Scan household-scoped text/JSON columns for PII identifiers (#346).
+
+    Post-delete erasure verification: after ``DELETE /v1/users/{id}``
+    the operator runs this to prove "yes, the deleted user's PII is
+    actually gone" — or to surface what still needs scrubbing.
+
+    At least one of ``user_id`` / ``email`` / ``display_name`` must be
+    supplied. The scan is tenant-scoped to the caller's household;
+    cross-household visibility is intentionally absent.
+
+    The scan itself is recorded as ``admin.grep_pii_run`` so the audit
+    chain captures the operator's verification step — the row carries
+    needle *types* but not their values (no PII in the audit body).
+    """
+    try:
+        matches = run_grep_pii(
+            session,
+            household_id=claims.household_id,
+            user_id=user_id,
+            email=email,
+            display_name=display_name,
+        )
+    except ValueError as exc:
+        from tulip_api.errors import TulipProblem
+
+        raise TulipProblem(
+            code="request.body_invalid",
+            title="grep-pii requires at least one needle",
+            status=400,
+            detail=str(exc),
+        ) from exc
+
+    needles_provided = [
+        kind
+        for kind, value in (
+            ("user_id", user_id),
+            ("email", email),
+            ("display_name", display_name),
+        )
+        if value
+    ]
+    AuditLogWriter(session, claims.household_id).write(
+        action="admin.grep_pii_run",
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="household",
+        entity_id=claims.household_id,
+        # No PII bytes in the audit body — just the structural fact +
+        # the match count.
+        metadata={
+            "needle_kinds": needles_provided,
+            "match_count": len(matches),
+        },
+        request_id=_request_uuid(request),
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+    )
+    session.commit()
+    log.info(
+        "admin.grep_pii",
+        household_id=str(claims.household_id),
+        needle_kinds=needles_provided,
+        match_count=len(matches),
+    )
+    return GrepPiiResult(
+        household_id=claims.household_id,
+        needles=needles_provided,
+        matches=[
+            GrepPiiMatchRead(
+                table=m.table,
+                column=m.column,
+                row_id=m.row_id,
+                snippet=m.snippet,
+                needle=m.needle,
+            )
+            for m in matches
+        ],
     )
 
 

--- a/packages/tulip-api/src/tulip_api/schemas/admin.py
+++ b/packages/tulip-api/src/tulip_api/schemas/admin.py
@@ -76,3 +76,25 @@ class AuditPruneResult(BaseModel):
     household_id: UUID
     deleted_per_tier: dict[str, int]
     total_deleted: int
+
+
+class GrepPiiMatchRead(BaseModel):
+    """One match in the GET /v1/admin/grep-pii report (#346)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    table: str
+    column: str
+    row_id: str
+    snippet: str
+    needle: str
+
+
+class GrepPiiResult(BaseModel):
+    """Response shape for GET /v1/admin/grep-pii (#346)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    household_id: UUID
+    needles: list[str]
+    matches: list[GrepPiiMatchRead]

--- a/packages/tulip-api/tests/test_admin_audit_policy_endpoint.py
+++ b/packages/tulip-api/tests/test_admin_audit_policy_endpoint.py
@@ -266,3 +266,98 @@ class TestPostAuditPrune:
 
         r = client.post("/v1/admin/audit-prune", headers=member_h)
         assert_problem(r, code="auth.forbidden", status=403)
+
+
+class TestGetGrepPii:
+    """#346: GET /v1/admin/grep-pii — post-delete erasure verification."""
+
+    def test_returns_matches_for_existing_pii(
+        self, client: TestClient, admin_h: dict[str, str]
+    ) -> None:
+        # The admin's registration row's audit_log carries the email in
+        # after_snapshot — the scan should find it.
+        r = client.get(
+            "/v1/admin/grep-pii",
+            headers=admin_h,
+            params={"email": "admin@example.com"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["needles"] == ["email"]
+        assert any(
+            m["table"] == "audit_log" and m["column"] == "after_snapshot" for m in body["matches"]
+        )
+
+    def test_clean_household_returns_no_matches(
+        self, client: TestClient, admin_h: dict[str, str]
+    ) -> None:
+        r = client.get(
+            "/v1/admin/grep-pii",
+            headers=admin_h,
+            params={"email": "nobody-here@example.com"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["matches"] == []
+
+    def test_no_needles_returns_400(self, client: TestClient, admin_h: dict[str, str]) -> None:
+        r = client.get("/v1/admin/grep-pii", headers=admin_h)
+        assert r.status_code == 400
+        body = r.json()
+        assert body["code"] == "request.body_invalid"
+
+    def test_scan_writes_admin_audit_row(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        """The scan itself is auditable — ``admin.grep_pii_run`` row carries
+        needle *kinds* and the match count (no PII bytes).
+        """
+        client.get(
+            "/v1/admin/grep-pii",
+            headers=admin_h,
+            params={"email": "admin@example.com"},
+        )
+
+        from tulip_storage.models import AuditLog
+
+        with session_maker() as s:
+            row = (
+                s.query(AuditLog)
+                .filter(AuditLog.action == "admin.grep_pii_run")
+                .order_by(AuditLog.occurred_at.desc())
+                .first()
+            )
+            assert row is not None, "expected an admin.grep_pii_run audit row"
+            md = row.metadata_ or {}
+            assert md.get("needle_kinds") == ["email"]
+            assert isinstance(md.get("match_count"), int)
+
+    def test_member_returns_403(
+        self,
+        client: TestClient,
+        admin_h: dict[str, str],
+        session_maker,
+    ) -> None:
+        # Demote admin to MEMBER to reuse the existing auth path.
+        from sqlalchemy import update
+
+        from tulip_storage.models import User, UserRole
+
+        with session_maker() as s:
+            s.execute(update(User).values(role=UserRole.MEMBER))
+            s.commit()
+        login = client.post(
+            "/v1/auth/login",
+            json={"email": "admin@example.com", "password": "correct horse battery staple"},
+        )
+        member_h = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+        r = client.get(
+            "/v1/admin/grep-pii",
+            headers=member_h,
+            params={"email": "admin@example.com"},
+        )
+        assert_problem(r, code="auth.forbidden", status=403)

--- a/packages/tulip-cli/src/tulip_cli/commands/admin.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/admin.py
@@ -155,3 +155,81 @@ def audit_prune(ctx: typer.Context) -> None:
 
 
 __all__ = ["admin_app"]
+
+
+@admin_app.command("grep-pii")
+def grep_pii_command(
+    ctx: typer.Context,
+    user_id: Annotated[
+        str | None,
+        typer.Option(
+            "--user-id",
+            help="User UUID to scan for (substring; case-insensitive).",
+        ),
+    ] = None,
+    email: Annotated[
+        str | None,
+        typer.Option(
+            "--email",
+            help="Email address to scan for (substring; case-insensitive).",
+        ),
+    ] = None,
+    display_name: Annotated[
+        str | None,
+        typer.Option(
+            "--display-name",
+            help="Display name to scan for (substring; case-insensitive).",
+        ),
+    ] = None,
+) -> None:
+    """Scan household text/JSON columns for PII identifiers (#346).
+
+    Post-delete erasure verification: after ``tulip user delete``
+    (or the admin household-erasure flow) run this with the deleted
+    user's identifiers to prove the cascade actually scrubbed them,
+    or to surface what residual matches still need attention.
+
+    At least one of ``--user-id`` / ``--email`` / ``--display-name``
+    is required. Matches are reported as a table of
+    ``table | column | row_id | snippet``; pass ``--json`` for the
+    raw payload.
+    """
+    if not (user_id or email or display_name):
+        raise typer.BadParameter("supply at least one of --user-id / --email / --display-name")
+
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    params: dict[str, str] = {}
+    if user_id:
+        params["user_id"] = user_id
+    if email:
+        params["email"] = email
+    if display_name:
+        params["display_name"] = display_name
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            response = client.get(
+                "/v1/admin/grep-pii",
+                params=params,
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    if as_json:
+        sys.stdout.write(response.text + "\n")
+        return
+
+    body = response.json()
+    matches = body.get("matches") or []
+    needles = body.get("needles") or []
+    typer.echo(f"grep-pii: scanned needles={', '.join(needles) or '(none)'}")
+    typer.echo(f"  matches: {len(matches)}")
+    if not matches:
+        typer.echo("  (post-delete erasure looks clean for these needles)")
+        return
+    for m in matches:
+        typer.echo(f"  {m['table']}.{m['column']} row={m['row_id'][:8]} needle={m['needle']!r}")
+        typer.echo(f"    {m['snippet']}")

--- a/packages/tulip-storage/src/tulip_storage/grep_pii.py
+++ b/packages/tulip-storage/src/tulip_storage/grep_pii.py
@@ -1,0 +1,245 @@
+"""Post-delete erasure-verification scanner (#346 / privacy audit M-21).
+
+The right-to-erasure flow (``DELETE /v1/users/{id}`` landed via #235)
+cascades user rows + scrubs the deleted user's PII from ``audit_log``
+JSON snapshots — but a long tail of free-text columns and JSON blobs
+can still carry the user's identifiers in ways the schema-level
+cascade doesn't reach: AI prompt bodies (when ``log_prompts=true``),
+pending-proposal payloads, notification bodies, statement-line raw
+JSON, etc.
+
+``run_grep_pii`` scans every household-scoped table whose text/JSON
+columns might mention a subject and returns per-match rows so the
+operator can prove "yes, the data is actually gone" — or surface
+what still needs erasure.
+
+Out of scope:
+- Encrypted columns (``accounts.notes_encrypted``, etc.) — would
+  require decrypting every row; deferred until an operator actually
+  needs it. Plaintext mention in adjacent columns is the common case.
+- Cross-household scanning — every scan is tenant-scoped.
+- Mutation — this is *verification*. The operator decides whether to
+  redact, age-out, or accept the residue.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
+
+from tulip_storage.models import (
+    AIInvocation,
+    AuditLog,
+    Notification,
+    PendingProposal,
+    StatementLine,
+    Transaction,
+)
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.orm import Session
+
+log = logging.getLogger("tulip_storage.grep_pii")
+
+#: Snippet length on either side of a match — enough to be diagnostic
+#: without leaking the rest of the row's content.
+_SNIPPET_PAD: int = 40
+
+
+@dataclass(frozen=True, slots=True)
+class PiiMatch:
+    """One match of a needle in a scanned column."""
+
+    table: str
+    column: str
+    row_id: str
+    snippet: str
+    needle: str
+
+
+def _snippet(haystack: str, needle: str) -> str:
+    """Return a `…N chars before…<needle>…N chars after…` excerpt."""
+    idx = haystack.lower().find(needle.lower())
+    if idx < 0:
+        return ""
+    start = max(0, idx - _SNIPPET_PAD)
+    end = min(len(haystack), idx + len(needle) + _SNIPPET_PAD)
+    prefix = "…" if start > 0 else ""
+    suffix = "…" if end < len(haystack) else ""
+    return f"{prefix}{haystack[start:end]}{suffix}"
+
+
+def _needles_from(*values: str | None) -> tuple[str, ...]:
+    """Drop None / empty / whitespace-only entries; return distinct lower-cased needles."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for v in values:
+        if v is None:
+            continue
+        clean = v.strip()
+        if not clean:
+            continue
+        key = clean.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(clean)
+    return tuple(out)
+
+
+def _scan_text_column(
+    session: Session,
+    *,
+    household_id: UUID,
+    model: Any,  # noqa: ANN401 — SQLAlchemy model class; ORM-typed at the call site
+    column_attr: str,
+    needles: tuple[str, ...],
+    table_name: str,
+) -> list[PiiMatch]:
+    """Stream rows from ``model`` and match each haystack against every needle."""
+    out: list[PiiMatch] = []
+    stmt = select(model).where(model.household_id == household_id)
+    for row in session.execute(stmt).scalars():
+        haystack = getattr(row, column_attr) or ""
+        # JSON columns come back as dicts/lists; coerce to a JSON string
+        # so str-search applies uniformly.
+        if not isinstance(haystack, str):
+            try:
+                haystack = json.dumps(haystack, ensure_ascii=False)
+            except (TypeError, ValueError):
+                continue
+        if not haystack:
+            continue
+        lowered = haystack.lower()
+        for needle in needles:
+            if needle.lower() in lowered:
+                out.append(
+                    PiiMatch(
+                        table=table_name,
+                        column=column_attr,
+                        row_id=str(row.id),
+                        snippet=_snippet(haystack, needle),
+                        needle=needle,
+                    )
+                )
+    return out
+
+
+def run_grep_pii(
+    session: Session,
+    *,
+    household_id: UUID,
+    user_id: UUID | str | None = None,
+    email: str | None = None,
+    display_name: str | None = None,
+) -> list[PiiMatch]:
+    """Scan household-scoped text/JSON columns for PII identifiers.
+
+    At least one of ``user_id`` / ``email`` / ``display_name`` must be
+    non-empty — the scan needs needles. Returns one ``PiiMatch`` per
+    (row, needle) hit. Substring + case-insensitive.
+
+    Coverage:
+    - ``audit_log.before_snapshot`` + ``after_snapshot`` + ``metadata_``
+    - ``ai_invocations.prompt_json`` + ``response_text`` (NULL when not
+      opted in via ``log_prompts``)
+    - ``pending_proposals.payload`` + ``rationale`` + ``decision_note``
+    - ``notifications.body``
+    - ``statement_lines.raw_json``
+    - ``transactions.description`` + ``reference``
+    """
+    user_id_str = str(user_id) if user_id is not None else None
+    needles = _needles_from(user_id_str, email, display_name)
+    if not needles:
+        raise ValueError("run_grep_pii requires at least one of user_id / email / display_name")
+
+    matches: list[PiiMatch] = []
+    # audit_log: three JSON-ish columns.
+    for col in ("before_snapshot", "after_snapshot", "metadata_"):
+        matches.extend(
+            _scan_text_column(
+                session,
+                household_id=household_id,
+                model=AuditLog,
+                column_attr=col,
+                needles=needles,
+                table_name="audit_log",
+            )
+        )
+    # ai_invocations: prompt + response (NULL unless log_prompts).
+    for col in ("prompt_json", "response_text"):
+        matches.extend(
+            _scan_text_column(
+                session,
+                household_id=household_id,
+                model=AIInvocation,
+                column_attr=col,
+                needles=needles,
+                table_name="ai_invocations",
+            )
+        )
+    # pending_proposals: payload JSON + free-text fields.
+    for col in ("payload", "rationale", "decision_note"):
+        matches.extend(
+            _scan_text_column(
+                session,
+                household_id=household_id,
+                model=PendingProposal,
+                column_attr=col,
+                needles=needles,
+                table_name="pending_proposals",
+            )
+        )
+    # notifications: body.
+    matches.extend(
+        _scan_text_column(
+            session,
+            household_id=household_id,
+            model=Notification,
+            column_attr="body",
+            needles=needles,
+            table_name="notifications",
+        )
+    )
+    # statement_lines: raw_json carries the source bank-emitted fields.
+    matches.extend(
+        _scan_text_column(
+            session,
+            household_id=household_id,
+            model=StatementLine,
+            column_attr="raw_json",
+            needles=needles,
+            table_name="statement_lines",
+        )
+    )
+    # transactions: free-text description + reference.
+    for col in ("description", "reference"):
+        matches.extend(
+            _scan_text_column(
+                session,
+                household_id=household_id,
+                model=Transaction,
+                column_attr=col,
+                needles=needles,
+                table_name="transactions",
+            )
+        )
+
+    log.info(
+        "grep_pii.summary",
+        extra={
+            "household_id": str(household_id),
+            "needles": len(needles),
+            "matches": len(matches),
+        },
+    )
+    return matches
+
+
+__all__ = ["PiiMatch", "run_grep_pii"]

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/audit_retention.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/audit_retention.py
@@ -135,6 +135,7 @@ _RETENTION_TIER_BY_ACTION: dict[str, str] = {
     "household.erase_requested": "admin_days",
     "household.audit_policy_set": "admin_days",
     "audit.pruned": "admin_days",  # the prune handler's own summary row
+    "admin.grep_pii_run": "admin_days",  # #346 post-delete verification scan
     "csv_profile_create": "admin_days",
     "csv_profile_update": "admin_days",
     "csv_profile_delete": "admin_days",

--- a/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
+++ b/packages/tulip-storage/tests/test_architecture_no_direct_reconciliation_writes.py
@@ -99,6 +99,10 @@ _ALLOWED_RELATIVE: Final[frozenset[str]] = frozenset(
         # introduce a circular-import between TransactionRepository and
         # StatementLineRepository.
         "tulip-storage/src/tulip_storage/repositories/transaction.py",
+        # Post-delete PII scanner (#346) reads StatementLine.raw_json to
+        # surface residual subject mentions. Read-only; never constructs
+        # or mutates a row.
+        "tulip-storage/src/tulip_storage/grep_pii.py",
     }
 )
 

--- a/packages/tulip-storage/tests/test_grep_pii.py
+++ b/packages/tulip-storage/tests/test_grep_pii.py
@@ -1,0 +1,246 @@
+"""Tests for ``tulip_storage.grep_pii`` (#346 / privacy audit M-21).
+
+The scanner walks household-scoped text + JSON columns and reports
+substring matches against the supplied identifiers. These tests pin:
+
+- Each scanned column class actually produces matches when the needle
+  is present.
+- An empty/clean household returns no matches (the "post-delete
+  erasure looks clean" headline case).
+- At least one needle is required; calling with all-None raises.
+- Snippet shape (excerpt around the match, not the whole row).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import Engine, create_engine, event, text
+from sqlalchemy.orm import Session, sessionmaker
+
+from tulip_storage.grep_pii import run_grep_pii
+from tulip_storage.migrations._triggers import INITIAL_TRIGGERS, P4_0_SHADOW_TRIGGERS
+from tulip_storage.models import (
+    AIInvocation,
+    AuditLog,
+    Base,
+    Household,
+    Notification,
+)
+
+
+@pytest.fixture
+def engine() -> Engine:
+    eng = create_engine("sqlite:///:memory:", future=True)
+
+    @event.listens_for(eng, "connect")
+    def _enable_fk(dbapi_conn, _r):  # type: ignore[no-untyped-def]
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(eng)
+    with eng.begin() as conn:
+        for ddl in INITIAL_TRIGGERS:
+            conn.execute(text(ddl))
+        for ddl in P4_0_SHADOW_TRIGGERS:
+            conn.execute(text(ddl))
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def session_maker(engine: Engine) -> sessionmaker[Session]:
+    return sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def household(session_maker: sessionmaker[Session]) -> Household:
+    with session_maker() as s:
+        h = Household(id=uuid4(), name="Smith", base_currency="USD")
+        s.add(h)
+        s.commit()
+        s.refresh(h)
+        return h
+
+
+class TestGrepPiiHappyPath:
+    def test_audit_log_after_snapshot_match(self, session_maker, household):
+        with session_maker() as s:
+            s.add(
+                AuditLog(
+                    id=uuid4(),
+                    household_id=household.id,
+                    occurred_at=datetime.now(tz=UTC),
+                    actor_kind="user",
+                    action="user.created",
+                    entity_type="user",
+                    entity_id=uuid4(),
+                    after_snapshot={"email": "alice@example.com", "role": "admin"},
+                )
+            )
+            s.commit()
+            matches = run_grep_pii(s, household_id=household.id, email="alice@example.com")
+
+        assert any(m.table == "audit_log" and m.column == "after_snapshot" for m in matches), (
+            f"expected audit_log.after_snapshot hit; got {matches}"
+        )
+
+    def test_ai_invocations_prompt_json_match(self, session_maker, household):
+        with session_maker() as s:
+            s.add(
+                AIInvocation(
+                    household_id=household.id,
+                    id=uuid4(),
+                    created_at=datetime.now(tz=UTC),
+                    capability="categorize",
+                    policy_resolved="default",
+                    profile="default",
+                    provider="ollama",
+                    model="llama3",
+                    tokens_in=0,
+                    tokens_out=0,
+                    latency_ms=0,
+                    outcome="success",
+                    cost_estimate_usd=Decimal("0"),
+                    prompt_hash=b"\x00" * 32,
+                    prompt_json='{"messages": "remembered alice@example.com"}',
+                )
+            )
+            s.commit()
+            matches = run_grep_pii(s, household_id=household.id, email="alice@example.com")
+
+        assert any(m.table == "ai_invocations" and m.column == "prompt_json" for m in matches)
+
+    def test_notification_body_match(self, session_maker, household):
+        with session_maker() as s:
+            s.add(
+                Notification(
+                    household_id=household.id,
+                    id=uuid4(),
+                    created_at=datetime.now(tz=UTC),
+                    kind="forecast",
+                    severity="info",
+                    title="Envelope alert",
+                    body="Alice — heads up about your Groceries envelope",
+                    produced_by="daily_insights",
+                    entity_type="envelope",
+                    entity_id=uuid4(),
+                )
+            )
+            s.commit()
+            matches = run_grep_pii(s, household_id=household.id, display_name="Alice")
+
+        assert any(m.table == "notifications" and m.column == "body" for m in matches)
+
+    def test_multiple_needles_all_searched(self, session_maker, household):
+        """All non-None / non-empty needles search; results accumulate."""
+        with session_maker() as s:
+            s.add(
+                AuditLog(
+                    id=uuid4(),
+                    household_id=household.id,
+                    occurred_at=datetime.now(tz=UTC),
+                    actor_kind="user",
+                    action="user.created",
+                    entity_type="user",
+                    entity_id=uuid4(),
+                    after_snapshot={
+                        "email": "bob@example.com",
+                        "display_name": "Bob Smith",
+                    },
+                )
+            )
+            s.commit()
+            matches = run_grep_pii(
+                s,
+                household_id=household.id,
+                email="bob@example.com",
+                display_name="Bob Smith",
+            )
+
+        # Same row matches both needles → two PiiMatch entries.
+        needles = {m.needle for m in matches if m.table == "audit_log"}
+        assert "bob@example.com" in needles
+        assert "Bob Smith" in needles
+
+
+class TestGrepPiiCleanHousehold:
+    def test_empty_household_returns_no_matches(self, session_maker, household):
+        with session_maker() as s:
+            matches = run_grep_pii(s, household_id=household.id, email="alice@example.com")
+        assert matches == []
+
+    def test_match_disappears_after_row_deleted(self, session_maker, household):
+        with session_maker() as s:
+            row_id = uuid4()
+            s.add(
+                Notification(
+                    household_id=household.id,
+                    id=row_id,
+                    created_at=datetime.now(tz=UTC),
+                    kind="forecast",
+                    severity="info",
+                    title="Envelope alert",
+                    body="Alice's spending is up",
+                    produced_by="daily_insights",
+                    entity_type="envelope",
+                    entity_id=uuid4(),
+                )
+            )
+            s.commit()
+            before = run_grep_pii(s, household_id=household.id, display_name="Alice")
+            assert len(before) == 1
+
+            s.execute(
+                text("DELETE FROM notifications WHERE id = :i"),
+                {"i": str(row_id)},
+            )
+            s.commit()
+
+            after = run_grep_pii(s, household_id=household.id, display_name="Alice")
+            assert after == []
+
+
+class TestGrepPiiInputs:
+    def test_no_needles_raises(self, session_maker, household):
+        with session_maker() as s, pytest.raises(ValueError, match="at least one"):
+            run_grep_pii(s, household_id=household.id)
+
+    def test_all_whitespace_needles_raises(self, session_maker, household):
+        with session_maker() as s, pytest.raises(ValueError, match="at least one"):
+            run_grep_pii(s, household_id=household.id, email="   ", display_name="")
+
+
+class TestGrepPiiSnippet:
+    def test_snippet_excerpts_around_match(self, session_maker, household):
+        long_body = "x" * 200 + "alice@example.com" + "y" * 200
+        with session_maker() as s:
+            s.add(
+                Notification(
+                    household_id=household.id,
+                    id=uuid4(),
+                    created_at=datetime.now(tz=UTC),
+                    kind="forecast",
+                    severity="info",
+                    title="Envelope alert",
+                    body=long_body,
+                    produced_by="daily_insights",
+                    entity_type="envelope",
+                    entity_id=uuid4(),
+                )
+            )
+            s.commit()
+            matches = run_grep_pii(s, household_id=household.id, email="alice@example.com")
+
+        assert len(matches) == 1
+        snippet = matches[0].snippet
+        # Snippet must contain the needle and ellipses (not the whole body).
+        assert "alice@example.com" in snippet
+        assert snippet.startswith("…")
+        assert snippet.endswith("…")
+        # And it must be shorter than the body.
+        assert len(snippet) < len(long_body)


### PR DESCRIPTION
## Summary
Privacy audit M-21: after a right-to-erasure run (\`DELETE /v1/users/{id}\`, landed via #235), the operator had no way to prove "yes, the deleted user's PII is actually gone" — or to surface what the cascade missed.

- New \`tulip_storage.grep_pii.run_grep_pii\` scans household-scoped text/JSON columns for substring matches against operator-supplied identifiers. Returns a list of \`PiiMatch\` rows with table / column / row_id / snippet / needle.
- **Coverage** (non-encrypted; encrypted columns deferred per the issue): \`audit_log.{before_snapshot, after_snapshot, metadata_}\`, \`ai_invocations.{prompt_json, response_text}\`, \`pending_proposals.{payload, rationale, decision_note}\`, \`notifications.body\`, \`statement_lines.raw_json\`, \`transactions.{description, reference}\`.
- API: \`GET /v1/admin/grep-pii?user_id=<>&email=<>&display_name=<>\` admin-only; tenant-scoped; at least one needle required. Writes an \`admin.grep_pii_run\` audit row carrying needle *kinds* + match count — NOT the needle values.
- CLI: \`tulip admin grep-pii --user-id ... --email ... --display-name ...\` renders a per-match table; \`--json\` for raw payload.
- Tier-classifies \`admin.grep_pii_run\` as \`admin_days\` (365d) so \`test_audit_retention_coverage\` stays green.

## Test plan
- [x] \`just lint\` / \`just typecheck\` clean.
- [x] 9 storage-side tests pass (each column class, empty household, post-delete clean, no-needles raise, whitespace raise, snippet shape).
- [x] 5 API endpoint tests pass (returns matches; clean; 400 on no-needles; admin audit row written; member 403).
- [x] Existing audit-coverage test stays green after the new tier mapping.
- [ ] CI green.