### PR TITLE
P9.2 — TUI transactions register (#309)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + P9.0 tulip-tui skeleton shipped + P9.1 accounts browser shipped** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell landed; P9.1 first real screen (accounts browser, grouped DataTable, in-memory loader seam) landed; P9.2–P9.4 queued per #309.
+**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + P9.0–P9.2 shipped (skeleton + accounts browser + transactions register with account drill-in)** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell landed; P9.1 first real screen (accounts browser, grouped DataTable, in-memory loader seam) landed; P9.2–P9.4 queued per #309.
 
 ---
 
@@ -1593,11 +1593,40 @@ first slice that performs an authenticated API round-trip.
   cross-cutting decisions ([TUI_WIREFRAMES.md § Cross-cutting
   decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17)).
 
-### P9.2 — Transaction register — ⏳ queued
+### P9.2 — Transaction register — ✅ *(2026-05-17)*
 
-Scrollable, filterable transaction list with a posting detail pane;
-honors the same status / account / date filters that `tulip
-transactions list` exposes.
+Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). Second TUI screen plus the
+first cross-screen navigation flow (drill into an account from the
+accounts browser).
+
+- **Data layer** — `tulip_tui/data/transactions.py` joins
+  `GET /v1/transactions` (filterable by `account_id` / `status` /
+  `from` / `to` / `limit`) with `GET /v1/accounts` for UUID→label
+  resolution. Unknown account ids render as `—`. Each
+  `TransactionSummary` carries an `amount_display` short string
+  (chosen as the first negative leg, sign preserved) so the table
+  doesn't recompute on every paint.
+- **TransactionsScreen** — DataTable with Date / Description /
+  Status / Postings (first two account+amount legs) / Amount;
+  posting-detail pane below that updates as the cursor moves and
+  surfaces reference + notes for the selected transaction.
+  `escape` pops back; `r` rebinds to refresh.
+- **Drill-in from AccountsScreen** — `Enter` on an account row fires
+  the new `on_open_account` callback (group-header / subtotal rows
+  are no-ops). The app wires that to push `TransactionsScreen` with
+  the account's id pre-filtered through a new
+  `transactions_loader_factory` constructor seam.
+- **Failure mode** — loader exceptions surface inline in both the
+  status strip and the detail pane; `escape` + `q` still work.
+- **Tests** — 7 unit tests for the data join (label resolution,
+  filter param passthrough, amount display, empty + error paths); 5
+  pilot tests for the screen + drill-in (row rendering, detail-pane
+  cursor follow, empty state, error path, accounts→transactions
+  navigation captures the right account id).
+- **Out of scope** — surfacing filter widgets in the UI (status /
+  date pickers), AI categorize / split / edit actions, the
+  "marker column" badges from the wireframe (those depend on data
+  the API doesn't yet expose).
 
 ### P9.3 — Reports viewer — ⏳ queued
 

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -1,20 +1,41 @@
 """The top-level Textual ``App`` for tulip-tui.
 
-P9.1 swaps the placeholder shell for the accounts browser as the
-default screen. The app accepts an optional ``loader`` callable so
-tests can inject in-memory ``AccountsData`` without spinning up a
-``TulipClient``; production wiring (``main.run``) installs the loader
-that round-trips through the API.
+The app boots into the accounts browser and supports drill-in to the
+transactions register from there. Both screens consume *loader*
+callables so tests inject in-memory fixtures through the same seam the
+production wiring uses.
+
+``transactions_loader_factory`` is parameterised by ``account_id`` so
+the drill-in passes the selected account through to the API filter; a
+top-level transactions view (no account constraint) calls it with
+``None``.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import ClassVar
 
 from textual.app import App
 from textual.binding import Binding, BindingType
 
 from tulip_tui.screens.accounts import AccountsLoader, AccountsScreen
+from tulip_tui.screens.transactions import TransactionsLoader, TransactionsScreen
+
+TransactionsLoaderFactory = Callable[[str | None], TransactionsLoader]
+
+
+def _no_op_transactions_factory(_account_id: str | None) -> TransactionsLoader:
+    """Default factory used when the caller didn't wire transactions yet.
+
+    Returning a loader that raises is the right shape so the screen's
+    inline error path kicks in (instead of crashing the app).
+    """
+
+    def _raise() -> object:
+        raise RuntimeError("transactions loader not configured")
+
+    return _raise  # type: ignore[return-value]
 
 
 class TulipTuiApp(App[None]):
@@ -24,11 +45,22 @@ class TulipTuiApp(App[None]):
     SUB_TITLE = "terminal UI"
     BINDINGS: ClassVar[list[BindingType]] = [Binding("q", "quit", "quit", show=True)]
 
-    def __init__(self, *, loader: AccountsLoader) -> None:
-        """Store the accounts loader the default screen will use on mount."""
+    def __init__(
+        self,
+        *,
+        loader: AccountsLoader,
+        transactions_loader_factory: TransactionsLoaderFactory = _no_op_transactions_factory,
+    ) -> None:
+        """Store the accounts loader + the transactions-loader factory."""
         super().__init__()
         self._loader = loader
+        self._transactions_factory = transactions_loader_factory
 
     def on_mount(self) -> None:
         """Push the accounts browser as the initial screen."""
-        self.push_screen(AccountsScreen(self._loader))
+        self.push_screen(AccountsScreen(self._loader, on_open_account=self.open_transactions))
+
+    def open_transactions(self, account_id: str | None) -> None:
+        """Push the transactions screen filtered to ``account_id`` (or all)."""
+        loader = self._transactions_factory(account_id)
+        self.push_screen(TransactionsScreen(loader=loader))

--- a/packages/tulip-tui/src/tulip_tui/data/transactions.py
+++ b/packages/tulip-tui/src/tulip_tui/data/transactions.py
@@ -1,0 +1,154 @@
+"""Transaction register data adapter.
+
+Combines ``GET /v1/transactions`` (the raw ledger rows) with
+``GET /v1/accounts`` (UUID → human name) so the screen renders rows
+like ``Trader Joe's · Checking → Groceries  -$67.21`` without doing
+the join itself.
+
+Filter parameters (``account_id`` / ``status`` / ``date_from`` /
+``date_to`` / ``limit``) map 1:1 onto the API's query string and stay
+omitted when the caller leaves them at their default of ``None``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import cast
+
+from tulip_cli.http import TulipClient
+
+
+@dataclass(frozen=True, slots=True)
+class PostingSummary:
+    """One posting line of a transaction with its account label pre-resolved."""
+
+    account_id: str
+    account_label: str
+    amount: Decimal
+    currency: str
+    memo: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TransactionSummary:
+    """One row of the transaction register."""
+
+    id: str
+    date: str
+    description: str
+    reference: str | None
+    notes: str | None
+    status: str
+    postings: tuple[PostingSummary, ...]
+    amount_display: str
+
+
+@dataclass(frozen=True, slots=True)
+class TransactionsData:
+    """The full payload the transactions screen needs."""
+
+    transactions: tuple[TransactionSummary, ...]
+
+
+def load_transactions(
+    client: TulipClient,
+    *,
+    account_id: str | None = None,
+    status: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    limit: int | None = None,
+) -> TransactionsData:
+    """Fetch transactions + the account lookup table, then join in memory."""
+    accounts_raw = client.get("/v1/accounts", authenticated=True).json()
+    label_by_id = {str(a["id"]): _account_label(a) for a in accounts_raw}
+
+    params: dict[str, str] = {}
+    if account_id is not None:
+        params["account_id"] = account_id
+    if status is not None:
+        params["status"] = status
+    if date_from is not None:
+        params["from"] = date_from
+    if date_to is not None:
+        params["to"] = date_to
+    if limit is not None:
+        params["limit"] = str(limit)
+
+    tx_raw = client.get(
+        "/v1/transactions",
+        authenticated=True,
+        params=params or None,
+    ).json()
+
+    summaries = tuple(_to_summary(row, label_by_id) for row in tx_raw)
+    return TransactionsData(transactions=summaries)
+
+
+def _account_label(account: dict[str, object]) -> str:
+    """Use the friendly ``name`` (matches the wireframe); fall back to ``code``."""
+    name = account.get("name")
+    if isinstance(name, str) and name:
+        return name
+    code = account.get("code")
+    return code if isinstance(code, str) and code else "—"
+
+
+def _to_summary(
+    row: dict[str, object],
+    label_by_id: dict[str, str],
+) -> TransactionSummary:
+    # The API returns a list of posting dicts; cast at the trust
+    # boundary instead of validating each field (the OpenAPI contract
+    # test already covers the schema).
+    raw_postings = cast("list[dict[str, object]]", row.get("postings") or [])
+    postings: list[PostingSummary] = []
+    for posting in raw_postings:
+        account_id = str(posting.get("account_id", ""))
+        postings.append(
+            PostingSummary(
+                account_id=account_id,
+                account_label=label_by_id.get(account_id, "—"),
+                amount=Decimal(str(posting.get("amount", "0"))),
+                currency=str(posting.get("currency", "")),
+                memo=_optional_str(posting.get("memo")),
+            )
+        )
+    return TransactionSummary(
+        id=str(row.get("id", "")),
+        date=str(row.get("date", "")),
+        description=str(row.get("description", "")),
+        reference=_optional_str(row.get("reference")),
+        notes=_optional_str(row.get("notes")),
+        status=str(row.get("status", "")),
+        postings=tuple(postings),
+        amount_display=_amount_display(postings),
+    )
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _amount_display(postings: list[PostingSummary]) -> str:
+    """One-line summary for the table — the net spend-side amount with sign.
+
+    Most transactions are two-posting: pick the negative leg (the
+    account that *paid*) and render it as the headline. Multi-currency
+    or multi-leg transactions fall back to the first posting's amount.
+    """
+    if not postings:
+        return ""
+    negatives = [p for p in postings if p.amount < 0]
+    chosen = negatives[0] if negatives else postings[0]
+    quantised = chosen.amount.quantize(Decimal("0.01"))
+    return f"{quantised:,.2f} {chosen.currency}"
+
+
+__all__: list[str] = [
+    "PostingSummary",
+    "TransactionSummary",
+    "TransactionsData",
+    "load_transactions",
+]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -1,9 +1,9 @@
 """Entry point for the ``tulip-tui`` console script.
 
-Resolves the CLI's stored ``api_url`` + on-disk token store, then
-hands a closure that round-trips ``load_accounts`` against that
-client into ``TulipTuiApp``. Tests bypass this path entirely by
-constructing ``TulipTuiApp(loader=...)`` directly.
+Resolves the CLI's stored ``api_url`` + on-disk token store, builds
+loaders for both the accounts and transactions screens, and hands
+them to ``TulipTuiApp``. Tests bypass this path entirely by
+constructing ``TulipTuiApp`` directly with their own loaders.
 """
 
 from __future__ import annotations
@@ -13,15 +13,31 @@ from tulip_cli.config import load_config
 from tulip_cli.http import TulipClient
 from tulip_tui.app import TulipTuiApp
 from tulip_tui.data.accounts import AccountsData, load_accounts
+from tulip_tui.data.transactions import TransactionsData, load_transactions
+from tulip_tui.screens.transactions import TransactionsLoader
 
 
-def _production_loader() -> AccountsData:
+def _accounts_loader() -> AccountsData:
     """Open a fresh ``TulipClient`` per load and round-trip ``load_accounts``."""
     config = load_config()
     with TulipClient(config, token_store=default_token_store()) as client:
         return load_accounts(client)
 
 
+def _transactions_loader_factory(account_id: str | None) -> TransactionsLoader:
+    """Build a loader that pulls transactions filtered by ``account_id``."""
+
+    def _load() -> TransactionsData:
+        config = load_config()
+        with TulipClient(config, token_store=default_token_store()) as client:
+            return load_transactions(client, account_id=account_id)
+
+    return _load
+
+
 def run() -> None:
     """Launch the Tulip TUI against the configured API."""
-    TulipTuiApp(loader=_production_loader).run()
+    TulipTuiApp(
+        loader=_accounts_loader,
+        transactions_loader_factory=_transactions_loader_factory,
+    ).run()

--- a/packages/tulip-tui/src/tulip_tui/screens/accounts.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/accounts.py
@@ -26,6 +26,11 @@ from textual.widgets import DataTable, Footer, Header, Static
 from tulip_tui.data.accounts import AccountsData, AccountSummary, CurrencyTotal
 
 AccountsLoader = Callable[[], AccountsData]
+OpenAccountHandler = Callable[[str | None], None]
+
+
+def _noop_open_account(_account_id: str | None) -> None:
+    """Default drill-in handler — used when no transactions screen is wired."""
 
 
 def _fmt_balance(balance: Decimal | None) -> str:
@@ -76,11 +81,18 @@ class AccountsScreen(Screen[None]):
     }
     """
 
-    def __init__(self, loader: AccountsLoader) -> None:
-        """Store the loader the screen will pull ``AccountsData`` from."""
+    def __init__(
+        self,
+        loader: AccountsLoader,
+        *,
+        on_open_account: OpenAccountHandler = _noop_open_account,
+    ) -> None:
+        """Store the loader and the drill-in callback used by ``enter``."""
         super().__init__()
         self._loader = loader
+        self._on_open_account = on_open_account
         self._rendered_rows: list[str] = []
+        self._row_index_to_account_id: list[str | None] = []
         self.last_error: str | None = None
         self._empty: bool = False
 
@@ -101,6 +113,21 @@ class AccountsScreen(Screen[None]):
     def action_refresh(self) -> None:
         """Re-run the loader and rebuild the table in place."""
         self._load()
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """Drill into the selected row's account, if it maps to one.
+
+        DataTable fires ``RowSelected`` on ``enter``. Group-header and
+        subtotal rows have no associated account id — those are no-ops
+        so the cursor stays free to traverse the whole table.
+        """
+        index = event.cursor_row
+        if index < 0 or index >= len(self._row_index_to_account_id):
+            return
+        account_id = self._row_index_to_account_id[index]
+        if account_id is None:
+            return
+        self._on_open_account(account_id)
 
     # -- internals -----------------------------------------------------
 
@@ -128,6 +155,7 @@ class AccountsScreen(Screen[None]):
         table = self.query_one("#accounts", DataTable)
         table.clear()
         self._rendered_rows = []
+        self._row_index_to_account_id = []
 
         status = self.query_one("#status", Static)
         status.update(f"as of {data.as_of} · {len(data.accounts)} accounts")
@@ -138,6 +166,7 @@ class AccountsScreen(Screen[None]):
             # condition in the status strip and skip row emission.
             table.add_row("—", "No accounts yet.", "—", "—", "—")
             self._rendered_rows.append("No accounts yet.")
+            self._row_index_to_account_id.append(None)
             return
 
         self._empty = False
@@ -145,11 +174,13 @@ class AccountsScreen(Screen[None]):
             header_text = _group_header_text(group.type)
             table.add_row(header_text, "", "", "", "")
             self._rendered_rows.append(header_text)
+            self._row_index_to_account_id.append(None)
             for account in group.accounts:
                 self._add_account_row(table, account)
             subtotal_text = _subtotal_row_text(group.totals)
             table.add_row("", subtotal_text, "", "", "")
             self._rendered_rows.append(subtotal_text)
+            self._row_index_to_account_id.append(None)
 
     def _add_account_row(self, table: DataTable[str], account: AccountSummary) -> None:
         code = account.code or "—"
@@ -160,11 +191,13 @@ class AccountsScreen(Screen[None]):
         self._rendered_rows.append(
             " ".join([code, account.name, account.type, account.currency, balance])
         )
+        self._row_index_to_account_id.append(account.id)
 
     def _render_error(self, exc: BaseException) -> None:
         table = self.query_one("#accounts", DataTable)
         table.clear()
         self._rendered_rows = []
+        self._row_index_to_account_id = []
         self._empty = False
         status = self.query_one("#status", Static)
         status.update(f"[red]error:[/red] {exc}")

--- a/packages/tulip-tui/src/tulip_tui/screens/transactions.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/transactions.py
@@ -1,0 +1,195 @@
+"""Transaction register — P9.2 of [#309](https://github.com/rmwarriner/tulip-accounting/issues/309).
+
+Scrollable list of transactions with a posting-detail pane that
+follows the cursor (mirrors `docs/TUI_WIREFRAMES.md § Transactions
+list`). Filters (status / date / account) flow through the loader at
+construction time; surfacing filter widgets in the UI is a separate
+slice.
+
+Reachable via ``Enter`` from the accounts screen (drills into that
+account's transactions) and via the back-pop binding ``escape``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+from tulip_tui.data.transactions import (
+    PostingSummary,
+    TransactionsData,
+    TransactionSummary,
+)
+
+TransactionsLoader = Callable[[], TransactionsData]
+
+
+def _row_text(tx: TransactionSummary) -> tuple[str, str, str, str, str]:
+    leg_summary = " · ".join(f"{p.account_label} {_signed(p)}" for p in tx.postings[:2])
+    if len(tx.postings) > 2:
+        leg_summary += f" (+{len(tx.postings) - 2})"
+    return (tx.date, tx.description, tx.status, leg_summary, tx.amount_display)
+
+
+def _signed(posting: PostingSummary) -> str:
+    quantised = posting.amount.quantize(Decimal("0.01"))
+    return f"{quantised:,.2f}"
+
+
+def _detail_text(tx: TransactionSummary) -> str:
+    lines = [f"[b]{tx.description}[/b]    {tx.date}    [{tx.status}]"]
+    if tx.reference:
+        lines.append(f"reference: {tx.reference}")
+    if tx.notes:
+        lines.append(f"notes: {tx.notes}")
+    lines.append("")
+    for posting in tx.postings:
+        memo = f"  ({posting.memo})" if posting.memo else ""
+        lines.append(f"  {posting.account_label:<24} {_signed(posting)} {posting.currency}{memo}")
+    return "\n".join(lines)
+
+
+class TransactionsScreen(Screen[None]):
+    """Scrollable transaction list with a posting-detail pane."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "app.pop_screen", "back", show=True),
+        Binding("r", "refresh", "refresh", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    TransactionsScreen {
+        layout: vertical;
+    }
+
+    TransactionsScreen #tx-status {
+        height: auto;
+        padding: 0 1;
+    }
+
+    TransactionsScreen #tx-table {
+        height: 2fr;
+    }
+
+    TransactionsScreen #tx-detail {
+        height: 1fr;
+        padding: 1 2;
+        border-top: solid $accent;
+    }
+    """
+
+    def __init__(self, loader: TransactionsLoader) -> None:
+        """Store the loader; the screen populates on mount."""
+        super().__init__()
+        self._loader = loader
+        self._data: TransactionsData = TransactionsData(transactions=())
+        self._rendered_rows: list[str] = []
+        self._empty = False
+        self._error: str | None = None
+        self._row_index_to_tx: list[TransactionSummary] = []
+        self._detail_text: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Lay out the status strip, table, and posting-detail pane."""
+        yield Header()
+        with Vertical():
+            yield Static("loading transactions…", id="tx-status")
+            yield DataTable(id="tx-table", zebra_stripes=True, cursor_type="row")
+            yield Static("", id="tx-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Install column headers and run the initial load."""
+        table = self.query_one("#tx-table", DataTable)
+        table.add_columns("Date", "Description", "Status", "Postings", "Amount")
+        self._load()
+
+    def action_refresh(self) -> None:
+        """Re-run the loader and repopulate the table in place."""
+        self._load()
+
+    def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
+        """Re-render the detail pane to match the newly-highlighted row."""
+        self._refresh_detail()
+
+    # -- internals -----------------------------------------------------
+
+    def _load(self) -> None:
+        self._error = None
+        try:
+            self._data = self._loader()
+        except Exception as exc:
+            self._error = str(exc)
+            self._render_error(exc)
+            return
+        self._populate(self._data)
+
+    def _populate(self, data: TransactionsData) -> None:
+        table = self.query_one("#tx-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._row_index_to_tx = []
+
+        status = self.query_one("#tx-status", Static)
+        status.update(f"{len(data.transactions)} transactions")
+
+        if not data.transactions:
+            self._empty = True
+            self._set_detail("No transactions match.")
+            return
+
+        self._empty = False
+        for tx in data.transactions:
+            cells = _row_text(tx)
+            table.add_row(*cells)
+            self._rendered_rows.append(" ".join(cells))
+            self._row_index_to_tx.append(tx)
+        self._refresh_detail()
+
+    def _refresh_detail(self) -> None:
+        if not self._row_index_to_tx:
+            return
+        table = self.query_one("#tx-table", DataTable)
+        cursor = table.cursor_row
+        # DataTable.cursor_row is -1 before any row exists; clamp to 0.
+        index = max(0, cursor)
+        if index >= len(self._row_index_to_tx):
+            return
+        tx = self._row_index_to_tx[index]
+        self._set_detail(_detail_text(tx))
+
+    def _render_error(self, exc: BaseException) -> None:
+        table = self.query_one("#tx-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._row_index_to_tx = []
+        self._empty = False
+        status = self.query_one("#tx-status", Static)
+        status.update(f"[red]error:[/red] {exc}")
+        self._set_detail(f"error: {exc}")
+
+    def _set_detail(self, text: str) -> None:
+        self._detail_text = text
+        detail = self.query_one("#tx-detail", Static)
+        detail.update(text)
+
+    # -- introspection used by tests ----------------------------------
+
+    def rendered_rows(self) -> list[str]:
+        """Return a string-only mirror of the table's rows for assertions."""
+        return list(self._rendered_rows)
+
+    def has_no_transactions(self) -> bool:
+        """True when the most-recent load returned zero rows."""
+        return self._empty
+
+    def detail_text(self) -> str:
+        """Return the current detail-pane text as a plain string."""
+        return self._detail_text

--- a/packages/tulip-tui/tests/test_transactions_data.py
+++ b/packages/tulip-tui/tests/test_transactions_data.py
@@ -1,0 +1,294 @@
+"""Unit tests for ``tulip_tui.data.transactions``.
+
+Joins ``GET /v1/transactions`` (raw transaction rows + postings) with
+``GET /v1/accounts`` (account UUID → human label lookup) so the screen
+can render rows that read like ``Trader Joe's · Checking → Groceries``
+without re-doing the join in the UI layer.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tulip_cli.config import Config
+from tulip_cli.http import TulipClient
+from tulip_tui.data.transactions import (
+    PostingSummary,
+    TransactionsData,
+    TransactionSummary,
+    load_transactions,
+)
+
+_TX_1 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_TX_2 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+_CHECKING = "11111111-1111-1111-1111-111111111111"
+_GROCERIES = "22222222-2222-2222-2222-222222222222"
+_VISA = "33333333-3333-3333-3333-333333333333"
+
+
+def _accounts_payload() -> list[dict[str, object]]:
+    return [
+        {
+            "id": _CHECKING,
+            "code": "assets:checking",
+            "name": "Checking",
+            "type": "asset",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+        },
+        {
+            "id": _GROCERIES,
+            "code": "expenses:groceries",
+            "name": "Groceries",
+            "type": "expense",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+        },
+        {
+            "id": _VISA,
+            "code": "liabilities:visa",
+            "name": "Visa",
+            "type": "liability",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+        },
+    ]
+
+
+def _transactions_payload() -> list[dict[str, object]]:
+    return [
+        {
+            "id": _TX_1,
+            "date": "2026-05-14",
+            "description": "Trader Joe's",
+            "reference": None,
+            "notes": None,
+            "status": "posted",
+            "postings": [
+                {
+                    "id": "p1",
+                    "account_id": _CHECKING,
+                    "amount": "-67.21",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+                {
+                    "id": "p2",
+                    "account_id": _GROCERIES,
+                    "amount": "67.21",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+            ],
+        },
+        {
+            "id": _TX_2,
+            "date": "2026-05-12",
+            "description": "Netflix",
+            "reference": "INV-12345",
+            "notes": "annual sub",
+            "status": "pending",
+            "postings": [
+                {
+                    "id": "p3",
+                    "account_id": _VISA,
+                    "amount": "-15.49",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+                {
+                    "id": "p4",
+                    "account_id": _GROCERIES,
+                    "amount": "15.49",
+                    "currency": "USD",
+                    "memo": "subscriptions bucket",
+                    "pool_id": None,
+                },
+            ],
+        },
+    ]
+
+
+class _FakeTokenStore:
+    def load(self, _api_url: str) -> object:
+        return SimpleNamespace(
+            email="t@example.invalid",
+            access_token="fake-access-token",
+            refresh_token="fake-refresh-token",
+            access_expires_at=2**31 - 1,
+        )
+
+    def save(self, _api_url: str, _tokens: object) -> None: ...
+    def clear(self, _api_url: str) -> None: ...
+
+
+def _build_client(handler: httpx.MockTransport) -> TulipClient:
+    return TulipClient(
+        Config(api_url="https://example.invalid"),
+        token_store=_FakeTokenStore(),  # type: ignore[arg-type]
+        transport=handler,
+    )
+
+
+def _handler_factory(
+    *,
+    tx_payload: list[dict[str, object]] | None = None,
+    account_payload: list[dict[str, object]] | None = None,
+    captured_params: dict[str, str] | None = None,
+) -> httpx.MockTransport:
+    """Build a mock transport that serves accounts + transactions."""
+
+    accounts = account_payload if account_payload is not None else _accounts_payload()
+    transactions = tx_payload if tx_payload is not None else _transactions_payload()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts)
+        if request.url.path == "/v1/transactions":
+            if captured_params is not None:
+                captured_params.update(dict(request.url.params))
+            return httpx.Response(200, json=transactions)
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    return httpx.MockTransport(handler)
+
+
+def test_load_transactions_returns_summary_objects() -> None:
+    """Each transaction becomes a ``TransactionSummary`` with typed postings."""
+    with _build_client(_handler_factory()) as client:
+        data = load_transactions(client)
+
+    assert isinstance(data, TransactionsData)
+    assert len(data.transactions) == 2
+    first = data.transactions[0]
+    assert isinstance(first, TransactionSummary)
+    assert first.id == _TX_1
+    assert first.date == "2026-05-14"
+    assert first.description == "Trader Joe's"
+    assert first.status == "posted"
+    assert first.reference is None
+    assert first.notes is None
+    assert len(first.postings) == 2
+    posting = first.postings[0]
+    assert isinstance(posting, PostingSummary)
+    assert posting.account_id == _CHECKING
+    assert posting.account_label == "Checking"
+    assert posting.amount == Decimal("-67.21")
+    assert posting.currency == "USD"
+
+
+def test_load_transactions_resolves_unknown_account_to_em_dash() -> None:
+    """A posting against an unknown account renders ``—`` rather than the UUID."""
+    tx_payload = [
+        {
+            "id": _TX_1,
+            "date": "2026-05-14",
+            "description": "Unknown",
+            "reference": None,
+            "notes": None,
+            "status": "posted",
+            "postings": [
+                {
+                    "id": "p1",
+                    "account_id": "99999999-9999-9999-9999-999999999999",
+                    "amount": "10.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+            ],
+        },
+    ]
+    with _build_client(_handler_factory(tx_payload=tx_payload)) as client:
+        data = load_transactions(client)
+
+    assert data.transactions[0].postings[0].account_label == "—"
+
+
+def test_load_transactions_passes_filter_params_through() -> None:
+    """``account_id`` / ``status`` / ``from`` / ``to`` / ``limit`` reach the API."""
+    captured: dict[str, str] = {}
+    with _build_client(_handler_factory(captured_params=captured)) as client:
+        load_transactions(
+            client,
+            account_id=_CHECKING,
+            status="posted",
+            date_from="2026-05-01",
+            date_to="2026-05-31",
+            limit=50,
+        )
+
+    assert captured == {
+        "account_id": _CHECKING,
+        "status": "posted",
+        "from": "2026-05-01",
+        "to": "2026-05-31",
+        "limit": "50",
+    }
+
+
+def test_load_transactions_omits_filter_params_when_none() -> None:
+    """Default call shape sends no query params."""
+    captured: dict[str, str] = {}
+    with _build_client(_handler_factory(captured_params=captured)) as client:
+        load_transactions(client)
+
+    assert captured == {}
+
+
+def test_load_transactions_summary_carries_amount_text() -> None:
+    """Each summary exposes a short, sign-bearing amount string for the table."""
+    with _build_client(_handler_factory()) as client:
+        data = load_transactions(client)
+
+    # The "amount" the table renders is the sum of the positive postings
+    # (i.e. the absolute movement) rendered with sign preserved on
+    # spend-side transactions.
+    first = data.transactions[0]
+    assert first.amount_display == "-67.21 USD"
+
+    second = data.transactions[1]
+    assert second.amount_display == "-15.49 USD"
+
+
+def test_load_transactions_handles_empty_result() -> None:
+    with _build_client(_handler_factory(tx_payload=[])) as client:
+        data = load_transactions(client)
+
+    assert data.transactions == ()
+
+
+def test_load_transactions_raises_on_api_error() -> None:
+    from tulip_cli.errors import CliError
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                "type": "/.well-known/errors/internal",
+                "title": "Internal server error",
+                "status": 500,
+                "detail": "boom",
+                "instance": "",
+                "code": "internal",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client, pytest.raises(CliError):
+        load_transactions(client)

--- a/packages/tulip-tui/tests/test_transactions_screen.py
+++ b/packages/tulip-tui/tests/test_transactions_screen.py
@@ -1,0 +1,230 @@
+"""Pilot-mode tests for ``TransactionsScreen``.
+
+The transactions register is the v1 TUI's second screen (P9.2 of
+[#309](https://github.com/rmwarriner/tulip-accounting/issues/309)).
+Tests inject ``TransactionsData`` directly through the screen's loader
+seam, mirroring the pattern in ``test_accounts_screen.py``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
+from tulip_tui.data.transactions import (
+    PostingSummary,
+    TransactionsData,
+    TransactionSummary,
+)
+from tulip_tui.screens.transactions import TransactionsScreen
+
+
+def _sample_data() -> TransactionsData:
+    first = TransactionSummary(
+        id="tx-1",
+        date="2026-05-14",
+        description="Trader Joe's",
+        reference=None,
+        notes=None,
+        status="posted",
+        postings=(
+            PostingSummary(
+                account_id="acc-1",
+                account_label="Checking",
+                amount=Decimal("-67.21"),
+                currency="USD",
+                memo=None,
+            ),
+            PostingSummary(
+                account_id="acc-2",
+                account_label="Groceries",
+                amount=Decimal("67.21"),
+                currency="USD",
+                memo=None,
+            ),
+        ),
+        amount_display="-67.21 USD",
+    )
+    second = TransactionSummary(
+        id="tx-2",
+        date="2026-05-12",
+        description="Netflix",
+        reference="INV-12345",
+        notes="annual sub",
+        status="pending",
+        postings=(
+            PostingSummary(
+                account_id="acc-3",
+                account_label="Visa",
+                amount=Decimal("-15.49"),
+                currency="USD",
+                memo=None,
+            ),
+            PostingSummary(
+                account_id="acc-4",
+                account_label="Subscriptions",
+                amount=Decimal("15.49"),
+                currency="USD",
+                memo="annual",
+            ),
+        ),
+        amount_display="-15.49 USD",
+    )
+    return TransactionsData(transactions=(first, second))
+
+
+async def _push_transactions(app: TulipTuiApp, data: TransactionsData) -> TransactionsScreen:
+    screen = TransactionsScreen(loader=lambda: data)
+    await app.push_screen(screen)
+    return screen
+
+
+@pytest.mark.asyncio
+async def test_transactions_screen_renders_rows() -> None:
+    """Each transaction becomes a row with date, description, status, amount."""
+    accounts_loader = lambda: AccountsData(  # noqa: E731
+        as_of="2026-05-17", accounts=(), groups=()
+    )
+    app = TulipTuiApp(loader=accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = await _push_transactions(app, _sample_data())
+        await pilot.pause()
+        rendered = screen.rendered_rows()
+
+    assert len(rendered) == 2
+    assert any("Trader Joe's" in row and "-67.21" in row for row in rendered)
+    assert any("Netflix" in row and "-15.49" in row for row in rendered)
+    assert any("posted" in row for row in rendered)
+    assert any("pending" in row for row in rendered)
+
+
+@pytest.mark.asyncio
+async def test_transactions_screen_detail_pane_follows_cursor() -> None:
+    """Detail pane shows the cursor row's postings and updates on move."""
+    accounts_loader = lambda: AccountsData(  # noqa: E731
+        as_of="2026-05-17", accounts=(), groups=()
+    )
+    app = TulipTuiApp(loader=accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = await _push_transactions(app, _sample_data())
+        await pilot.pause()
+
+        detail = screen.detail_text()
+        assert "Trader Joe's" in detail
+        assert "Checking" in detail
+        assert "Groceries" in detail
+        assert "-67.21" in detail
+        assert "67.21 USD" in detail  # both legs
+
+        # Move the cursor down → the detail pane now reflects the second row.
+        await pilot.press("down")
+        await pilot.pause()
+        detail = screen.detail_text()
+        assert "Netflix" in detail
+        assert "Visa" in detail
+        assert "Subscriptions" in detail
+        assert "INV-12345" in detail  # reference surfaces in detail
+        assert "annual sub" in detail  # notes surface in detail
+
+
+@pytest.mark.asyncio
+async def test_transactions_screen_empty_state() -> None:
+    """Zero transactions → an explanatory message, not a confusing empty table."""
+    accounts_loader = lambda: AccountsData(  # noqa: E731
+        as_of="2026-05-17", accounts=(), groups=()
+    )
+    app = TulipTuiApp(loader=accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = await _push_transactions(app, TransactionsData(transactions=()))
+        await pilot.pause()
+        assert screen.has_no_transactions()
+        assert "no transactions" in screen.detail_text().lower()
+
+
+@pytest.mark.asyncio
+async def test_transactions_screen_renders_loader_error_inline() -> None:
+    """A loader exception surfaces in the detail pane; the app stays interactive."""
+
+    def boom() -> TransactionsData:
+        raise RuntimeError("network blip")
+
+    accounts_loader = lambda: AccountsData(  # noqa: E731
+        as_of="2026-05-17", accounts=(), groups=()
+    )
+    app = TulipTuiApp(loader=accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = TransactionsScreen(loader=boom)
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "network blip" in screen.detail_text()
+        # The screen pops back to accounts cleanly on escape.
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.press("q")
+    assert app.return_code == 0
+
+
+@pytest.mark.asyncio
+async def test_accounts_screen_enter_pushes_transactions_screen() -> None:
+    """Pressing ``enter`` on an account row drills into the transactions screen."""
+    from tulip_tui.data.accounts import (
+        AccountGroup,
+        AccountSummary,
+        CurrencyTotal,
+    )
+
+    checking = AccountSummary(
+        id="acc-1",
+        code="assets:checking",
+        name="Checking",
+        type="asset",
+        currency="USD",
+        balance=Decimal("100.00"),
+    )
+    accounts_data = AccountsData(
+        as_of="2026-05-17",
+        accounts=(checking,),
+        groups=(
+            AccountGroup(
+                type="asset",
+                accounts=(checking,),
+                totals=(CurrencyTotal(currency="USD", amount=Decimal("100.00")),),
+            ),
+        ),
+    )
+
+    captured: dict[str, str | None] = {}
+
+    def tx_loader_factory(account_id: str | None) -> object:
+        captured["account_id"] = account_id
+
+        def _load() -> TransactionsData:
+            return TransactionsData(transactions=())
+
+        return _load
+
+    app = TulipTuiApp(
+        loader=lambda: accounts_data,
+        transactions_loader_factory=tx_loader_factory,  # type: ignore[arg-type]
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Cursor starts at row 0 (the group header); one ``down`` moves
+        # it onto the first real account row. ``enter`` drills in.
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        from tulip_tui.screens.transactions import TransactionsScreen as _TS
+
+        assert isinstance(app.screen, _TS)
+
+    # The drill-in passes the selected account's id into the factory.
+    assert captured["account_id"] == "acc-1"


### PR DESCRIPTION
## Summary

- Second TUI screen plus the first cross-screen navigation flow (drill into an account from the accounts browser). Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309) and the [`Transactions list` wireframe](docs/TUI_WIREFRAMES.md#transactions-list).
- New `tulip_tui.data.transactions` joins `GET /v1/transactions` (filterable by `account_id` / `status` / `from` / `to` / `limit`) with `GET /v1/accounts` for UUID→label resolution. Unknown account ids render as `—`. Each summary carries a pre-computed `amount_display` short string so the table doesn't recompute on every paint.
- `TransactionsScreen` is a `DataTable` (Date / Description / Status / Postings / Amount) with a posting-detail pane below that follows the cursor — surfaces reference + notes when present.
- Drill-in: `Enter` on an account row fires the new `on_open_account` callback on `AccountsScreen`. The app wires that to push `TransactionsScreen` with the selected `account_id` pre-filtered through a new `transactions_loader_factory` constructor seam. Group-header / subtotal rows are no-ops.
- Loader exceptions render inline (status strip + detail pane); `escape` pops back, `q` still quits.

## Test plan

- [x] `uv run pytest packages/tulip-tui/tests -q` — 24 passing (12 from P9.1 + 7 new data tests + 5 new screen / drill-in tests).
- [x] `just lint` / `just typecheck` / `just format-check` — clean.
- [x] Manual smoke (requires a logged-in `tulip` CLI session against a running API):

      uv run --package tulip-tui tulip-tui

  Expected: app boots into the accounts browser. Press `enter` on an account row → transactions screen opens filtered to that account; cursor up/down updates the detail pane underneath. `escape` returns to accounts. `q` quits cleanly.

  To stress the error path:

      TULIP_API_URL=http://127.0.0.1:1 uv run --package tulip-tui tulip-tui

  Expected: accounts screen shows the connection error in red; press `enter` on the placeholder row → transactions screen mounts with the same error inline (no traceback).

- [ ] CI green on this PR.