### PR TITLE
P9.4 — TUI reconciliations + imports browse (closes Phase 9 v1) (#309)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + P9.0–P9.3 shipped (skeleton + accounts browser + transactions register + reports viewer)** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell landed; P9.1 first real screen (accounts browser, grouped DataTable, in-memory loader seam) landed; P9.2–P9.4 queued per #309.
+**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + Phase 9 v1 shipped (skeleton + accounts browser + transactions register + reports viewer + reconciliations / imports browse)** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell landed; P9.1 first real screen (accounts browser, grouped DataTable, in-memory loader seam) landed; P9.2–P9.4 queued per #309.
 
 ---
 
@@ -1663,12 +1663,38 @@ SQL the user has to type).
   cash-flow, year-over-year diffs on income-statement, etc.); a
   custom-query screen with a SQL editor.
 
-### P9.4 — Reconciliation + import status (read-only) — ⏳ queued
+### P9.4 — Reconciliation + import status (read-only) — ✅ *(2026-05-17)*
 
-Browse reconciliation envelopes (4-section state) and import batches
-(parsed lines). **Read only** — *acting* on a reconciliation is a
-mutation flow punted to post-v1 (see TUI_WIREFRAMES.md "Screens not yet
-mocked").
+Per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). Read-only browse of
+reconciliation envelopes and import batches. *Acting* on either
+(auto-match / manual match / complete; apply / revert) remains on
+the CLI per ADR-0007.
+
+- **Data layer** — `tulip_tui/data/reconciliations.py` wraps
+  `GET /v1/reconciliations` into `ReconciliationsData`;
+  `tulip_tui/data/imports.py` wraps `GET /v1/imports` into
+  `ImportsData`. Both are immutable triples of summary dataclasses
+  plus a thin loader.
+- **ReconciliationsScreen** — DataTable (Status / Period / Closing /
+  Id) with a detail pane below that surfaces the full envelope
+  (account_id, period bounds, starting + ending balances, created /
+  completed timestamps, source import-batch reference when present).
+- **ImportsScreen** — DataTable (Format / Filename / Status /
+  Counts / Id) with a detail pane (account_id, format, filename,
+  imported / skipped / error counts, created / applied / reverted
+  timestamps).
+- **App wiring** — new app-wide bindings `c` ("reconcile") and `i`
+  ("imports") push the respective screens. New
+  `reconciliations_loader` and `imports_loader` constructor seams
+  mirror the existing pattern; production `main.run()` installs
+  loaders that open a fresh `TulipClient` per fetch.
+- **Failure mode** — loader exceptions render inline in the detail
+  pane; `escape` + `q` still work on both screens.
+- **Tests** — 6 data-layer tests (3 per adapter: normal payload,
+  empty response, API error); 10 screen tests (4 per screen + 2 app
+  binding tests for `c` / `i`).
+- **Out of scope (per design pass)** — actioning reconciliations
+  (mutation), per-batch line drill-in (later polish if needed).
 
 ---
 

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -1,16 +1,16 @@
 """The top-level Textual ``App`` for tulip-tui.
 
-The app boots into the accounts browser and supports drill-in to the
-transactions register from there, plus an app-wide ``p`` binding to
-push the reports browser. Every screen consumes a *loader* callable
-so tests inject in-memory fixtures through the same seam the
-production wiring uses.
+The app boots into the accounts browser and exposes app-wide bindings
+to push the reports / reconciliations / imports browsers. Every
+screen consumes a *loader* callable so tests inject in-memory
+fixtures through the same seam the production wiring uses.
 
 ``transactions_loader_factory`` is parameterised by ``account_id`` so
 the drill-in passes the selected account through to the API filter; a
 top-level transactions view (no account constraint) calls it with
-``None``. ``reports_loader`` is the per-spec fetcher the reports
-screen calls when the user moves their cursor over a menu row.
+``None``. ``reports_loader`` / ``reconciliations_loader`` /
+``imports_loader`` are the per-screen fetchers their screens call on
+mount and on refresh.
 """
 
 from __future__ import annotations
@@ -21,13 +21,19 @@ from typing import ClassVar
 from textual.app import App
 from textual.binding import Binding, BindingType
 
+from tulip_tui.data.imports import ImportsData
+from tulip_tui.data.reconciliations import ReconciliationsData
 from tulip_tui.data.reports import ReportPayload, ReportSpec
 from tulip_tui.screens.accounts import AccountsLoader, AccountsScreen
+from tulip_tui.screens.imports import ImportsScreen
+from tulip_tui.screens.reconciliations import ReconciliationsScreen
 from tulip_tui.screens.reports import ReportsScreen
 from tulip_tui.screens.transactions import TransactionsLoader, TransactionsScreen
 
 TransactionsLoaderFactory = Callable[[str | None], TransactionsLoader]
 ReportLoader = Callable[[ReportSpec], ReportPayload]
+ReconciliationsLoader = Callable[[], ReconciliationsData]
+ImportsLoader = Callable[[], ImportsData]
 
 
 def _no_op_transactions_factory(_account_id: str | None) -> TransactionsLoader:
@@ -47,6 +53,14 @@ def _no_op_reports_loader(_spec: ReportSpec) -> ReportPayload:
     raise RuntimeError("reports loader not configured")
 
 
+def _no_op_reconciliations_loader() -> ReconciliationsData:
+    raise RuntimeError("reconciliations loader not configured")
+
+
+def _no_op_imports_loader() -> ImportsData:
+    raise RuntimeError("imports loader not configured")
+
+
 class TulipTuiApp(App[None]):
     """Tulip TUI shell — boots into the accounts browser."""
 
@@ -55,6 +69,8 @@ class TulipTuiApp(App[None]):
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "quit", "quit", show=True),
         Binding("p", "open_reports", "reports", show=True),
+        Binding("c", "open_reconciliations", "reconcile", show=True),
+        Binding("i", "open_imports", "imports", show=True),
     ]
 
     def __init__(
@@ -63,12 +79,16 @@ class TulipTuiApp(App[None]):
         loader: AccountsLoader,
         transactions_loader_factory: TransactionsLoaderFactory = _no_op_transactions_factory,
         reports_loader: ReportLoader = _no_op_reports_loader,
+        reconciliations_loader: ReconciliationsLoader = _no_op_reconciliations_loader,
+        imports_loader: ImportsLoader = _no_op_imports_loader,
     ) -> None:
         """Store the per-screen loaders / factories used at mount and drill-in."""
         super().__init__()
         self._loader = loader
         self._transactions_factory = transactions_loader_factory
         self._reports_loader = reports_loader
+        self._reconciliations_loader = reconciliations_loader
+        self._imports_loader = imports_loader
 
     def on_mount(self) -> None:
         """Push the accounts browser as the initial screen."""
@@ -82,3 +102,11 @@ class TulipTuiApp(App[None]):
     def action_open_reports(self) -> None:
         """Push the reports browser onto the screen stack."""
         self.push_screen(ReportsScreen(loader=self._reports_loader))
+
+    def action_open_reconciliations(self) -> None:
+        """Push the reconciliations browser onto the screen stack."""
+        self.push_screen(ReconciliationsScreen(loader=self._reconciliations_loader))
+
+    def action_open_imports(self) -> None:
+        """Push the import batches browser onto the screen stack."""
+        self.push_screen(ImportsScreen(loader=self._imports_loader))

--- a/packages/tulip-tui/src/tulip_tui/data/imports.py
+++ b/packages/tulip-tui/src/tulip_tui/data/imports.py
@@ -1,0 +1,81 @@
+"""Import-batch browse-list data adapter.
+
+Wraps ``GET /v1/imports`` into an immutable ``ImportsData`` value
+object. The TUI v1 surfaces this as read-only — *applying* /
+*reverting* a batch stays on the CLI per ADR-0007.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tulip_cli.http import TulipClient
+
+
+@dataclass(frozen=True, slots=True)
+class ImportBatchSummary:
+    """One import batch as the browse screen needs it."""
+
+    id: str
+    account_id: str
+    source_format: str
+    source_filename: str
+    status: str
+    imported_count: int
+    skipped_count: int
+    error_count: int
+    created_at: str
+    applied_at: str | None
+    reverted_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ImportsData:
+    """The full payload the imports screen renders."""
+
+    batches: tuple[ImportBatchSummary, ...]
+
+
+def load_import_batches(client: TulipClient) -> ImportsData:
+    """Fetch and parse ``/v1/imports``."""
+    raw = client.get("/v1/imports", authenticated=True).json()
+    items = tuple(_to_summary(row) for row in raw)
+    return ImportsData(batches=items)
+
+
+def _to_summary(row: dict[str, object]) -> ImportBatchSummary:
+    return ImportBatchSummary(
+        id=str(row.get("id", "")),
+        account_id=str(row.get("account_id", "")),
+        source_format=str(row.get("source_format", "")),
+        source_filename=str(row.get("source_filename", "")),
+        status=str(row.get("status", "")),
+        imported_count=_optional_int(row.get("imported_count")),
+        skipped_count=_optional_int(row.get("skipped_count")),
+        error_count=_optional_int(row.get("error_count")),
+        created_at=str(row.get("created_at", "")),
+        applied_at=_optional_str(row.get("applied_at")),
+        reverted_at=_optional_str(row.get("reverted_at")),
+    )
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_int(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+__all__: list[str] = [
+    "ImportBatchSummary",
+    "ImportsData",
+    "load_import_batches",
+]

--- a/packages/tulip-tui/src/tulip_tui/data/reconciliations.py
+++ b/packages/tulip-tui/src/tulip_tui/data/reconciliations.py
@@ -1,0 +1,71 @@
+"""Reconciliations browse-list data adapter.
+
+Wraps ``GET /v1/reconciliations`` into an immutable
+``ReconciliationsData`` value object. The TUI v1 surfaces this as
+read-only — *acting* on a reconciliation (auto-match, manual match,
+complete) stays on the CLI per ADR-0007 and the design pass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tulip_cli.http import TulipClient
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationSummary:
+    """One reconciliation envelope as the browse screen needs it."""
+
+    id: str
+    account_id: str
+    statement_period_start: str
+    statement_period_end: str
+    statement_starting_balance: str
+    statement_ending_balance: str
+    currency: str
+    status: str
+    source_import_batch_id: str | None
+    created_at: str
+    completed_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationsData:
+    """The full payload the reconciliations screen renders."""
+
+    reconciliations: tuple[ReconciliationSummary, ...]
+
+
+def load_reconciliations(client: TulipClient) -> ReconciliationsData:
+    """Fetch and parse ``/v1/reconciliations``."""
+    raw = client.get("/v1/reconciliations", authenticated=True).json()
+    items = tuple(_to_summary(row) for row in raw)
+    return ReconciliationsData(reconciliations=items)
+
+
+def _to_summary(row: dict[str, object]) -> ReconciliationSummary:
+    return ReconciliationSummary(
+        id=str(row.get("id", "")),
+        account_id=str(row.get("account_id", "")),
+        statement_period_start=str(row.get("statement_period_start", "")),
+        statement_period_end=str(row.get("statement_period_end", "")),
+        statement_starting_balance=str(row.get("statement_starting_balance", "")),
+        statement_ending_balance=str(row.get("statement_ending_balance", "")),
+        currency=str(row.get("currency", "")),
+        status=str(row.get("status", "")),
+        source_import_batch_id=_optional_str(row.get("source_import_batch_id")),
+        created_at=str(row.get("created_at", "")),
+        completed_at=_optional_str(row.get("completed_at")),
+    )
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+__all__: list[str] = [
+    "ReconciliationSummary",
+    "ReconciliationsData",
+    "load_reconciliations",
+]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -13,6 +13,8 @@ from tulip_cli.config import load_config
 from tulip_cli.http import TulipClient
 from tulip_tui.app import TulipTuiApp
 from tulip_tui.data.accounts import AccountsData, load_accounts
+from tulip_tui.data.imports import ImportsData, load_import_batches
+from tulip_tui.data.reconciliations import ReconciliationsData, load_reconciliations
 from tulip_tui.data.reports import ReportPayload, ReportSpec, load_report
 from tulip_tui.data.transactions import TransactionsData, load_transactions
 from tulip_tui.screens.transactions import TransactionsLoader
@@ -43,10 +45,24 @@ def _reports_loader(spec: ReportSpec) -> ReportPayload:
         return load_report(client, spec)
 
 
+def _reconciliations_loader() -> ReconciliationsData:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return load_reconciliations(client)
+
+
+def _imports_loader() -> ImportsData:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return load_import_batches(client)
+
+
 def run() -> None:
     """Launch the Tulip TUI against the configured API."""
     TulipTuiApp(
         loader=_accounts_loader,
         transactions_loader_factory=_transactions_loader_factory,
         reports_loader=_reports_loader,
+        reconciliations_loader=_reconciliations_loader,
+        imports_loader=_imports_loader,
     ).run()

--- a/packages/tulip-tui/src/tulip_tui/screens/imports.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/imports.py
@@ -1,0 +1,174 @@
+"""Import batches browser — P9.4 of [#309](https://github.com/rmwarriner/tulip-accounting/issues/309).
+
+Read-only browse of recent import batches (per
+``docs/TUI_WIREFRAMES.md``). The v1 TUI does not act on a batch —
+apply / revert stay on the ``tulip imports`` CLI per ADR-0007.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+from tulip_tui.data.imports import ImportBatchSummary, ImportsData
+
+ImportsLoader = Callable[[], ImportsData]
+
+
+def _row_for(batch: ImportBatchSummary) -> tuple[str, str, str, str, str]:
+    counts = (
+        f"{batch.imported_count} imported · "
+        f"{batch.skipped_count} skipped · "
+        f"{batch.error_count} errors"
+    )
+    return (
+        batch.source_format,
+        batch.source_filename,
+        batch.status,
+        counts,
+        batch.id[:8] if batch.id else "—",
+    )
+
+
+def _detail_for(batch: ImportBatchSummary) -> str:
+    lines = [
+        f"[b]{batch.id}[/b]    [{batch.status}]",
+        f"account_id:    {batch.account_id}",
+        f"format:        {batch.source_format}",
+        f"filename:      {batch.source_filename}",
+        f"created_at:    {batch.created_at}",
+        f"imported:      {batch.imported_count}",
+        f"skipped:       {batch.skipped_count}",
+        f"errors:        {batch.error_count}",
+    ]
+    if batch.applied_at:
+        lines.append(f"applied_at:    {batch.applied_at}")
+    if batch.reverted_at:
+        lines.append(f"reverted_at:   {batch.reverted_at}")
+    return "\n".join(lines)
+
+
+class ImportsScreen(Screen[None]):
+    """Browse the household's import batches."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "app.pop_screen", "back", show=True),
+        Binding("r", "refresh", "refresh", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    ImportsScreen {
+        layout: vertical;
+    }
+
+    ImportsScreen #imp-status {
+        height: auto;
+        padding: 0 1;
+    }
+
+    ImportsScreen #imp-table {
+        height: 2fr;
+    }
+
+    ImportsScreen #imp-detail {
+        height: 1fr;
+        padding: 1 2;
+        border-top: solid $accent;
+    }
+    """
+
+    def __init__(self, loader: ImportsLoader) -> None:
+        """Store the loader; the screen populates on mount."""
+        super().__init__()
+        self._loader = loader
+        self._rendered_rows: list[str] = []
+        self._index: list[ImportBatchSummary] = []
+        self._detail: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Lay out the status strip, the list table, and the detail pane."""
+        yield Header()
+        with Vertical():
+            yield Static("loading import batches…", id="imp-status")
+            yield DataTable(id="imp-table", zebra_stripes=True, cursor_type="row")
+            yield Static("", id="imp-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Install column headers and trigger the initial load."""
+        table = self.query_one("#imp-table", DataTable)
+        table.add_columns("Format", "Filename", "Status", "Counts", "Id")
+        self._load()
+
+    def action_refresh(self) -> None:
+        """Re-run the loader and rebuild the table in place."""
+        self._load()
+
+    def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
+        """Re-render the detail pane to match the newly-highlighted row."""
+        self._refresh_detail()
+
+    # -- internals -----------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            data = self._loader()
+        except Exception as exc:
+            self._render_error(exc)
+            return
+        self._populate(data)
+
+    def _populate(self, data: ImportsData) -> None:
+        table = self.query_one("#imp-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        status = self.query_one("#imp-status", Static)
+        status.update(f"{len(data.batches)} import batches")
+        if not data.batches:
+            self._set_detail("No import batches yet.")
+            return
+        for batch in data.batches:
+            cells = _row_for(batch)
+            table.add_row(*cells)
+            self._rendered_rows.append(" ".join(cells))
+            self._index.append(batch)
+        self._refresh_detail()
+
+    def _refresh_detail(self) -> None:
+        if not self._index:
+            return
+        table = self.query_one("#imp-table", DataTable)
+        cursor = max(0, table.cursor_row)
+        if cursor >= len(self._index):
+            return
+        self._set_detail(_detail_for(self._index[cursor]))
+
+    def _render_error(self, exc: BaseException) -> None:
+        table = self.query_one("#imp-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        status = self.query_one("#imp-status", Static)
+        status.update(f"[red]error:[/red] {exc}")
+        self._set_detail(f"error: {exc}")
+
+    def _set_detail(self, text: str) -> None:
+        self._detail = text
+        self.query_one("#imp-detail", Static).update(text)
+
+    # -- introspection used by tests ----------------------------------
+
+    def rendered_rows(self) -> list[str]:
+        """Return a string-only mirror of the table's rows for assertions."""
+        return list(self._rendered_rows)
+
+    def detail_text(self) -> str:
+        """Return the current detail-pane text as a plain string."""
+        return self._detail

--- a/packages/tulip-tui/src/tulip_tui/screens/reconciliations.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/reconciliations.py
@@ -1,0 +1,172 @@
+"""Reconciliations browser — P9.4 of [#309](https://github.com/rmwarriner/tulip-accounting/issues/309).
+
+Read-only browse of reconciliation envelopes (the four-section state
+in `docs/TUI_WIREFRAMES.md`). The v1 TUI does not act on a
+reconciliation — apply / match / complete stay on the
+``tulip reconcile`` CLI per ADR-0007.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal, InvalidOperation
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+from tulip_tui.data.reconciliations import ReconciliationsData, ReconciliationSummary
+
+ReconciliationsLoader = Callable[[], ReconciliationsData]
+
+
+def _fmt_balance(value: str) -> str:
+    try:
+        return f"{Decimal(value).quantize(Decimal('0.01')):,.2f}"
+    except (InvalidOperation, ValueError):
+        return value or "—"
+
+
+def _row_for(rec: ReconciliationSummary) -> tuple[str, str, str, str]:
+    period = f"{rec.statement_period_start}..{rec.statement_period_end}"
+    closing = f"{_fmt_balance(rec.statement_ending_balance)} {rec.currency}"
+    return (rec.status, period, closing, rec.id[:8] if rec.id else "—")
+
+
+def _detail_for(rec: ReconciliationSummary) -> str:
+    lines = [
+        f"[b]{rec.id}[/b]    [{rec.status}]",
+        f"account_id:    {rec.account_id}",
+        f"period:        {rec.statement_period_start} .. {rec.statement_period_end}",
+        f"starting:      {_fmt_balance(rec.statement_starting_balance)} {rec.currency}",
+        f"ending:        {_fmt_balance(rec.statement_ending_balance)} {rec.currency}",
+        f"created_at:    {rec.created_at}",
+    ]
+    if rec.completed_at:
+        lines.append(f"completed_at:  {rec.completed_at}")
+    if rec.source_import_batch_id:
+        lines.append(f"source batch:  {rec.source_import_batch_id}")
+    return "\n".join(lines)
+
+
+class ReconciliationsScreen(Screen[None]):
+    """Browse the household's reconciliations."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "app.pop_screen", "back", show=True),
+        Binding("r", "refresh", "refresh", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    ReconciliationsScreen {
+        layout: vertical;
+    }
+
+    ReconciliationsScreen #rec-status {
+        height: auto;
+        padding: 0 1;
+    }
+
+    ReconciliationsScreen #rec-table {
+        height: 2fr;
+    }
+
+    ReconciliationsScreen #rec-detail {
+        height: 1fr;
+        padding: 1 2;
+        border-top: solid $accent;
+    }
+    """
+
+    def __init__(self, loader: ReconciliationsLoader) -> None:
+        """Store the loader; the screen populates on mount."""
+        super().__init__()
+        self._loader = loader
+        self._rendered_rows: list[str] = []
+        self._index: list[ReconciliationSummary] = []
+        self._detail: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Lay out the status strip, the list table, and the detail pane."""
+        yield Header()
+        with Vertical():
+            yield Static("loading reconciliations…", id="rec-status")
+            yield DataTable(id="rec-table", zebra_stripes=True, cursor_type="row")
+            yield Static("", id="rec-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Install column headers and trigger the initial load."""
+        table = self.query_one("#rec-table", DataTable)
+        table.add_columns("Status", "Period", "Closing", "Id")
+        self._load()
+
+    def action_refresh(self) -> None:
+        """Re-run the loader and rebuild the table in place."""
+        self._load()
+
+    def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
+        """Re-render the detail pane to match the newly-highlighted row."""
+        self._refresh_detail()
+
+    # -- internals -----------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            data = self._loader()
+        except Exception as exc:
+            self._render_error(exc)
+            return
+        self._populate(data)
+
+    def _populate(self, data: ReconciliationsData) -> None:
+        table = self.query_one("#rec-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        status = self.query_one("#rec-status", Static)
+        status.update(f"{len(data.reconciliations)} reconciliations")
+        if not data.reconciliations:
+            self._set_detail("No reconciliations yet.")
+            return
+        for rec in data.reconciliations:
+            cells = _row_for(rec)
+            table.add_row(*cells)
+            self._rendered_rows.append(" ".join(cells))
+            self._index.append(rec)
+        self._refresh_detail()
+
+    def _refresh_detail(self) -> None:
+        if not self._index:
+            return
+        table = self.query_one("#rec-table", DataTable)
+        cursor = max(0, table.cursor_row)
+        if cursor >= len(self._index):
+            return
+        self._set_detail(_detail_for(self._index[cursor]))
+
+    def _render_error(self, exc: BaseException) -> None:
+        table = self.query_one("#rec-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        status = self.query_one("#rec-status", Static)
+        status.update(f"[red]error:[/red] {exc}")
+        self._set_detail(f"error: {exc}")
+
+    def _set_detail(self, text: str) -> None:
+        self._detail = text
+        self.query_one("#rec-detail", Static).update(text)
+
+    # -- introspection used by tests ----------------------------------
+
+    def rendered_rows(self) -> list[str]:
+        """Return a string-only mirror of the table's rows for assertions."""
+        return list(self._rendered_rows)
+
+    def detail_text(self) -> str:
+        """Return the current detail-pane text as a plain string."""
+        return self._detail

--- a/packages/tulip-tui/tests/test_recon_imports_data.py
+++ b/packages/tulip-tui/tests/test_recon_imports_data.py
@@ -1,0 +1,203 @@
+"""Unit tests for ``tulip_tui.data.reconciliations`` + ``data.imports``.
+
+Both adapters wrap a single read endpoint with no joining or
+mutation. Empty-state, normal-state, and API-error paths are covered.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tulip_cli.config import Config
+from tulip_cli.http import TulipClient
+from tulip_tui.data.imports import (
+    ImportBatchSummary,
+    ImportsData,
+    load_import_batches,
+)
+from tulip_tui.data.reconciliations import (
+    ReconciliationsData,
+    ReconciliationSummary,
+    load_reconciliations,
+)
+
+
+class _FakeTokenStore:
+    def load(self, _api_url: str) -> object:
+        return SimpleNamespace(
+            email="t@example.invalid",
+            access_token="fake-access-token",
+            refresh_token="fake-refresh-token",
+            access_expires_at=2**31 - 1,
+        )
+
+    def save(self, _api_url: str, _tokens: object) -> None: ...
+    def clear(self, _api_url: str) -> None: ...
+
+
+def _build_client(handler: httpx.MockTransport) -> TulipClient:
+    return TulipClient(
+        Config(api_url="https://example.invalid"),
+        token_store=_FakeTokenStore(),  # type: ignore[arg-type]
+        transport=handler,
+    )
+
+
+# ---- reconciliations ------------------------------------------------
+
+
+_RECON_PAYLOAD = [
+    {
+        "id": "rec-1",
+        "account_id": "acc-1",
+        "statement_period_start": "2026-04-01",
+        "statement_period_end": "2026-04-30",
+        "statement_starting_balance": "1000.00",
+        "statement_ending_balance": "1234.56",
+        "currency": "USD",
+        "status": "complete",
+        "source_import_batch_id": None,
+        "created_at": "2026-05-01T12:00:00Z",
+        "completed_at": "2026-05-02T09:30:00Z",
+    },
+    {
+        "id": "rec-2",
+        "account_id": "acc-2",
+        "statement_period_start": "2026-05-01",
+        "statement_period_end": "2026-05-31",
+        "statement_starting_balance": "500.00",
+        "statement_ending_balance": "725.10",
+        "currency": "USD",
+        "status": "open",
+        "source_import_batch_id": "batch-9",
+        "created_at": "2026-05-15T08:00:00Z",
+        "completed_at": None,
+    },
+]
+
+
+def test_load_reconciliations_returns_summary_list() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/reconciliations"
+        return httpx.Response(200, json=_RECON_PAYLOAD)
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_reconciliations(client)
+
+    assert isinstance(data, ReconciliationsData)
+    assert len(data.reconciliations) == 2
+    first = data.reconciliations[0]
+    assert isinstance(first, ReconciliationSummary)
+    assert first.id == "rec-1"
+    assert first.status == "complete"
+    assert first.currency == "USD"
+    assert first.statement_period_start == "2026-04-01"
+    assert first.statement_period_end == "2026-04-30"
+    assert first.statement_ending_balance == "1234.56"
+
+
+def test_load_reconciliations_handles_empty() -> None:
+    with _build_client(httpx.MockTransport(lambda _r: httpx.Response(200, json=[]))) as client:
+        data = load_reconciliations(client)
+    assert data.reconciliations == ()
+
+
+def test_load_reconciliations_raises_on_error() -> None:
+    from tulip_cli.errors import CliError
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                "type": "/.well-known/errors/internal",
+                "title": "Internal server error",
+                "status": 500,
+                "detail": "boom",
+                "instance": "",
+                "code": "internal",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client, pytest.raises(CliError):
+        load_reconciliations(client)
+
+
+# ---- import batches -------------------------------------------------
+
+
+_IMPORTS_PAYLOAD = [
+    {
+        "id": "batch-1",
+        "account_id": "acc-1",
+        "source_format": "ofx",
+        "source_filename": "april.qfx",
+        "status": "applied",
+        "imported_count": 42,
+        "skipped_count": 0,
+        "error_count": 0,
+        "created_at": "2026-05-01T12:00:00Z",
+        "applied_at": "2026-05-01T12:05:00Z",
+        "reverted_at": None,
+    },
+    {
+        "id": "batch-2",
+        "account_id": "acc-2",
+        "source_format": "csv",
+        "source_filename": "visa.csv",
+        "status": "parsed",
+        "imported_count": 0,
+        "skipped_count": 0,
+        "error_count": 0,
+        "created_at": "2026-05-10T09:00:00Z",
+        "applied_at": None,
+        "reverted_at": None,
+    },
+]
+
+
+def test_load_import_batches_returns_summary_list() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/imports"
+        return httpx.Response(200, json=_IMPORTS_PAYLOAD)
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_import_batches(client)
+
+    assert isinstance(data, ImportsData)
+    assert len(data.batches) == 2
+    first = data.batches[0]
+    assert isinstance(first, ImportBatchSummary)
+    assert first.id == "batch-1"
+    assert first.source_format == "ofx"
+    assert first.source_filename == "april.qfx"
+    assert first.status == "applied"
+    assert first.imported_count == 42
+
+
+def test_load_import_batches_handles_empty() -> None:
+    with _build_client(httpx.MockTransport(lambda _r: httpx.Response(200, json=[]))) as client:
+        data = load_import_batches(client)
+    assert data.batches == ()
+
+
+def test_load_import_batches_raises_on_error() -> None:
+    from tulip_cli.errors import CliError
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                "type": "/.well-known/errors/internal",
+                "title": "Internal server error",
+                "status": 500,
+                "detail": "boom",
+                "instance": "",
+                "code": "internal",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client, pytest.raises(CliError):
+        load_import_batches(client)

--- a/packages/tulip-tui/tests/test_recon_imports_screens.py
+++ b/packages/tulip-tui/tests/test_recon_imports_screens.py
@@ -1,0 +1,251 @@
+"""Pilot-mode tests for ``ReconciliationsScreen`` and ``ImportsScreen``.
+
+Both screens are list + cursor-follows detail. Tests inject a loader
+so no API call is involved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
+from tulip_tui.data.imports import ImportBatchSummary, ImportsData
+from tulip_tui.data.reconciliations import (
+    ReconciliationsData,
+    ReconciliationSummary,
+)
+from tulip_tui.screens.imports import ImportsScreen
+from tulip_tui.screens.reconciliations import ReconciliationsScreen
+
+
+def _accounts_loader() -> AccountsData:
+    return AccountsData(as_of="2026-05-17", accounts=(), groups=())
+
+
+# ---- reconciliations ------------------------------------------------
+
+
+def _sample_recons() -> ReconciliationsData:
+    return ReconciliationsData(
+        reconciliations=(
+            ReconciliationSummary(
+                id="rec-1",
+                account_id="acc-1",
+                statement_period_start="2026-04-01",
+                statement_period_end="2026-04-30",
+                statement_starting_balance="1000.00",
+                statement_ending_balance="1234.56",
+                currency="USD",
+                status="complete",
+                source_import_batch_id=None,
+                created_at="2026-05-01T12:00:00Z",
+                completed_at="2026-05-02T09:30:00Z",
+            ),
+            ReconciliationSummary(
+                id="rec-2",
+                account_id="acc-2",
+                statement_period_start="2026-05-01",
+                statement_period_end="2026-05-31",
+                statement_starting_balance="500.00",
+                statement_ending_balance="725.10",
+                currency="USD",
+                status="open",
+                source_import_batch_id="batch-9",
+                created_at="2026-05-15T08:00:00Z",
+                completed_at=None,
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconciliations_screen_lists_envelopes() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationsScreen(loader=lambda: _sample_recons())
+        await app.push_screen(screen)
+        await pilot.pause()
+        rendered = screen.rendered_rows()
+
+    assert len(rendered) == 2
+    assert any("complete" in row and "1,234.56" in row for row in rendered)
+    assert any("open" in row and "725.10" in row for row in rendered)
+
+
+@pytest.mark.asyncio
+async def test_reconciliations_screen_detail_follows_cursor() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationsScreen(loader=lambda: _sample_recons())
+        await app.push_screen(screen)
+        await pilot.pause()
+        first = screen.detail_text()
+        assert "rec-1" in first
+        assert "complete" in first
+        await pilot.press("down")
+        await pilot.pause()
+        second = screen.detail_text()
+        assert "rec-2" in second
+        assert "open" in second
+        assert "batch-9" in second  # source_import_batch_id surfaces in detail
+
+
+@pytest.mark.asyncio
+async def test_reconciliations_screen_empty_state() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationsScreen(loader=lambda: ReconciliationsData(reconciliations=()))
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "no reconciliations" in screen.detail_text().lower()
+
+
+@pytest.mark.asyncio
+async def test_reconciliations_screen_renders_error_inline() -> None:
+    def boom() -> ReconciliationsData:
+        raise RuntimeError("api down")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationsScreen(loader=boom)
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "api down" in screen.detail_text()
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.press("q")
+    assert app.return_code == 0
+
+
+# ---- imports --------------------------------------------------------
+
+
+def _sample_imports() -> ImportsData:
+    return ImportsData(
+        batches=(
+            ImportBatchSummary(
+                id="batch-1",
+                account_id="acc-1",
+                source_format="ofx",
+                source_filename="april.qfx",
+                status="applied",
+                imported_count=42,
+                skipped_count=0,
+                error_count=0,
+                created_at="2026-05-01T12:00:00Z",
+                applied_at="2026-05-01T12:05:00Z",
+                reverted_at=None,
+            ),
+            ImportBatchSummary(
+                id="batch-2",
+                account_id="acc-2",
+                source_format="csv",
+                source_filename="visa.csv",
+                status="parsed",
+                imported_count=0,
+                skipped_count=0,
+                error_count=0,
+                created_at="2026-05-10T09:00:00Z",
+                applied_at=None,
+                reverted_at=None,
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_imports_screen_lists_batches() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportsScreen(loader=lambda: _sample_imports())
+        await app.push_screen(screen)
+        await pilot.pause()
+        rendered = screen.rendered_rows()
+
+    assert len(rendered) == 2
+    assert any("ofx" in row and "april.qfx" in row and "applied" in row for row in rendered)
+    assert any("csv" in row and "visa.csv" in row and "parsed" in row for row in rendered)
+
+
+@pytest.mark.asyncio
+async def test_imports_screen_detail_follows_cursor() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportsScreen(loader=lambda: _sample_imports())
+        await app.push_screen(screen)
+        await pilot.pause()
+        first = screen.detail_text()
+        assert "batch-1" in first
+        assert "april.qfx" in first
+        assert "42" in first  # imported_count
+        await pilot.press("down")
+        await pilot.pause()
+        second = screen.detail_text()
+        assert "batch-2" in second
+        assert "visa.csv" in second
+        assert "parsed" in second
+
+
+@pytest.mark.asyncio
+async def test_imports_screen_empty_state() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportsScreen(loader=lambda: ImportsData(batches=()))
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "no import batches" in screen.detail_text().lower()
+
+
+@pytest.mark.asyncio
+async def test_imports_screen_error_inline() -> None:
+    def boom() -> ImportsData:
+        raise RuntimeError("api blip")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportsScreen(loader=boom)
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "api blip" in screen.detail_text()
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.press("q")
+    assert app.return_code == 0
+
+
+# ---- app bindings ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_app_binding_c_pushes_reconciliations_screen() -> None:
+    app = TulipTuiApp(
+        loader=_accounts_loader,
+        reconciliations_loader=lambda: _sample_recons(),
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("c")
+        await pilot.pause()
+        assert isinstance(app.screen, ReconciliationsScreen)
+
+
+@pytest.mark.asyncio
+async def test_app_binding_i_pushes_imports_screen() -> None:
+    app = TulipTuiApp(
+        loader=_accounts_loader,
+        imports_loader=lambda: _sample_imports(),
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("i")
+        await pilot.pause()
+        assert isinstance(app.screen, ImportsScreen)


### PR DESCRIPTION
## Summary

Closes the v1 read-only TUI surface area per ADR-0007. Acting on either (auto-match / manual match / complete; apply / revert) stays on the CLI.

- New `tulip_tui.data.reconciliations` wraps `GET /v1/reconciliations` into an immutable `ReconciliationsData`; `tulip_tui.data.imports` wraps `GET /v1/imports` into `ImportsData`. Both are summary dataclasses + thin loaders.
- `ReconciliationsScreen` — `DataTable` (Status / Period / Closing / Id) with a detail pane below that surfaces the full envelope (account_id, period bounds, starting + ending balances, created / completed timestamps, source import-batch reference when present).
- `ImportsScreen` — `DataTable` (Format / Filename / Status / Counts / Id) with a detail pane (account_id, format, filename, imported / skipped / error counts, created / applied / reverted timestamps).
- New app-wide bindings `c` (reconcile) and `i` (imports) push the respective screens; `escape` pops. New `reconciliations_loader` and `imports_loader` constructor seams mirror the existing pattern; production `main.run()` opens a fresh `TulipClient` per fetch.
- Loader exceptions render inline in the detail pane; `escape` + `q` still work on both screens.

## Test plan

- [x] `uv run pytest packages/tulip-tui/tests -q` — 50 passing (34 carried forward + 6 data-layer tests + 10 screen + binding tests).
- [x] `just lint` / `just typecheck` / `just format-check` — clean.
- [x] Manual smoke (requires a logged-in `tulip` CLI session against a running API):

      uv run --package tulip-tui tulip-tui

  Expected: accounts browser opens. Press `c` → reconciliations list pushes with detail pane following cursor. `escape` returns. Press `i` → import-batches list pushes with detail pane. `escape` returns. `q` quits cleanly. With no reconciliations / imports yet the detail pane shows "No reconciliations yet." / "No import batches yet."

- [ ] CI green on this PR.

## Phase 9 v1 status

With this PR, the v1 read-only TUI is complete. Across P9.0–P9.4: workspace skeleton, accounts browser, transactions register with drill-in, reports viewer, reconciliations + imports browse — 50 tests, lint / mypy --strict / format clean. Mutation screens (categorize / split / edit / reconcile-action / apply-import) remain on the CLI per ADR-0007; the design pass ([TUI_WIREFRAMES.md § Cross-cutting decisions](docs/TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17)) tracks where they'll resurface as later slices.