### PR TITLE
cli(imports): prompt to create missing account on import (closes #196)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/_account_prompt.py
+++ b/packages/tulip-cli/src/tulip_cli/_account_prompt.py
@@ -1,0 +1,134 @@
+"""Interactive create-missing-account prompt for the import commands (#196).
+
+Used by ``tulip imports {ofx,qif,csv}`` when ``_resolve_account`` raises
+``account.not_found``: at a TTY (and not in ``--json`` mode) we offer to
+create the missing account inline rather than forcing the user to switch
+terminals to ``tulip accounts add``. Scripts, CI, and JSON callers get
+``None`` immediately so they hit the legacy fail-fast path unchanged.
+
+Smart defaults from the identifier the user originally passed:
+
+* purely numeric (``"1010"``) → use as the account ``code``; prompt for
+  the human-readable ``name``.
+* colon-path (``"assets:checking"``) → use as the ``code`` and default
+  the ``name`` to the leaf segment.
+* anything else → default the ``name`` to the identifier verbatim; no
+  ``code`` default.
+
+The helper does not retry on API failures (e.g., duplicate code, invalid
+parent) — those bubble out as ``CliError`` to the caller, which decides
+whether to fall back to the original error path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import typer
+
+from tulip_cli._picker import is_interactive
+from tulip_cli.http import TulipClient
+
+#: Account types accepted by the API. The prompt re-asks on any other
+#: value so we never POST a body that the server will reject for a
+#: trivially-fixable reason.
+_VALID_TYPES: Final[frozenset[str]] = frozenset(
+    {"asset", "liability", "equity", "income", "expense"}
+)
+
+
+def prompt_create_missing_account(
+    client: TulipClient,
+    identifier: str,
+    *,
+    as_json: bool,
+) -> dict[str, Any] | None:
+    """Offer to create ``identifier`` as a new account; return it on success.
+
+    Returns ``None`` when:
+
+    * stdin is not a TTY (``is_interactive() is False``),
+    * the caller is in ``--json`` mode (``as_json=True``),
+    * the user declines the create-it prompt or sends EOF.
+
+    On success the returned dict is the API's ``AccountRead`` body — the
+    caller uses ``["id"]`` for the retry. Any API failure during the
+    inline create raises ``CliError`` (the caller can decide to fall
+    through to the original ``account.unknown`` rendering).
+    """
+    if as_json or not is_interactive():
+        return None
+
+    default_name, default_code = _smart_defaults(identifier)
+
+    try:
+        confirm = typer.confirm(
+            f"Account {identifier!r} not found. Create it now?",
+            default=True,
+        )
+    except (typer.Abort, EOFError):
+        return None
+    if not confirm:
+        return None
+
+    try:
+        name = typer.prompt("  name", default=default_name).strip()
+        type_ = _prompt_account_type()
+        currency = typer.prompt("  currency", default="USD").strip().upper()
+        code = typer.prompt(
+            "  code (blank for none)",
+            default=default_code or "",
+            show_default=bool(default_code),
+        ).strip()
+    except (typer.Abort, EOFError):
+        return None
+
+    body: dict[str, Any] = {
+        "name": name,
+        "type": type_,
+        "currency": currency,
+        "visibility": "shared",
+    }
+    if code:
+        body["code"] = code
+
+    response = client.post("/v1/accounts", json=body, authenticated=True)
+    return dict(response.json())
+
+
+def _smart_defaults(identifier: str) -> tuple[str, str | None]:
+    """Pick ``(default_name, default_code)`` from the failing identifier."""
+    if not identifier:
+        return ("", None)
+    if identifier.isdigit():
+        # Looks like an account number; surface it as the code, leave
+        # the name blank so the user types something human-readable.
+        return ("", identifier)
+    if ":" in identifier:
+        leaf = identifier.split(":")[-1].strip()
+        return (leaf, identifier)
+    return (identifier, None)
+
+
+def _prompt_account_type() -> str:
+    """Re-prompt until the user types one of the accepted account types."""
+    while True:
+        try:
+            raw: str = typer.prompt(
+                "  type (asset / liability / equity / income / expense)",
+            )
+        except (typer.Abort, EOFError) as exc:
+            # Propagate so the caller can return ``None`` rather than
+            # looping forever on a closed stdin.
+            raise EOFError from exc
+        value = raw.strip().lower()
+        if value in _VALID_TYPES:
+            return value
+        typer.echo(
+            f"  '{value}' is not a valid account type — try one of "
+            "asset / liability / equity / income / expense.",
+            err=True,
+        )
+
+
+__all__: list[str] = ["prompt_create_missing_account"]

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -20,6 +20,7 @@ from typing import Annotated, Any
 import httpx
 import typer
 
+from tulip_cli._account_prompt import prompt_create_missing_account
 from tulip_cli._picker import is_interactive, pick
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.commands.accounts import _resolve_account
@@ -27,6 +28,30 @@ from tulip_cli.commands.csv_profiles import csv_profiles_app
 from tulip_cli.config import Config
 from tulip_cli.errors import EXIT_USER, CliError
 from tulip_cli.http import TulipClient
+
+
+def _resolve_or_offer_create(
+    client: TulipClient, identifier: str, *, as_json: bool
+) -> dict[str, Any]:
+    """Resolve ``identifier`` to an account, offering to create on miss (#196).
+
+    On ``account.not_found`` AND a TTY (and not ``--json``), prompt the
+    user to create the account inline and return the freshly-created
+    record. Any other failure mode — non-interactive, ``--json``,
+    declined prompt, or a different error code — re-raises the original
+    :class:`CliError` so the import command's existing render-and-exit
+    path is unchanged.
+    """
+    try:
+        return _resolve_account(client, identifier)
+    except CliError as err:
+        if err.problem.get("code") != "account.not_found":
+            raise
+        created = prompt_create_missing_account(client, identifier, as_json=as_json)
+        if created is None:
+            raise
+        return created
+
 
 imports_app = typer.Typer(
     name="imports",
@@ -78,7 +103,7 @@ def _do_import(
 
     try:
         with _client(config, as_json=as_json) as client:
-            account_record = _resolve_account(client, account)
+            account_record = _resolve_or_offer_create(client, account, as_json=as_json)
             account_id = str(account_record["id"])
             raw_bytes = file_path.read_bytes()
             data: dict[str, str] = {
@@ -820,7 +845,7 @@ def import_qif(
         # can render the friendly starter map instead of the raw error.
         try:
             with _client(config, as_json=as_json) as client:
-                account_record = _resolve_account(client, account)
+                account_record = _resolve_or_offer_create(client, account, as_json=as_json)
                 summary = _post_qif_single(
                     client, file_path, raw_bytes, account_id=str(account_record["id"])
                 )
@@ -863,8 +888,12 @@ def import_qif(
     name_to_identifier = _load_account_map(account_map)
     try:
         with _client(config, as_json=as_json) as client:
+            # Iteratively resolve each map entry so a missing account can
+            # surface the create-it prompt inline (#196) and the rest of
+            # the map still resolves cleanly. Each prompt landing creates
+            # an account in this household; subsequent attempts find it.
             resolved: dict[str, str] = {
-                qif_name: str(_resolve_account(client, identifier)["id"])
+                qif_name: str(_resolve_or_offer_create(client, identifier, as_json=as_json)["id"])
                 for qif_name, identifier in name_to_identifier.items()
             }
             response = client.post_multipart(

--- a/packages/tulip-cli/tests/test_account_prompt.py
+++ b/packages/tulip-cli/tests/test_account_prompt.py
@@ -1,0 +1,310 @@
+"""Unit tests for ``tulip_cli._account_prompt`` (#196).
+
+The helper intercepts ``account.not_found`` from ``_resolve_account``
+during imports and offers to create the missing account inline, then
+returns the created account dict so the caller can retry the import.
+
+Non-TTY callers (scripts, CI, ``--json``) must get ``None`` immediately
+so the caller can fall through to the legacy ``account.unknown`` error
+path — no prompt, no hang.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from tulip_cli._account_prompt import prompt_create_missing_account
+from tulip_cli.auth.tokens import TokenSet, TokenStore
+from tulip_cli.config import Config
+from tulip_cli.http import TulipClient
+
+_API = "https://example.invalid"
+
+
+def _seeded_store(tmp_path: Path) -> TokenStore:
+    store = TokenStore(file_path=tmp_path / "tokens.json")
+    store.save(
+        _API,
+        TokenSet(
+            email="alice@example.com",
+            access_token="access",
+            refresh_token="refresh",
+            access_expires_at=9_999_999_999,
+        ),
+    )
+    return store
+
+
+def _build_client(transport: httpx.MockTransport, tmp_path: Path) -> TulipClient:
+    return TulipClient(
+        Config(api_url=_API),
+        token_store=_seeded_store(tmp_path),
+        transport=transport,
+    )
+
+
+def _capture_handler(
+    response_body: dict[str, Any] | None = None,
+) -> tuple[httpx.MockTransport, list[httpx.Request]]:
+    seen: list[httpx.Request] = []
+
+    def _dispatch(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.method == "POST" and request.url.path == "/v1/accounts":
+            return httpx.Response(
+                201,
+                json=response_body
+                or {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "code": "assets:checking",
+                    "name": "Checking",
+                    "type": "asset",
+                    "subtype": None,
+                    "currency": "USD",
+                    "visibility": "shared",
+                    "is_active": True,
+                    "parent_account_id": None,
+                },
+            )
+        return httpx.Response(500, json={"unexpected": f"{request.method} {request.url.path}"})
+
+    return httpx.MockTransport(_dispatch), seen
+
+
+def test_returns_none_when_non_interactive(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """No TTY → no prompt, no POST, return ``None``."""
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False, raising=False)
+    transport, seen = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        result = prompt_create_missing_account(client, "missing", as_json=False)
+    assert result is None
+    assert seen == []
+
+
+def test_returns_none_in_json_mode_even_if_interactive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--json`` callers never get a prompt regardless of TTY state."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("y\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    transport, seen = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        result = prompt_create_missing_account(client, "missing", as_json=True)
+    assert result is None
+    assert seen == []
+
+
+def test_user_declines_returns_none(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Answering ``n`` to the create-it prompt skips the POST and returns ``None``."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    transport, seen = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        result = prompt_create_missing_account(client, "missing", as_json=False)
+    assert result is None
+    assert seen == []
+
+
+def test_creates_account_and_returns_record(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Answering ``y`` walks through the fields and POSTs to /v1/accounts."""
+    # Sequence: confirm-create, name, type, currency, code (blank → no code).
+    monkeypatch.setattr("sys.stdin", io.StringIO("y\nChecking\nasset\nUSD\n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    transport, seen = _capture_handler(
+        response_body={
+            "id": "22222222-2222-2222-2222-222222222222",
+            "code": None,
+            "name": "Checking",
+            "type": "asset",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+        }
+    )
+    with _build_client(transport, tmp_path) as client:
+        result = prompt_create_missing_account(client, "Checking", as_json=False)
+
+    assert result is not None
+    assert result["id"] == "22222222-2222-2222-2222-222222222222"
+    assert len(seen) == 1
+    posted_request = seen[0]
+    assert posted_request.method == "POST"
+    assert posted_request.url.path == "/v1/accounts"
+    import json as _json
+
+    body = _json.loads(posted_request.content)
+    assert body["name"] == "Checking"
+    assert body["type"] == "asset"
+    assert body["currency"] == "USD"
+    assert "code" not in body  # blank code → field omitted
+
+
+def test_smart_default_code_from_numeric_identifier(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A purely numeric identifier prefills ``--code`` automatically."""
+    # confirm-create, name, type, currency, code (accept default by hitting enter).
+    monkeypatch.setattr("sys.stdin", io.StringIO("y\nChecking\nasset\nUSD\n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    transport, seen = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        prompt_create_missing_account(client, "1010", as_json=False)
+
+    import json as _json
+
+    body = _json.loads(seen[0].content)
+    # The numeric identifier flowed into ``code`` as the default; the
+    # user accepted by leaving the prompt blank.
+    assert body["code"] == "1010"
+
+
+def test_smart_default_name_from_hierarchical_identifier(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An ``assets:checking`` identifier prefills both ``code`` and ``name``."""
+    # confirm, name (accept default), type, currency, code (accept default).
+    monkeypatch.setattr("sys.stdin", io.StringIO("y\n\nasset\nUSD\n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    transport, seen = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        prompt_create_missing_account(client, "assets:checking", as_json=False)
+
+    import json as _json
+
+    body = _json.loads(seen[0].content)
+    assert body["name"] == "checking"  # leaf segment, case-preserving from input
+    assert body["code"] == "assets:checking"
+
+
+def test_rejects_invalid_account_type(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An invalid type re-prompts; second valid answer wins."""
+    # confirm, name, type=bogus (rejected), type=asset (accepted), currency, code (blank).
+    monkeypatch.setattr("sys.stdin", io.StringIO("y\nChecking\nbogus\nasset\nUSD\n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    transport, seen = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        result = prompt_create_missing_account(client, "Checking", as_json=False)
+
+    assert result is not None
+    import json as _json
+
+    body = _json.loads(seen[0].content)
+    assert body["type"] == "asset"
+
+
+def test_eof_during_prompt_returns_none(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Ctrl-D / EOF during the prompt cancels cleanly without raising."""
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))  # immediate EOF
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    transport, seen = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        result = prompt_create_missing_account(client, "Checking", as_json=False)
+
+    assert result is None
+    assert seen == []
+
+
+# -- _resolve_or_offer_create wiring (imports.py) ------------------------
+
+
+def test_resolve_or_offer_create_passes_through_on_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Happy path: existing account resolves normally; no prompt fires."""
+    from tulip_cli.commands import imports as imports_mod
+
+    expected = {"id": "abc", "code": "assets:checking", "name": "Checking"}
+    monkeypatch.setattr(imports_mod, "_resolve_account", lambda _c, _i: expected)
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))  # would EOF if prompted
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    transport, _ = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        result = imports_mod._resolve_or_offer_create(client, "assets:checking", as_json=False)
+    assert result == expected
+
+
+def test_resolve_or_offer_create_reraises_non_not_found_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A different error code (e.g. ambiguous_code) bubbles out unchanged."""
+    from tulip_cli.commands import imports as imports_mod
+    from tulip_cli.errors import CliError
+
+    def _raise(_c: object, _i: str) -> dict[str, Any]:
+        raise CliError(
+            problem={"code": "account.ambiguous_code", "title": "ambig", "status": 0},
+            as_json=False,
+        )
+
+    monkeypatch.setattr(imports_mod, "_resolve_account", _raise)
+
+    transport, _ = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        with pytest.raises(CliError) as excinfo:
+            imports_mod._resolve_or_offer_create(client, "checking", as_json=False)
+    assert excinfo.value.problem["code"] == "account.ambiguous_code"
+
+
+def test_resolve_or_offer_create_reraises_when_user_declines(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """User declines the create-it prompt → original ``account.not_found`` re-raises."""
+    from tulip_cli.commands import imports as imports_mod
+    from tulip_cli.errors import CliError
+
+    def _raise(_c: object, _i: str) -> dict[str, Any]:
+        raise CliError(
+            problem={"code": "account.not_found", "title": "missing", "status": 0},
+            as_json=False,
+        )
+
+    monkeypatch.setattr(imports_mod, "_resolve_account", _raise)
+    monkeypatch.setattr("sys.stdin", io.StringIO("n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    transport, _ = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        with pytest.raises(CliError) as excinfo:
+            imports_mod._resolve_or_offer_create(client, "checking", as_json=False)
+    assert excinfo.value.problem["code"] == "account.not_found"
+
+
+def test_resolve_or_offer_create_returns_created_account_on_accept(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Accepting the prompt returns the newly-created account so the caller can retry."""
+    from tulip_cli.commands import imports as imports_mod
+    from tulip_cli.errors import CliError
+
+    def _raise(_c: object, _i: str) -> dict[str, Any]:
+        raise CliError(
+            problem={"code": "account.not_found", "title": "missing", "status": 0},
+            as_json=False,
+        )
+
+    monkeypatch.setattr(imports_mod, "_resolve_account", _raise)
+    monkeypatch.setattr("sys.stdin", io.StringIO("y\nChecking\nasset\nUSD\n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    transport, seen = _capture_handler()
+    with _build_client(transport, tmp_path) as client:
+        result = imports_mod._resolve_or_offer_create(client, "checking", as_json=False)
+    assert result is not None
+    assert result["id"] == "11111111-1111-1111-1111-111111111111"
+    # One POST /v1/accounts from the inline create.
+    assert [r.method + " " + r.url.path for r in seen] == ["POST /v1/accounts"]


### PR DESCRIPTION
## Summary

When `tulip imports {ofx,qif,csv} --account ACCT` (or `--account-map`'s unresolved entries) fail with `account.not_found`, intercept at a TTY and offer to create the account inline rather than forcing the user to switch terminals to `tulip accounts add`. Closes [#196](https://github.com/rmwarriner/tulip-accounting/issues/196).

- New `_account_prompt.prompt_create_missing_account(client, identifier, *, as_json)` — walks `name` → `type` → `currency` → optional `code`. Smart defaults from the failing identifier:
  - purely numeric (`1010`) → prefills `code`
  - colon-path (`assets:checking`) → prefills `code` and defaults `name` to the leaf segment
  - otherwise → defaults `name` to the identifier verbatim
- **Non-TTY callers (scripts, CI, `--json`) get `None` immediately** so the legacy fail-fast path through `account.unknown` is unchanged. No prompt, no hang, no behavior change for automation.
- Type re-prompts on invalid input rather than silently sending a body the server will reject.
- New `_resolve_or_offer_create` wrapper in `commands/imports.py` routes through the prompt only on `account.not_found`, re-raises any other error code (e.g. `account.ambiguous_code`) unchanged.
- Wired into:
  - OFX + CSV via `_do_import`
  - QIF single-account path
  - QIF `--account-map` per-entry resolution loop (one prompt per unresolved name)

## Test plan

- [x] `uv run pytest packages/tulip-cli/tests/test_account_prompt.py -v` — 12 passing:
  - 8 covering the helper itself (non-TTY return, `--json` bypass, decline, accept-and-create, smart defaults × 3, invalid-type re-prompt, EOF cancel)
  - 4 covering the `_resolve_or_offer_create` wiring (passthrough on success, re-raise on other codes, re-raise on decline, return-created on accept)
- [x] `uv run pytest packages/tulip-cli/tests -q -n auto` — 481 passing locally.
- [x] `just lint` / `just typecheck` / `just format-check` — clean.
- [x] Manual smoke (requires an authenticated `tulip` session at a TTY):

      tulip imports qif statement.qif --account does-not-exist

  Expected: `Account 'does-not-exist' not found. Create it now? [Y/n]:` — answer `y`, walk through name / type / currency / code; import proceeds against the newly-created account.

      tulip imports qif statement.qif --account does-not-exist --json

  Expected: immediate `account.not_found` problem-detail JSON, exit 2 (no prompt).

      tulip imports qif statement.qif --account does-not-exist </dev/null

  Expected: immediate `account.not_found` error, exit 2 (no prompt eaten silently).

- [ ] CI green on this PR.