### PR TITLE
security: tulip backup / restore emit audit_log rows per household (closes #368)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/backup.py
+++ b/packages/tulip-cli/src/tulip_cli/backup.py
@@ -60,6 +60,62 @@ _DB_PATH_PREFIX = "db/"
 _ATTACHMENTS_PATH_PREFIX = "attachments/"
 
 
+def write_backup_audit_rows(
+    *,
+    db_path: Path,
+    action: str,
+    metadata: dict[str, object],
+) -> None:
+    """Write one ``audit_log`` row per household via raw sqlite3 (#368, audit L-24).
+
+    The CLI can't import SQLAlchemy (arch test), so this uses stdlib
+    sqlite3 + hand-written SQL. Best-effort — a failure here logs and
+    returns rather than blocking the backup itself.
+
+    Targets the file at ``db_path``:
+    - For ``tulip backup`` (action="backup.created"), this is the LIVE
+      database — the audit row lands in the running app's DB and is
+      included in the *next* backup.
+    - For ``tulip restore`` (action="backup.restored"), this is the
+      RESTORED database — the audit row joins the post-restore state.
+    """
+    import uuid as _uuid
+
+    if not db_path.exists():
+        return  # nothing to write to
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            now_iso = datetime.now(UTC).isoformat(sep=" ", timespec="microseconds")
+            now_iso = now_iso.replace("+00:00", "")
+            metadata_json = json.dumps(metadata, ensure_ascii=False)
+            for (hh_id,) in conn.execute("SELECT id FROM households"):
+                conn.execute(
+                    "INSERT INTO audit_log "
+                    "(household_id, id, occurred_at, actor_user_id, actor_kind, "
+                    "action, entity_type, entity_id, request_id, "
+                    "ip_address, user_agent, before_snapshot, after_snapshot, metadata) "
+                    "VALUES (?, ?, ?, NULL, 'system', ?, 'household', ?, "
+                    "NULL, NULL, NULL, NULL, NULL, ?)",
+                    (
+                        hh_id,
+                        str(_uuid.uuid4()),
+                        now_iso,
+                        action,
+                        hh_id,
+                        metadata_json,
+                    ),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        # Best-effort: never block the backup on an audit-row failure.
+        # The user-facing tarball / restore action is the load-bearing
+        # output; the audit row is the trace.
+        return
+
+
 class BackupError(Exception):
     """Raised when backup creation fails for a recoverable reason."""
 

--- a/packages/tulip-cli/src/tulip_cli/commands/backup_restore.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/backup_restore.py
@@ -19,6 +19,7 @@ from tulip_cli.backup import (
     resolve_db_path_from_url,
     restore_backup,
     write_backup,
+    write_backup_audit_rows,
 )
 from tulip_cli.backup import (
     load_master_key_from_env as _load_master_key,
@@ -81,6 +82,17 @@ def backup_command(
             tulip_version=_tulip_version(),
             out=sys.stdout.buffer,
         )
+        write_backup_audit_rows(
+            db_path=db_path,
+            action="backup.created",
+            metadata={
+                "out": "-",
+                "format_version": manifest.format_version,
+                "tulip_version": manifest.tulip_version,
+                "alembic_head": manifest.alembic_head,
+                "timestamp": manifest.timestamp,
+            },
+        )
         if not as_json:
             # Stderr so stdout is the tar bytes only.
             typer.echo(f"backup: streamed to stdout (timestamp {manifest.timestamp})", err=True)
@@ -102,6 +114,19 @@ def backup_command(
         if out_path.exists():
             out_path.unlink()
         raise typer.Exit(2) from None
+
+    write_backup_audit_rows(
+        db_path=db_path,
+        action="backup.created",
+        metadata={
+            "out": str(out_path),
+            "format_version": manifest.format_version,
+            "tulip_version": manifest.tulip_version,
+            "alembic_head": manifest.alembic_head,
+            "timestamp": manifest.timestamp,
+            "size_bytes": out_path.stat().st_size,
+        },
+    )
 
     if as_json:
         sys.stdout.write(
@@ -179,6 +204,19 @@ def restore_command(
     except RestoreError as exc:
         typer.echo(f"restore: {exc}", err=True)
         raise typer.Exit(2) from None
+
+    write_backup_audit_rows(
+        db_path=db_path,
+        action="backup.restored",
+        metadata={
+            "in_path": str(in_path),
+            "format_version": manifest.format_version,
+            "tulip_version": manifest.tulip_version,
+            "alembic_head": manifest.alembic_head,
+            "hostname": manifest.hostname,
+            "timestamp": manifest.timestamp,
+        },
+    )
 
     if as_json:
         sys.stdout.write(

--- a/packages/tulip-cli/tests/test_backup_restore.py
+++ b/packages/tulip-cli/tests/test_backup_restore.py
@@ -27,6 +27,7 @@ from tulip_cli.backup import (
     restore_backup,
     snapshot_sqlite_db,
     write_backup,
+    write_backup_audit_rows,
 )
 
 # ---- Manifest + envelope --------------------------------------------------
@@ -515,6 +516,110 @@ def test_cli_restore_wrong_key_exits_2(tmp_path: Path):
     result = _run_cli("restore", str(backup_path), env=restore_env)
     assert result.returncode == 2
     assert "envelope" in (result.stdout + result.stderr).lower()
+
+
+def _audit_log_seeded_db(tmp_path: Path, household_ids: list[str]) -> Path:
+    """SQLite DB with a minimal households + audit_log schema for the audit-row helper tests."""
+    db = tmp_path / "audit-seed.db"
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute("CREATE TABLE households (id TEXT NOT NULL PRIMARY KEY)")
+        conn.execute(
+            "CREATE TABLE audit_log ("
+            "id TEXT NOT NULL PRIMARY KEY, "
+            "household_id TEXT NOT NULL, "
+            "occurred_at TEXT NOT NULL, "
+            "actor_user_id TEXT, "
+            "actor_kind TEXT NOT NULL, "
+            "action TEXT NOT NULL, "
+            "entity_type TEXT NOT NULL, "
+            "entity_id TEXT NOT NULL, "
+            "before_snapshot TEXT, "
+            "after_snapshot TEXT, "
+            "request_id TEXT, "
+            "ip_address TEXT, "
+            "user_agent TEXT, "
+            "metadata TEXT"
+            ")"
+        )
+        for hh_id in household_ids:
+            conn.execute("INSERT INTO households (id) VALUES (?)", (hh_id,))
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+class TestWriteBackupAuditRows:
+    def test_writes_one_row_per_household(self, tmp_path: Path):
+        db = _audit_log_seeded_db(tmp_path, ["hh-1", "hh-2"])
+        write_backup_audit_rows(
+            db_path=db,
+            action="backup.created",
+            metadata={"out": "x.tar.gz"},
+        )
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = conn.execute(
+                "SELECT household_id, action, actor_kind, entity_type, entity_id, metadata "
+                "FROM audit_log ORDER BY household_id"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert len(rows) == 2
+        assert {r[0] for r in rows} == {"hh-1", "hh-2"}
+        assert all(r[1] == "backup.created" for r in rows)
+        assert all(r[2] == "system" for r in rows)
+        assert all(r[3] == "household" for r in rows)
+        # entity_id == household_id (the household IS the entity scope of a backup).
+        assert all(r[4] == r[0] for r in rows)
+        # metadata round-trips as JSON.
+        for r in rows:
+            assert json.loads(r[5]) == {"out": "x.tar.gz"}
+
+    def test_missing_db_is_noop(self, tmp_path: Path):
+        # No exception even though file doesn't exist.
+        write_backup_audit_rows(
+            db_path=tmp_path / "missing.db",
+            action="backup.created",
+            metadata={},
+        )
+
+    def test_missing_audit_log_table_is_silent(self, tmp_path: Path):
+        # A DB that doesn't have the audit_log table (e.g. pre-migration)
+        # must not raise — best-effort.
+        db = tmp_path / "schemaless.db"
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute("CREATE TABLE households (id TEXT PRIMARY KEY)")
+            conn.execute("INSERT INTO households (id) VALUES ('hh-x')")
+            conn.commit()
+        finally:
+            conn.close()
+        write_backup_audit_rows(db_path=db, action="backup.restored", metadata={"k": "v"})
+
+    def test_no_households_means_no_rows(self, tmp_path: Path):
+        db = _audit_log_seeded_db(tmp_path, [])
+        write_backup_audit_rows(db_path=db, action="backup.created", metadata={})
+        conn = sqlite3.connect(str(db))
+        try:
+            n = conn.execute("SELECT COUNT(*) FROM audit_log").fetchone()[0]
+        finally:
+            conn.close()
+        assert n == 0
+
+    def test_action_string_is_passed_through(self, tmp_path: Path):
+        db = _audit_log_seeded_db(tmp_path, ["hh-1"])
+        write_backup_audit_rows(
+            db_path=db, action="backup.restored", metadata={"in_path": "b.tar.gz"}
+        )
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute("SELECT action, metadata FROM audit_log").fetchone()
+        finally:
+            conn.close()
+        assert row[0] == "backup.restored"
+        assert json.loads(row[1]) == {"in_path": "b.tar.gz"}
 
 
 @pytest.mark.integration

--- a/packages/tulip-storage/src/tulip_storage/runner/handlers/audit_retention.py
+++ b/packages/tulip-storage/src/tulip_storage/runner/handlers/audit_retention.py
@@ -139,6 +139,8 @@ _RETENTION_TIER_BY_ACTION: dict[str, str] = {
     "csv_profile_update": "admin_days",
     "csv_profile_delete": "admin_days",
     "csv_profile_import": "admin_days",
+    "backup.created": "admin_days",
+    "backup.restored": "admin_days",
 }
 
 


### PR DESCRIPTION
## Summary
- Audit L-24: `tulip backup` and `tulip restore` had no audit trail — a restore could silently overwrite household state with no evidence.
- Adds `write_backup_audit_rows()` helper in `tulip_cli/backup.py` that uses raw stdlib `sqlite3` to INSERT one `audit_log` row per household (the CLI arch test forbids `tulip_storage` / `sqlalchemy` / `alembic` imports — see `packages/tulip-cli/tests/test_architecture.py`).
- Wires the helper into `backup_command` (both file and stdout paths) and `restore_command` after success. Failures inside the helper are swallowed so an audit-row hiccup never blocks the user-facing backup/restore.
- Registers `backup.created` and `backup.restored` in `_RETENTION_TIER_BY_ACTION` under `admin_days` (365d) — matches `household.deleted` / `csv_profile_*` precedent.

## Test plan
- [x] `uv run pytest packages/tulip-cli/tests/test_backup_restore.py packages/tulip-cli/tests/test_architecture.py` — 33 passed (5 new + existing round-trip + architecture-boundary).
- [x] `uv run pytest packages/tulip-storage/tests/test_audit_retention_handler.py packages/tulip-api/tests/test_audit_retention_coverage.py` — 14 passed; tier-coverage / handler tests still green with the new actions.
- [x] `just lint typecheck` — clean.
- [ ] CI green on this PR.

## Manual smoke test
\`\`\`bash
set -euo pipefail
TMPDIR=\$(mktemp -d)
export TULIP_MASTER_KEY=\$(uv run python -c \"import base64,os;print(base64.b64encode(os.urandom(32)).decode())\")
export TULIP_DATABASE_URL=\"sqlite:///\$TMPDIR/tulip.db\"
export TULIP_ATTACHMENT_ROOT=\"\$TMPDIR/attachments\"
mkdir -p \"\$TULIP_ATTACHMENT_ROOT\"
uv run alembic -c packages/tulip-storage/alembic.ini upgrade head
uv run tulip register --household \"AcmeHousehold\" --email \"audit@example.com\" --password-stdin <<<'pw-Long-Enough-1234'
uv run tulip backup --out \"\$TMPDIR/backup.tar.gz\"
uv run sqlite3 \"\$TMPDIR/tulip.db\" \"SELECT action, actor_kind FROM audit_log WHERE action LIKE 'backup.%' ORDER BY occurred_at DESC LIMIT 1\"
uv run tulip restore \"\$TMPDIR/backup.tar.gz\" --force
uv run sqlite3 \"\$TMPDIR/tulip.db\" \"SELECT action, actor_kind FROM audit_log WHERE action LIKE 'backup.%' ORDER BY occurred_at DESC LIMIT 2\"
rm -rf \"\$TMPDIR\"
\`\`\`
Expected: \`backup.created\` row after \`tulip backup\`; \`backup.restored\` + the earlier \`backup.created\` after \`tulip restore\` (both with \`actor_kind=system\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)