### PR TITLE
sec(auth): TOTP step-replay defence on login-mfa (closes #330)

### DIFF
--- a/packages/tulip-api/src/tulip_api/auth/mfa.py
+++ b/packages/tulip-api/src/tulip_api/auth/mfa.py
@@ -7,6 +7,7 @@ secrets via the field-encryption helper in ``tulip-storage``.
 
 from __future__ import annotations
 
+import time
 from typing import Final
 
 import pyotp
@@ -15,6 +16,10 @@ from tulip_storage.encryption.field import decrypt_field, encrypt_field
 
 #: Default issuer name shown in authenticator apps.
 DEFAULT_ISSUER: Final[str] = "Tulip Accounting"
+
+#: TOTP step size in seconds per RFC 6238. Hard-coded; changing this
+#: would invalidate every enrolled secret.
+_STEP_SECONDS: Final[int] = 30
 
 #: ±1 30-second windows of slack tolerated when verifying codes — i.e.
 #: the previous and next windows count as valid. Standard practice for
@@ -32,14 +37,37 @@ def build_provisioning_uri(*, secret: str, email: str, issuer: str = DEFAULT_ISS
     return pyotp.TOTP(secret).provisioning_uri(name=email, issuer_name=issuer)
 
 
-def verify_totp_code(secret: str, code: str) -> bool:
-    """Return True if ``code`` is a currently-valid TOTP for ``secret``.
+def verify_totp_code(
+    secret: str, code: str, *, last_step: int | None = None
+) -> tuple[bool, int | None]:
+    """Return ``(verified, step)`` for a candidate TOTP.
 
-    Tolerates ±1 window of clock skew.
+    ``step`` is the Unix-epoch-seconds / 30 of the matched window, so
+    callers can persist it in ``users.last_totp_step`` to defeat replays
+    (security audit M-5, #330). When ``last_step`` is provided, any
+    candidate step ``<= last_step`` is treated as a replay and rejected
+    even if the code matches.
+
+    The valid window is ``[current - VERIFY_WINDOW, current + VERIFY_WINDOW]``;
+    the loop checks each step explicitly so we can both honour the
+    replay gate AND learn which step matched (``pyotp.TOTP.verify``'s
+    bool answer doesn't tell us).
+
+    Returns ``(False, None)`` on malformed input, replay, or no match.
     """
     if not code or not code.isdigit():
-        return False
-    return pyotp.TOTP(secret).verify(code, valid_window=_VERIFY_WINDOW)
+        return (False, None)
+    totp = pyotp.TOTP(secret)
+    current_step = int(time.time()) // _STEP_SECONDS
+    for offset in range(-_VERIFY_WINDOW, _VERIFY_WINDOW + 1):
+        candidate_step = current_step + offset
+        if last_step is not None and candidate_step <= last_step:
+            continue
+        # ``totp.at`` takes a Unix timestamp (seconds), not a step number,
+        # so multiply back to seconds for the lookup.
+        if totp.at(candidate_step * _STEP_SECONDS) == code:
+            return (True, candidate_step)
+    return (False, None)
 
 
 def encrypt_totp_secret(secret: str, *, master_key: bytes) -> bytes:

--- a/packages/tulip-api/src/tulip_api/routers/auth.py
+++ b/packages/tulip-api/src/tulip_api/routers/auth.py
@@ -356,7 +356,8 @@ def login_mfa(
         raise InvalidMfaTokenError()
 
     secret = decrypt_totp_secret(user.totp_secret_encrypted, master_key=settings.master_key)
-    if not verify_totp_code(secret, body.code):
+    verified, matched_step = verify_totp_code(secret, body.code, last_step=user.last_totp_step)
+    if not verified:
         log.info("user.login.mfa_code_rejected", user_id=str(user.id))
         AuditLogWriter(session, user.household_id).write(
             action="mfa.code_rejected",
@@ -371,6 +372,10 @@ def login_mfa(
         session.commit()
         raise MfaInvalidCodeError()
 
+    # Replay-defence: persist the highest accepted step in the same
+    # commit as the session mint (security audit M-5, #330).
+    if matched_step is not None:
+        user.last_totp_step = matched_step
     AuditLogWriter(session, user.household_id).write(
         action="login_mfa_success",
         actor_kind="user",
@@ -629,7 +634,14 @@ def mfa_verify(
         raise MfaNotPendingError()
 
     secret = decrypt_totp_secret(user.totp_secret_encrypted, master_key=settings.master_key)
-    if not verify_totp_code(secret, body.code):
+    # Replay defence (#330) does NOT apply on enrollment-verify: the
+    # user has just typed the code from their authenticator app and is
+    # about to log in with the same code — the replay gate would lock
+    # them out of their own first login. The login-mfa path is where
+    # the replay gate matters (a token-stealer with a captured mfa
+    # challenge token could otherwise re-submit a window-valid code).
+    verified, _ = verify_totp_code(secret, body.code)
+    if not verified:
         log.info("user.mfa_verify_failed", user_id=str(user.id))
         raise MfaInvalidCodeError()
 
@@ -759,7 +771,11 @@ def mfa_regenerate_recovery_codes(
         raise MfaNotEnrolledError()
 
     secret = decrypt_totp_secret(user.totp_secret_encrypted, master_key=settings.master_key)
-    if not verify_totp_code(secret, body.code):
+    # Replay defence (#330) does not apply on the regenerate-recovery
+    # path either — the same fresh-MFA gate as enroll. The login-mfa
+    # path is the load-bearing site.
+    verified, _ = verify_totp_code(secret, body.code)
+    if not verified:
         log.info("user.mfa_regenerate_failed", user_id=str(user.id))
         raise MfaInvalidCodeError()
 

--- a/packages/tulip-api/tests/test_mfa_login_endpoints.py
+++ b/packages/tulip-api/tests/test_mfa_login_endpoints.py
@@ -342,3 +342,52 @@ class TestAuthRateLimit:
         assert last is not None
         assert_problem(last, code="auth.rate_limited", status=429)
         assert "Retry-After" in last.headers
+
+
+class TestLoginMfaReplayDefence:
+    """#330 / security audit M-5: a successful login-mfa burns the TOTP
+    step. A captured TOTP code can't be re-submitted in a second login
+    within the same window — even with a valid mfa_token.
+    """
+
+    def test_replay_after_login_mfa_success_rejected(
+        self,
+        client: TestClient,
+        registered: dict[str, str],
+        session_maker: sessionmaker[Session],
+    ):
+        # Enroll-verify so the user has a TOTP secret.
+        access = _login(client, registered["email"]).json()["access_token"]
+        secret = _enroll_and_verify(client, access)
+
+        # Issue two MFA-challenge tokens (the simulated "captured" case
+        # uses one) by calling login twice. Both should be valid for
+        # different login attempts.
+        challenge1 = _login(client, registered["email"]).json()
+        challenge2 = _login(client, registered["email"]).json()
+        mfa_token1 = challenge1["mfa_token"]
+        mfa_token2 = challenge2["mfa_token"]
+
+        code = pyotp.TOTP(secret).now()
+        # First submission succeeds and burns the step.
+        r1 = client.post(
+            "/v1/auth/login/mfa",
+            json={"mfa_token": mfa_token1, "code": code},
+        )
+        assert r1.status_code == 200, r1.text
+
+        # Second submission with the SAME TOTP code on the second valid
+        # mfa_token must fail with auth.mfa_invalid_code — the replay
+        # gate trips even though the code is window-valid.
+        r2 = client.post(
+            "/v1/auth/login/mfa",
+            json={"mfa_token": mfa_token2, "code": code},
+        )
+        assert_problem(r2, code="auth.mfa_invalid_code", status=401)
+
+        # And a mfa.code_rejected audit row landed.
+        from tulip_storage.models import AuditLog
+
+        with session_maker() as s:
+            rejections = s.query(AuditLog).filter(AuditLog.action == "mfa.code_rejected").all()
+            assert len(rejections) >= 1

--- a/packages/tulip-api/tests/test_mfa_service.py
+++ b/packages/tulip-api/tests/test_mfa_service.py
@@ -63,19 +63,27 @@ class TestVerifyTotpCode:
     def test_accepts_current_code(self):
         secret = generate_totp_secret()
         code = pyotp.TOTP(secret).now()
-        assert verify_totp_code(secret, code) is True
+        ok, step = verify_totp_code(secret, code)
+        assert ok is True
+        assert step is not None
 
     def test_rejects_wrong_code(self):
         secret = generate_totp_secret()
         # 000000 is statistically near-certain not to be the current code.
         # Even on the off chance it is, the next assertion below will fail
         # on a different random secret — flake budget is effectively zero.
-        assert verify_totp_code(secret, "000000") is False
+        ok, step = verify_totp_code(secret, "000000")
+        assert ok is False
+        assert step is None
 
     def test_rejects_garbage(self):
         secret = generate_totp_secret()
-        assert verify_totp_code(secret, "not-a-code") is False
-        assert verify_totp_code(secret, "") is False
+        ok1, step1 = verify_totp_code(secret, "not-a-code")
+        assert ok1 is False
+        assert step1 is None
+        ok2, step2 = verify_totp_code(secret, "")
+        assert ok2 is False
+        assert step2 is None
 
     def test_accepts_previous_window(self):
         # ±1 window tolerates clock skew up to ±30s, the standard practice.
@@ -85,7 +93,9 @@ class TestVerifyTotpCode:
         import time
 
         past_code = totp.at(int(time.time()) - 30)
-        assert verify_totp_code(secret, past_code) is True
+        ok, step = verify_totp_code(secret, past_code)
+        assert ok is True
+        assert step is not None
 
 
 def _b32_decodable(secret: str) -> bool:

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260517_1900_c2a9f4b7e1d8_users_last_totp_step.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260517_1900_c2a9f4b7e1d8_users_last_totp_step.py
@@ -1,0 +1,45 @@
+"""Add users.last_totp_step column for TOTP step-replay defence (#330).
+
+Per the security audit's M-5: ``verify_totp_code`` was a stateless
+wrapper over ``pyotp.TOTP.verify(valid_window=1)`` — nothing recorded
+"this 6-digit code was already accepted." An attacker who observed
+a successful TOTP (unencrypted local channel / screen recording /
+forgotten log line) had up to ~90 s (±1 window) to replay it from
+a different session.
+
+The fix tracks the highest TOTP step Unix-epoch-divided-by-30 that
+the user successfully verified. Every subsequent verify refuses
+matches at or below that step. The login flow persists the accepted
+step in the same commit as session mint.
+
+Column is nullable — users who have never verified a TOTP have NULL,
+and the verify path treats NULL as "no replay history yet."
+
+Revision ID: c2a9f4b7e1d8
+Revises: a6f1c9b3d8e4
+Create Date: 2026-05-17 19:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c2a9f4b7e1d8"
+down_revision: str | None = "a6f1c9b3d8e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``users.last_totp_step`` column."""
+    with op.batch_alter_table("users", schema=None) as batch:
+        batch.add_column(sa.Column("last_totp_step", sa.BigInteger(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the ``users.last_totp_step`` column."""
+    with op.batch_alter_table("users", schema=None) as batch:
+        batch.drop_column("last_totp_step")

--- a/packages/tulip-storage/src/tulip_storage/models/user.py
+++ b/packages/tulip-storage/src/tulip_storage/models/user.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     DateTime,
     ForeignKey,
     LargeBinary,
@@ -60,6 +61,11 @@ class User(Base):
     totp_enrolled_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # Highest TOTP step (``int(time.time()) // 30``) the user has
+    # successfully verified. Every subsequent verify refuses matches at
+    # or below this step (security audit M-5, #330). NULL = never
+    # verified a TOTP yet — verify treats as "no replay history."
+    last_totp_step: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     last_login_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()


### PR DESCRIPTION
## Summary
Security audit M-5: \`verify_totp_code\` was stateless. An attacker who observed a successful TOTP had up to ~90s (±1 window) to re-submit it from a different session.

- Migration \`c2a9f4b7e1d8\` adds \`users.last_totp_step\` (BigInteger, nullable).
- \`verify_totp_code\` returns \`(verified, matched_step)\` with explicit step iteration so we can honour an optional \`last_step\` replay gate AND learn which step matched (pyotp's bool doesn't expose that).
- Login-MFA path reads \`user.last_totp_step\`, passes it to verify, and persists the matched step in the same commit as session-mint. Re-submitting the same TOTP on a different mfa_token now → \`auth.mfa_invalid_code\` + \`mfa.code_rejected\` audit row.

## Scope cut
Replay gate is NOT applied to enrollment-verify or recovery-codes-regenerate. The legitimate user flow is "enroll → immediately log in" — burning the step on enrollment would lock the user out of their own first login. The login-mfa site is the only one where replay actually matters (an attacker's payoff is a new session); the other paths happen in the user's already-authenticated session.

## Test plan
- [x] \`just lint\` / \`just typecheck\` clean.
- [x] New \`TestLoginMfaReplayDefence\` × 1 passes (enroll → 2 mfa_tokens → first TOTP succeeds → same TOTP on second token rejected + audit row).
- [x] All 48 existing MFA tests pass.
- [ ] CI green.