### PR TITLE
security(ai): atomic household-write-lock at cost-cap + rate-limit gate (closes #334)

### DIFF
--- a/docs/adrs/0005-ai-integration.md
+++ b/docs/adrs/0005-ai-integration.md
@@ -285,6 +285,8 @@ A new table `ai_invocations`, written by `tulip_ai.audit.AIInvocationWriter`. Ar
 
 Estimated cost is a heuristic from token counts × per-million rate. Post-call, the row's `cost_estimate_usd` is updated with the actual; the reservation is released and the actual is debited. Atomic via a single transaction that writes the `ai_invocations` row.
 
+**Atomicity under concurrent callers (#334, audit M-23).** The cost-cap + rate-limit gate is a read-then-act on `ai_invocations`; two concurrent capabilities can otherwise both observe `spent < cap` and both commit success rows. `tulip_ai.cost._acquire_household_gate_lock` runs at the top of `enforce_pre_call` and takes a write lock on the household row — on SQLite via a no-op `UPDATE households SET id = id WHERE id = :hid` that escalates the transaction to RESERVED; on PostgreSQL (Phase 9) via `SELECT 1 FROM households ... FOR UPDATE`. Callers MUST commit (or rollback) the same session after writing the matching `ai_invocations` row so the lock releases. The concurrency regression tests in `packages/tulip-ai/tests/test_cost.py::TestHouseholdGateLockSerialization` demonstrate the serialization.
+
 **Rate limit is per-user, sliding window.** Default 60 invocations/hour per user across all capabilities. Sliding window because monthly aggregates obscure runaway loops; the bound is "no more than a hot stove" not "no more than a budget."
 
 **At cap.** Per `households.ai_policy.cost_cap_behaviour` (new field, default `degrade`):

--- a/packages/tulip-ai/src/tulip_ai/cost.py
+++ b/packages/tulip-ai/src/tulip_ai/cost.py
@@ -18,7 +18,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 
 from tulip_storage.models import AIInvocation, AIOutcome
 
@@ -62,6 +62,46 @@ def _billable_outcomes() -> tuple[str, ...]:
     rate-limited / disabled rows never reached the wire, so they don't.
     """
     return (AIOutcome.SUCCESS.value, AIOutcome.PROVIDER_ERROR.value)
+
+
+def _acquire_household_gate_lock(session: Session, household_id: UUID) -> None:
+    """Serialize concurrent pre-call gates on the same household (#334, M-23).
+
+    The cost-cap + rate-limit gate reads `SUM(cost_estimate_usd)` and
+    `COUNT(*)` from `ai_invocations`, then writes one new row. Without
+    a write lock at the entry, two concurrent capabilities can both
+    observe `spent < cap` and both commit success rows — the audit's
+    classic TOCTOU race documented in M-23.
+
+    Strategy:
+    - SQLite: issue a no-op UPDATE on the household row. Any UPDATE in
+      a SQLAlchemy session escalates the connection's transaction from
+      DEFERRED to RESERVED, which is SQLite's single-writer chokepoint;
+      concurrent gates serialize through here. The row content is
+      unchanged (``SET id = id``), so this is purely a lock acquisition.
+    - PostgreSQL (Phase 9): issue ``SELECT 1 FROM households ... FOR UPDATE``
+      to acquire a row-level lock with the same serialization semantics
+      without writing the row.
+
+    The lock is held until the surrounding session's transaction commits —
+    callers MUST commit (or rollback) after writing the matching
+    ``ai_invocations`` row, otherwise the lock leaks and subsequent gates
+    will block.
+    """
+    dialect_name = session.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        session.execute(
+            text("SELECT 1 FROM households WHERE id = :hid FOR UPDATE"),
+            {"hid": str(household_id)},
+        )
+    else:
+        # SQLite (and other dialects without FOR UPDATE — sqlite is the
+        # only one in scope today). The no-op UPDATE promotes BEGIN to
+        # RESERVED, blocking concurrent writers until commit.
+        session.execute(
+            text("UPDATE households SET id = id WHERE id = :hid"),
+            {"hid": str(household_id)},
+        )
 
 
 def check_cost_cap(
@@ -187,7 +227,15 @@ def enforce_pre_call(
     ``cost_cap_behaviour=degrade`` and a configured ``fallback_provider``,
     returns an approval that swaps provider/model. Otherwise, returns a
     block — the capability writes the matching audit row and raises.
+
+    The whole check runs under a household write-lock (#334, M-23) so
+    that two concurrent callers can't both observe ``spent < cap`` and
+    both commit success rows. The lock releases when the surrounding
+    session commits or rolls back, which is the same boundary the
+    capability uses to persist the matching ``ai_invocations`` row.
     """
+    _acquire_household_gate_lock(session, household_id)
+
     rate = check_rate_limit(
         session,
         household_id=household_id,

--- a/packages/tulip-ai/tests/test_cost.py
+++ b/packages/tulip-ai/tests/test_cost.py
@@ -352,3 +352,145 @@ class TestEnforcePreCall:
             result = enforce_pre_call(s, **kwargs)
         assert isinstance(result, PreCallBlock)
         assert result.outcome == "cost_capped"
+
+
+# ---- M-23 (#334): atomic-gate lock ----------------------------------------
+
+
+class TestHouseholdGateLockSerialization:
+    """Concurrency tests for ``_acquire_household_gate_lock`` (#334)."""
+
+    def _file_engine_and_household(self, db_path, *, busy_timeout_ms: int = 200):
+        """Build a file-backed SQLite engine + seed one household.
+
+        File-backed (not :memory:) so two separate connections see the
+        same data; in-memory SQLite is per-connection and would defeat
+        the concurrency test.
+        """
+        from sqlalchemy import create_engine, event
+        from sqlalchemy.orm import sessionmaker
+
+        from tulip_storage.migrations._triggers import (
+            INITIAL_TRIGGERS,
+            P4_0_SHADOW_TRIGGERS,
+        )
+        from tulip_storage.models import Base, Household
+
+        eng = create_engine(
+            f"sqlite:///{db_path}",
+            future=True,
+            connect_args={"timeout": busy_timeout_ms / 1000},
+        )
+
+        @event.listens_for(eng, "connect")
+        def _enable_fk(dbapi_conn, _record):  # type: ignore[no-untyped-def]
+            cursor = dbapi_conn.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
+
+        Base.metadata.create_all(eng)
+        from sqlalchemy import text as _text
+
+        with eng.begin() as conn:
+            for ddl in INITIAL_TRIGGERS:
+                conn.execute(_text(ddl))
+            for ddl in P4_0_SHADOW_TRIGGERS:
+                conn.execute(_text(ddl))
+
+        sm = sessionmaker(eng, expire_on_commit=False)
+        with sm() as s:
+            h = Household(id=uuid4(), name="LockTest", base_currency="USD")
+            s.add(h)
+            s.commit()
+            s.refresh(h)
+        return eng, sm, h
+
+    def test_second_writer_blocks_until_first_commits(self, tmp_path) -> None:
+        """A held gate lock forces a concurrent gate to wait or error."""
+        import sqlalchemy.exc
+
+        from tulip_ai.cost import _acquire_household_gate_lock
+
+        eng, sm, h = self._file_engine_and_household(tmp_path / "lock.db", busy_timeout_ms=100)
+        try:
+            s_a = sm()
+            s_b = sm()
+            try:
+                # Session A grabs the lock (no commit; tx stays open).
+                _acquire_household_gate_lock(s_a, h.id)
+
+                # Session B tries to acquire the same lock — SQLite has
+                # one global writer, so B's UPDATE must wait the 100ms
+                # busy_timeout and then raise.
+                import pytest as _pytest
+
+                with _pytest.raises(sqlalchemy.exc.OperationalError) as exc_info:
+                    _acquire_household_gate_lock(s_b, h.id)
+                assert "locked" in str(exc_info.value).lower()
+            finally:
+                s_a.rollback()
+                s_b.rollback()
+                s_a.close()
+                s_b.close()
+        finally:
+            eng.dispose()
+
+    def test_lock_released_after_commit_allows_next_gate(self, tmp_path) -> None:
+        """Committing the first transaction must release the lock."""
+        from tulip_ai.cost import _acquire_household_gate_lock
+
+        eng, sm, h = self._file_engine_and_household(tmp_path / "lock2.db")
+        try:
+            s_a = sm()
+            try:
+                _acquire_household_gate_lock(s_a, h.id)
+                s_a.commit()
+            finally:
+                s_a.close()
+
+            # Fresh session — lock must be available immediately.
+            s_b = sm()
+            try:
+                _acquire_household_gate_lock(s_b, h.id)
+                s_b.commit()
+            finally:
+                s_b.close()
+        finally:
+            eng.dispose()
+
+    def test_enforce_pre_call_acquires_lock(self, tmp_path) -> None:
+        """``enforce_pre_call`` blocks a concurrent gate on the same household."""
+        import sqlalchemy.exc
+
+        eng, sm, h = self._file_engine_and_household(tmp_path / "lock3.db", busy_timeout_ms=100)
+        try:
+            kwargs = {
+                "household_id": h.id,
+                "user_id": None,
+                "rate_limit_per_hour": 60,
+                "monthly_cost_cap_usd": None,
+                "cost_cap_behaviour": "degrade",
+                "fallback_provider": "ollama",
+                "fallback_model": "llama3:70b",
+                "primary_provider": "anthropic",
+                "primary_model": "claude-opus-4-7",
+            }
+
+            s_a = sm()
+            s_b = sm()
+            try:
+                result = enforce_pre_call(s_a, **kwargs)
+                assert isinstance(result, PreCallApproval)
+                # s_a's transaction is still open (no commit yet); the
+                # lock from inside enforce_pre_call must still be held.
+                import pytest as _pytest
+
+                with _pytest.raises(sqlalchemy.exc.OperationalError):
+                    enforce_pre_call(s_b, **kwargs)
+            finally:
+                s_a.rollback()
+                s_b.rollback()
+                s_a.close()
+                s_b.close()
+        finally:
+            eng.dispose()


### PR DESCRIPTION
## Summary
- Audit M-23: \`enforce_pre_call\` reads \`SUM(cost_estimate_usd)\` then writes a new \`ai_invocations\` row — concurrent callers can both observe \`spent < cap\` and both pass the gate (the classic TOCTOU). Same shape for rate-limit window counts.
- Add \`_acquire_household_gate_lock()\` in \`tulip_ai.cost\` and call it at the top of \`enforce_pre_call\`. SQLite uses a no-op \`UPDATE households SET id = id WHERE id = :hid\` to escalate the transaction to RESERVED (single-writer chokepoint); PostgreSQL (Phase 9) uses \`SELECT 1 FROM households ... FOR UPDATE\`. Lock releases at session commit/rollback, same boundary the capability already uses for its \`ai_invocations\` write.
- New tests in \`TestHouseholdGateLockSerialization\` use a file-backed SQLite + short \`busy_timeout\` to verify: held lock blocks the second writer, commit releases it, and \`enforce_pre_call\` itself acquires the lock end-to-end.
- ADR-0005 §Q7 carries the atomicity note.

## Test plan
- [x] \`uv run pytest packages/tulip-ai/tests/test_cost.py -xvs\` — 19 passed (16 existing + 3 new concurrency tests).
- [x] \`uv run pytest packages/tulip-ai/ packages/tulip-storage/ -q\` — 366 passed (no regressions in cost/categorize/proposals/forecast flows that all share \`enforce_pre_call\`).
- [x] \`just lint typecheck\` — clean.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)