### PR TITLE
docs: bring Phase 9 references current with the shipped v1 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When the command returns, the API is live on `http://127.0.0.1:8000`. The full w
 
 Honest expectations matter for internal-beta. The following are deliberately deferred:
 
-- **Web / mobile UI.** Tulip is API-first with a Typer CLI client; the web client lands as a separate phase. The CLI is the supported UI.
+- **Web / mobile UI.** Tulip is API-first with two clients today: the Typer CLI (the scriptable / automation surface) and `tulip-tui`, a Textual terminal UI for interactive browsing (Phase 9 v1, read-only — accounts, transactions, reports, reconciliations + import batches; mutations stay on the CLI). A web / mobile client lands as a separate phase.
 - **Multi-tenant cloud hosting.** Tulip is single-machine, single-tenant SQLite for internal beta. Postgres + KMS + multi-tenant scaling is a future phase.
 - **Reverse-proxy / TLS tutorial.** Run behind Caddy or Tailscale Funnel; we don't ship a TLS setup guide.
 - **Full-DB encryption at rest (SQLCipher).** Field-level AES-256-GCM protects the most sensitive columns + attachments today; whole-database SQLCipher is a Phase 8 hardening item still in flight.
@@ -57,11 +57,11 @@ The full deferred-features list and the ordered roadmap is the contributor-side 
 
 ## For contributors
 
-> **Status:** Internal beta. Phases 0–7 complete (project bootstrap, storage + accounting engine, API surface, scriptable CLI, envelopes + sinking funds + scheduled refills, OFX/QIF/CSV importers + statement-driven reconciliation, opt-in AI integration with BYOK provider keys + cost-cap + rate limit + audited proposals, nine reports in HTML/PDF/CSV + hledger journal export/import + `tulip reports` and `tulip journal` CLI). **Phase 8 (operations + hardening) is in progress:** the deep security and deep privacy audits have shipped ([docs/audits/](docs/audits/)), along with their highest-severity Wave-1 follow-ups (auth rate limiting, single-use MFA-challenge tokens, GDPR right-to-erasure) and a post-audit CLI/importers usability bundle. See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
+> **Status:** Internal beta. Phases 0–7 complete (project bootstrap, storage + accounting engine, API surface, scriptable CLI, envelopes + sinking funds + scheduled refills, OFX/QIF/CSV importers + statement-driven reconciliation, opt-in AI integration with BYOK provider keys + cost-cap + rate limit + audited proposals, nine reports in HTML/PDF/CSV + hledger journal export/import + `tulip reports` and `tulip journal` CLI). **Phase 8 (operations + hardening) is in progress:** the deep security and deep privacy audits have shipped ([docs/audits/](docs/audits/)), along with their highest-severity Wave-1 follow-ups (auth rate limiting, single-use MFA-challenge tokens, GDPR right-to-erasure) and a post-audit CLI/importers usability bundle. **Phase 9 (terminal UI) v1 shipped** — a Textual TUI (`tulip-tui`) as an additive read-only browse surface alongside the CLI; mutations stay on the CLI per [ADR-0007](docs/adrs/0007-terminal-ui.md). See [docs/PHASE_STATUS.md](docs/PHASE_STATUS.md) for the full picture and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the design.
 
 ### Architecture at a glance
 
-Python 3.14 + FastAPI + SQLAlchemy 2.0 + Pydantic v2, as a `uv` workspace monorepo of seven packages, with TDD-mandatory development discipline. Full details in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+Python 3.14 + FastAPI + SQLAlchemy 2.0 + Pydantic v2, as a `uv` workspace monorepo of eight packages, with TDD-mandatory development discipline. Full details in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ```
 tulip-accounting/
@@ -72,7 +72,8 @@ tulip-accounting/
 │   ├── tulip-ai/           # AI adapter layer (litellm)
 │   ├── tulip-importers/    # OFX, QIF, CSV, journal-format
 │   ├── tulip-reports/      # toner-friendly PDF, HTML, CSV
-│   └── tulip-cli/          # Typer-based CLI client
+│   ├── tulip-cli/          # Typer-based CLI client
+│   └── tulip-tui/          # Textual terminal UI client (read-only; reuses tulip-cli HTTP layer)
 ├── deploy/                 # Docker, systemd, deployment scripts
 └── docs/                   # ARCHITECTURE, QUICKSTART, THREAT_MODEL, ADRs
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -902,12 +902,20 @@ tulip-accounting/
 │   │   │   └── templates/     # Jinja2 + tulip-print.css
 │   │   └── tests/
 │   │
-│   └── tulip-cli/             # CLI client (Typer)
-│       ├── src/tulip_cli/
-│       │   ├── commands/      # add, register, balance, accounts, import, export, ...
-│       │   ├── auth/          # token storage via keyring
+│   ├── tulip-cli/             # CLI client (Typer)
+│   │   ├── src/tulip_cli/
+│   │   │   ├── commands/      # add, register, balance, accounts, import, export, ...
+│   │   │   ├── auth/          # token storage via keyring
+│   │   │   └── main.py
+│   │   └── tests/
+│   │
+│   └── tulip-tui/             # Terminal UI client (Textual) — Phase 9 v1, read-only
+│       ├── src/tulip_tui/
+│       │   ├── data/          # API → value-object adapters (accounts, transactions, reports, …)
+│       │   ├── screens/       # Textual Screen subclasses, one per browse surface
+│       │   ├── app.py         # TulipTuiApp + app-wide bindings
 │       │   └── main.py
-│       └── tests/
+│       └── tests/             # pilot-mode tests via Textual's headless harness
 │
 ├── deploy/
 │   ├── docker/                # Dockerfile + docker-compose.yml for home-server install
@@ -931,6 +939,7 @@ tulip-accounting/
 - `tulip-storage` may import `tulip-core`. The reverse is forbidden.
 - `tulip-api` orchestrates `tulip-core`, `tulip-storage`, `tulip-ai`. It is the only layer that knows about HTTP.
 - `tulip-cli` talks to `tulip-api` over HTTP. It does not import `tulip-storage` or `tulip-core` directly. (This is the same contract a future web client will follow.)
+- `tulip-tui` talks to `tulip-api` over HTTP via the `tulip-cli` HTTP client + token store (the only `tulip-cli` import it makes). It must not import `tulip-storage`, `tulip-api`, `tulip-ai`, `tulip-importers`, `tulip-reports`, `sqlalchemy`, `alembic`, `fastapi`, `starlette`, or `uvicorn`; the boundary is enforced by `packages/tulip-tui/tests/test_architecture.py`.
 - `tulip-importers` and `tulip-reports` are CLI tools / libraries that call the API.
 
 ---
@@ -1033,7 +1042,7 @@ Per [ADR-0004](adrs/0004-reconciliation.md). Closed 2026-05-07 across nine sub-s
 - 🔄 **Documentation pass** — ARCHITECTURE, THREAT_MODEL, PHASE_STATUS, README, QUICKSTART brought current through Phase 8. DEPLOYMENT, SECURITY, AI docs still pending.
 - Performance pass on common queries *(pending)*
 
-### Phase 9 — Terminal UI (TUI)
+### Phase 9 — Terminal UI (TUI) — ✅ v1 shipped (2026-05-17 → 2026-05-18)
 
 Per [ADR-0007](adrs/0007-terminal-ui.md). A [Textual](https://textual.textualize.io/)
 terminal UI as an **additive client** — the CLI stays as the scriptable
@@ -1041,15 +1050,22 @@ terminal UI as an **additive client** — the CLI stays as the scriptable
 review surface. Same HTTP API, no backend changes, no new attack
 surface.
 
-- New workspace package `tulip-tui` — an API client like `tulip-cli`;
-  the architecture-boundary test extends to it (no server / storage
-  imports).
-- **v1 TUI scope is read / browse only** — navigable account browser,
-  transaction register, reports, reconciliation status, import
-  batches. No mutations in the first cut; editing / posting /
-  reconcile actions land in later Phase 9 slices once the navigation
-  shell + read surfaces are proven.
-- Tested headlessly via Textual's pilot mode; a `Test (tulip-tui)`
+- ✅ Workspace package `tulip-tui` lives in the tree — an API client
+  like `tulip-cli`; the architecture-boundary test rejects any
+  `tulip_storage` / `tulip_api` / `tulip_ai` / `tulip_importers` /
+  `tulip_reports` / `sqlalchemy` / `alembic` / `fastapi` / `starlette`
+  / `uvicorn` import.
+- ✅ **v1 TUI scope is read / browse only** — slices P9.0 (skeleton),
+  P9.1 (accounts browser), P9.2 (transactions register with
+  account drill-in), P9.3 (reports viewer over the eight
+  `/v1/reports/*` reports), P9.4 (reconciliations + import-batches
+  browse). App-wide bindings: `q` quit · `p` reports · `c` reconcile
+  · `i` imports · `enter` (on account row) → transactions · `escape`
+  pop · `r` refresh.
+- Mutation surfaces (categorize / split / edit / reconcile-action /
+  apply-import) stay on the CLI for v1 and surface as later Phase 9
+  slices when the read surfaces have soaked.
+- ✅ Tested headlessly via Textual's pilot mode; the `Test (tulip-tui)`
   shard joins the per-package CI matrix (ADR-0006).
 - The CLI is **not** deprecated — the README's "scriptable CLI client"
   value proposition stands.

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-17 · `main` @ **Phase 8 deep security audit complete + Phase 9 design pass complete + Phase 9 v1 shipped (skeleton + accounts browser + transactions register + reports viewer + reconciliations / imports browse)** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318); P9.0 `tulip-tui` workspace package + Textual app shell landed; P9.1 first real screen (accounts browser, grouped DataTable, in-memory loader seam) landed; P9.2–P9.4 queued per #309.
+**Last updated:** 2026-05-18 · `main` @ **Phase 8 deep security audit complete + Phase 9 v1 shipped (read-only TUI: skeleton + accounts browser + transactions register + reports viewer + reconciliations / imports browse)** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318) and all five P9.0–P9.4 slices merged across PRs #383 / #384 / #385 / #386 against umbrella [#309](https://github.com/rmwarriner/tulip-accounting/issues/309); mutation surfaces (categorize / split / edit / reconcile-action / apply-import) deliberately remain on the CLI for v1 per ADR-0007.
 
 ---
 
@@ -30,9 +30,9 @@ Single source of truth for what's shipped, what's in flight, and what's queued. 
 
 - **CLI + importers usability bundle (post-audit):** ✅ shipped — transaction id-prefix display + prefix resolution (#207/#211), interactive reconciliation wizard (#205), `tulip imports show`/`list` (#203/#272), QIF split-posting fidelity (#270) + non-transaction-section skipping (#198) + multi-account import with transfer pairing (#195a/#195b), paper-statement reconciliation (#275), `tulip imports apply --posted` (#210), currency-natural amount precision (#213), account names in `transactions list`/`show` (#214), transaction-level notes (#271), account resolution by name / hierarchical path (#197), interactive UUID picker (#273), `--pending` balance toggle (#274), Rich `Console` honouring `COLUMNS` (#285), right-aligned numeric columns (#289), `/reject` OpenAPI 400 (#194).
 
-- **Phase 9 (terminal UI):** 🔄 design pass complete (2026-05-17) + P9.0 skeleton shipped (2026-05-17) + P9.1 accounts browser shipped (2026-05-17) — per [ADR-0007](adrs/0007-terminal-ui.md), a Textual TUI as an additive client (CLI stays the scriptable surface). v1 scope is read/browse only. Cross-cutting design questions resolved: bill data-model in [ADR-0008](adrs/0008-bills-data-model.md), other four in [TUI_WIREFRAMES.md § Cross-cutting decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17). `packages/tulip-tui/` workspace package, pilot-mode smoke test, and the accounts browser (grouped DataTable with per-currency subtotals, loader-seam tested in-memory) now in tree; P9.2–P9.4 (transaction register, reports viewer, reconciliation/import status) queued per [#309](https://github.com/rmwarriner/tulip-accounting/issues/309). Sits after Phase 8 wraps; pre-cloud preparation renumbers to **Phase 10**.
+- **Phase 9 (terminal UI):** ✅ **v1 shipped** (read-only, 2026-05-17 → 2026-05-18) — per [ADR-0007](adrs/0007-terminal-ui.md), a Textual TUI as an additive client (the CLI stays the scriptable surface). All five P9.0–P9.4 slices merged: workspace skeleton, accounts browser, transactions register with account drill-in, reports viewer (eight `/v1/reports/*` reports), and reconciliations + import-batches browse. App-wide bindings: `q` quit · `p` reports · `c` reconcile · `i` imports · `enter` (on account row) → transactions · `escape` pop · `r` refresh. Cross-cutting design questions resolved during the design pass: bill data-model in [ADR-0008](adrs/0008-bills-data-model.md), other four in [TUI_WIREFRAMES.md § Cross-cutting decisions](TUI_WIREFRAMES.md#cross-cutting-decisions-2026-05-17). Mutation surfaces (categorize / split / edit / reconcile-action / apply-import) deliberately remain on the CLI for v1; surfacing them as TUI flows is the next slice. Pre-cloud preparation remains **Phase 10**.
 
-**Tests:** 1828 passing · **CI:** green on `main`
+**Tests:** 2182 collected (3 benchmark-marker skips) · **CI:** green on `main`
 
 ---
 
@@ -1481,13 +1481,14 @@ No code changes; design-only slice. Implementation begins with P6.1.
 
 ---
 
-## Phase 9 — Terminal UI (TUI) — P9.0 shipped, P9.1+ queued
+## Phase 9 — Terminal UI (TUI) — ✅ v1 shipped (P9.0–P9.4)
 
 Per [ADR-0007](adrs/0007-terminal-ui.md). A Textual TUI as an **additive
 client** (CLI stays the scriptable surface; the TUI is the comfortable
-human surface). v1 scope is read/browse only — mutations land in later
-slices after the read surfaces prove out. Phase 9 sits after Phase 8
-wraps; pre-cloud preparation moved to Phase 10 when ADR-0007 was accepted.
+human surface). v1 scope is read/browse only — mutations stay on the
+CLI and surface as a follow-up phase once the read surfaces have
+soaked. Pre-cloud preparation moved to Phase 10 when ADR-0007 was
+accepted.
 
 ### P9.D — design pass — ✅ *(2026-05-17; closes [#318](https://github.com/rmwarriner/tulip-accounting/issues/318))*
 
@@ -1749,4 +1750,4 @@ Supporting changes:
 
 ## Reference: full phase roadmap
 
-See [ARCHITECTURE.md §10](ARCHITECTURE.md). Phases 0–7 are complete; Phase 8 (operations + hardening) is in progress — the deep security + privacy audits and security/privacy Wave-1 are done. Phase 9 (terminal UI — [ADR-0007](adrs/0007-terminal-ui.md)) is scoped but not started. Phase 10 (pre-cloud preparation + re-audit) follows.
+See [ARCHITECTURE.md §10](ARCHITECTURE.md). Phases 0–7 are complete; Phase 8 (operations + hardening) is in progress — the deep security + privacy audits and security/privacy Wave-1 are done. Phase 9 (terminal UI — [ADR-0007](adrs/0007-terminal-ui.md)) v1 read-only surface shipped (2026-05-17 → 2026-05-18); TUI mutation flows are a follow-up phase. Phase 10 (pre-cloud preparation + re-audit) follows.

--- a/docs/adrs/0007-terminal-ui.md
+++ b/docs/adrs/0007-terminal-ui.md
@@ -1,6 +1,30 @@
 # ADR-0007: Terminal UI (TUI) as Phase 9 — an additive Textual client
 
-**Status:** Accepted. No code shipped with this ADR; it scopes Phase 9.
+**Status:** Accepted (2026-05-14). **Phase 9 v1 shipped 2026-05-17 → 2026-05-18.**
+
+## Phase 9 v1 implementation note (2026-05-18)
+
+The read-only scope this ADR proposes is now in tree on `main`. Five
+slices merged against umbrella [#309](https://github.com/rmwarriner/tulip-accounting/issues/309):
+
+- **P9.0** — `packages/tulip-tui/` workspace skeleton + pilot-mode
+  smoke test + architecture-boundary test (PR #382 predecessor;
+  P9.0 itself landed earlier as the skeleton commit).
+- **P9.1** — accounts browser (PR #383 → `7bb52a0`).
+- **P9.2** — transactions register with account drill-in
+  (PR #384 → `164424a`).
+- **P9.3** — reports viewer over the eight `/v1/reports/*` reports
+  (PR #385 → `32e456b`).
+- **P9.4** — reconciliations + import-batches browse
+  (PR #386 → `0bd5d32`).
+
+App-wide bindings as shipped: `q` quit · `p` reports · `c` reconcile ·
+`i` imports · `enter` (on account row) → transactions · `escape` pop ·
+`r` refresh. Mutation surfaces (categorize / split / edit /
+reconcile-action / apply-import) stay on the CLI for v1 as scoped; a
+follow-up phase will pull them into the TUI once the read surfaces
+have soaked. The ADR's "rejected for now: web / desktop GUI" stance is
+unchanged.
 
 **Date:** 2026-05-14
 


### PR DESCRIPTION
## Summary

All five P9.0–P9.4 slices landed (PRs #383, #384, #385, #386 against umbrella [#309](https://github.com/rmwarriner/tulip-accounting/issues/309)) but several headline lines and detail-prose sections still described Phase 9 as "queued" or "P9.0 shipped, P9.1+ queued". This is doc-only cleanup so the long-form references match the shipped state.

- **PHASE_STATUS.md** — top-of-file last-updated line, the *Current state* Phase 9 bullet, the Phase 9 section heading + intro, the reference-roadmap line at the bottom, and the tests counter (now 2182 collected, up from 1828).
- **ARCHITECTURE.md** — added `tulip-tui` to the §9 project-structure tree and the boundary-rules list (with the explicit forbidden-import set the architecture test enforces); rewrote the §10 Phase 9 section in past tense with per-slice landed markers + the shipped binding map.
- **README.md** — bumped package count seven → eight in the tree and added `tulip-tui` to it; updated the "Web / mobile UI" deferred note to acknowledge the TUI as a second supported client (read-only); updated the *For contributors* Status line to mention Phase 9 v1 shipped.
- **ADR-0007** — moved Status from "Accepted; no code shipped" to "Accepted; Phase 9 v1 shipped" and added a v1 implementation note cataloguing the five merged slices, their PRs and squashed commits, and the shipped binding map (this matches the ADR's own status-update trigger).

No code changes. Files I considered but left alone: `CLAUDE.md` (the only Phase 9 line is the generic "what's in flight" pointer, which is still accurate); `CONTRIBUTING.md` (no Phase 9 references); `docs/QUICKSTART.md` (focused on the API/CLI happy path; mentioning the TUI here would be polish and slightly off-topic for a 20-minute install walkthrough); `docs/TUI_WIREFRAMES.md` (already records the v1 read-only scope at § Cross-cutting decisions); `docs/THREAT_MODEL.md` (the TUI is just another HTTP client of the same API surface — no new attack surface to document).

## Test plan

- [x] `grep -i "P9.1+ queued\|scoped but not started\|Phase 9 sits after\|P9.2-P9.4.*queued"` across docs returns no matches.
- [x] `git diff --stat` shows only the four expected files touched.
- [x] No `.py` / `.toml` / `.yaml` files changed → CI's path-conditional `changes` job will skip the test + type-check shards. Expect lint, secrets-scan, area-labels, CodeQL to run.