### PR TITLE
P9.1 — TUI accounts browser (#309)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + P9.0 tulip-tui skeleton shipped** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell + pilot-mode smoke test landed; P9.1+ queued per #309.
+**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + P9.0 tulip-tui skeleton shipped + P9.1 accounts browser shipped** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell landed; P9.1 first real screen (accounts browser, grouped DataTable, in-memory loader seam) landed; P9.2–P9.4 queued per #309.
 
 ---
 
@@ -30,7 +30,7 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **CLI + importers usability bundle (post-audit):** ✅ shipped — transaction id-prefix display + prefix resolution (#207/#211), interactive reconciliation wizard (#205), `tulip imports show`/`list` (#203/#272), QIF split-posting fidelity (#270) + non-transaction-section skipping (#198) + multi-account import with transfer pairing (#195a/#195b), paper-statement reconciliation (#275), `tulip imports apply --posted` (#210), currency-natural amount precision (#213), account names in `transactions list`/`show` (#214), transaction-level notes (#271), account resolution by name / hierarchical path (#197), interactive UUID picker (#273), `--pending` balance toggle (#274), Rich `Console` honouring `COLUMNS` (#285), right-aligned numeric columns (#289), `/reject` OpenAPI 400 (#194).
 
-- **Phase 9 (terminal UI):** 🔄 design pass complete (2026-05-17) + P9.0 skeleton shipped (2026-05-17) — per [ADR-0007](adrs/0007-terminal-ui.md), a Textual TUI as an additive client (CLI stays the scriptable surface). v1 scope is read/browse only. Cross-cutting design questions resolved: bill data-model in [ADR-0008](adrs/0008-bills-data-model.md), other four in [TUI_WIREFRAMES.md § Cross-cutting decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17). `packages/tulip-tui/` workspace package + pilot-mode smoke test now in tree; P9.1–P9.4 (account browser, transaction register, reports viewer, reconciliation/import status) queued per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). Sits after Phase 8 wraps; pre-cloud preparation renumbers to **Phase 10**.
+- **Phase 9 (terminal UI):** 🔄 design pass complete (2026-05-17) + P9.0 skeleton shipped (2026-05-17) + P9.1 accounts browser shipped (2026-05-17) — per [ADR-0007](adrs/0007-terminal-ui.md), a Textual TUI as an additive client (CLI stays the scriptable surface). v1 scope is read/browse only. Cross-cutting design questions resolved: bill data-model in [ADR-0008](adrs/0008-bills-data-model.md), other four in [TUI_WIREFRAMES.md § Cross-cutting decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17). `packages/tulip-tui/` workspace package, pilot-mode smoke test, and the accounts browser (grouped DataTable with per-currency subtotals, loader-seam tested in-memory) now in tree; P9.2–P9.4 (transaction register, reports viewer, reconciliation/import status) queued per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). Sits after Phase 8 wraps; pre-cloud preparation renumbers to **Phase 10**.
 
 **Tests:** 1828 passing · **CI:** green on `main`
 
@@ -1557,10 +1557,41 @@ shell that the rest of Phase 9 fills in.
 The next slice (P9.1 — account browser) is the first to introduce a
 real screen and the first real API call.
 
-### P9.1 — Account browser — ⏳ queued
+### P9.1 — Account browser — ✅ *(2026-05-17)*
 
-Navigable tree/list of the chart of accounts with balances; drill into
-an account to see its transactions (reusing the P9.2 register).
+Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). First real Tulip TUI screen and the
+first slice that performs an authenticated API round-trip.
+
+- **Data layer** — `tulip_tui/data/accounts.py` adds an immutable
+  `AccountSummary` / `AccountGroup` / `AccountsData` triple and a
+  `load_accounts(client)` function that joins `GET /v1/accounts`
+  (every active account, including ones with no postings) with
+  `GET /v1/reports/trial-balance` (per-account balances). Accounts
+  with no trial-balance row keep `balance = None` so the screen can
+  render `—` instead of a misleading `0.00`.
+- **AccountsScreen** — grouped `DataTable` rendering: one row per
+  group header (`── ASSET ──`), member account rows beneath, and a
+  per-group subtotal row (`subtotal: 15,741.18 USD, …`). Comma-grouped
+  balances; sign preserved on negatives; `r` rebinds to refresh.
+- **App wiring** — `TulipTuiApp(loader: AccountsLoader)` pushes
+  `AccountsScreen` on mount. Production `main.run()` installs a loader
+  that opens a `TulipClient` per load against the CLI's stored
+  `api_url` + token store; tests inject in-memory `AccountsData`
+  through the same constructor.
+- **Failure mode** — loader exceptions render inline in the status
+  strip and the `q` quit binding still works. A network blip should
+  not pull the user out of their TUI session.
+- **Tests** — 5 unit tests cover the data join (balance fill, empty
+  household, error propagation); 4 pilot tests cover the screen
+  (group/subtotal rendering, empty state, error state, `—`
+  no-postings render). The P9.0 boot test now boots into the screen
+  with an empty loader; the architecture test is unchanged.
+- **Out of scope** — drill-in to per-account transactions
+  (lands in P9.2); status markers (`●` / `⚠`), reconcile badges,
+  account-number masking, credit-card sub-rows: those require API
+  surfaces that don't exist yet and are part of the broader Phase 9
+  cross-cutting decisions ([TUI_WIREFRAMES.md § Cross-cutting
+  decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17)).
 
 ### P9.2 — Transaction register — ⏳ queued
 

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -1,32 +1,34 @@
 """The top-level Textual ``App`` for tulip-tui.
 
-P9.0 ships only the shell - a mounted app that reaches a runnable state
-and quits cleanly on ``q``. Real screens (account browser, transaction
-register, reports, reconciliation/import status) arrive in P9.1-P9.4 per
-[#309](https://github.com/rmwarriner/tulip-accounting/issues/309).
+P9.1 swaps the placeholder shell for the accounts browser as the
+default screen. The app accepts an optional ``loader`` callable so
+tests can inject in-memory ``AccountsData`` without spinning up a
+``TulipClient``; production wiring (``main.run``) installs the loader
+that round-trips through the API.
 """
 
 from __future__ import annotations
 
 from typing import ClassVar
 
-from textual.app import App, ComposeResult
+from textual.app import App
 from textual.binding import Binding, BindingType
-from textual.widgets import Footer, Header, Static
+
+from tulip_tui.screens.accounts import AccountsLoader, AccountsScreen
 
 
 class TulipTuiApp(App[None]):
-    """Tulip TUI shell - placeholder until P9.1 lands the first real screen."""
+    """Tulip TUI shell — boots into the accounts browser."""
 
     TITLE = "tulip"
     SUB_TITLE = "terminal UI"
     BINDINGS: ClassVar[list[BindingType]] = [Binding("q", "quit", "quit", show=True)]
 
-    def compose(self) -> ComposeResult:
-        """Yield the static placeholder layout for the P9.0 shell."""
-        yield Header()
-        yield Static(
-            "tulip-tui - Phase 9 shell.\nScreens land in subsequent slices (see #309).",
-            id="welcome",
-        )
-        yield Footer()
+    def __init__(self, *, loader: AccountsLoader) -> None:
+        """Store the accounts loader the default screen will use on mount."""
+        super().__init__()
+        self._loader = loader
+
+    def on_mount(self) -> None:
+        """Push the accounts browser as the initial screen."""
+        self.push_screen(AccountsScreen(self._loader))

--- a/packages/tulip-tui/src/tulip_tui/data/__init__.py
+++ b/packages/tulip-tui/src/tulip_tui/data/__init__.py
@@ -1,0 +1,7 @@
+"""Data-layer adapters for the Tulip TUI.
+
+Pure Python: assemble domain-shaped value objects from the API's JSON
+responses so the Textual layer never has to reach into raw dicts. Lets
+screens be tested against in-memory fixtures without spinning up a
+client or stubbing httpx.
+"""

--- a/packages/tulip-tui/src/tulip_tui/data/accounts.py
+++ b/packages/tulip-tui/src/tulip_tui/data/accounts.py
@@ -1,0 +1,125 @@
+"""Accounts-screen data adapter.
+
+Combines two API reads into one immutable value object:
+
+* ``GET /v1/accounts`` — every active account visible to the caller.
+  Returns rows even when they have no postings, which matters for the
+  TUI: a brand-new account should still appear in the browser.
+* ``GET /v1/reports/trial-balance`` — current per-account balance in
+  each account's currency. Only contains rows for accounts that have at
+  least one posting.
+
+The join is by ``account_id``. Accounts with no trial-balance row keep
+``balance = None`` so the screen can distinguish "zero" (a real
+$0.00 ledger) from "never posted" (no data yet).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from tulip_cli.http import TulipClient
+
+
+@dataclass(frozen=True, slots=True)
+class CurrencyTotal:
+    """Sum of balances within a single currency."""
+
+    currency: str
+    amount: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class AccountSummary:
+    """One row in the account browser."""
+
+    id: str
+    code: str | None
+    name: str
+    type: str
+    currency: str
+    balance: Decimal | None
+
+
+@dataclass(frozen=True, slots=True)
+class AccountGroup:
+    """Accounts sharing an account ``type`` (``asset`` / ``liability`` / …)."""
+
+    type: str
+    accounts: tuple[AccountSummary, ...]
+    totals: tuple[CurrencyTotal, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AccountsData:
+    """The full payload the accounts screen needs to render."""
+
+    as_of: str
+    accounts: tuple[AccountSummary, ...]
+    groups: tuple[AccountGroup, ...]
+
+
+def load_accounts(client: TulipClient) -> AccountsData:
+    """Fetch + join ``/v1/accounts`` and ``/v1/reports/trial-balance``."""
+    accounts_raw = client.get("/v1/accounts", authenticated=True).json()
+    trial_raw = client.get("/v1/reports/trial-balance", authenticated=True).json()
+
+    balances_by_id = {
+        str(row["account_id"]): Decimal(str(row["balance"])) for row in trial_raw.get("rows", [])
+    }
+
+    summaries: list[AccountSummary] = []
+    for raw in accounts_raw:
+        account_id = str(raw["id"])
+        summaries.append(
+            AccountSummary(
+                id=account_id,
+                code=raw.get("code"),
+                name=str(raw.get("name", "")),
+                type=str(raw.get("type", "")),
+                currency=str(raw.get("currency", "")),
+                balance=balances_by_id.get(account_id),
+            )
+        )
+
+    return AccountsData(
+        as_of=str(trial_raw.get("as_of", "")),
+        accounts=tuple(summaries),
+        groups=tuple(_group_by_type(summaries)),
+    )
+
+
+def _group_by_type(summaries: list[AccountSummary]) -> list[AccountGroup]:
+    """Group summaries by ``type`` preserving first-seen order; sum per-currency."""
+    bucketed: dict[str, list[AccountSummary]] = {}
+    for summary in summaries:
+        bucketed.setdefault(summary.type, []).append(summary)
+
+    groups: list[AccountGroup] = []
+    for atype, members in bucketed.items():
+        per_currency: dict[str, Decimal] = {}
+        for member in members:
+            if member.balance is None:
+                continue
+            per_currency[member.currency] = (
+                per_currency.get(member.currency, Decimal("0")) + member.balance
+            )
+        totals = tuple(CurrencyTotal(currency=cur, amount=amt) for cur, amt in per_currency.items())
+        groups.append(
+            AccountGroup(
+                type=atype,
+                accounts=tuple(members),
+                totals=totals,
+            )
+        )
+    return groups
+
+
+__all__: list[str] = [
+    "AccountGroup",
+    "AccountSummary",
+    "AccountsData",
+    "CurrencyTotal",
+    "load_accounts",
+]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -1,10 +1,27 @@
-"""Entry point for the ``tulip-tui`` console script."""
+"""Entry point for the ``tulip-tui`` console script.
+
+Resolves the CLI's stored ``api_url`` + on-disk token store, then
+hands a closure that round-trips ``load_accounts`` against that
+client into ``TulipTuiApp``. Tests bypass this path entirely by
+constructing ``TulipTuiApp(loader=...)`` directly.
+"""
 
 from __future__ import annotations
 
+from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.config import load_config
+from tulip_cli.http import TulipClient
 from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData, load_accounts
+
+
+def _production_loader() -> AccountsData:
+    """Open a fresh ``TulipClient`` per load and round-trip ``load_accounts``."""
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return load_accounts(client)
 
 
 def run() -> None:
-    """Launch the Tulip TUI under the user's terminal."""
-    TulipTuiApp().run()
+    """Launch the Tulip TUI against the configured API."""
+    TulipTuiApp(loader=_production_loader).run()

--- a/packages/tulip-tui/src/tulip_tui/screens/__init__.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/__init__.py
@@ -1,0 +1,5 @@
+"""Textual screens for the Tulip TUI.
+
+Each screen is a self-contained view: it is built with a *loader*
+callable so production wiring and tests both swap data in the same way.
+"""

--- a/packages/tulip-tui/src/tulip_tui/screens/accounts.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/accounts.py
@@ -1,0 +1,180 @@
+"""Accounts browser — the v1 TUI's default screen.
+
+Renders the chart of accounts grouped by type with per-currency
+subtotals (mirrors the wireframe in ``docs/TUI_WIREFRAMES.md §
+Accounts``). The screen is built with a *loader* callable so production
+wiring (a real ``TulipClient`` round-trip) and tests (an in-memory
+fixture) flow through the same seam.
+
+A loader exception is rendered inline rather than crashing the app —
+the TUI is the user's whole working environment for the session, so a
+network blip shouldn't pull them out of it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+from tulip_tui.data.accounts import AccountsData, AccountSummary, CurrencyTotal
+
+AccountsLoader = Callable[[], AccountsData]
+
+
+def _fmt_balance(balance: Decimal | None) -> str:
+    """Render a balance with sign preserved; ``—`` when no postings exist."""
+    if balance is None:
+        return "—"
+    quantised = balance.quantize(Decimal("0.01"))
+    return f"{quantised:,.2f}"
+
+
+def _fmt_subtotal(total: CurrencyTotal) -> str:
+    return f"{_fmt_balance(total.amount)} {total.currency}"
+
+
+def _group_header_text(group_type: str) -> str:
+    return f"── {group_type.upper()} ──"
+
+
+def _subtotal_row_text(totals: tuple[CurrencyTotal, ...]) -> str:
+    if not totals:
+        return "subtotal: —"
+    return "subtotal: " + ", ".join(_fmt_subtotal(t) for t in totals)
+
+
+class AccountsScreen(Screen[None]):
+    """List accounts grouped by type with per-currency subtotals."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("r", "refresh", "refresh", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    AccountsScreen {
+        layout: vertical;
+    }
+
+    AccountsScreen #status {
+        height: auto;
+        padding: 0 1;
+    }
+
+    AccountsScreen #empty {
+        padding: 1 2;
+    }
+
+    AccountsScreen DataTable {
+        height: 1fr;
+    }
+    """
+
+    def __init__(self, loader: AccountsLoader) -> None:
+        """Store the loader the screen will pull ``AccountsData`` from."""
+        super().__init__()
+        self._loader = loader
+        self._rendered_rows: list[str] = []
+        self.last_error: str | None = None
+        self._empty: bool = False
+
+    def compose(self) -> ComposeResult:
+        """Lay out the header, status strip, data table, and footer."""
+        yield Header()
+        with Vertical():
+            yield Static("loading accounts…", id="status")
+            yield DataTable(id="accounts", zebra_stripes=True, cursor_type="row")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Install column headers, then run the initial load."""
+        table = self.query_one("#accounts", DataTable)
+        table.add_columns("Code", "Account", "Type", "Currency", "Balance")
+        self._load()
+
+    def action_refresh(self) -> None:
+        """Re-run the loader and rebuild the table in place."""
+        self._load()
+
+    # -- internals -----------------------------------------------------
+
+    def _load(self) -> None:
+        """Run the loader synchronously and rebuild the table.
+
+        The loader is sync today (production wraps a blocking
+        ``httpx.Client``). The accounts read is small enough that the
+        UI doesn't notice; moving the call onto a worker thread is the
+        right answer once a screen actually starts blocking on
+        large responses.
+        """
+        self.last_error = None
+        try:
+            data = self._loader()
+        except Exception as exc:
+            # Loader failures (network blip, expired token, server 5xx)
+            # must surface inline rather than crashing the TUI.
+            self.last_error = str(exc)
+            self._render_error(exc)
+            return
+        self._populate(data)
+
+    def _populate(self, data: AccountsData) -> None:
+        table = self.query_one("#accounts", DataTable)
+        table.clear()
+        self._rendered_rows = []
+
+        status = self.query_one("#status", Static)
+        status.update(f"as of {data.as_of} · {len(data.accounts)} accounts")
+
+        if not data.accounts:
+            self._empty = True
+            # An empty table is jarring without context; surface the
+            # condition in the status strip and skip row emission.
+            table.add_row("—", "No accounts yet.", "—", "—", "—")
+            self._rendered_rows.append("No accounts yet.")
+            return
+
+        self._empty = False
+        for group in data.groups:
+            header_text = _group_header_text(group.type)
+            table.add_row(header_text, "", "", "", "")
+            self._rendered_rows.append(header_text)
+            for account in group.accounts:
+                self._add_account_row(table, account)
+            subtotal_text = _subtotal_row_text(group.totals)
+            table.add_row("", subtotal_text, "", "", "")
+            self._rendered_rows.append(subtotal_text)
+
+    def _add_account_row(self, table: DataTable[str], account: AccountSummary) -> None:
+        code = account.code or "—"
+        balance = _fmt_balance(account.balance)
+        table.add_row(code, account.name, account.type, account.currency, balance)
+        # Maintain a string-only mirror so tests can assert content
+        # without depending on DataTable internals.
+        self._rendered_rows.append(
+            " ".join([code, account.name, account.type, account.currency, balance])
+        )
+
+    def _render_error(self, exc: BaseException) -> None:
+        table = self.query_one("#accounts", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._empty = False
+        status = self.query_one("#status", Static)
+        status.update(f"[red]error:[/red] {exc}")
+
+    # -- introspection used by tests ----------------------------------
+
+    def rendered_rows(self) -> list[str]:
+        """Return a string-only mirror of the table's rows for assertions."""
+        return list(self._rendered_rows)
+
+    def has_no_accounts(self) -> bool:
+        """True when the most-recent load returned zero accounts."""
+        return self._empty

--- a/packages/tulip-tui/tests/test_accounts_data.py
+++ b/packages/tulip-tui/tests/test_accounts_data.py
@@ -1,0 +1,294 @@
+"""Unit tests for ``tulip_tui.data.accounts``.
+
+The data layer composes ``GET /v1/accounts`` (every active account in
+the household, including those with no postings) with
+``GET /v1/reports/trial-balance`` (balances per account in its currency)
+into a single value object that screens can render without touching
+JSON or httpx. Accounts with no postings get a ``None`` balance so the
+screen can distinguish "zero" from "never posted".
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tulip_cli.config import Config
+from tulip_cli.http import TulipClient
+from tulip_tui.data.accounts import (
+    AccountsData,
+    AccountSummary,
+    CurrencyTotal,
+    load_accounts,
+)
+
+_ACCOUNT_CHECKING_ID = "11111111-1111-1111-1111-111111111111"
+_ACCOUNT_SAVINGS_ID = "22222222-2222-2222-2222-222222222222"
+_ACCOUNT_VISA_ID = "33333333-3333-3333-3333-333333333333"
+_ACCOUNT_EXPENSE_ID = "44444444-4444-4444-4444-444444444444"
+_ACCOUNT_NO_POSTING_ID = "55555555-5555-5555-5555-555555555555"
+
+
+def _accounts_response() -> list[dict[str, object]]:
+    return [
+        {
+            "id": _ACCOUNT_CHECKING_ID,
+            "code": "assets:checking",
+            "name": "Checking",
+            "type": "asset",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+        },
+        {
+            "id": _ACCOUNT_SAVINGS_ID,
+            "code": "assets:savings",
+            "name": "Savings",
+            "type": "asset",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+        },
+        {
+            "id": _ACCOUNT_VISA_ID,
+            "code": "liabilities:visa",
+            "name": "Visa",
+            "type": "liability",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+        },
+        {
+            "id": _ACCOUNT_EXPENSE_ID,
+            "code": "expenses:groceries",
+            "name": "Groceries",
+            "type": "expense",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+        },
+        {
+            "id": _ACCOUNT_NO_POSTING_ID,
+            "code": "assets:vacation-fund",
+            "name": "Vacation Fund",
+            "type": "asset",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+        },
+    ]
+
+
+def _trial_balance_response() -> dict[str, object]:
+    return {
+        "as_of": "2026-05-17",
+        "rows": [
+            {
+                "account_id": _ACCOUNT_CHECKING_ID,
+                "code": "assets:checking",
+                "name": "Checking",
+                "type": "asset",
+                "currency": "USD",
+                "balance": "3241.18",
+                "has_pending": False,
+            },
+            {
+                "account_id": _ACCOUNT_SAVINGS_ID,
+                "code": "assets:savings",
+                "name": "Savings",
+                "type": "asset",
+                "currency": "USD",
+                "balance": "12500.00",
+                "has_pending": False,
+            },
+            {
+                "account_id": _ACCOUNT_VISA_ID,
+                "code": "liabilities:visa",
+                "name": "Visa",
+                "type": "liability",
+                "currency": "USD",
+                "balance": "-842.55",
+                "has_pending": False,
+            },
+            {
+                "account_id": _ACCOUNT_EXPENSE_ID,
+                "code": "expenses:groceries",
+                "name": "Groceries",
+                "type": "expense",
+                "currency": "USD",
+                "balance": "256.40",
+                "has_pending": False,
+            },
+        ],
+        "totals_by_currency": [
+            {"currency": "USD", "debits": "15997.58", "credits": "-842.55"},
+        ],
+        "pending_included": False,
+        "pending_count": 0,
+    }
+
+
+class _FakeTokenStore:
+    """Stand-in for ``tulip_cli.auth.tokens.TokenStore``.
+
+    Returns a token whose ``access_expires_at`` is far enough in the
+    future that ``TulipClient`` never tries the refresh path during a
+    test. ``save`` / ``clear`` are no-ops because the mock transport
+    never returns a 4xx that would trigger them.
+    """
+
+    def load(self, _api_url: str) -> object:
+        return SimpleNamespace(
+            email="t@example.invalid",
+            access_token="fake-access-token",
+            refresh_token="fake-refresh-token",
+            access_expires_at=2**31 - 1,
+        )
+
+    def save(self, _api_url: str, _tokens: object) -> None: ...
+    def clear(self, _api_url: str) -> None: ...
+
+
+def _build_client(handler: httpx.MockTransport) -> TulipClient:
+    return TulipClient(
+        Config(api_url="https://example.invalid"),
+        token_store=_FakeTokenStore(),  # type: ignore[arg-type]
+        transport=handler,
+    )
+
+
+def test_load_accounts_joins_accounts_and_trial_balance() -> None:
+    """``load_accounts`` joins by ``id`` / ``account_id`` and fills balances."""
+    accounts_payload = _accounts_response()
+    trial_payload = _trial_balance_response()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts_payload)
+        if request.url.path == "/v1/reports/trial-balance":
+            return httpx.Response(200, json=trial_payload)
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_accounts(client)
+
+    assert isinstance(data, AccountsData)
+    assert data.as_of == "2026-05-17"
+    by_id = {a.id: a for a in data.accounts}
+    assert by_id[_ACCOUNT_CHECKING_ID].balance == Decimal("3241.18")
+    assert by_id[_ACCOUNT_SAVINGS_ID].balance == Decimal("12500.00")
+    assert by_id[_ACCOUNT_VISA_ID].balance == Decimal("-842.55")
+    assert by_id[_ACCOUNT_EXPENSE_ID].balance == Decimal("256.40")
+    # Vacation Fund has no trial-balance row → balance is None, not zero.
+    assert by_id[_ACCOUNT_NO_POSTING_ID].balance is None
+
+
+def test_load_accounts_surfaces_account_metadata() -> None:
+    """Each summary carries the metadata the screen needs to render rows."""
+    accounts_payload = _accounts_response()
+    trial_payload = _trial_balance_response()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts_payload)
+        if request.url.path == "/v1/reports/trial-balance":
+            return httpx.Response(200, json=trial_payload)
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_accounts(client)
+
+    checking = next(a for a in data.accounts if a.id == _ACCOUNT_CHECKING_ID)
+    assert isinstance(checking, AccountSummary)
+    assert checking.code == "assets:checking"
+    assert checking.name == "Checking"
+    assert checking.type == "asset"
+    assert checking.currency == "USD"
+
+
+def test_load_accounts_groups_by_type_with_subtotals_per_currency() -> None:
+    """Per-group subtotals roll up the balances in each currency."""
+    accounts_payload = _accounts_response()
+    trial_payload = _trial_balance_response()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts_payload)
+        if request.url.path == "/v1/reports/trial-balance":
+            return httpx.Response(200, json=trial_payload)
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_accounts(client)
+
+    # Five accounts → three type groups: asset, liability, expense. Each
+    # group has one ``CurrencyTotal`` per distinct currency in the group;
+    # the Vacation Fund (no postings) does not contribute to the subtotal.
+    by_type = {g.type: g for g in data.groups}
+    assert set(by_type) == {"asset", "liability", "expense"}
+    assert by_type["asset"].totals == (CurrencyTotal(currency="USD", amount=Decimal("15741.18")),)
+    assert by_type["liability"].totals == (
+        CurrencyTotal(currency="USD", amount=Decimal("-842.55")),
+    )
+    assert by_type["expense"].totals == (CurrencyTotal(currency="USD", amount=Decimal("256.40")),)
+
+
+def test_load_accounts_handles_empty_household() -> None:
+    """No accounts → empty ``AccountsData`` with today's ``as_of`` echoed."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=[])
+        if request.url.path == "/v1/reports/trial-balance":
+            return httpx.Response(
+                200,
+                json={
+                    "as_of": "2026-05-17",
+                    "rows": [],
+                    "totals_by_currency": [],
+                    "pending_included": False,
+                    "pending_count": 0,
+                },
+            )
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_accounts(client)
+
+    assert data.accounts == ()
+    assert data.groups == ()
+    assert data.as_of == "2026-05-17"
+
+
+def test_load_accounts_raises_when_api_returns_error() -> None:
+    """API errors bubble out as ``CliError`` for the screen to surface."""
+    from tulip_cli.errors import CliError
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                "type": "/.well-known/errors/internal",
+                "title": "Internal server error",
+                "status": 500,
+                "detail": "boom",
+                "instance": "",
+                "code": "internal",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client, pytest.raises(CliError):
+        load_accounts(client)

--- a/packages/tulip-tui/tests/test_accounts_screen.py
+++ b/packages/tulip-tui/tests/test_accounts_screen.py
@@ -1,0 +1,156 @@
+"""Pilot-mode tests for ``AccountsScreen``.
+
+The screen is the v1 TUI's default surface (per #309 / P9.1). These
+tests boot the full ``TulipTuiApp`` with a synchronous fake loader so
+no API call or thread pool is involved — we only need to assert the
+screen renders the rows it was given. Async-load + error paths are
+covered separately.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import (
+    AccountGroup,
+    AccountsData,
+    AccountSummary,
+    CurrencyTotal,
+)
+from tulip_tui.screens.accounts import AccountsScreen
+
+
+def _sample_data() -> AccountsData:
+    checking = AccountSummary(
+        id="acc-1",
+        code="assets:checking",
+        name="Checking",
+        type="asset",
+        currency="USD",
+        balance=Decimal("3241.18"),
+    )
+    savings = AccountSummary(
+        id="acc-2",
+        code="assets:savings",
+        name="Savings",
+        type="asset",
+        currency="USD",
+        balance=Decimal("12500.00"),
+    )
+    visa = AccountSummary(
+        id="acc-3",
+        code="liabilities:visa",
+        name="Visa",
+        type="liability",
+        currency="USD",
+        balance=Decimal("-842.55"),
+    )
+    return AccountsData(
+        as_of="2026-05-17",
+        accounts=(checking, savings, visa),
+        groups=(
+            AccountGroup(
+                type="asset",
+                accounts=(checking, savings),
+                totals=(CurrencyTotal(currency="USD", amount=Decimal("15741.18")),),
+            ),
+            AccountGroup(
+                type="liability",
+                accounts=(visa,),
+                totals=(CurrencyTotal(currency="USD", amount=Decimal("-842.55")),),
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_accounts_screen_renders_groups_subtotals_and_accounts() -> None:
+    """Each group emits a header + member rows + subtotal row."""
+    data = _sample_data()
+    app = TulipTuiApp(loader=lambda: data)
+    async with app.run_test() as pilot:
+        # The loader is synchronous + injected, so the screen has its
+        # data by the time the first paint settles.
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, AccountsScreen)
+        rendered = screen.rendered_rows()
+
+    # Two groups; each emits (1 header + N member rows + 1 subtotal).
+    # Assets has 2 members, liabilities has 1, so 4 + 3 = 7 rows total.
+    assert len(rendered) == 7
+
+    asset_header = rendered[0]
+    assert "asset" in asset_header.lower()
+
+    # Account rows include code + name + balance text. Balances are
+    # comma-grouped for readability ("3,241.18" not "3241.18").
+    assert any("Checking" in row and "3,241.18" in row for row in rendered)
+    assert any("Savings" in row and "12,500.00" in row for row in rendered)
+    # Negative liability balance is rendered with the sign preserved.
+    assert any("Visa" in row and "-842.55" in row for row in rendered)
+
+    # Each group's subtotal row carries the per-currency rollup.
+    assert any("15,741.18" in row for row in rendered)
+    assert any("-842.55" in row for row in rendered if "Visa" not in row)
+
+
+@pytest.mark.asyncio
+async def test_accounts_screen_shows_empty_state_when_no_accounts() -> None:
+    """Zero accounts → an explanatory ``Static`` instead of the table."""
+    empty = AccountsData(as_of="2026-05-17", accounts=(), groups=())
+    app = TulipTuiApp(loader=lambda: empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, AccountsScreen)
+        assert screen.has_no_accounts()
+
+
+@pytest.mark.asyncio
+async def test_accounts_screen_renders_error_when_loader_raises() -> None:
+    """A loader exception surfaces inline; the app stays interactive."""
+
+    def boom() -> AccountsData:
+        raise RuntimeError("api unreachable")
+
+    app = TulipTuiApp(loader=boom)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, AccountsScreen)
+        assert screen.last_error == "api unreachable"
+        # Still runnable: quit binding must continue to work.
+        await pilot.press("q")
+    assert app.return_code == 0
+
+
+@pytest.mark.asyncio
+async def test_accounts_screen_shows_balance_dash_when_no_postings() -> None:
+    """An account with ``balance=None`` renders as ``—`` (not ``0.00``)."""
+    fresh = AccountSummary(
+        id="acc-4",
+        code="assets:fresh",
+        name="Fresh",
+        type="asset",
+        currency="USD",
+        balance=None,
+    )
+    data = AccountsData(
+        as_of="2026-05-17",
+        accounts=(fresh,),
+        groups=(AccountGroup(type="asset", accounts=(fresh,), totals=()),),
+    )
+    app = TulipTuiApp(loader=lambda: data)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, AccountsScreen)
+        rendered = screen.rendered_rows()
+
+    fresh_row = next(row for row in rendered if "Fresh" in row)
+    assert "—" in fresh_row
+    assert "0.00" not in fresh_row

--- a/packages/tulip-tui/tests/test_app_boot.py
+++ b/packages/tulip-tui/tests/test_app_boot.py
@@ -1,10 +1,9 @@
 """Pilot-mode boot-and-quit smoke test for the Tulip TUI app shell.
 
-The first slice (P9.0 of [#309](https://github.com/rmwarriner/tulip-accounting/issues/309))
-ships a non-functional app shell — no screens yet, no API calls — but
-asserting boot-and-quit under Textual's headless ``run_test`` harness
-proves the package is wired correctly and gives subsequent slices a
-test scaffold to build on.
+The check shifted from a placeholder-only shell to one that mounts the
+``AccountsScreen`` on startup (P9.1 of [#309](https://github.com/rmwarriner/tulip-accounting/issues/309)).
+We inject an empty ``AccountsData`` loader so the boot path is fully
+in-memory — no API client, no thread pool.
 """
 
 from __future__ import annotations
@@ -12,11 +11,13 @@ from __future__ import annotations
 import pytest
 
 from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
 
 
 @pytest.mark.asyncio
 async def test_app_boots_and_quits_cleanly() -> None:
-    app = TulipTuiApp()
+    empty = AccountsData(as_of="2026-05-17", accounts=(), groups=())
+    app = TulipTuiApp(loader=lambda: empty)
     async with app.run_test() as pilot:
         assert app.is_running
         await pilot.press("q")


### PR DESCRIPTION
## Summary

- First real Tulip TUI screen and the first slice with an authenticated API round-trip. Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309) and the design pass in [`docs/TUI_WIREFRAMES.md § Accounts`](docs/TUI_WIREFRAMES.md#accounts).
- New data layer (`tulip_tui.data.accounts`) joins `GET /v1/accounts` with `GET /v1/reports/trial-balance` into an immutable `AccountsData` value object. Accounts with no postings keep `balance=None` so the screen renders `—` (not a misleading `0.00`).
- `AccountsScreen` renders a grouped `DataTable` with per-currency subtotals, comma-grouped balances, sign preserved on negatives. `r` rebinds to refresh.
- `TulipTuiApp(loader=AccountsLoader)` is the new constructor seam: production `main.run()` opens a fresh `TulipClient` per load against the CLI's stored `api_url` + token store; tests inject `AccountsData` directly through the same callable.
- Loader exceptions render inline in the status strip; `q` still quits. A network blip should not eject the user.

Out of scope (lands in later slices): drill-in to per-account transactions (P9.2); status markers (●/⚠), reconcile badges, account-number masking, credit-card sub-rows — those depend on API surfaces that don't exist yet.

## Test plan

- [x] ` uv run pytest packages/tulip-tui/tests -v` — 12 passing (5 data-join unit tests, 4 screen pilot tests, the boot smoke test, the architecture-boundary test, the src-dir guard).
- [x] `just lint` — clean.
- [x] `just typecheck` — clean (`mypy --strict` over 276 source files).
- [x] `just format-check` — clean.
- [x] Manual smoke (paste-and-run; requires an active `tulip auth login` session against a running API):

      uv run --package tulip-tui tulip-tui

  Expected: the TUI boots into the accounts browser, shows a grouped table (asset / liability / etc.) with comma-grouped balances and a per-currency subtotal row per group. `r` reloads. `q` quits cleanly.

  To stress the error path, run with no API reachable:

      TULIP_API_URL=http://127.0.0.1:1 uv run --package tulip-tui tulip-tui

  Expected: the screen mounts, the status strip shows the connection error in red, and `q` still quits cleanly (no traceback).

- [ ] CI green on this PR.