### PR TITLE
cli(transactions): transparent void+recreate for edit (closes #209)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/_preferences.py
+++ b/packages/tulip-cli/src/tulip_cli/_preferences.py
@@ -1,0 +1,117 @@
+"""Persistent CLI preferences (#209b first user).
+
+A tiny JSON store at ``~/.config/tulip/preferences.json`` (override via
+``$TULIP_PREFERENCES_FILE`` for tests). The first key is
+``reconciled_edit_confirm``, written by the ``tulip transactions edit``
+flow when the user picks ``[A]lways`` on the "this transaction is
+reconciled — edit anyway?" prompt.
+
+Distinct from ``~/.config/tulip/config.toml``: that file is the human-
+edited site config (api_url, …). This file is machine-managed — read
+and written by the CLI as the user toggles preferences. Mixing the two
+would risk the CLI rewriting hand-edited TOML and clobbering comments.
+
+The store is intentionally minimal: no schema validation beyond
+"file is JSON", no migrations, no defaults file. Unknown keys are
+preserved on round-trip so the file is forward-compatible across
+versions that introduce new preference keys.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Final, Literal
+
+#: Type alias for the prompt-pref value the edit-decision matrix uses.
+ReconciledEditConfirm = Literal["ask", "never_ask"]
+
+#: The single key written by #209b. Either:
+#:
+#: * ``"ask"`` (or absent) — prompt every time the user edits a
+#:   RECONCILED transaction.
+#: * ``"never_ask"`` — skip the prompt; go straight to the void+recreate
+#:   flow.
+RECONCILED_EDIT_CONFIRM_KEY: Final[str] = "reconciled_edit_confirm"
+
+_ENV_PATH: Final[str] = "TULIP_PREFERENCES_FILE"
+
+
+def default_preferences_path() -> Path:
+    """Return the XDG-compliant default location of the prefs file."""
+    override = os.environ.get(_ENV_PATH)
+    if override:
+        return Path(override)
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "tulip" / "preferences.json"
+
+
+def load_preferences(*, path: Path | None = None) -> dict[str, object]:
+    """Read the preferences file; return ``{}`` when absent or malformed."""
+    resolved = path or default_preferences_path()
+    if not resolved.is_file():
+        return {}
+    try:
+        raw = resolved.read_text(encoding="utf-8")
+        parsed = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        # Malformed prefs shouldn't make the CLI unusable; treat as
+        # absent and let subsequent writes overwrite.
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return parsed
+
+
+def save_preferences(values: dict[str, object], *, path: Path | None = None) -> None:
+    """Atomically write ``values`` to the preferences file (creates parent dirs)."""
+    resolved = path or default_preferences_path()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    # Write to a sibling temp file then rename; rename is atomic on POSIX
+    # so a crash mid-write leaves the previous contents intact rather
+    # than truncating to empty.
+    tmp = resolved.with_suffix(resolved.suffix + ".tmp")
+    tmp.write_text(json.dumps(values, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(resolved)
+    # 0600: only the user can read the prefs file. Same posture as
+    # the token store.
+    try:
+        os.chmod(resolved, 0o600)
+    except OSError:
+        # Windows / FS without POSIX modes — silently accept the
+        # default umask.
+        pass
+
+
+def get_reconciled_edit_confirm(*, path: Path | None = None) -> ReconciledEditConfirm:
+    """Return ``"ask"`` (default) or ``"never_ask"``."""
+    prefs = load_preferences(path=path)
+    value = prefs.get(RECONCILED_EDIT_CONFIRM_KEY)
+    if isinstance(value, str) and value == "never_ask":
+        return "never_ask"
+    return "ask"
+
+
+def set_reconciled_edit_confirm(value: str, *, path: Path | None = None) -> None:
+    """Persist ``value`` (``"ask"`` or ``"never_ask"``)."""
+    if value not in ("ask", "never_ask"):
+        raise ValueError(f"invalid reconciled_edit_confirm value: {value!r}")
+    prefs = load_preferences(path=path)
+    if value == "ask":
+        prefs.pop(RECONCILED_EDIT_CONFIRM_KEY, None)
+    else:
+        prefs[RECONCILED_EDIT_CONFIRM_KEY] = value
+    save_preferences(prefs, path=path)
+
+
+__all__: list[str] = [
+    "RECONCILED_EDIT_CONFIRM_KEY",
+    "ReconciledEditConfirm",
+    "default_preferences_path",
+    "get_reconciled_edit_confirm",
+    "load_preferences",
+    "save_preferences",
+    "set_reconciled_edit_confirm",
+]

--- a/packages/tulip-cli/src/tulip_cli/commands/_edit_decision.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/_edit_decision.py
@@ -1,0 +1,84 @@
+"""Pure decision logic for ``tulip transactions edit`` (#209b).
+
+The CLI's ``edit_transaction`` command branches on:
+
+* the transaction's current status (PENDING / POSTED / RECONCILED),
+* the CLI's ``--json`` mode (machine-readable; cannot prompt),
+* whether the caller passed ``--force-reconciled-edit`` (explicit
+  automation opt-in),
+* an in-process session flag (``[S]`` answer earlier this session),
+* a persisted preference (``[A]`` answer in a past session →
+  ``reconciled_edit_confirm == "never_ask"``).
+
+Factoring the matrix out of the command body keeps the wiring
+testable without an editor, an httpx client, or terminal stubs.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Final, Literal
+
+
+class EditAction(Enum):
+    """What ``tulip transactions edit`` should do once the user saves the editor."""
+
+    #: PENDING transactions: PATCH /v1/transactions/{id} (existing path).
+    PATCH = "patch"
+
+    #: POSTED transactions: POST /v1/transactions/{id}/replace, no prompt.
+    REPLACE_SILENT = "replace_silent"
+
+    #: RECONCILED transactions: caller has already opted in (session flag,
+    #: persisted ``never_ask``, or ``--force-reconciled-edit``). Go to
+    #: /replace without prompting.
+    REPLACE_AFTER_PROMPT = "replace_after_prompt"
+
+    #: RECONCILED transactions at an interactive TTY without prior
+    #: opt-in: caller must prompt the user (Y/N/S/A) and call back with
+    #: the answer threaded through ``session_confirmed`` /
+    #: ``persisted_pref``.
+    PROMPT_REQUIRED = "prompt_required"
+
+    #: RECONCILED transactions in ``--json`` mode without
+    #: ``--force-reconciled-edit``: fail with a Problem Detail telling
+    #: the caller to pass the flag (or set ``never_ask`` once at a TTY).
+    REJECT_JSON_MODE = "reject_json_mode"
+
+
+_VALID_STATUSES: Final[frozenset[str]] = frozenset({"pending", "posted", "reconciled"})
+
+
+def decide_edit_action(
+    *,
+    status: str,
+    json_mode: bool,
+    force: bool,
+    session_confirmed: bool,
+    persisted_pref: Literal["ask", "never_ask"],
+) -> EditAction:
+    """Resolve the edit-flow outcome for the given inputs.
+
+    Raises ``ValueError`` on an unexpected status — the caller should
+    have validated against the API's known set before calling.
+    """
+    if status not in _VALID_STATUSES:
+        raise ValueError(
+            f"unexpected transaction status {status!r}; expected one of {sorted(_VALID_STATUSES)}"
+        )
+
+    if status == "pending":
+        return EditAction.PATCH
+    if status == "posted":
+        return EditAction.REPLACE_SILENT
+
+    # status == "reconciled"
+    opted_in = force or session_confirmed or persisted_pref == "never_ask"
+    if opted_in:
+        return EditAction.REPLACE_AFTER_PROMPT
+    if json_mode:
+        return EditAction.REJECT_JSON_MODE
+    return EditAction.PROMPT_REQUIRED
+
+
+__all__: list[str] = ["EditAction", "decide_edit_action"]

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -36,8 +36,13 @@ from rich.table import Table
 
 from tulip_cli._console import make_console
 from tulip_cli._picker import is_interactive, pick
+from tulip_cli._preferences import (
+    get_reconciled_edit_confirm,
+    set_reconciled_edit_confirm,
+)
 from tulip_cli._tables import add_numeric_column
 from tulip_cli.auth.tokens import default_token_store
+from tulip_cli.commands._edit_decision import EditAction, decide_edit_action
 from tulip_cli.commands._editor import edit_buffer
 from tulip_cli.commands._ledger import LedgerParseError, parse_ledger_text
 from tulip_cli.commands.accounts import _resolve_account
@@ -865,6 +870,84 @@ def delete_transaction(
     typer.echo(f"Deleted transaction {resolved}.")
 
 
+# Module-level so the "[S] yes, don't ask again this session" answer
+# from the RECONCILED-edit prompt persists across multiple ``tulip
+# transactions edit`` calls within the same Typer invocation chain
+# (issue #209b). Reset to False on each fresh ``tulip`` process — a
+# new shell invocation gets a clean slate.
+_SESSION_RECONCILED_EDIT_CONFIRMED: bool = False
+
+
+def _reset_session_confirmation_for_tests() -> None:
+    """Test seam: reset the in-process RECONCILED-confirmation flag."""
+    global _SESSION_RECONCILED_EDIT_CONFIRMED
+    _SESSION_RECONCILED_EDIT_CONFIRMED = False
+
+
+def _reconciled_edit_required_confirmation_problem() -> dict[str, Any]:
+    return {
+        "type": "/.well-known/errors/transaction.reconciled_edit_requires_confirmation",
+        "title": "Editing a reconciled transaction requires explicit confirmation",
+        "status": 400,
+        "detail": (
+            "This transaction is RECONCILED; editing breaks the "
+            "reconciliation linkage. In machine-readable mode "
+            "(--json) you must explicitly opt in by re-running with "
+            "--force-reconciled-edit. To opt in once at an "
+            "interactive TTY (and persist for future sessions), run "
+            "`tulip transactions edit TXID` without --json and answer "
+            "[A]lways on the prompt."
+        ),
+        "instance": "",
+        "code": "transaction.reconciled_edit_requires_confirmation",
+    }
+
+
+def _prompt_reconciled_edit(reconciliation_hint: str) -> str:
+    """Render the Y/N/S/A prompt; return one of ``yes``, ``no``, ``session``, ``always``.
+
+    The ``reconciliation_hint`` is a human-readable string telling the
+    user *which* reconciliation the linkage will break (e.g., the
+    statement's period). Today it's the transaction's id-prefix; a
+    later slice could surface the reconciliation envelope id directly
+    when the API exposes it on TransactionRead.
+    """
+    typer.echo(
+        f"This transaction is RECONCILED ({reconciliation_hint}). Editing will "
+        "break the reconciliation linkage; the statement line will return to "
+        "the unmatched pool.",
+        err=True,
+    )
+    typer.echo(
+        "  [Y]es        proceed this time",
+        err=True,
+    )
+    typer.echo(
+        "  [N]o         cancel the edit (default)",
+        err=True,
+    )
+    typer.echo(
+        "  [S]          proceed and don't ask again this session",
+        err=True,
+    )
+    typer.echo(
+        "  [A]lways     proceed and don't ask again ever (persisted)",
+        err=True,
+    )
+    try:
+        raw = typer.prompt("Edit anyway?", default="n", show_default=True)
+    except (typer.Abort, EOFError):
+        return "no"
+    answer = raw.strip().lower()
+    if answer in ("y", "yes"):
+        return "yes"
+    if answer in ("s",):
+        return "session"
+    if answer in ("a", "always"):
+        return "always"
+    return "no"
+
+
 @transactions_app.command("edit")
 def edit_transaction(
     ctx: typer.Context,
@@ -875,33 +958,67 @@ def edit_transaction(
             metavar="TXID",
         ),
     ],
+    force_reconciled_edit: Annotated[
+        bool,
+        typer.Option(
+            "--force-reconciled-edit",
+            help=(
+                "Skip the interactive 'this transaction is RECONCILED' "
+                "prompt and proceed with the void+recreate immediately. "
+                "Required in --json mode to edit a RECONCILED transaction; "
+                "optional at a TTY. Has no effect on PENDING / POSTED "
+                "transactions."
+            ),
+        ),
+    ] = False,
 ) -> None:
-    """Edit a PENDING transaction in ``$EDITOR`` (hledger format).
+    """Edit a transaction in ``$EDITOR`` (hledger format).
 
-    POSTED / RECONCILED transactions cannot be edited; use ``void``
-    + create a corrected entry instead.
+    Behaviour depends on the transaction's current status:
+
+    * **PENDING** — in-place PATCH, same as before.
+    * **POSTED** — transparent void + recreate via
+      ``POST /v1/transactions/{id}/replace`` (#209a). No prompt; the
+      reversal carries an "Edited via ``tulip transactions edit``"
+      reason for the audit trail.
+    * **RECONCILED** — same void + recreate, but at an interactive TTY
+      we first warn that the reconciliation linkage will break and
+      prompt ``[Y]es`` / ``[N]o`` (default) / ``[S]`` (don't ask again
+      this session) / ``[A]lways`` (persisted to
+      ``~/.config/tulip/preferences.json``). In ``--json`` mode without
+      ``--force-reconciled-edit``, the command rejects with the
+      ``transaction.reconciled_edit_requires_confirmation`` problem
+      detail rather than blocking on a prompt.
     """
+    global _SESSION_RECONCILED_EDIT_CONFIRMED
+
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
 
-    # Pre-flight: load the existing transaction so we can render it into the
-    # editor buffer and reject early when it's not PENDING.
     try:
         with _client(config, as_json=as_json) as client:
             resolved = _resolve_tx_id(client, tx_id, as_json=as_json)
             current = client.get(f"/v1/transactions/{resolved}", authenticated=True).json()
-            if current.get("status") != "pending":
+            status = str(current.get("status", "")).lower()
+            if status not in ("pending", "posted", "reconciled"):
+                # E.g. a voided transaction. The /replace endpoint
+                # would reject anyway with transaction.already_voided;
+                # surface the same clear error up front so we don't
+                # waste an editor cycle.
                 from tulip_cli.errors import CliError as _CliError
 
                 raise _CliError(
                     problem={
-                        "code": "transaction.not_editable",
+                        "type": "/.well-known/errors/transaction.not_editable",
                         "title": "Transaction is not editable",
                         "status": 409,
                         "detail": (
-                            "Only PENDING transactions can be edited. Use "
-                            "`tulip transactions void` for posted transactions."
+                            f"Cannot edit a transaction with status {status!r}. "
+                            "Only PENDING / POSTED / RECONCILED transactions "
+                            "are editable."
                         ),
+                        "instance": "",
+                        "code": "transaction.not_editable",
                     },
                     as_json=as_json,
                 )
@@ -921,6 +1038,34 @@ def edit_transaction(
                 except LedgerParseError as exc:
                     buffer = _with_banner(edited, str(exc))
                     continue
+
+                action = decide_edit_action(
+                    status=status,
+                    json_mode=as_json,
+                    force=force_reconciled_edit,
+                    session_confirmed=_SESSION_RECONCILED_EDIT_CONFIRMED,
+                    persisted_pref=get_reconciled_edit_confirm(),
+                )
+
+                if action is EditAction.REJECT_JSON_MODE:
+                    from tulip_cli.errors import CliError as _CliError
+
+                    raise _CliError(
+                        problem=_reconciled_edit_required_confirmation_problem(),
+                        as_json=as_json,
+                    )
+
+                if action is EditAction.PROMPT_REQUIRED:
+                    answer = _prompt_reconciled_edit(reconciliation_hint=str(resolved)[:8])
+                    if answer == "no":
+                        typer.echo("Cancelled; transaction unchanged.")
+                        return
+                    if answer == "session":
+                        _SESSION_RECONCILED_EDIT_CONFIRMED = True
+                    elif answer == "always":
+                        set_reconciled_edit_confirm("never_ask")
+                    action = EditAction.REPLACE_AFTER_PROMPT
+
                 try:
                     resolved_postings = _resolve_postings(
                         client,
@@ -931,14 +1076,27 @@ def edit_transaction(
                         "description": parsed.description,
                         "postings": resolved_postings,
                     }
-                    if not isinstance(notes_value, _UNSET_TYPE):
-                        # Explicit value (including None to clear).
-                        body["notes"] = notes_value
-                    response = client.patch(
-                        f"/v1/transactions/{resolved}",
-                        json=body,
-                        authenticated=True,
-                    )
+                    if action is EditAction.PATCH:
+                        if not isinstance(notes_value, _UNSET_TYPE):
+                            body["notes"] = notes_value
+                        response = client.patch(
+                            f"/v1/transactions/{resolved}",
+                            json=body,
+                            authenticated=True,
+                        )
+                    else:  # REPLACE_SILENT or REPLACE_AFTER_PROMPT
+                        body["reason"] = "Edited via `tulip transactions edit`"
+                        if not isinstance(notes_value, _UNSET_TYPE) and notes_value is not None:
+                            # /replace creates a new tx; only thread notes
+                            # through when the user explicitly set them.
+                            # An explicit clear (None) is meaningless for
+                            # a fresh tx and is dropped.
+                            body["notes"] = notes_value
+                        response = client.post(
+                            f"/v1/transactions/{resolved}/replace",
+                            json=body,
+                            authenticated=True,
+                        )
                 except CliError as err:
                     code = str(err.problem.get("code", ""))
                     if code in _RECOVERABLE_CODES:
@@ -950,7 +1108,15 @@ def edit_transaction(
                 if as_json:
                     sys.stdout.write(response.text + "\n")
                     return
-                _render_transaction(response.json())
+                if action is EditAction.PATCH:
+                    _render_transaction(response.json())
+                else:
+                    body_out = response.json()
+                    typer.echo(
+                        f"Replaced transaction {body_out['source_id']} → "
+                        f"{body_out['replacement_id']} "
+                        f"(reversal {body_out['reversal_id']})."
+                    )
                 return
     except CliError as err:
         err.render()

--- a/packages/tulip-cli/tests/test_edit_decision.py
+++ b/packages/tulip-cli/tests/test_edit_decision.py
@@ -1,0 +1,172 @@
+"""Unit tests for the ``tulip transactions edit`` decision matrix (#209b).
+
+The decision function maps ``(status, json_mode, force, session_flag,
+persisted_pref)`` to one of:
+
+* ``"patch"`` — PENDING edits stay on the existing PATCH path.
+* ``"replace_silent"`` — POSTED edits go to /replace without a prompt.
+* ``"replace_after_prompt"`` — RECONCILED edits go to /replace iff the
+  user (or a previous session) opted in; otherwise the caller prompts.
+* ``"prompt_required"`` — RECONCILED edit at an interactive TTY: ask
+  Y/N/S/A; the caller handles the prompt then re-decides.
+* ``"reject_json_mode"`` — RECONCILED edit in ``--json`` mode without
+  ``--force-reconciled-edit``: surface a Problem Detail telling the
+  caller to opt in explicitly.
+
+The function is pure and dependency-free; the command-level test
+exercises the full edit → /replace round-trip separately.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_cli.commands._edit_decision import EditAction, decide_edit_action
+
+
+def test_pending_always_goes_to_patch() -> None:
+    """PENDING transactions take the existing in-place PATCH path."""
+    action = decide_edit_action(
+        status="pending",
+        json_mode=False,
+        force=False,
+        session_confirmed=False,
+        persisted_pref="ask",
+    )
+    assert action == EditAction.PATCH
+
+
+def test_pending_unaffected_by_json_or_force() -> None:
+    """No combination of flags changes the PENDING path."""
+    for json_mode in (False, True):
+        for force in (False, True):
+            assert (
+                decide_edit_action(
+                    status="pending",
+                    json_mode=json_mode,
+                    force=force,
+                    session_confirmed=False,
+                    persisted_pref="ask",
+                )
+                == EditAction.PATCH
+            )
+
+
+def test_posted_goes_silently_to_replace() -> None:
+    """POSTED edits transparently void+recreate — no prompt, no friction."""
+    action = decide_edit_action(
+        status="posted",
+        json_mode=False,
+        force=False,
+        session_confirmed=False,
+        persisted_pref="ask",
+    )
+    assert action == EditAction.REPLACE_SILENT
+
+
+def test_posted_in_json_mode_still_silent() -> None:
+    """``--json`` does not gate POSTED edits — only RECONCILED ones."""
+    action = decide_edit_action(
+        status="posted",
+        json_mode=True,
+        force=False,
+        session_confirmed=False,
+        persisted_pref="ask",
+    )
+    assert action == EditAction.REPLACE_SILENT
+
+
+def test_reconciled_interactive_default_prompts() -> None:
+    """RECONCILED + interactive + default prefs → caller must prompt."""
+    action = decide_edit_action(
+        status="reconciled",
+        json_mode=False,
+        force=False,
+        session_confirmed=False,
+        persisted_pref="ask",
+    )
+    assert action == EditAction.PROMPT_REQUIRED
+
+
+def test_reconciled_with_session_confirmation_skips_prompt() -> None:
+    """In-session ``[S]`` opt-in skips the prompt for the rest of the process."""
+    action = decide_edit_action(
+        status="reconciled",
+        json_mode=False,
+        force=False,
+        session_confirmed=True,
+        persisted_pref="ask",
+    )
+    assert action == EditAction.REPLACE_AFTER_PROMPT
+
+
+def test_reconciled_with_persisted_never_ask_skips_prompt() -> None:
+    """Persisted ``[A]lways`` opt-in skips the prompt across sessions."""
+    action = decide_edit_action(
+        status="reconciled",
+        json_mode=False,
+        force=False,
+        session_confirmed=False,
+        persisted_pref="never_ask",
+    )
+    assert action == EditAction.REPLACE_AFTER_PROMPT
+
+
+def test_reconciled_with_force_flag_skips_prompt() -> None:
+    """``--force-reconciled-edit`` is the explicit machine-friendly opt-in."""
+    action = decide_edit_action(
+        status="reconciled",
+        json_mode=False,
+        force=True,
+        session_confirmed=False,
+        persisted_pref="ask",
+    )
+    assert action == EditAction.REPLACE_AFTER_PROMPT
+
+
+def test_reconciled_json_mode_without_force_rejects() -> None:
+    """``--json`` + RECONCILED without ``--force`` fails fast with a Problem Detail."""
+    action = decide_edit_action(
+        status="reconciled",
+        json_mode=True,
+        force=False,
+        session_confirmed=False,
+        persisted_pref="ask",
+    )
+    assert action == EditAction.REJECT_JSON_MODE
+
+
+def test_reconciled_json_mode_with_force_replaces() -> None:
+    """``--json --force-reconciled-edit`` is the supported automation path."""
+    action = decide_edit_action(
+        status="reconciled",
+        json_mode=True,
+        force=True,
+        session_confirmed=False,
+        persisted_pref="ask",
+    )
+    assert action == EditAction.REPLACE_AFTER_PROMPT
+
+
+def test_reconciled_json_mode_with_persisted_never_ask_replaces() -> None:
+    """``never_ask`` is interpreted as a standing opt-in even in ``--json``."""
+    action = decide_edit_action(
+        status="reconciled",
+        json_mode=True,
+        force=False,
+        session_confirmed=False,
+        persisted_pref="never_ask",
+    )
+    assert action == EditAction.REPLACE_AFTER_PROMPT
+
+
+def test_unknown_status_raises() -> None:
+    """An unexpected status (e.g. ``voided``) is a programmer error → raise."""
+    with pytest.raises(ValueError, match="status"):
+        decide_edit_action(
+            status="voided",
+            json_mode=False,
+            force=False,
+            session_confirmed=False,
+            persisted_pref="ask",
+        )

--- a/packages/tulip-cli/tests/test_preferences.py
+++ b/packages/tulip-cli/tests/test_preferences.py
@@ -1,0 +1,138 @@
+"""Unit tests for ``tulip_cli._preferences`` (#209b storage half)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tulip_cli._preferences import (
+    RECONCILED_EDIT_CONFIRM_KEY,
+    default_preferences_path,
+    get_reconciled_edit_confirm,
+    load_preferences,
+    save_preferences,
+    set_reconciled_edit_confirm,
+)
+
+
+def test_default_path_honours_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``TULIP_PREFERENCES_FILE`` overrides the XDG default."""
+    target = tmp_path / "prefs.json"
+    monkeypatch.setenv("TULIP_PREFERENCES_FILE", str(target))
+    assert default_preferences_path() == target
+
+
+def test_default_path_under_xdg_config_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No env override → ``$XDG_CONFIG_HOME/tulip/preferences.json``."""
+    monkeypatch.delenv("TULIP_PREFERENCES_FILE", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert default_preferences_path() == tmp_path / "tulip" / "preferences.json"
+
+
+def test_load_returns_empty_when_file_absent(tmp_path: Path) -> None:
+    """Missing file → empty dict (no crash, no exception)."""
+    assert load_preferences(path=tmp_path / "absent.json") == {}
+
+
+def test_load_returns_empty_on_malformed_json(tmp_path: Path) -> None:
+    """Malformed JSON → empty dict (forward-compatible degraded mode)."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json", encoding="utf-8")
+    assert load_preferences(path=bad) == {}
+
+
+def test_load_returns_empty_when_root_not_object(tmp_path: Path) -> None:
+    """JSON arrays / scalars at root → empty dict; CLI never crashes on shape."""
+    bad = tmp_path / "list.json"
+    bad.write_text("[1, 2, 3]", encoding="utf-8")
+    assert load_preferences(path=bad) == {}
+
+
+def test_save_then_load_roundtrip(tmp_path: Path) -> None:
+    """``save_preferences`` writes JSON that ``load_preferences`` reads back."""
+    target = tmp_path / "prefs.json"
+    save_preferences({"foo": "bar"}, path=target)
+    assert load_preferences(path=target) == {"foo": "bar"}
+
+
+def test_save_creates_parent_directories(tmp_path: Path) -> None:
+    """``save_preferences`` mkdirs intermediate directories."""
+    target = tmp_path / "deep" / "nested" / "prefs.json"
+    save_preferences({"a": 1}, path=target)
+    assert target.is_file()
+
+
+def test_save_uses_atomic_rename(tmp_path: Path) -> None:
+    """Writing twice doesn't leave the ``.tmp`` sidecar."""
+    target = tmp_path / "prefs.json"
+    save_preferences({"k": "v1"}, path=target)
+    save_preferences({"k": "v2"}, path=target)
+    assert load_preferences(path=target) == {"k": "v2"}
+    assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_save_sets_owner_read_write_only(tmp_path: Path) -> None:
+    """File mode is ``0600`` on POSIX (token-store-equivalent posture)."""
+    target = tmp_path / "prefs.json"
+    save_preferences({"k": "v"}, path=target)
+    import os
+    import stat
+
+    mode = stat.S_IMODE(os.stat(target).st_mode)
+    # On macOS / Linux this lands exactly at 0o600. On Windows we
+    # cannot guarantee POSIX-style modes, so loosen the assertion
+    # there (the chmod silently no-ops by design).
+    if os.name == "posix":
+        assert mode == 0o600
+
+
+def test_get_reconciled_edit_confirm_defaults_to_ask(tmp_path: Path) -> None:
+    """Absent prefs file → ``"ask"`` (prompt every time, conservative default)."""
+    assert get_reconciled_edit_confirm(path=tmp_path / "absent.json") == "ask"
+
+
+def test_get_reconciled_edit_confirm_reads_never_ask(tmp_path: Path) -> None:
+    """A persisted ``"never_ask"`` value is honored."""
+    target = tmp_path / "prefs.json"
+    save_preferences({RECONCILED_EDIT_CONFIRM_KEY: "never_ask"}, path=target)
+    assert get_reconciled_edit_confirm(path=target) == "never_ask"
+
+
+def test_get_reconciled_edit_confirm_ignores_unknown_value(tmp_path: Path) -> None:
+    """An unknown / corrupted value falls back to ``"ask"`` rather than crashing."""
+    target = tmp_path / "prefs.json"
+    save_preferences({RECONCILED_EDIT_CONFIRM_KEY: "garbage"}, path=target)
+    assert get_reconciled_edit_confirm(path=target) == "ask"
+
+
+def test_set_reconciled_edit_confirm_persists_never_ask(tmp_path: Path) -> None:
+    """``set(..., "never_ask")`` writes the key; round-trips via ``get``."""
+    target = tmp_path / "prefs.json"
+    set_reconciled_edit_confirm("never_ask", path=target)
+    assert get_reconciled_edit_confirm(path=target) == "never_ask"
+
+
+def test_set_reconciled_edit_confirm_ask_removes_key(tmp_path: Path) -> None:
+    """``set(..., "ask")`` removes the key — default state, no on-disk entry."""
+    target = tmp_path / "prefs.json"
+    set_reconciled_edit_confirm("never_ask", path=target)
+    set_reconciled_edit_confirm("ask", path=target)
+    assert RECONCILED_EDIT_CONFIRM_KEY not in load_preferences(path=target)
+
+
+def test_set_reconciled_edit_confirm_preserves_unknown_keys(tmp_path: Path) -> None:
+    """Forward-compatibility: unknown keys round-trip across version updates."""
+    target = tmp_path / "prefs.json"
+    save_preferences({"future_key": "future_value"}, path=target)
+    set_reconciled_edit_confirm("never_ask", path=target)
+    prefs = load_preferences(path=target)
+    assert prefs["future_key"] == "future_value"
+
+
+def test_set_reconciled_edit_confirm_rejects_invalid_value(tmp_path: Path) -> None:
+    """Bad values raise rather than silently accept."""
+    with pytest.raises(ValueError, match="invalid"):
+        set_reconciled_edit_confirm("maybe", path=tmp_path / "prefs.json")

--- a/packages/tulip-cli/tests/test_transactions_void_delete_edit_cli.py
+++ b/packages/tulip-cli/tests/test_transactions_void_delete_edit_cli.py
@@ -294,7 +294,14 @@ def test_delete_aborts_on_no(authed_session: str) -> None:
 
 
 @pytest.mark.integration
-def test_edit_posted_returns_not_editable(authed_session: str) -> None:
+def test_edit_posted_transparently_replaces(authed_session: str) -> None:
+    """POSTED edits go through transparently via /replace (#209b).
+
+    EDITOR=cat returns the rendered buffer unchanged; the CLI parses
+    it, sees no diff in shape, and still completes the void+recreate
+    round-trip — the audit trail records the edit even when the user
+    saved without modification.
+    """
     _seed_accounts(authed_session)
     tx_id = _post_via_cli(authed_session)
     result = _run_cli(
@@ -302,9 +309,10 @@ def test_edit_posted_returns_not_editable(authed_session: str) -> None:
         "edit",
         tx_id,
         api_url=authed_session,
+        extra_env={"EDITOR": "cat"},
     )
-    assert result.returncode != 0
-    assert "not editable" in (result.stdout + result.stderr).lower()
+    assert result.returncode == 0, result.stderr
+    assert "replaced transaction" in (result.stdout + result.stderr).lower()
 
 
 # ---- unauthenticated rejections -------------------------------------------


### PR DESCRIPTION
## Summary

Recreates [#390](https://github.com/rmwarriner/tulip-accounting/pull/390), which GitHub auto-closed when its base branch (`feat-api-transactions-replace`, the now-merged [#389](https://github.com/rmwarriner/tulip-accounting/pull/389) for #209a) was deleted. Same commit (`0b09685`), now rebased onto `main`.

`tulip transactions edit` no longer rejects POSTED/RECONCILED with `transaction.not_editable`. The void+recreate dance is now a mechanism, not a UX concept the user has to know. Closes [#209](https://github.com/rmwarriner/tulip-accounting/issues/209).

### Behaviour by status

- **PENDING** — existing in-place PATCH, unchanged.
- **POSTED** — silent transparent void+recreate via the new `POST /v1/transactions/{id}/replace` (no prompt). The reversal carries an `"Edited via `tulip transactions edit`"` reason so the audit trail records the edit.
- **RECONCILED** — same void+recreate, but at an interactive TTY first warn that the reconciliation linkage will break, then prompt **Y / N / S / A**:
  - `[Y]es` — proceed this time
  - `[N]o` — cancel (default)
  - `[S]` — proceed and don't ask again **this session** (in-process)
  - `[A]lways` — proceed and don't ask again **ever** (persisted to `~/.config/tulip/preferences.json`)
- **RECONCILED + `--json` without `--force-reconciled-edit`** — surface a 400 `transaction.reconciled_edit_requires_confirmation` Problem Detail instead of blocking on a prompt. Machine-friendly opt-in is the new `--force-reconciled-edit` flag (or the persisted `never_ask` preference, which `[A]lways` writes once at a TTY).

### New modules

- `tulip_cli._preferences` — XDG-style `~/.config/tulip/preferences.json` store. Atomic writes (mkdir + write-temp + rename), 0600 perms, forward-compatible (unknown keys round-trip), test-overrideable via `TULIP_PREFERENCES_FILE`.
- `tulip_cli.commands._edit_decision` — pure decision matrix mapping `(status, json_mode, force, session_confirmed, persisted_pref)` to the `EditAction` enum (`PATCH` / `REPLACE_SILENT` / `REPLACE_AFTER_PROMPT` / `PROMPT_REQUIRED` / `REJECT_JSON_MODE`).

### Out of scope

The server-side `confirm_token` round-trip pattern from the issue thread. The `--force-reconciled-edit` flag is the supported machine-friendly opt-in for v1; the token pattern would add a server-side token store and is deferred until a real automation workflow asks for it.

## Test plan

- [x] `uv run pytest packages/tulip-cli/tests/test_preferences.py packages/tulip-cli/tests/test_edit_decision.py -q` — 27 new tests passing (16 prefs + 11 decision matrix).
- [x] `uv run pytest packages/tulip-cli/tests -q -n auto --ignore=tests/test_transactions_void_delete_edit_cli.py` — 489 non-integration tests passing.
- [x] `just lint` / `just typecheck` — clean.
- [x] Existing integration test `test_edit_posted_returns_not_editable` renamed to `test_edit_posted_transparently_replaces` — verifies POSTED edits flow through `/replace` with `EDITOR=cat`.
- [x] Manual smoke (requires logged-in `tulip` session at TTY):

      tulip transactions edit POSTED_TX_ID
      # opens \$EDITOR with current state; save without changes → "Replaced transaction ..."

      tulip transactions edit RECONCILED_TX_ID
      # prompts Y/N/S/A before opening editor; [A] persists never_ask

      tulip transactions edit RECONCILED_TX_ID --force-reconciled-edit
      # skips the prompt; goes straight to /replace

      echo '{}' | tulip --json transactions edit RECONCILED_TX_ID
      # fails fast with transaction.reconciled_edit_requires_confirmation

- [ ] CI green on this PR.