### PR TITLE
security: composite PK on audit_log (household_id, id) (closes #337)

### DIFF
--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260517_1400_c7a3f9e2b1d8_audit_log_composite_pk.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260517_1400_c7a3f9e2b1d8_audit_log_composite_pk.py
@@ -1,0 +1,84 @@
+"""Composite primary key on ``audit_log`` (#337, audit M-12).
+
+Promotes ``audit_log.id`` to a composite ``(household_id, id)`` PK so
+the household-scoped-model pattern from ARCHITECTURE §3.3 is enforced
+at the schema layer for audit rows the same way it is for accounts,
+transactions, periods, etc. Today the writer always passes
+``household_id`` correctly, but the schema doesn't prevent a future
+caller (or a manual ``sqlite3`` shell INSERT) from writing a row whose
+``household_id`` points at a tenant that didn't produce it.
+
+The single-column FK to ``households(id)`` stays unchanged — audit_log
+has no children that FK back into it, so there's no composite FK to
+add elsewhere.
+
+SQLite implementation notes:
+
+- SQLite cannot ALTER a table's PRIMARY KEY in place; alembic's
+  ``batch_alter_table`` recreates the table (create new → copy → drop
+  old → rename).
+- Recreating the table drops the BEFORE UPDATE / BEFORE DELETE
+  immutability triggers from #333 (a6f1c9b3d8e4). The migration drops
+  them explicitly before the batch and reinstalls them after — leaving
+  them in place would silently disappear on tables-recreate, which is
+  exactly the kind of "the trigger was here yesterday, where did it go"
+  that M-22 is meant to prevent.
+
+Revision ID: c7a3f9e2b1d8
+Revises: a6f1c9b3d8e4
+Create Date: 2026-05-17 14:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "c7a3f9e2b1d8"
+down_revision: str | None = "a6f1c9b3d8e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_TRIGGER_NO_UPDATE_SQL = """
+CREATE TRIGGER trg_audit_log_no_update
+BEFORE UPDATE ON audit_log
+BEGIN
+  SELECT RAISE(ABORT, 'audit_log is append-only (M-22)');
+END;
+"""
+
+_TRIGGER_NO_DELETE_SQL = """
+CREATE TRIGGER trg_audit_log_no_delete
+BEFORE DELETE ON audit_log
+BEGIN
+  SELECT RAISE(ABORT, 'audit_log is append-only (M-22)');
+END;
+"""
+
+
+def upgrade() -> None:
+    """Drop immutability triggers, swap PK to composite, reinstall triggers."""
+    op.execute("DROP TRIGGER IF EXISTS trg_audit_log_no_update")
+    op.execute("DROP TRIGGER IF EXISTS trg_audit_log_no_delete")
+
+    with op.batch_alter_table("audit_log", schema=None) as batch_op:
+        batch_op.drop_constraint("pk_audit_log", type_="primary")
+        batch_op.create_primary_key("pk_audit_log", ["household_id", "id"])
+
+    op.execute(_TRIGGER_NO_UPDATE_SQL)
+    op.execute(_TRIGGER_NO_DELETE_SQL)
+
+
+def downgrade() -> None:
+    """Restore the single-column ``id`` PK; reinstall the triggers."""
+    op.execute("DROP TRIGGER IF EXISTS trg_audit_log_no_update")
+    op.execute("DROP TRIGGER IF EXISTS trg_audit_log_no_delete")
+
+    with op.batch_alter_table("audit_log", schema=None) as batch_op:
+        batch_op.drop_constraint("pk_audit_log", type_="primary")
+        batch_op.create_primary_key("pk_audit_log", ["id"])
+
+    op.execute(_TRIGGER_NO_UPDATE_SQL)
+    op.execute(_TRIGGER_NO_DELETE_SQL)

--- a/packages/tulip-storage/src/tulip_storage/models/audit_log.py
+++ b/packages/tulip-storage/src/tulip_storage/models/audit_log.py
@@ -16,21 +16,26 @@ from tulip_storage.models.household import Household
 class AuditLog(Base):
     """An append-only audit row.
 
-    Schema follows ARCHITECTURE §4.1. v1 doesn't physically enforce
-    immutability (true OS-level append-only is deferred to the Postgres
-    phase per §1.3); the application layer simply never updates or
-    deletes rows in this table.
+    Schema follows ARCHITECTURE §4.1. Composite primary key
+    ``(household_id, id)`` matches the household-scoped-model pattern
+    in §3.3 (#337, audit M-12): cross-tenant inserts become a schema-
+    level impossibility rather than a writer-class invariant. The single
+    -column FK to ``households.id`` stays — audit_log has no children, so
+    no other table needs a composite FK into it.
+
+    Application-level immutability (the writer never updates or deletes
+    rows) is paired with SQLite triggers from #333 (M-22).
     """
 
     __tablename__ = "audit_log"
 
-    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
     household_id: Mapped[UUID] = mapped_column(
         GUID(),
         ForeignKey("households.id", ondelete="CASCADE"),
-        nullable=False,
+        primary_key=True,
         index=True,
     )
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
     occurred_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, index=True
     )

--- a/packages/tulip-storage/tests/test_migrations.py
+++ b/packages/tulip-storage/tests/test_migrations.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 from alembic.command import downgrade, upgrade
 from alembic.config import Config
-from sqlalchemy import event, inspect
+from sqlalchemy import event, inspect, text
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -114,6 +114,63 @@ class TestCompositeFkAiInvocationId:
             with pytest.raises(IntegrityError):
                 s.flush()
             s.rollback()
+
+
+class TestAuditLogCompositePk:
+    """#337 (audit M-12): ``audit_log`` PK is ``(household_id, id)`` post-migration."""
+
+    def test_audit_log_pk_is_composite_at_head(self, migrated_db):
+        _, maker = migrated_db
+        with maker() as s:
+            cols = [r[1] for r in s.execute(text("PRAGMA table_info(audit_log)")) if r[5]]
+        # PRAGMA table_info `pk` (column 5) is 1-based ordinal in the PK;
+        # both household_id and id should be present in the PK column set.
+        assert "household_id" in cols
+        assert "id" in cols
+        assert set(cols) == {"household_id", "id"}
+
+    def test_immutability_triggers_survive_pk_migration(self, migrated_db):
+        """The PK swap recreates the table; triggers must be reinstalled."""
+        _, maker = migrated_db
+        with maker() as s:
+            names = {
+                r[0]
+                for r in s.execute(
+                    text(
+                        "SELECT name FROM sqlite_master WHERE type='trigger' "
+                        "AND name LIKE 'trg_audit_log%'"
+                    )
+                )
+            }
+        assert names == {"trg_audit_log_no_update", "trg_audit_log_no_delete"}
+
+    def test_audit_log_pk_round_trips(self, tmp_path):
+        """Upgrade → downgrade-1 → upgrade restores the composite PK + triggers."""
+        from sqlalchemy import create_engine
+
+        db_path = tmp_path / "audit_pk_roundtrip.db"
+        cfg = _make_alembic_cfg(f"sqlite:///{db_path}")
+        upgrade(cfg, "head")
+        downgrade(cfg, "-1")
+        upgrade(cfg, "head")
+
+        eng = create_engine(f"sqlite:///{db_path}", future=True)
+        try:
+            with eng.connect() as conn:
+                pk_cols = [r[1] for r in conn.execute(text("PRAGMA table_info(audit_log)")) if r[5]]
+                trigger_names = {
+                    r[0]
+                    for r in conn.execute(
+                        text(
+                            "SELECT name FROM sqlite_master WHERE type='trigger' "
+                            "AND name LIKE 'trg_audit_log%'"
+                        )
+                    )
+                }
+        finally:
+            eng.dispose()
+        assert set(pk_cols) == {"household_id", "id"}
+        assert trigger_names == {"trg_audit_log_no_update", "trg_audit_log_no_delete"}
 
 
 class TestMigrationsRoundTrip:


### PR DESCRIPTION
## Summary
- Audit M-12: every household-scoped model in ARCHITECTURE §3.3 carries a composite \`(household_id, id)\` PK — except \`audit_log\`. AuditLogWriter always passes the correct \`household_id\`, but a future regression (or a manual \`sqlite3\` shell INSERT) could plant a row pointing at a tenant that didn't produce it, with nothing at the schema layer to catch.
- Promote \`audit_log.id\` to a composite \`(household_id, id)\` PK to match the rest of the schema. \`audit_log\` has no children that FK into it, so the single-column FK to \`households(id)\` stays — no composite FK needed downstream.
- SQLite specifics: \`batch_alter_table\` recreates the table, which drops the \`BEFORE UPDATE\` / \`BEFORE DELETE\` immutability triggers from #333. The migration drops them explicitly first, swaps the PK, then reinstalls — both up and down — so the M-22 enforcement layer survives the schema change.

## Test plan
- [x] New \`TestAuditLogCompositePk\` (3 tests): post-migration PK columns are \`{household_id, id}\`; both immutability triggers survive; upgrade → downgrade → upgrade preserves PK + triggers.
- [x] \`uv run pytest packages/tulip-storage/ -q\` — 249 passed (no regressions in audit-retention handler, writer chokepoint, or migration round-trip).
- [x] \`uv run pytest packages/tulip-api/ -q\` — 888 passed; 8 pre-existing macOS \`libpango\` PDF-render failures unchanged.
- [x] \`just lint typecheck\` — clean.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)