### PR TITLE
P9.3 — TUI reports viewer (#309)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + P9.0–P9.2 shipped (skeleton + accounts browser + transactions register with account drill-in)** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell landed; P9.1 first real screen (accounts browser, grouped DataTable, in-memory loader seam) landed; P9.2–P9.4 queued per #309.
+**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + P9.0–P9.3 shipped (skeleton + accounts browser + transactions register + reports viewer)** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell landed; P9.1 first real screen (accounts browser, grouped DataTable, in-memory loader seam) landed; P9.2–P9.4 queued per #309.
 
 ---
 
@@ -1628,10 +1628,40 @@ accounts browser).
   "marker column" badges from the wireframe (those depend on data
   the API doesn't yet expose).
 
-### P9.3 — Reports viewer — ⏳ queued
+### P9.3 — Reports viewer — ✅ *(2026-05-17)*
 
-On-screen render of the nine Phase 7 reports. The HTML/PDF/CSV exporters
-stay on `tulip reports` (CLI); this slice is the in-TUI browse surface.
+Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). In-TUI browse surface for the
+eight `/v1/reports/*` reports (custom-query stays CLI-only — it needs
+SQL the user has to type).
+
+- **Data layer** — `tulip_tui/data/reports.py` defines a
+  `ReportSpec` (key, title, endpoint, default-params factory) and the
+  immutable `REPORT_CATALOGUE` tuple of all eight v1 reports.
+  `load_report(client, spec)` round-trips the matching endpoint with
+  `?format=json` and the spec's default params (current month for
+  income-statement / cash-flow; `as_of`-defaults for the rest).
+- **ReportsScreen** — left pane is a `DataTable` menu of the eight
+  reports; right pane is a Static with the cursor's report rendered
+  in place. The generic body renderer turns top-level arrays into
+  fixed-width tables, nested objects into key/value blocks, and
+  scalars into `key: value` lines — enough structure for browsing
+  without per-report hand-tuning.
+- **App wiring** — new app-wide binding `p` ("peek at reports")
+  pushes `ReportsScreen`; `escape` pops it. New
+  `reports_loader: ReportLoader = Callable[[ReportSpec], ReportPayload]`
+  constructor seam mirrors the accounts / transactions pattern.
+  Production `main.run()` installs the loader that opens a
+  `TulipClient` per fetch.
+- **Failure mode** — loader exceptions render inline in the content
+  pane; `escape` + `q` still work.
+- **Tests** — 5 data-layer tests (catalogue contents, JSON
+  round-trip, default-param passthrough, API-error propagation,
+  spec immutability); 5 screen tests (menu populated, first report
+  loads on mount, cursor swap triggers re-fetch, inline-error path,
+  non-rows body rendering).
+- **Out of scope** — per-report hand-tuned views (sparklines on
+  cash-flow, year-over-year diffs on income-statement, etc.); a
+  custom-query screen with a SQL editor.
 
 ### P9.4 — Reconciliation + import status (read-only) — ⏳ queued
 

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -1,14 +1,16 @@
 """The top-level Textual ``App`` for tulip-tui.
 
 The app boots into the accounts browser and supports drill-in to the
-transactions register from there. Both screens consume *loader*
-callables so tests inject in-memory fixtures through the same seam the
+transactions register from there, plus an app-wide ``p`` binding to
+push the reports browser. Every screen consumes a *loader* callable
+so tests inject in-memory fixtures through the same seam the
 production wiring uses.
 
 ``transactions_loader_factory`` is parameterised by ``account_id`` so
 the drill-in passes the selected account through to the API filter; a
 top-level transactions view (no account constraint) calls it with
-``None``.
+``None``. ``reports_loader`` is the per-spec fetcher the reports
+screen calls when the user moves their cursor over a menu row.
 """
 
 from __future__ import annotations
@@ -19,10 +21,13 @@ from typing import ClassVar
 from textual.app import App
 from textual.binding import Binding, BindingType
 
+from tulip_tui.data.reports import ReportPayload, ReportSpec
 from tulip_tui.screens.accounts import AccountsLoader, AccountsScreen
+from tulip_tui.screens.reports import ReportsScreen
 from tulip_tui.screens.transactions import TransactionsLoader, TransactionsScreen
 
 TransactionsLoaderFactory = Callable[[str | None], TransactionsLoader]
+ReportLoader = Callable[[ReportSpec], ReportPayload]
 
 
 def _no_op_transactions_factory(_account_id: str | None) -> TransactionsLoader:
@@ -38,23 +43,32 @@ def _no_op_transactions_factory(_account_id: str | None) -> TransactionsLoader:
     return _raise  # type: ignore[return-value]
 
 
+def _no_op_reports_loader(_spec: ReportSpec) -> ReportPayload:
+    raise RuntimeError("reports loader not configured")
+
+
 class TulipTuiApp(App[None]):
     """Tulip TUI shell — boots into the accounts browser."""
 
     TITLE = "tulip"
     SUB_TITLE = "terminal UI"
-    BINDINGS: ClassVar[list[BindingType]] = [Binding("q", "quit", "quit", show=True)]
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("q", "quit", "quit", show=True),
+        Binding("p", "open_reports", "reports", show=True),
+    ]
 
     def __init__(
         self,
         *,
         loader: AccountsLoader,
         transactions_loader_factory: TransactionsLoaderFactory = _no_op_transactions_factory,
+        reports_loader: ReportLoader = _no_op_reports_loader,
     ) -> None:
-        """Store the accounts loader + the transactions-loader factory."""
+        """Store the per-screen loaders / factories used at mount and drill-in."""
         super().__init__()
         self._loader = loader
         self._transactions_factory = transactions_loader_factory
+        self._reports_loader = reports_loader
 
     def on_mount(self) -> None:
         """Push the accounts browser as the initial screen."""
@@ -64,3 +78,7 @@ class TulipTuiApp(App[None]):
         """Push the transactions screen filtered to ``account_id`` (or all)."""
         loader = self._transactions_factory(account_id)
         self.push_screen(TransactionsScreen(loader=loader))
+
+    def action_open_reports(self) -> None:
+        """Push the reports browser onto the screen stack."""
+        self.push_screen(ReportsScreen(loader=self._reports_loader))

--- a/packages/tulip-tui/src/tulip_tui/data/reports.py
+++ b/packages/tulip-tui/src/tulip_tui/data/reports.py
@@ -1,0 +1,120 @@
+"""Reports browser data adapter.
+
+The catalogue (`REPORT_CATALOGUE`) is the v1 list of TUI-browseable
+reports — the eight ``/v1/reports/*`` endpoints with sensible default
+params for an interactive browse session. ``custom-query`` is omitted
+because it requires SQL the user has to type out; surfacing that as a
+TUI surface is a later slice.
+
+Date defaults for period-based reports use the current calendar
+month — interactive browsing is "show me what's happening *now*",
+and the user can drill deeper via the CLI when they need a different
+window.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from typing import Any
+
+from tulip_cli.http import TulipClient
+
+
+def _month_bounds() -> dict[str, str]:
+    today = datetime.now(UTC).date()
+    start = today.replace(day=1)
+    # First day of next month - one day → last day of this month.
+    if start.month == 12:
+        next_month = start.replace(year=start.year + 1, month=1)
+    else:
+        next_month = start.replace(month=start.month + 1)
+    end = date.fromordinal(next_month.toordinal() - 1)
+    return {"start": start.isoformat(), "end": end.isoformat()}
+
+
+@dataclass(frozen=True, slots=True)
+class ReportSpec:
+    """One entry in the reports catalogue."""
+
+    key: str
+    title: str
+    endpoint: str
+    default_params_factory: Callable[[], dict[str, str]] = field(default=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ReportPayload:
+    """A fetched report — the spec it came from plus the parsed JSON body."""
+
+    spec: ReportSpec
+    body: dict[str, Any]
+
+
+REPORT_CATALOGUE: tuple[ReportSpec, ...] = (
+    ReportSpec(
+        key="trial-balance",
+        title="Trial balance",
+        endpoint="/v1/reports/trial-balance",
+    ),
+    ReportSpec(
+        key="balance-sheet",
+        title="Balance sheet",
+        endpoint="/v1/reports/balance-sheet",
+    ),
+    ReportSpec(
+        key="income-statement",
+        title="Income statement (this month)",
+        endpoint="/v1/reports/income-statement",
+        default_params_factory=_month_bounds,
+    ),
+    ReportSpec(
+        key="cash-flow",
+        title="Cash flow (this month)",
+        endpoint="/v1/reports/cash-flow",
+        default_params_factory=_month_bounds,
+    ),
+    ReportSpec(
+        key="envelope-status",
+        title="Envelope status",
+        endpoint="/v1/reports/envelope-status",
+    ),
+    ReportSpec(
+        key="sinking-fund-progress",
+        title="Sinking fund progress",
+        endpoint="/v1/reports/sinking-fund-progress",
+    ),
+    ReportSpec(
+        key="reconciliation-summary",
+        title="Reconciliation summary",
+        endpoint="/v1/reports/reconciliation-summary",
+    ),
+    ReportSpec(
+        key="audit-log",
+        title="Audit log (most recent)",
+        endpoint="/v1/reports/audit-log",
+    ),
+)
+
+
+def load_report(client: TulipClient, spec: ReportSpec) -> ReportPayload:
+    """Fetch ``spec`` from the API and return the parsed JSON body."""
+    params = dict(spec.default_params_factory())
+    params.setdefault("format", "json")
+    response = client.get(spec.endpoint, authenticated=True, params=params)
+    body = response.json()
+    if not isinstance(body, dict):
+        # The API contract is "report responses are JSON objects." A
+        # non-object body would be a contract violation — wrap it so
+        # the screen can render *something* rather than crash.
+        body = {"value": body}
+    return ReportPayload(spec=spec, body=body)
+
+
+__all__: list[str] = [
+    "REPORT_CATALOGUE",
+    "ReportPayload",
+    "ReportSpec",
+    "load_report",
+]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -1,9 +1,9 @@
 """Entry point for the ``tulip-tui`` console script.
 
 Resolves the CLI's stored ``api_url`` + on-disk token store, builds
-loaders for both the accounts and transactions screens, and hands
-them to ``TulipTuiApp``. Tests bypass this path entirely by
-constructing ``TulipTuiApp`` directly with their own loaders.
+loaders for every screen, and hands them to ``TulipTuiApp``. Tests
+bypass this path entirely by constructing ``TulipTuiApp`` directly
+with their own loaders.
 """
 
 from __future__ import annotations
@@ -13,6 +13,7 @@ from tulip_cli.config import load_config
 from tulip_cli.http import TulipClient
 from tulip_tui.app import TulipTuiApp
 from tulip_tui.data.accounts import AccountsData, load_accounts
+from tulip_tui.data.reports import ReportPayload, ReportSpec, load_report
 from tulip_tui.data.transactions import TransactionsData, load_transactions
 from tulip_tui.screens.transactions import TransactionsLoader
 
@@ -35,9 +36,17 @@ def _transactions_loader_factory(account_id: str | None) -> TransactionsLoader:
     return _load
 
 
+def _reports_loader(spec: ReportSpec) -> ReportPayload:
+    """Open a fresh ``TulipClient`` per fetch and round-trip ``load_report``."""
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return load_report(client, spec)
+
+
 def run() -> None:
     """Launch the Tulip TUI against the configured API."""
     TulipTuiApp(
         loader=_accounts_loader,
         transactions_loader_factory=_transactions_loader_factory,
+        reports_loader=_reports_loader,
     ).run()

--- a/packages/tulip-tui/src/tulip_tui/screens/reports.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/reports.py
@@ -1,0 +1,174 @@
+"""Reports browser — P9.3 of [#309](https://github.com/rmwarriner/tulip-accounting/issues/309).
+
+Left-hand menu of the eight TUI-browseable reports; right-hand content
+pane filled with the cursor's report. The on-screen render is the
+v1 browse surface — HTML / PDF / CSV exporters remain on the
+``tulip reports`` CLI per ADR-0007.
+
+Content rendering is intentionally generic: arrays under any key are
+laid out as tables, scalars as ``key: value`` lines. Per-report
+hand-tuned views can replace the generic renderer in a later slice
+when there's enough TUI usage feedback to know which views need
+polish first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Horizontal
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+from tulip_tui.data.reports import REPORT_CATALOGUE, ReportPayload, ReportSpec
+
+ReportLoader = Callable[[ReportSpec], ReportPayload]
+
+
+def _format_value(value: object) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _render_table(rows: list[object]) -> str:
+    """Render ``rows`` as a fixed-width plain-text table.
+
+    Inspect the first row to infer columns. Falls back to single-column
+    rendering if rows aren't dict-shaped.
+    """
+    if not rows:
+        return "(no rows)"
+    if not isinstance(rows[0], dict):
+        return "\n".join(f"  • {_format_value(r)}" for r in rows)
+    columns = list(rows[0].keys())
+    widths = {col: len(col) for col in columns}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        for col in columns:
+            widths[col] = max(widths[col], len(_format_value(row.get(col))))
+    header = "  ".join(col.ljust(widths[col]) for col in columns)
+    sep = "  ".join("-" * widths[col] for col in columns)
+    lines = [header, sep]
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        lines.append("  ".join(_format_value(row.get(col)).ljust(widths[col]) for col in columns))
+    return "\n".join(lines)
+
+
+def _render_body(body: dict[str, object]) -> str:
+    """Render a report body — array sections become tables, scalars become lines."""
+    lines: list[str] = []
+    for key, value in body.items():
+        if isinstance(value, list):
+            lines.append(f"[b]{key}[/b]")
+            lines.append(_render_table(value))
+            lines.append("")
+        elif isinstance(value, dict):
+            lines.append(f"[b]{key}[/b]")
+            for k, v in value.items():
+                lines.append(f"  {k}: {_format_value(v)}")
+            lines.append("")
+        else:
+            lines.append(f"{key}: {_format_value(value)}")
+    return "\n".join(lines).rstrip()
+
+
+class ReportsScreen(Screen[None]):
+    """Browse the eight ``/v1/reports/*`` reports inside the TUI."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "app.pop_screen", "back", show=True),
+        Binding("r", "refresh", "refresh", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    ReportsScreen {
+        layout: vertical;
+    }
+
+    ReportsScreen Horizontal {
+        height: 1fr;
+    }
+
+    ReportsScreen #report-menu {
+        width: 32;
+        border-right: solid $accent;
+    }
+
+    ReportsScreen #report-content {
+        width: 1fr;
+        padding: 1 2;
+    }
+    """
+
+    def __init__(self, loader: ReportLoader) -> None:
+        """Store the loader; the screen mounts the menu and loads row 0."""
+        super().__init__()
+        self._loader = loader
+        self._menu_rows: list[str] = []
+        self._content_text: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Lay out the report menu (left) and content pane (right)."""
+        yield Header()
+        with Horizontal():
+            yield DataTable(id="report-menu", zebra_stripes=True, cursor_type="row")
+            yield Static("", id="report-content")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Populate the menu and trigger the initial report load."""
+        table = self.query_one("#report-menu", DataTable)
+        table.add_column("Report")
+        self._menu_rows = []
+        for spec in REPORT_CATALOGUE:
+            table.add_row(spec.title)
+            self._menu_rows.append(spec.title)
+        self._load_for_cursor()
+
+    def action_refresh(self) -> None:
+        """Re-fetch the currently selected report."""
+        self._load_for_cursor()
+
+    def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
+        """Load the highlighted report into the content pane."""
+        self._load_for_cursor()
+
+    # -- internals -----------------------------------------------------
+
+    def _load_for_cursor(self) -> None:
+        table = self.query_one("#report-menu", DataTable)
+        cursor = table.cursor_row
+        index = max(0, cursor)
+        if index >= len(REPORT_CATALOGUE):
+            return
+        spec = REPORT_CATALOGUE[index]
+        try:
+            payload = self._loader(spec)
+        except Exception as exc:
+            self._set_content(f"[red]error loading {spec.key}:[/red] {exc}")
+            return
+        self._set_content(_render_body(payload.body))
+
+    def _set_content(self, text: str) -> None:
+        self._content_text = text
+        pane = self.query_one("#report-content", Static)
+        pane.update(text)
+
+    # -- introspection used by tests ----------------------------------
+
+    def menu_rows(self) -> list[str]:
+        """Return the menu row labels in display order."""
+        return list(self._menu_rows)
+
+    def content_text(self) -> str:
+        """Return the rendered content pane as a plain string."""
+        return self._content_text

--- a/packages/tulip-tui/tests/test_reports_data.py
+++ b/packages/tulip-tui/tests/test_reports_data.py
@@ -1,0 +1,154 @@
+"""Unit tests for ``tulip_tui.data.reports``.
+
+The reports browser doesn't transform the API response heavily — it
+just fetches the raw JSON body and hands it to a renderer. The data
+layer's job is to:
+
+* Carry the catalogue of browsable reports (name, endpoint, default
+  params) — single source of truth that the screen iterates over.
+* Wrap the actual HTTP fetch so the screen layer can be tested
+  against in-memory fixtures.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tulip_cli.config import Config
+from tulip_cli.http import TulipClient
+from tulip_tui.data.reports import (
+    REPORT_CATALOGUE,
+    ReportPayload,
+    load_report,
+)
+
+
+class _FakeTokenStore:
+    def load(self, _api_url: str) -> object:
+        return SimpleNamespace(
+            email="t@example.invalid",
+            access_token="fake-access-token",
+            refresh_token="fake-refresh-token",
+            access_expires_at=2**31 - 1,
+        )
+
+    def save(self, _api_url: str, _tokens: object) -> None: ...
+    def clear(self, _api_url: str) -> None: ...
+
+
+def _build_client(handler: httpx.MockTransport) -> TulipClient:
+    return TulipClient(
+        Config(api_url="https://example.invalid"),
+        token_store=_FakeTokenStore(),  # type: ignore[arg-type]
+        transport=handler,
+    )
+
+
+def test_report_catalogue_lists_browsable_reports() -> None:
+    """All eight v1 browse-able reports are catalogued in display order."""
+    keys = [spec.key for spec in REPORT_CATALOGUE]
+    assert keys == [
+        "trial-balance",
+        "balance-sheet",
+        "income-statement",
+        "cash-flow",
+        "envelope-status",
+        "sinking-fund-progress",
+        "reconciliation-summary",
+        "audit-log",
+    ]
+    for spec in REPORT_CATALOGUE:
+        assert spec.title  # non-empty label
+        assert spec.endpoint.startswith("/v1/reports/")
+
+
+def test_load_report_round_trips_json_payload() -> None:
+    """``load_report`` fetches the endpoint and wraps the JSON body."""
+    spec = next(s for s in REPORT_CATALOGUE if s.key == "trial-balance")
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == spec.endpoint
+        captured.update(dict(request.url.params))
+        return httpx.Response(
+            200,
+            json={
+                "as_of": "2026-05-17",
+                "rows": [
+                    {
+                        "account_id": "a",
+                        "code": "assets:checking",
+                        "name": "Checking",
+                        "type": "asset",
+                        "currency": "USD",
+                        "balance": "100.00",
+                        "has_pending": False,
+                    }
+                ],
+                "totals_by_currency": [{"currency": "USD", "debits": "100.00", "credits": "0.00"}],
+                "pending_included": False,
+                "pending_count": 0,
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        payload = load_report(client, spec)
+
+    # JSON format is forced when the spec's default doesn't override it.
+    assert captured.get("format") == "json"
+    assert isinstance(payload, ReportPayload)
+    assert payload.spec is spec
+    assert isinstance(payload.body, dict)
+    assert payload.body["as_of"] == "2026-05-17"
+
+
+def test_load_report_passes_default_params_through() -> None:
+    """Reports with default params (e.g., income-statement) send them through."""
+    spec = next(s for s in REPORT_CATALOGUE if s.key == "income-statement")
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(dict(request.url.params))
+        return httpx.Response(
+            200,
+            json={"start": "2026-05-01", "end": "2026-05-31", "revenue": [], "expenses": []},
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        load_report(client, spec)
+
+    assert "start" in captured
+    assert "end" in captured
+
+
+def test_load_report_propagates_api_error() -> None:
+    """An API error bubbles out as ``CliError`` for the screen to render."""
+    from tulip_cli.errors import CliError
+
+    spec = REPORT_CATALOGUE[0]
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                "type": "/.well-known/errors/internal",
+                "title": "Internal server error",
+                "status": 500,
+                "detail": "boom",
+                "instance": "",
+                "code": "internal",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client, pytest.raises(CliError):
+        load_report(client, spec)
+
+
+def test_report_spec_is_immutable() -> None:
+    """``ReportSpec`` is a frozen dataclass — catalogue entries can't be mutated."""
+    spec = REPORT_CATALOGUE[0]
+    with pytest.raises(AttributeError):
+        spec.title = "tampered"  # type: ignore[misc]

--- a/packages/tulip-tui/tests/test_reports_screen.py
+++ b/packages/tulip-tui/tests/test_reports_screen.py
@@ -1,0 +1,134 @@
+"""Pilot-mode tests for ``ReportsScreen``.
+
+The reports screen pairs a left-hand menu (one row per catalogued
+report) with a right-hand content pane that fills with the chosen
+report's body. Tests inject a synchronous ``loader`` so no API call
+is involved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
+from tulip_tui.data.reports import REPORT_CATALOGUE, ReportPayload, ReportSpec
+from tulip_tui.screens.reports import ReportsScreen
+
+
+def _accounts_loader() -> AccountsData:
+    return AccountsData(as_of="2026-05-17", accounts=(), groups=())
+
+
+def _fake_payload(spec: ReportSpec) -> ReportPayload:
+    return ReportPayload(
+        spec=spec,
+        body={
+            "as_of": "2026-05-17",
+            "rows": [
+                {"code": "assets:checking", "name": "Checking", "balance": "100.00"},
+                {"code": "expenses:groceries", "name": "Groceries", "balance": "25.00"},
+            ],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_reports_screen_lists_all_catalogue_entries() -> None:
+    """Every catalogued report appears as a row in the left-hand menu."""
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReportsScreen(loader=_fake_payload)
+        await app.push_screen(screen)
+        await pilot.pause()
+        menu_text = " ".join(screen.menu_rows())
+
+    for spec in REPORT_CATALOGUE:
+        assert spec.title in menu_text
+
+
+@pytest.mark.asyncio
+async def test_reports_screen_loads_first_report_by_default() -> None:
+    """The first row is highlighted on mount and its body fills the pane."""
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReportsScreen(loader=_fake_payload)
+        await app.push_screen(screen)
+        await pilot.pause()
+        content = screen.content_text()
+
+    # The fake payload's rendering should mention a row from the table.
+    assert "Checking" in content
+    assert "100.00" in content
+
+
+@pytest.mark.asyncio
+async def test_reports_screen_swap_on_cursor_move() -> None:
+    """Moving the cursor fetches and renders the new report."""
+    seen: list[str] = []
+
+    def loader(spec: ReportSpec) -> ReportPayload:
+        seen.append(spec.key)
+        return ReportPayload(
+            spec=spec,
+            body={"title": f"render of {spec.key}", "rows": []},
+        )
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReportsScreen(loader=loader)
+        await app.push_screen(screen)
+        await pilot.pause()
+        # First report should already be loaded.
+        assert seen[0] == REPORT_CATALOGUE[0].key
+        # Move down → second report loads.
+        await pilot.press("down")
+        await pilot.pause()
+        assert seen[-1] == REPORT_CATALOGUE[1].key
+        content = screen.content_text()
+        assert "render of " + REPORT_CATALOGUE[1].key in content
+
+
+@pytest.mark.asyncio
+async def test_reports_screen_renders_error_inline() -> None:
+    """A loader exception surfaces in the content pane; ``escape`` still works."""
+
+    def boom(_spec: ReportSpec) -> ReportPayload:
+        raise RuntimeError("api down")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReportsScreen(loader=boom)
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "api down" in screen.content_text()
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.press("q")
+    assert app.return_code == 0
+
+
+@pytest.mark.asyncio
+async def test_reports_screen_handles_non_row_body() -> None:
+    """A report without a top-level ``rows`` list is rendered as key/value lines."""
+    spec = REPORT_CATALOGUE[0]
+    payload = ReportPayload(
+        spec=spec,
+        body={"summary": "ok", "as_of": "2026-05-17", "totals": {"USD": "0.00"}},
+    )
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReportsScreen(loader=lambda _s: payload)
+        await app.push_screen(screen)
+        await pilot.pause()
+        content = screen.content_text()
+
+    assert "summary" in content
+    assert "ok" in content
+    assert "as_of" in content
+    assert "2026-05-17" in content


### PR DESCRIPTION
## Summary

- In-TUI browse surface for the eight `/v1/reports/*` reports (custom-query stays CLI-only — it needs SQL the user has to type). Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309) and ADR-0007.
- New `tulip_tui.data.reports` defines a `ReportSpec` (key / title / endpoint / default-params factory) and the immutable `REPORT_CATALOGUE` tuple of all eight v1 reports. `load_report(client, spec)` round-trips the matching endpoint with `?format=json` and the spec's defaults (current month for income-statement / cash-flow; `as_of`-defaults for the rest).
- `ReportsScreen` is a split view: left-pane `DataTable` menu (one row per catalogue entry) + right-pane `Static` that fills with the cursor's report. Generic body renderer turns top-level arrays into fixed-width tables, nested objects into key/value blocks, scalars into `key: value` lines — enough structure for browsing without per-report hand-tuning.
- New app-wide binding `p` ("peek at reports") pushes `ReportsScreen` from any screen; `escape` pops. New `reports_loader: Callable[[ReportSpec], ReportPayload]` constructor seam mirrors the accounts / transactions pattern.
- Loader exceptions render inline in the content pane; `escape` + `q` still work.

## Test plan

- [x] `uv run pytest packages/tulip-tui/tests -q` — 34 passing (24 carried forward + 5 data-layer tests + 5 screen tests).
- [x] `just lint` / `just typecheck` / `just format-check` — clean.
- [x] Manual smoke (requires a logged-in `tulip` CLI session against a running API):

      uv run --package tulip-tui tulip-tui

  Expected: accounts browser opens. Press `p` → reports screen pushes; arrow keys move between the eight reports and the content pane swaps. `escape` returns to accounts. `q` quits cleanly.

- [ ] CI green on this PR.