### PR TITLE
cli: editor renders codeless accounts as name, not UUID (closes #304)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/commands/_ledger.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/_ledger.py
@@ -29,7 +29,23 @@ from datetime import date as date_type
 from decimal import Decimal, InvalidOperation
 
 _HEADER_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})(?:\s+(.+))?\s*$")
+# Posting line: ``<account>  <amount> [<currency>]``.
+#
+# The account/amount separator is **two or more whitespace characters**
+# (hledger convention). This lets account names contain single spaces —
+# `My Checking Account  -12.50 USD` parses cleanly because the parser
+# splits at the first run of 2+ whitespace. Single-space separators
+# (`assets:cash -1.00`) used to work pre-#304 and still do, but only
+# when the account itself is a single non-whitespace token.
 _POSTING_RE = re.compile(
+    r"^(?P<account>\S+(?:[ \t]\S+)*)"
+    r"\s{2,}"
+    r"(?P<amount>-?\d+(?:\.\d+)?)\s*(?P<currency>\S+)?\s*$"
+)
+# Fallback: tolerates a single-space separator when the account is a
+# single non-whitespace token. Preserves backward compat with buffers
+# that pre-date the two-space rule. Tried in order after _POSTING_RE.
+_POSTING_RE_SINGLE_SPACE = re.compile(
     r"^(?P<account>\S+)\s+(?P<amount>-?\d+(?:\.\d+)?)\s*(?P<currency>\S+)?\s*$"
 )
 _CURRENCY_RE = re.compile(r"^[A-Za-z]{3}$")
@@ -114,13 +130,15 @@ def parse_ledger_text(text: str) -> ParsedLedgerTransaction:
                 f"Line {line_idx}: posting lines must be indented (start with whitespace)."
             )
         body = raw.strip()
-        match = _POSTING_RE.match(body)
+        match = _POSTING_RE.match(body) or _POSTING_RE_SINGLE_SPACE.match(body)
         if match is None:
             raise LedgerParseError(
                 f"Line {line_idx}: could not parse posting "
-                f"(expected '<account>  <amount> [<currency>]')."
+                f"(expected '<account>  <amount> [<currency>]'; "
+                "separate the account from the amount with two-or-more "
+                "spaces if the account name contains a space)."
             )
-        account = match.group("account")
+        account = match.group("account").strip()
         amount_str = match.group("amount")
         currency = match.group("currency")
         try:

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -1123,20 +1123,47 @@ def edit_transaction(
         raise typer.Exit(err.exit_code) from None
 
 
+def _account_display_for_edit(account_id: str, accounts_by_id: dict[str, dict[str, Any]]) -> str:
+    """Pick the most-readable label for an account in the editor buffer (#304).
+
+    Fallback order:
+
+    1. ``code`` — already-namespaced and parser-safe (matches the user's
+       chart-of-accounts shorthand).
+    2. ``name`` — works for the common case of code-less accounts created
+       by an importer (e.g., "Checking"). Names with spaces survive the
+       round-trip because the parser accepts the hledger two-space
+       account/amount separator.
+    3. ``account_id`` — last-resort, for orphaned references where the
+       account row didn't come back in the lookup. The user will see a
+       UUID and can fix or delete the row by hand.
+    """
+    account = accounts_by_id.get(account_id, {})
+    code = account.get("code")
+    if isinstance(code, str) and code:
+        return code
+    name = account.get("name")
+    if isinstance(name, str) and name:
+        return name
+    return account_id
+
+
 def _render_tx_for_edit(tx: dict[str, Any], accounts_by_id: dict[str, dict[str, Any]]) -> str:
     """Render an existing transaction back into the hledger-subset format.
 
-    Uses account ``code`` when available; falls back to UUID. Inverse of
-    :func:`tulip_cli.commands._ledger.parse_ledger_text`. Notes (if any)
-    are rendered as a bracketed comment block at the bottom of the
-    buffer; see :func:`_extract_notes_block`.
+    Inverse of :func:`tulip_cli.commands._ledger.parse_ledger_text`.
+    Account labels use the fallback chain in
+    :func:`_account_display_for_edit` so code-less accounts render as
+    their human-readable name rather than a bare UUID (#304). The
+    account/amount separator is two spaces — the hledger convention the
+    parser also accepts so names containing single spaces round-trip.
+    Notes (if any) are rendered as a bracketed comment block at the
+    bottom of the buffer; see :func:`_extract_notes_block`.
     """
     lines: list[str] = [_EDITOR_TEMPLATE_HEADER, ""]
     lines.append(f"{tx.get('date', '')} {tx.get('description', '')}")
     for p in tx.get("postings", []):
-        account_ref = accounts_by_id.get(p.get("account_id", ""), {}).get("code") or p.get(
-            "account_id", ""
-        )
+        account_ref = _account_display_for_edit(str(p.get("account_id", "")), accounts_by_id)
         amount = p.get("amount", "")
         currency = p.get("currency", "")
         lines.append(f"  {account_ref}  {amount} {currency}")

--- a/packages/tulip-cli/tests/test_ledger_parser.py
+++ b/packages/tulip-cli/tests/test_ledger_parser.py
@@ -142,6 +142,32 @@ def test_unparseable_amount_raises() -> None:
         parse_ledger_text("2026-05-01 Lunch\n  expenses:food not-a-number\n  assets:cash -1.00\n")
 
 
+def test_account_name_can_contain_spaces_with_two_space_separator() -> None:
+    """hledger-style two-space separator lets account names contain spaces (#304)."""
+    text = """
+    2026-05-01 Groceries
+      expenses:groceries     12.50
+      My Checking Account   -12.50 USD
+    """
+    parsed = parse_ledger_text(text)
+    assert parsed.postings[0].account == "expenses:groceries"
+    assert parsed.postings[1].account == "My Checking Account"
+    assert parsed.postings[1].amount == Decimal("-12.50")
+    assert parsed.postings[1].currency == "USD"
+
+
+def test_single_token_account_with_single_space_still_works() -> None:
+    """Pre-#304 buffers with single-space separator remain accepted."""
+    text = """
+    2026-05-01 Coffee
+      expenses:coffee 3.50
+      assets:cash -3.50
+    """
+    parsed = parse_ledger_text(text)
+    assert parsed.postings[0].account == "expenses:coffee"
+    assert parsed.postings[1].account == "assets:cash"
+
+
 def test_unindented_after_header_raises_or_ignores() -> None:
     """A non-indented, non-blank, non-comment line after the header is invalid."""
     with pytest.raises(LedgerParseError):

--- a/packages/tulip-cli/tests/test_tx_edit_render.py
+++ b/packages/tulip-cli/tests/test_tx_edit_render.py
@@ -1,0 +1,147 @@
+"""Round-trip tests for the transactions-edit buffer renderer (#304).
+
+The contract the issue calls out: a transaction rendered to the buffer
+and saved *unmodified* must parse back to the identical posting set.
+Pre-#304 the renderer fell back from ``code`` straight to the bare
+UUID, which round-tripped fine but was unreadable for importer-created
+accounts. Post-#304 the renderer falls back ``code → name → UUID`` and
+the parser accepts hledger's two-space account/amount separator so
+multi-word names also round-trip.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from tulip_cli.commands._ledger import parse_ledger_text
+from tulip_cli.commands.transactions import (
+    _account_display_for_edit,
+    _render_tx_for_edit,
+)
+
+
+def _accounts(*entries: tuple[str, str | None, str]) -> dict[str, dict[str, Any]]:
+    """Build an accounts-by-id dict from ``(id, code, name)`` tuples."""
+    return {
+        account_id: {"id": account_id, "code": code, "name": name}
+        for account_id, code, name in entries
+    }
+
+
+def test_display_prefers_code_over_name() -> None:
+    """A code-bearing account renders as its code (terser, namespaced)."""
+    accounts_by_id = _accounts(("acc-1", "assets:checking", "Checking"))
+    assert _account_display_for_edit("acc-1", accounts_by_id) == "assets:checking"
+
+
+def test_display_falls_back_to_name_when_no_code() -> None:
+    """A codeless account renders as its human-readable name (#304)."""
+    accounts_by_id = _accounts(("acc-1", None, "Checking"))
+    assert _account_display_for_edit("acc-1", accounts_by_id) == "Checking"
+
+
+def test_display_falls_back_to_uuid_when_account_unknown() -> None:
+    """Orphaned references render as the bare UUID — last-resort, but truthful."""
+    accounts_by_id: dict[str, dict[str, Any]] = {}
+    assert (
+        _account_display_for_edit("11111111-1111-1111-1111-111111111111", accounts_by_id)
+        == "11111111-1111-1111-1111-111111111111"
+    )
+
+
+def test_display_falls_back_to_uuid_when_neither_code_nor_name() -> None:
+    """Both fields empty/null → UUID. Defensive against malformed API responses."""
+    accounts_by_id = _accounts(("acc-1", None, ""))
+    assert _account_display_for_edit("acc-1", accounts_by_id) == "acc-1"
+
+
+def test_render_and_parse_round_trip_with_codes() -> None:
+    """code-bearing postings render via code and parse back to the same identifiers."""
+    accounts_by_id = _accounts(
+        ("acc-1", "assets:checking", "Checking"),
+        ("acc-2", "expenses:groceries", "Groceries"),
+    )
+    tx: dict[str, Any] = {
+        "date": "2026-05-01",
+        "description": "Lunch",
+        "postings": [
+            {"account_id": "acc-1", "amount": "-12.50", "currency": "USD"},
+            {"account_id": "acc-2", "amount": "12.50", "currency": "USD"},
+        ],
+    }
+    buffer = _render_tx_for_edit(tx, accounts_by_id)
+    parsed = parse_ledger_text(buffer)
+
+    assert parsed.description == "Lunch"
+    assert [p.account for p in parsed.postings] == [
+        "assets:checking",
+        "expenses:groceries",
+    ]
+    assert [p.amount for p in parsed.postings] == [
+        Decimal("-12.50"),
+        Decimal("12.50"),
+    ]
+
+
+def test_render_and_parse_round_trip_with_codeless_single_word_names() -> None:
+    """Codeless single-word names (the common QIF/OFX import case) round-trip cleanly."""
+    accounts_by_id = _accounts(
+        ("acc-1", None, "Checking"),
+        ("acc-2", None, "Groceries"),
+    )
+    tx: dict[str, Any] = {
+        "date": "2026-05-01",
+        "description": "Lunch",
+        "postings": [
+            {"account_id": "acc-1", "amount": "-12.50", "currency": "USD"},
+            {"account_id": "acc-2", "amount": "12.50", "currency": "USD"},
+        ],
+    }
+    buffer = _render_tx_for_edit(tx, accounts_by_id)
+    parsed = parse_ledger_text(buffer)
+
+    assert [p.account for p in parsed.postings] == ["Checking", "Groceries"]
+    # Crucially: no UUIDs appear in the buffer or in the parsed accounts.
+    for posting in parsed.postings:
+        assert "acc-" not in posting.account, (
+            f"UUID leaked into buffer for codeless account: {posting.account}"
+        )
+
+
+def test_render_and_parse_round_trip_with_multi_word_name() -> None:
+    """Multi-word names round-trip via the hledger two-space separator (#304)."""
+    accounts_by_id = _accounts(
+        ("acc-1", None, "My Checking Account"),
+        ("acc-2", "expenses:groceries", "Groceries"),
+    )
+    tx: dict[str, Any] = {
+        "date": "2026-05-01",
+        "description": "Lunch",
+        "postings": [
+            {"account_id": "acc-1", "amount": "-12.50", "currency": "USD"},
+            {"account_id": "acc-2", "amount": "12.50", "currency": "USD"},
+        ],
+    }
+    buffer = _render_tx_for_edit(tx, accounts_by_id)
+    parsed = parse_ledger_text(buffer)
+
+    assert [p.account for p in parsed.postings] == [
+        "My Checking Account",
+        "expenses:groceries",
+    ]
+
+
+def test_render_emits_two_space_separator() -> None:
+    """The renderer always emits at least two spaces — that's what the parser needs."""
+    accounts_by_id = _accounts(("acc-1", "assets:checking", "Checking"))
+    tx: dict[str, Any] = {
+        "date": "2026-05-01",
+        "description": "x",
+        "postings": [{"account_id": "acc-1", "amount": "1.00", "currency": "USD"}],
+    }
+    buffer = _render_tx_for_edit(tx, accounts_by_id)
+    # The buffer's posting line uses "  " (two spaces) between account
+    # and amount; the renderer doesn't depend on the account being a
+    # single token.
+    assert "assets:checking  1.00 USD" in buffer


### PR DESCRIPTION
## Summary

`tulip transactions edit` opened on a transaction whose postings touch codeless accounts (the common shape of QIF / OFX imports — the importers don't assign codes) rendered the account references as bare UUIDs. The buffer was unreadable and unmodifiable without a parallel \`tulip accounts show\` round-trip. Surfaced during the Banktivity migration. Closes [#304](https://github.com/rmwarriner/getting-tulip-tested/issues/304).

Two halves matching the issue's framing:

- **Render side** — new \`_account_display_for_edit\` falls back \`code → name → UUID\` (was \`code → UUID\`). The bare-UUID fallback remains for orphaned references where the account row didn't come back in the lookup; everywhere else the buffer now shows the human-readable shape.
- **Parse side** — \`_POSTING_RE\` accepts hledger's two-space account/amount separator so multi-word account names like \`My Checking Account\` round-trip cleanly. The pre-existing single-space regex stays as a fallback (\`_POSTING_RE_SINGLE_SPACE\`) so buffers that pre-date this change still parse. The error message names the convention when both regexes fail.

The resolver (\`_resolve_account\`) already accepts unique names and hierarchical paths via [#197](https://github.com/rmwarriner/tulip-accounting/issues/197), so the name fallback resolves on save without further server-side work.

## Test plan

- [x] \`uv run pytest packages/tulip-cli/tests/test_tx_edit_render.py packages/tulip-cli/tests/test_ledger_parser.py -v\` — 25 passing (17 ledger, 8 render).
- [x] \`uv run pytest packages/tulip-cli/tests -q -n auto --ignore=tests/test_transactions_void_delete_edit_cli.py\` — 511 non-integration tests passing.
- [x] \`just lint\` / \`just typecheck\` — clean.
- [x] Round-trip invariant (the acceptance criterion the issue calls out): render-then-save-unmodified produces an identical posting set, exercised in \`test_render_and_parse_round_trip_*\` for code-bearing, codeless-single-word, and multi-word account names.
- [ ] CI green on this PR.