### PR TITLE
api+cli: POST /v1/accounts create_parents=true walks colon-paths (closes #46)

### DIFF
--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -540,6 +540,30 @@ class AccountUnknownError(TulipProblem):
         )
 
 
+class AccountPathInvalidError(TulipProblem):
+    """``code`` passed with ``create_parents=true`` failed path validation (#46)."""
+
+    def __init__(self, reason: str) -> None:
+        """Build the account.path_invalid problem.
+
+        ``reason`` is the specific validation that tripped (empty
+        segment, unknown root, type/inference mismatch, etc.) — surfaced
+        verbatim in ``detail`` so the caller knows exactly what to fix.
+        """
+        super().__init__(
+            code="account.path_invalid",
+            title="Invalid account path for create_parents",
+            status=400,
+            detail=(
+                f"Account path is invalid: {reason}. With "
+                "``create_parents=true``, ``code`` must be a non-empty "
+                "colon-delimited path whose root segment names an account "
+                "type (assets / liabilities / equity / income / expenses) "
+                "and whose remaining segments are non-empty."
+            ),
+        )
+
+
 class TransactionInvalidError(TulipProblem):
     """A transaction failed domain-level validation (e.g. empty postings, bad shape)."""
 

--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -20,6 +20,7 @@ from tulip_api.errors import (
     AccountParentNotFoundError,
     AccountParentTypeMismatchError,
     AccountParentVisibilityViolationError,
+    AccountPathInvalidError,
     ForbiddenError,
     problem_response,
 )
@@ -53,6 +54,60 @@ def _to_read(a: Account) -> AccountRead:
         is_active=a.is_active,
         parent_account_id=a.parent_account_id,
     )
+
+
+# Root-segment → account-type mapping for the create_parents path-walker (#46).
+# Mirrors ``tulip_cli.commands.accounts._TYPE_ALIASES`` so a path that
+# resolves on the read side also infers cleanly on the write side.
+_PATH_ROOT_TYPES: dict[str, str] = {
+    "asset": "asset",
+    "assets": "asset",
+    "liability": "liability",
+    "liabilities": "liability",
+    "equity": "equity",
+    "equities": "equity",
+    "income": "income",
+    "incomes": "income",
+    "expense": "expense",
+    "expenses": "expense",
+}
+
+
+def _parse_account_path(code: str | None, leaf_type: str) -> tuple[list[str], str]:
+    """Validate ``code`` as a colon-path; return (segments, inferred_type).
+
+    Used only when ``create_parents=True``. Raises
+    :class:`AccountPathInvalidError` for empty input, single-segment
+    input, empty / whitespace-only segments, leading/trailing colons,
+    unknown root segment, or root → ``leaf_type`` type mismatch.
+    """
+    if not code:
+        raise AccountPathInvalidError("``code`` is required when create_parents=true")
+    if ":" not in code:
+        raise AccountPathInvalidError(
+            f"path {code!r} has a single segment; create_parents needs at "
+            "least one parent to create (use create_parents=false instead)"
+        )
+    raw_segments = code.split(":")
+    if any(not seg.strip() for seg in raw_segments):
+        raise AccountPathInvalidError(
+            f"path {code!r} has an empty / whitespace-only segment; every "
+            "segment must be a non-empty identifier"
+        )
+    segments = [seg.strip() for seg in raw_segments]
+    root = segments[0].lower()
+    if root not in _PATH_ROOT_TYPES:
+        raise AccountPathInvalidError(
+            f"root segment {segments[0]!r} does not name an account type; "
+            f"expected one of {sorted(set(_PATH_ROOT_TYPES))}"
+        )
+    inferred = _PATH_ROOT_TYPES[root]
+    if inferred != leaf_type:
+        raise AccountPathInvalidError(
+            f"path root segment implies type {inferred!r}, but the body's "
+            f"``type`` is {leaf_type!r}; the two must match"
+        )
+    return segments, inferred
 
 
 def _filter_for_role(account: Account, claims: Claims) -> bool:
@@ -152,6 +207,7 @@ def list_accounts(
             "account.parent_type_mismatch",
             "account.parent_currency_mismatch",
             "account.parent_visibility_violation",
+            "account.path_invalid",
         ),
         422: problem_response("validation.failed"),
     },
@@ -162,8 +218,39 @@ def create_account(
     claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
     session: Session = Depends(get_session),  # noqa: B008
 ) -> AccountRead:
-    """Create a new account in the caller's household."""
+    """Create a new account in the caller's household.
+
+    With ``create_parents=true``, ``code`` is parsed as a colon-path and
+    any missing ancestor accounts are auto-created in the same commit
+    (#46). The root segment determines the account type for every
+    account in the chain; the body's ``type`` must match. The leaf
+    takes the body's ``name`` / ``subtype`` / ``visibility``; parents
+    take their segment as the name and inherit currency from the body.
+    """
     repo = AccountRepository(session, claims.household_id)
+    audit = AuditLogWriter(session, claims.household_id)
+    request_id = _request_uuid(request)
+
+    if body.create_parents:
+        leaf, parents_created = _create_with_parents(
+            repo=repo,
+            audit=audit,
+            body=body,
+            claims=claims,
+            request_id=request_id,
+        )
+        session.commit()
+        log.info(
+            "account.created_with_parents",
+            account_id=str(leaf.id),
+            parents_created=[str(p.id) for p in parents_created],
+        )
+        read = _to_read(leaf)
+        # The PR description: parents are listed root → leaf-parent in
+        # creation order; the leaf itself is the top-level response.
+        read.parents_created = [_to_read(p) for p in parents_created]
+        return read
+
     if body.parent_account_id is not None:
         _validate_parent(
             repo,
@@ -184,18 +271,87 @@ def create_account(
         visibility=body.visibility,
         created_by_user_id=claims.user_id,
     )
-    AuditLogWriter(session, claims.household_id).write(
+    audit.write(
         action="create",
         actor_kind="user",
         actor_user_id=claims.user_id,
         entity_type="account",
         entity_id=a.id,
         after={"name": a.name, "type": a.type.value, "currency": a.currency},
-        request_id=_request_uuid(request),
+        request_id=request_id,
     )
     session.commit()
     log.info("account.created", account_id=str(a.id))
     return _to_read(a)
+
+
+def _create_with_parents(
+    *,
+    repo: AccountRepository,
+    audit: AuditLogWriter,
+    body: AccountCreate,
+    claims: Claims,
+    request_id: UUID | None,
+) -> tuple[Account, list[Account]]:
+    """Walk the path root → leaf, creating any missing segment.
+
+    Returns ``(leaf, parents_created)`` where ``parents_created`` is the
+    list of auto-created ancestors in creation order (root first). Pre-
+    existing accounts along the path are reused — they don't appear in
+    ``parents_created``. Idempotent: re-running with the same path
+    returns the original leaf and an empty ``parents_created``.
+    """
+    segments, inferred_type = _parse_account_path(body.code, body.type)
+    parents_created: list[Account] = []
+    parent: Account | None = None
+    for index, segment in enumerate(segments):
+        prefix_code = ":".join(segments[: index + 1])
+        existing = repo.get_by_code(prefix_code)
+        is_leaf = index == len(segments) - 1
+        if existing is not None:
+            parent = existing
+            continue
+        # Need to create this segment. Leaf takes body.name / subtype /
+        # visibility; intermediates take their segment as the name and
+        # share currency + visibility with the leaf.
+        if is_leaf:
+            new_name = body.name
+            new_subtype = body.subtype
+        else:
+            new_name = segment
+            new_subtype = None
+        parent_id = parent.id if parent is not None else None
+        created = repo.create(
+            name=new_name,
+            type=AccountType(inferred_type),
+            currency=body.currency,
+            code=prefix_code,
+            subtype=new_subtype,
+            parent_account_id=parent_id,
+            visibility=body.visibility,
+            created_by_user_id=claims.user_id,
+        )
+        audit.write(
+            action="create",
+            actor_kind="user",
+            actor_user_id=claims.user_id,
+            entity_type="account",
+            entity_id=created.id,
+            after={
+                "name": created.name,
+                "type": created.type.value,
+                "currency": created.currency,
+                "auto_created_parent_of": (":".join(segments) if not is_leaf else None),
+            },
+            request_id=request_id,
+        )
+        parent = created
+        if not is_leaf:
+            parents_created.append(created)
+    # ``parent`` is the leaf — either the freshly-created last segment
+    # or the pre-existing account when the path already terminated.
+    assert parent is not None  # noqa: S101 — segments non-empty by validation
+    return parent, parents_created
 
 
 @router.get(

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -31,6 +31,7 @@ router = APIRouter(prefix="/.well-known/errors", tags=["docs"])
 # subclasses shouldn't be coupled to docs availability).
 _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
     "MfaRequiredError": {"mfa_token": "<mfa-challenge-jwt>", "expires_in": 300},
+    "AccountPathInvalidError": {"reason": "root segment 'widgets' does not name an account type"},
     "AccountUnknownError": {"account_id": "<account-uuid>"},
     "AccountParentTypeMismatchError": {"child_type": "expense", "parent_type": "asset"},
     "AccountParentCurrencyMismatchError": {

--- a/packages/tulip-api/src/tulip_api/schemas/account.py
+++ b/packages/tulip-api/src/tulip_api/schemas/account.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    pass
 
 
 class AccountCreate(BaseModel):
@@ -13,10 +17,20 @@ class AccountCreate(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     type: str = Field(pattern=r"^(asset|liability|equity|income|expense)$")
     currency: str = Field(min_length=3, max_length=3)
-    code: str | None = Field(default=None, max_length=50)
+    code: str | None = Field(default=None, max_length=200)
     subtype: str | None = Field(default=None, max_length=50)
     parent_account_id: UUID | None = None
     visibility: str = Field(default="shared", pattern=r"^(shared|private)$")
+    create_parents: bool = Field(
+        default=False,
+        description=(
+            "When true, ``code`` is parsed as a colon-delimited path "
+            "(``assets:current:checking``) and every segment that doesn't "
+            "already exist is auto-created in the same commit. The root "
+            "segment maps to the account type via the same ``_TYPE_ALIASES`` "
+            "table the resolver uses for hierarchical-path lookups (#46)."
+        ),
+    )
 
 
 class AccountUpdate(BaseModel):
@@ -49,3 +63,12 @@ class AccountRead(BaseModel):
     visibility: str
     is_active: bool
     parent_account_id: UUID | None
+    parents_created: list[AccountRead] | None = Field(
+        default=None,
+        description=(
+            "Populated only on responses to POST /v1/accounts with "
+            "create_parents=true: the auto-created ancestors (root → "
+            "leaf-parent) in creation order. Null on GET / PATCH and on "
+            "POST without create_parents (#46)."
+        ),
+    )

--- a/packages/tulip-api/tests/test_accounts_create_parents.py
+++ b/packages/tulip-api/tests/test_accounts_create_parents.py
@@ -1,0 +1,331 @@
+"""Tests for ``POST /v1/accounts`` with ``create_parents=true`` (#46).
+
+When the caller passes a colon-delimited ``code`` like
+``assets:current:checking`` and sets ``create_parents=true``, the
+endpoint walks the path root → leaf, creating any segment that doesn't
+already exist. Existing parents are reused. The whole walk commits in
+one transaction, so a mid-path failure rolls back any parents already
+created during the same call.
+
+Type inference: the root segment determines the type for every account
+in the chain. ``assets`` / ``liabilities`` / ``equity`` / ``income``
+/ ``expenses`` (plus singular aliases) map to the API's type enum via
+the same ``_TYPE_ALIASES`` table the resolver uses for hierarchical-
+path lookups (#197). Unrecognised root segments → 400.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r.json()["access_token"]
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+class TestCreateParentsHappyPath:
+    def test_creates_full_chain_from_root(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        """`assets:current:checking` → asset, asset:current, asset:current:checking."""
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Checking",
+                "type": "asset",
+                "currency": "USD",
+                "code": "assets:current:checking",
+                "create_parents": True,
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        # Leaf is the returned account.
+        assert body["code"] == "assets:current:checking"
+        assert body["name"] == "Checking"
+        assert body["type"] == "asset"
+        # parents_created lists the (newly-created) ancestors root → leaf-parent.
+        parents = body.get("parents_created") or []
+        assert len(parents) == 2
+        assert parents[0]["code"] == "assets"
+        assert parents[1]["code"] == "assets:current"
+        assert all(p["type"] == "asset" for p in parents)
+        # Parent links: assets.parent = null; assets:current.parent = assets;
+        # leaf.parent = assets:current.
+        assert parents[0]["parent_account_id"] is None
+        assert parents[1]["parent_account_id"] == parents[0]["id"]
+        assert body["parent_account_id"] == parents[1]["id"]
+
+    def test_reuses_existing_parents(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        """Pre-existing parents along the path are reused, not re-created."""
+        # Pre-create the root.
+        existing = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "assets",
+                "type": "asset",
+                "currency": "USD",
+                "code": "assets",
+            },
+        ).json()
+        # Now create the leaf with create_parents=true; only the new
+        # intermediate + leaf get created.
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Savings",
+                "type": "asset",
+                "currency": "USD",
+                "code": "assets:current:savings",
+                "create_parents": True,
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        parents = body.get("parents_created") or []
+        # Only the intermediate `assets:current` was created; `assets`
+        # was reused, so it's NOT in the parents_created list.
+        assert [p["code"] for p in parents] == ["assets:current"]
+        # The intermediate's parent links back to the pre-existing root.
+        assert parents[0]["parent_account_id"] == existing["id"]
+
+    def test_idempotent_when_full_path_exists(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """Re-running the same create-path call after the first returns the existing leaf."""
+        first = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Checking",
+                "type": "asset",
+                "currency": "USD",
+                "code": "assets:current:checking",
+                "create_parents": True,
+            },
+        )
+        assert first.status_code == 201
+        first_id = first.json()["id"]
+
+        second = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Checking",
+                "type": "asset",
+                "currency": "USD",
+                "code": "assets:current:checking",
+                "create_parents": True,
+            },
+        )
+        # Idempotent: the leaf is returned with the original id, no new
+        # accounts in parents_created.
+        assert second.status_code == 201
+        body = second.json()
+        assert body["id"] == first_id
+        assert (body.get("parents_created") or []) == []
+
+    def test_two_level_path(self, client: TestClient, auth_h: dict[str, str]) -> None:
+        """A two-segment path creates the root and the leaf."""
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Groceries",
+                "type": "expense",
+                "currency": "USD",
+                "code": "expenses:groceries",
+                "create_parents": True,
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        parents = body.get("parents_created") or []
+        assert [p["code"] for p in parents] == ["expenses"]
+        assert parents[0]["type"] == "expense"
+
+
+class TestCreateParentsTypeInference:
+    @pytest.mark.parametrize(
+        ("root_segment", "expected_type"),
+        [
+            ("assets", "asset"),
+            ("asset", "asset"),
+            ("liabilities", "liability"),
+            ("liability", "liability"),
+            ("equity", "equity"),
+            ("income", "income"),
+            ("expenses", "expense"),
+            ("expense", "expense"),
+        ],
+    )
+    def test_root_segment_maps_to_type(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        root_segment: str,
+        expected_type: str,
+    ) -> None:
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Leaf",
+                "type": expected_type,
+                "currency": "USD",
+                "code": f"{root_segment}:leaf",
+                "create_parents": True,
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        # Root parent was created with the inferred type.
+        parents = body.get("parents_created") or []
+        assert parents[0]["type"] == expected_type
+
+    def test_unknown_root_segment_rejected(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """An unrecognised root (e.g. `widgets`) can't infer a type — reject."""
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Leaf",
+                "type": "asset",
+                "currency": "USD",
+                "code": "widgets:thing:leaf",
+                "create_parents": True,
+            },
+        )
+        assert r.status_code == 400
+        assert_problem(r, code="account.path_invalid", status=400)
+
+    def test_leaf_type_must_match_inferred(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """The body's `type` must match what the root segment implies."""
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Leaf",
+                "type": "liability",
+                "currency": "USD",
+                "code": "assets:misnamed:leaf",
+                "create_parents": True,
+            },
+        )
+        assert r.status_code == 400
+        assert_problem(r, code="account.path_invalid", status=400)
+
+
+class TestCreateParentsValidation:
+    @pytest.mark.parametrize(
+        "bad_code",
+        [
+            "",  # empty
+            ":",  # colon-only
+            ":assets:leaf",  # leading colon
+            "assets:leaf:",  # trailing colon
+            "assets::leaf",  # empty middle segment
+            "assets:   :leaf",  # whitespace-only segment
+            "assets",  # single segment (no parent to create)
+        ],
+    )
+    def test_malformed_path_rejected(
+        self, client: TestClient, auth_h: dict[str, str], bad_code: str
+    ) -> None:
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Leaf",
+                "type": "asset",
+                "currency": "USD",
+                "code": bad_code,
+                "create_parents": True,
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert_problem(r, code="account.path_invalid", status=400)
+
+    def test_create_parents_without_code_rejected(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """create_parents=true requires a path-shaped `code`."""
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Leaf",
+                "type": "asset",
+                "currency": "USD",
+                "create_parents": True,
+            },
+        )
+        assert r.status_code == 400
+        assert_problem(r, code="account.path_invalid", status=400)
+
+
+class TestCreateParentsBackwardCompat:
+    def test_omitting_create_parents_works_as_before(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """The default (create_parents=false) preserves the existing endpoint behavior."""
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Checking",
+                "type": "asset",
+                "currency": "USD",
+                "code": "assets:checking",  # colon allowed but treated as literal
+            },
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert body["code"] == "assets:checking"
+        # parents_created not present (or null) in the default response.
+        assert body.get("parents_created") in (None, [])
+
+    def test_create_parents_false_explicitly(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """Explicit create_parents=false matches the omitted-flag behavior."""
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Checking",
+                "type": "asset",
+                "currency": "USD",
+                "code": "assets:checking",
+                "create_parents": False,
+            },
+        )
+        assert r.status_code == 201
+        assert r.json().get("parents_created") in (None, [])

--- a/packages/tulip-cli/src/tulip_cli/commands/accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/accounts.py
@@ -419,8 +419,34 @@ def add_account(
             ),
         ),
     ] = None,
+    create_parents: Annotated[
+        bool,
+        typer.Option(
+            "--create-parents",
+            help=(
+                "Parse --code as a colon-delimited path (e.g. "
+                "'assets:current:checking') and auto-create any missing "
+                "ancestor accounts in one atomic call (#46). The root "
+                "segment determines the type — it must match --type. "
+                "Mutually exclusive with --parent (parents come from the "
+                "path)."
+            ),
+        ),
+    ] = False,
 ) -> None:
-    """Create a new account in the logged-in user's household."""
+    """Create a new account in the logged-in user's household.
+
+    With ``--create-parents``, ``--code`` is parsed as a colon-path and
+    any missing ancestors are auto-created in the same atomic request.
+    """
+    if create_parents and parent is not None:
+        raise typer.BadParameter(
+            "--create-parents derives the parent chain from --code; "
+            "passing --parent at the same time is ambiguous"
+        )
+    if create_parents and not code:
+        raise typer.BadParameter("--create-parents requires --code (the colon-path)")
+
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
 
@@ -434,6 +460,8 @@ def add_account(
         body["code"] = code
     if subtype is not None:
         body["subtype"] = subtype
+    if create_parents:
+        body["create_parents"] = True
 
     try:
         with _client(config, as_json=as_json) as client:
@@ -450,7 +478,18 @@ def add_account(
         return
 
     payload = response.json()
-    typer.echo(f"Created account {payload.get('id', '')}")
+    parents_created = payload.get("parents_created") or []
+    if parents_created:
+        typer.echo(
+            f"Created account {payload.get('id', '')} along with {len(parents_created)} parent(s):"
+        )
+        for parent_account in parents_created:
+            typer.echo(
+                f"  + {parent_account.get('code') or '—'}  ({parent_account.get('name', '')})"
+            )
+        typer.echo("Leaf:")
+    else:
+        typer.echo(f"Created account {payload.get('id', '')}")
     _render_account(payload)
 
 


### PR DESCRIPTION
## Summary

Adds a `create_parents: bool = False` field to `AccountCreate`. When true, the existing `code` field is parsed as a colon-delimited path (e.g. `assets:current:checking`) and every segment that doesn't already exist is auto-created in the same atomic commit. Closes [#46](https://github.com/rmwarriner/tulip-accounting/issues/46).

### Design choices (resolved with the maintainer before building)

- **Type inference**: root segment → type. `assets` / `liabilities` / `equity` / `income` / `expenses` (and singular aliases) map via `_PATH_ROOT_TYPES`, mirroring the `_TYPE_ALIASES` table the read-side resolver uses for [#197](https://github.com/rmwarriner/tulip-accounting/issues/197). Unknown root → 400 `account.path_invalid`. The body's `type` must match the inferred type — catches "assets:..." with `type=liability` early.
- **API surface**: existing endpoint gains the flag rather than a new `/from-path` endpoint. Backward-compat: omitting the flag (or passing `false`) preserves the pre-existing one-account-create behavior verbatim. `AccountRead` grows an optional `parents_created: list[AccountRead] | None` field, populated only when parents were auto-created.
- **Validation**: empty input, single-segment (no `:`), empty / whitespace-only segments, leading/trailing colons all reject with `account.path_invalid` + a remediation in the detail.
- **Atomicity**: single `session.commit()` — engine rolls back parent creations if the leaf fails. Idempotent: re-running with the same path returns the original leaf with `parents_created=[]`.
- **Audit**: one `create` audit entry per account created. Parent entries' after-state carries an `auto_created_parent_of` field pointing at the full path so an audit walker can group the batch.

### CLI

`tulip accounts add` gains `--create-parents`. Mutually exclusive with `--parent` (parents come from the path). Output lists created parents above the leaf summary:

    Created account 22222222-... along with 2 parent(s):
      + assets         (assets)
      + assets:current (current)
    Leaf:
    id:        22222222-...
    code:      assets:current:checking
    name:      Checking
    type:      asset
    ...

## Test plan

- [x] `uv run pytest packages/tulip-api/tests/test_accounts_create_parents.py -q` — 24 passing covering happy path (full chain, reuse-existing, idempotent, two-level), type inference (all 8 root/plural aliases + unknown root + leaf-type mismatch), validation (empty / single-segment / leading-or-trailing colon / empty middle / whitespace-only / missing-code), backward compat.
- [x] `uv run pytest packages/tulip-api/tests/test_accounts_endpoints.py packages/tulip-api/tests/test_account_nesting.py packages/tulip-api/tests/test_audit_retention_coverage.py -q` — 28 passing (no regression in existing endpoints).
- [x] `uv run pytest packages/tulip-api/tests/test_openapi_contract.py -q` — 120 passing, 6 unrelated skips (path-collision shape).
- [x] `just lint` / `just typecheck` — clean.
- [ ] CI green on this PR.