### PR TITLE
api+cli: v1 labels-only tags on transactions (closes #39)

### DIFF
--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -540,26 +540,25 @@ class AccountUnknownError(TulipProblem):
         )
 
 
-class AccountPathInvalidError(TulipProblem):
-    """``code`` passed with ``create_parents=true`` failed path validation (#46)."""
+class TagInvalidError(TulipProblem):
+    """A tag string failed validation on POST/PATCH /v1/transactions (#39)."""
 
     def __init__(self, reason: str) -> None:
-        """Build the account.path_invalid problem.
+        """Build the tag.invalid problem.
 
-        ``reason`` is the specific validation that tripped (empty
-        segment, unknown root, type/inference mismatch, etc.) — surfaced
-        verbatim in ``detail`` so the caller knows exactly what to fix.
+        ``reason`` is the specific validation message (empty, too long,
+        illegal characters) — surfaced verbatim in ``detail`` so the
+        caller knows which tag to fix.
         """
         super().__init__(
-            code="account.path_invalid",
-            title="Invalid account path for create_parents",
+            code="tag.invalid",
+            title="Invalid tag",
             status=400,
             detail=(
-                f"Account path is invalid: {reason}. With "
-                "``create_parents=true``, ``code`` must be a non-empty "
-                "colon-delimited path whose root segment names an account "
-                "type (assets / liabilities / equity / income / expenses) "
-                "and whose remaining segments are non-empty."
+                f"Tag rejected: {reason}. Tags must be 1-64 characters "
+                "of letters, digits, ``_``, ``-``, ``.``, ``/``, or ``:`` — "
+                "no spaces (the URL filter would be ambiguous) and no "
+                "control characters."
             ),
         )
 

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -540,6 +540,30 @@ class AccountUnknownError(TulipProblem):
         )
 
 
+class AccountPathInvalidError(TulipProblem):
+    """``code`` passed with ``create_parents=true`` failed path validation (#46)."""
+
+    def __init__(self, reason: str) -> None:
+        """Build the account.path_invalid problem.
+
+        ``reason`` is the specific validation that tripped (empty
+        segment, unknown root, type/inference mismatch, etc.) — surfaced
+        verbatim in ``detail`` so the caller knows exactly what to fix.
+        """
+        super().__init__(
+            code="account.path_invalid",
+            title="Invalid account path for create_parents",
+            status=400,
+            detail=(
+                f"Account path is invalid: {reason}. With "
+                "``create_parents=true``, ``code`` must be a non-empty "
+                "colon-delimited path whose root segment names an account "
+                "type (assets / liabilities / equity / income / expenses) "
+                "and whose remaining segments are non-empty."
+            ),
+        )
+
+
 class TagInvalidError(TulipProblem):
     """A tag string failed validation on POST/PATCH /v1/transactions (#39)."""
 

--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -21,6 +21,7 @@ from tulip_api.errors import (
     PoolInvalidAccountTypePairingError,
     PoolNotFoundError,
     ShadowLedgerInternalError,
+    TagInvalidError,
     TransactionAlreadyVoidedError,
     TransactionInvalidError,
     TransactionNotDeletableError,
@@ -76,6 +77,7 @@ from tulip_storage.repositories import (
     PeriodRepository,
     ShadowTransactionRepository,
     TransactionRepository,
+    TransactionTagRepository,
 )
 from tulip_storage.repositories.transaction import (
     UNSET,
@@ -88,6 +90,9 @@ from tulip_storage.repositories.transaction import (
 )
 from tulip_storage.repositories.transaction import (
     TransactionNotRectifiableError as RepoNotRectifiableError,
+)
+from tulip_storage.repositories.transaction_tag import (
+    TagInvalidError as RepoTagInvalidError,
 )
 
 if TYPE_CHECKING:
@@ -115,6 +120,7 @@ log = structlog.get_logger("tulip_api.transactions")
             "pool.currency_mismatch",
             "pool.invalid_account_type_pairing",
             "request.body_invalid",
+            "tag.invalid",
         ),
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
@@ -252,6 +258,16 @@ def create_transaction(
         shadow_repo = ShadowTransactionRepository(session, claims.household_id)
         saved_shadow = shadow_repo.save_balanced(shadow_tx)
         paired_shadow_tx_id = saved_shadow.id
+
+    # #39: write tags after the transaction lands so the FK target exists.
+    # Tag validation runs inside the repo; surface failures as 400 tag.invalid.
+    if body.tags:
+        try:
+            TransactionTagRepository(session, claims.household_id).set_tags(
+                saved.id, list(body.tags)
+            )
+        except RepoTagInvalidError as exc:
+            raise TagInvalidError(reason=str(exc)) from exc
 
     audit_after: dict[str, str] = {
         "description": saved.description,
@@ -696,7 +712,7 @@ def _resolve_notes_patch(body: TransactionUpdate) -> str | None | object:
     "/{tx_id}",
     response_model=TransactionRead,
     responses={
-        400: problem_response("account.unknown"),
+        400: problem_response("account.unknown", "tag.invalid"),
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
         404: problem_response("transaction.not_found"),
@@ -772,6 +788,14 @@ def patch_transaction(
         )
     except RepoNotEditableError as exc:
         raise TransactionNotEditableError() from exc
+
+    # #39: PATCH semantics for tags — omitting the field leaves the
+    # current set alone; passing a list (including []) replaces it.
+    if body.tags is not None:
+        try:
+            TransactionTagRepository(session, claims.household_id).set_tags(tx_id, list(body.tags))
+        except RepoTagInvalidError as exc:
+            raise TagInvalidError(reason=str(exc)) from exc
 
     after_snapshot: dict[str, object] = {
         "date": new_date.isoformat(),
@@ -981,6 +1005,14 @@ def list_transactions(
         ),
         pattern="^[0-9a-fA-F-]{1,36}$",
     ),
+    tag: str | None = Query(
+        default=None,
+        description=(
+            "Restrict to transactions that carry this tag (#39 v1). "
+            "Tags are case-insensitive on lookup. Single-tag filter only "
+            "in v1; multi-tag / boolean grammar is a follow-up slice."
+        ),
+    ),
     limit: int | None = Query(
         default=None,
         ge=1,
@@ -994,11 +1026,24 @@ def list_transactions(
 
     All filter params are optional and AND together. ``account_id`` is
     a UUID. Date params use the ``from`` / ``to`` query keys (inclusive
-    on both ends). ``status`` is one of the lifecycle states.
+    on both ends). ``status`` is one of the lifecycle states. ``tag``
+    restricts to transactions carrying the given label (#39 v1).
     """
     storage_status: StorageTxStatus | None = (
         StorageTxStatus(status_) if status_ is not None else None
     )
+    tag_tx_ids: list[UUID] | None
+    if tag is not None:
+        try:
+            tag_tx_ids = TransactionTagRepository(
+                session, claims.household_id
+            ).find_transaction_ids_by_tag(tag)
+        except RepoTagInvalidError as exc:
+            raise TagInvalidError(reason=str(exc)) from exc
+        if not tag_tx_ids:
+            return []
+    else:
+        tag_tx_ids = None
     rows = TransactionRepository(session, claims.household_id).list_headers(
         account_id=account_id,
         from_date=from_date,
@@ -1007,6 +1052,9 @@ def list_transactions(
         id_prefix=id_prefix,
         limit=limit,
     )
+    if tag_tx_ids is not None:
+        tag_id_set = set(tag_tx_ids)
+        rows = [r for r in rows if r.id in tag_id_set]
     return [_read_response(t.id, claims.household_id, session) for t in rows]
 
 
@@ -1044,6 +1092,7 @@ def _read_response(
         paired_shadow_tx_id = ShadowTransactionRepository(
             session, household_id
         ).get_paired_id_for_main_tx(tx_id)
+    tags = TransactionTagRepository(session, household_id).list_tags(tx_id)
     return TransactionRead(
         id=header.id,
         date=header.date,
@@ -1065,6 +1114,7 @@ def _read_response(
         paired_shadow_tx_id=paired_shadow_tx_id,
         voided_by_transaction_id=header.voided_by_transaction_id,
         voided_at=header.voided_at,
+        tags=tags,
     )
 
 

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -33,6 +33,7 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
     "MfaRequiredError": {"mfa_token": "<mfa-challenge-jwt>", "expires_in": 300},
     "AccountPathInvalidError": {"reason": "root segment 'widgets' does not name an account type"},
     "AccountUnknownError": {"account_id": "<account-uuid>"},
+    "TagInvalidError": {"reason": "tag 'has space' must be 1-64 chars of [A-Za-z0-9_-./:]"},
     "AccountParentTypeMismatchError": {"child_type": "expense", "parent_type": "asset"},
     "AccountParentCurrencyMismatchError": {
         "child_currency": "EUR",

--- a/packages/tulip-api/src/tulip_api/schemas/transaction.py
+++ b/packages/tulip-api/src/tulip_api/schemas/transaction.py
@@ -43,6 +43,15 @@ class TransactionCreate(BaseModel):
         ),
     )
     postings: list[PostingCreate] = Field(min_length=2)
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Free-form labels attached to this transaction (#39 v1). Each "
+            "tag is 1-64 chars of ``[A-Za-z0-9_-./:]``; case-insensitive "
+            "and deduplicated on store. Filter via ``?tag=foo`` on the "
+            "list endpoint."
+        ),
+    )
 
 
 class PostingRead(BaseModel):
@@ -69,6 +78,13 @@ class TransactionRead(BaseModel):
     paired_shadow_tx_id: UUID | None = None
     voided_by_transaction_id: UUID | None = None
     voided_at: datetime | None = None
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Free-form labels attached to this transaction (#39 v1), "
+            "alphabetised and lowercased. Empty list when no tags are set."
+        ),
+    )
 
 
 class TransactionVoidRequest(BaseModel):
@@ -206,3 +222,11 @@ class TransactionUpdate(BaseModel):
         ),
     )
     postings: list[PostingCreate] | None = Field(default=None, min_length=2)
+    tags: list[str] | None = Field(
+        default=None,
+        description=(
+            "Free-form labels (#39 v1). Omit to leave the current set "
+            "unchanged; pass an explicit list (including ``[]``) to "
+            "replace the set wholesale."
+        ),
+    )

--- a/packages/tulip-api/tests/test_transactions_tags.py
+++ b/packages/tulip-api/tests/test_transactions_tags.py
@@ -1,0 +1,243 @@
+"""Tests for the v1 transaction-tags surface (#39).
+
+Covers POST/GET/PATCH plumbing and the `?tag=foo` filter on the list
+endpoint. Validation lives in the repo (`TransactionTagRepository`)
+and surfaces as a 400 `tag.invalid` Problem Detail.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+from _problem_details import assert_problem
+
+
+@pytest.fixture
+def admin_token(client: TestClient) -> str:
+    client.post(
+        "/v1/auth/register",
+        json={
+            "email": "admin@example.com",
+            "password": "correct horse battery staple",
+            "display_name": "Admin",
+            "household_name": "Smith",
+        },
+    )
+    r = client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "correct horse battery staple"},
+    )
+    return r.json()["access_token"]
+
+
+@pytest.fixture
+def auth_h(admin_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+@pytest.fixture
+def cash_and_food(client: TestClient, auth_h: dict[str, str]) -> tuple[str, str]:
+    cash = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Cash", "type": "asset", "currency": "USD", "code": "1110"},
+    ).json()
+    food = client.post(
+        "/v1/accounts",
+        headers=auth_h,
+        json={"name": "Food", "type": "expense", "currency": "USD", "code": "5100"},
+    ).json()
+    return cash["id"], food["id"]
+
+
+def _lunch_body(cash: str, food: str, tags: list[str] | None = None) -> dict:
+    body = {
+        "date": date.today().isoformat(),
+        "description": "Lunch",
+        "postings": [
+            {"account_id": food, "amount": "12.50", "currency": "USD"},
+            {"account_id": cash, "amount": "-12.50", "currency": "USD"},
+        ],
+    }
+    if tags is not None:
+        body["tags"] = tags
+    return body
+
+
+class TestTagsRoundTrip:
+    def test_create_with_tags_stores_them(
+        self, client: TestClient, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+    ):
+        cash, food = cash_and_food
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["work", "client/acme"]),
+        )
+        assert r.status_code == 201, r.text
+        assert sorted(r.json()["tags"]) == ["client/acme", "work"]
+
+    def test_create_without_tags_returns_empty_list(
+        self, client: TestClient, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+    ):
+        cash, food = cash_and_food
+        r = client.post("/v1/transactions", headers=auth_h, json=_lunch_body(cash, food))
+        assert r.status_code == 201
+        assert r.json()["tags"] == []
+
+    def test_create_normalises_case_and_dedupes(
+        self, client: TestClient, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+    ):
+        cash, food = cash_and_food
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["Work", "WORK", "work"]),
+        )
+        assert r.status_code == 201
+        assert r.json()["tags"] == ["work"]
+
+    def test_get_returns_tags(
+        self, client: TestClient, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+    ):
+        cash, food = cash_and_food
+        created = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["reimbursable"]),
+        ).json()
+        fetched = client.get(f"/v1/transactions/{created['id']}", headers=auth_h).json()
+        assert fetched["tags"] == ["reimbursable"]
+
+    def test_list_returns_tags_per_row(
+        self, client: TestClient, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+    ):
+        cash, food = cash_and_food
+        client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["work"]),
+        )
+        client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["personal"]),
+        )
+        rows = client.get("/v1/transactions", headers=auth_h).json()
+        # Two rows; each carries its own tag set.
+        tag_sets = sorted(tuple(sorted(r["tags"])) for r in rows)
+        assert tag_sets == [("personal",), ("work",)]
+
+
+class TestPatchPendingOnly:
+    """Tag changes via PATCH inherit the PENDING-only constraint (#39 v1).
+
+    The PATCH endpoint already returns 409 ``transaction.not_editable``
+    for POSTED / RECONCILED. Tags ride that same gate — users wanting
+    to edit tags on a POSTED transaction go through ``/replace``
+    (#209a/b) the same way they'd edit any other field. A dedicated
+    tag-only PATCH endpoint that bypasses the status check is a
+    candidate follow-up if usage warrants.
+
+    Since the test harness can only create POSTED transactions through
+    POST /v1/transactions, all we can verify here is that PATCH'ing
+    tags on a POSTED transaction returns 409 (the body's wiring is
+    exercised; the success-path coverage rides on the existing
+    PATCH-PENDING tests + the tag-on-POST + tag-via-/replace tests).
+    """
+
+    def test_patch_tags_on_posted_returns_not_editable(
+        self, client: TestClient, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+    ):
+        cash, food = cash_and_food
+        created = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["work"]),
+        ).json()
+        r = client.patch(
+            f"/v1/transactions/{created['id']}",
+            headers=auth_h,
+            json={"tags": ["audited"]},
+        )
+        assert r.status_code == 409
+        # Tags are unchanged.
+        fetched = client.get(f"/v1/transactions/{created['id']}", headers=auth_h).json()
+        assert fetched["tags"] == ["work"]
+
+
+class TestListFilter:
+    def test_filter_matches_only_tagged_transactions(
+        self, client: TestClient, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+    ):
+        cash, food = cash_and_food
+        tagged = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["work"]),
+        ).json()
+        client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["personal"]),
+        )
+        # No tag → both come back.
+        rows = client.get("/v1/transactions", headers=auth_h).json()
+        assert len(rows) == 2
+        # ?tag=work → only the work-tagged one.
+        rows = client.get("/v1/transactions", params={"tag": "work"}, headers=auth_h).json()
+        assert [r["id"] for r in rows] == [tagged["id"]]
+
+    def test_filter_is_case_insensitive(
+        self, client: TestClient, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+    ):
+        cash, food = cash_and_food
+        client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["work"]),
+        )
+        rows = client.get("/v1/transactions", params={"tag": "WORK"}, headers=auth_h).json()
+        assert len(rows) == 1
+
+    def test_filter_with_no_matches_returns_empty(
+        self, client: TestClient, auth_h: dict[str, str], cash_and_food: tuple[str, str]
+    ):
+        cash, food = cash_and_food
+        client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=["work"]),
+        )
+        rows = client.get("/v1/transactions", params={"tag": "nonexistent"}, headers=auth_h).json()
+        assert rows == []
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "bad_tag",
+        ["", "   ", "x" * 65, "has space", "embedded\nnewline", "control\x00char"],
+    )
+    def test_create_with_invalid_tag_rejected(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        cash_and_food: tuple[str, str],
+        bad_tag: str,
+    ):
+        cash, food = cash_and_food
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json=_lunch_body(cash, food, tags=[bad_tag]),
+        )
+        assert r.status_code == 400, r.text
+        assert_problem(r, code="tag.invalid", status=400)
+
+    def test_filter_with_invalid_tag_rejected(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.get("/v1/transactions", params={"tag": "has space"}, headers=auth_h)
+        assert r.status_code == 400
+        assert_problem(r, code="tag.invalid", status=400)

--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -171,6 +171,17 @@ def add(
             help="Optional external reference (check number, statement id, etc.).",
         ),
     ] = None,
+    tags: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--tag",
+            help=(
+                "Free-form label to attach to this transaction (#39). "
+                "Repeat the flag for multiple tags. Tags are case-"
+                "insensitive and deduplicated server-side."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Create a balanced transaction.
 
@@ -203,6 +214,8 @@ def add(
         with _client(config, as_json=as_json) as client:
             postings_body = _resolve_postings(client, parsed)
             body = _build_tx_body(tx_date, description, postings_body, reference)
+            if tags:
+                body["tags"] = list(tags)
             response = client.post("/v1/transactions", json=body, authenticated=True)
     except CliError as err:
         err.render()
@@ -593,6 +606,16 @@ def list_transactions(
             help="One of: pending, posted, reconciled.",
         ),
     ] = None,
+    tag: Annotated[
+        str | None,
+        typer.Option(
+            "--tag",
+            help=(
+                "Filter to transactions carrying this label (#39 v1). "
+                "Case-insensitive. Single-tag filter in v1."
+            ),
+        ),
+    ] = None,
     limit: Annotated[
         int | None,
         typer.Option(
@@ -625,6 +648,8 @@ def list_transactions(
                 params["to"] = to_date
             if status_ is not None:
                 params["status"] = status_
+            if tag is not None:
+                params["tag"] = tag
             if limit is not None:
                 params["limit"] = str(limit)
             response = client.get("/v1/transactions", authenticated=True, params=params)

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260518_0600_f5b8d3a1c6e4_transaction_tags_v1.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260518_0600_f5b8d3a1c6e4_transaction_tags_v1.py
@@ -1,0 +1,65 @@
+"""Add transaction_tags table for the v1 labels-only tags surface (#39).
+
+The first slice of #39 ships free-form string tags on transactions
+only — no cascade, no key=value pairs, no account- or posting-level
+tags. The schema is a separate `transaction_tags` table keyed on
+``(household_id, transaction_id, tag)`` so the (household, tag)
+filter lookup is index-served (``ix_transaction_tags_household_tag``)
+and the per-transaction tag list is index-served via the composite PK.
+
+Composite FK to ``transactions.(household_id, id)`` with
+``ON DELETE CASCADE`` so deleting a transaction sweeps its tags
+without leaving orphans. The composite shape also means a tenant
+boundary breach would have to forge both columns — same posture as
+the postings table.
+
+Revision ID: f5b8d3a1c6e4
+Revises: e9c4f1b7d2a5
+Create Date: 2026-05-18 06:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f5b8d3a1c6e4"
+down_revision: str | None = "e9c4f1b7d2a5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``transaction_tags`` table + filter-friendly composite index."""
+    op.create_table(
+        "transaction_tags",
+        sa.Column("household_id", sa.Uuid(), nullable=False),
+        sa.Column("transaction_id", sa.Uuid(), nullable=False),
+        sa.Column("tag", sa.String(length=64), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["household_id", "transaction_id"],
+            ["transactions.household_id", "transactions.id"],
+            ondelete="CASCADE",
+            name="fk_transaction_tags_transaction",
+        ),
+        sa.PrimaryKeyConstraint(
+            "household_id", "transaction_id", "tag", name="pk_transaction_tags"
+        ),
+    )
+    # Index that serves the ``GET /v1/transactions?tag=foo`` filter:
+    # the API scopes to a household + filters by tag, and the index
+    # prefix matches. Tied to the table — drops automatically on
+    # downgrade.
+    op.create_index(
+        "ix_transaction_tags_household_tag",
+        "transaction_tags",
+        ["household_id", "tag"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the index then the table."""
+    op.drop_index("ix_transaction_tags_household_tag", table_name="transaction_tags")
+    op.drop_table("transaction_tags")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -60,6 +60,7 @@ from tulip_storage.models.shadow_transaction import (
 from tulip_storage.models.sinking_fund import ContributionStrategy, SinkingFund
 from tulip_storage.models.statement_line import StatementLine
 from tulip_storage.models.transaction import Transaction, TransactionStatus
+from tulip_storage.models.transaction_tag import TransactionTag
 from tulip_storage.models.used_mfa_challenge import UsedMfaChallenge
 from tulip_storage.models.user import User, UserRole
 
@@ -112,6 +113,7 @@ __all__ = [
     "StatementLine",
     "Transaction",
     "TransactionStatus",
+    "TransactionTag",
     "UsedMfaChallenge",
     "User",
     "UserRole",

--- a/packages/tulip-storage/src/tulip_storage/models/transaction_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/models/transaction_tag.py
@@ -1,0 +1,39 @@
+"""Transaction-tag model — v1 labels-only tags surface (#39).
+
+A free-form string tag attached to a transaction. The composite PK
+``(household_id, transaction_id, tag)`` gives us uniqueness for free
+(no separate UniqueConstraint) and matches the indexing strategy in
+the migration: per-tx tag lookups hit the PK prefix, per-household
+tag-filter lookups hit ``ix_transaction_tags_household_tag``.
+
+This is intentionally the smallest useful slice of #39. Out of scope
+for v1: account / posting tags, cascade semantics, key=value pairs,
+filter grammar beyond a single ``?tag=`` parameter.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import ForeignKeyConstraint, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class TransactionTag(Base):
+    """One free-form tag attached to a transaction (#39, v1)."""
+
+    __tablename__ = "transaction_tags"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "transaction_id"],
+            ["transactions.household_id", "transactions.id"],
+            ondelete="CASCADE",
+            name="fk_transaction_tags_transaction",
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    transaction_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    tag: Mapped[str] = mapped_column(String(64), primary_key=True)

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -34,6 +34,11 @@ from tulip_storage.repositories.transaction import (
     TransactionRepository,
     TrialBalanceRow,
 )
+from tulip_storage.repositories.transaction_tag import (
+    TagInvalidError,
+    TransactionTagRepository,
+    normalise_tag,
+)
 
 __all__ = [
     "AIInvocationRepository",
@@ -55,6 +60,9 @@ __all__ = [
     "ShadowTransactionRepository",
     "SinkingFundRepository",
     "StatementLineRepository",
+    "TagInvalidError",
     "TransactionRepository",
+    "TransactionTagRepository",
     "TrialBalanceRow",
+    "normalise_tag",
 ]

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction_tag.py
@@ -1,0 +1,138 @@
+"""Repository for the v1 ``transaction_tags`` table (#39)."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import delete, select
+
+from tulip_storage.models import TransactionTag
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class TagInvalidError(ValueError):
+    """A tag string failed validation (empty, too long, illegal chars)."""
+
+
+#: Tags are intentionally restrictive in v1: printable, non-whitespace
+#: identifiers up to 64 chars. Whitespace-bearing tags would make
+#: filter URL syntax ambiguous; control chars + null bytes have no
+#: legitimate use. The grammar can widen in later slices (#39 follow-up).
+_TAG_RE = re.compile(r"^[A-Za-z0-9_\-./:][A-Za-z0-9_\-./:]{0,63}$")
+
+
+def normalise_tag(value: str) -> str:
+    """Strip + lowercase a tag candidate; raise :class:`TagInvalidError` on bad input."""
+    if not isinstance(value, str):
+        raise TagInvalidError(f"tag must be a string, got {type(value).__name__}")
+    stripped = value.strip().lower()
+    if not stripped:
+        raise TagInvalidError("tag cannot be empty")
+    if len(stripped) > 64:
+        raise TagInvalidError(f"tag {stripped!r} exceeds 64 characters")
+    if not _TAG_RE.fullmatch(stripped):
+        raise TagInvalidError(f"tag {stripped!r} must be 1-64 chars of [A-Z a-z 0-9 _ - . / :]")
+    return stripped
+
+
+class TransactionTagRepository:
+    """Per-household repository for the v1 transaction_tags surface (#39)."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the repo to a session + household tenant scope."""
+        self._session = session
+        self._household_id = household_id
+
+    def set_tags(self, transaction_id: UUID, tags: list[str]) -> list[str]:
+        """Replace the transaction's tags with the given set (atomic per-call).
+
+        Each tag is normalised + deduplicated; the stored set is the
+        deduplicated union of the input. Returns the stored list in
+        sorted order for deterministic round-trip.
+        """
+        normalised = sorted({normalise_tag(t) for t in tags})
+        self._session.execute(
+            delete(TransactionTag).where(
+                TransactionTag.household_id == self._household_id,
+                TransactionTag.transaction_id == transaction_id,
+            )
+        )
+        for tag in normalised:
+            self._session.add(
+                TransactionTag(
+                    household_id=self._household_id,
+                    transaction_id=transaction_id,
+                    tag=tag,
+                )
+            )
+        return normalised
+
+    def list_tags(self, transaction_id: UUID) -> list[str]:
+        """Return the transaction's tags in sorted order (alphabetical)."""
+        rows = (
+            self._session.execute(
+                select(TransactionTag.tag)
+                .where(
+                    TransactionTag.household_id == self._household_id,
+                    TransactionTag.transaction_id == transaction_id,
+                )
+                .order_by(TransactionTag.tag)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+    def list_tags_for_transactions(self, transaction_ids: list[UUID]) -> dict[UUID, list[str]]:
+        """Batch lookup: return ``{tx_id: [tag, …]}`` for a list of transactions.
+
+        Used by the list-endpoint render so we don't fire one query per
+        row. Tags are sorted within each transaction.
+        """
+        if not transaction_ids:
+            return {}
+        rows = self._session.execute(
+            select(TransactionTag.transaction_id, TransactionTag.tag)
+            .where(
+                TransactionTag.household_id == self._household_id,
+                TransactionTag.transaction_id.in_(transaction_ids),
+            )
+            .order_by(TransactionTag.transaction_id, TransactionTag.tag)
+        ).all()
+        by_tx: dict[UUID, list[str]] = {tx_id: [] for tx_id in transaction_ids}
+        for tx_id, tag in rows:
+            by_tx[tx_id].append(tag)
+        return by_tx
+
+    def find_transaction_ids_by_tag(self, tag: str) -> list[UUID]:
+        """Return the household's transaction ids that carry ``tag``.
+
+        Used by ``GET /v1/transactions?tag=foo``. The tag is normalised
+        before lookup so the URL filter is case-insensitive. Hits the
+        ``ix_transaction_tags_household_tag`` index.
+        """
+        normalised = normalise_tag(tag)
+        rows = (
+            self._session.execute(
+                select(TransactionTag.transaction_id)
+                .where(
+                    TransactionTag.household_id == self._household_id,
+                    TransactionTag.tag == normalised,
+                )
+                .order_by(TransactionTag.transaction_id)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+
+__all__: list[str] = [
+    "TagInvalidError",
+    "TransactionTagRepository",
+    "normalise_tag",
+]


### PR DESCRIPTION
## Summary

First slice of [#39](https://github.com/rmwarriner/tulip-accounting/issues/39) — free-form string tags on transactions only. Scope cut sharp per the design discussion: no cascade, no account- or posting-level tags, no key=value pairs, no multi-tag filter grammar. v1 ships a single useful primitive; the harder questions get follow-up issues.

### Storage

- New \`transaction_tags\` table keyed on \`(household_id, transaction_id, tag)\` — composite PK gives uniqueness for free. Composite FK to \`transactions.(household_id, id)\` with \`ON DELETE CASCADE\` so deleting a transaction sweeps its tags. Tenant-boundary posture matches \`postings\`. Index \`ix_transaction_tags_household_tag\` serves the \`?tag=foo\` filter.
- New \`TransactionTag\` model + \`TransactionTagRepository\` with \`set_tags\`, \`list_tags\`, \`list_tags_for_transactions\`, \`find_transaction_ids_by_tag\`. Validation in \`normalise_tag\` (1-64 chars, \`[A-Za-z0-9_-./:]\`, case-insensitive, no whitespace because the URL filter would be ambiguous).
- Alembic migration \`f5b8d3a1c6e4\` chained off the \`e9c4f1b7d2a5\` (encryption_v1_wrap) head.

### API

- \`TransactionCreate.tags\` — write on create; dedupe + case-fold server-side. \`TransactionRead.tags\` surfaces them on GET (single + list). \`TransactionUpdate.tags\` PATCH semantics (omit to leave alone, pass \`[]\` to clear).
- \`GET /v1/transactions?tag=foo\` — case-insensitive filter served by the household+tag index, AND-s with existing filters.
- New 400 \`tag.invalid\` Problem Detail; auto-published at \`/.well-known/errors/\`.

### CLI

- \`tulip add --tag foo --tag bar\` repeated flag.
- \`tulip transactions list --tag foo\` filter.

### Out of scope (file follow-ups when usage warrants)

- Account-level tags + cascade semantics (the issue's larger primary case).
- Posting-level tags.
- Key=value pairs alongside labels.
- Filter grammar beyond a single \`?tag=\` (boolean / multi-tag).
- PATCH-tag-on-POSTED bypassing the not_editable gate — currently inherits the existing PATCH-PENDING-only constraint; tag edits on POSTED go through \`/replace\` (#209a/b) like any other field.

## Test plan

- [x] \`uv run pytest packages/tulip-api/tests/test_transactions_tags.py -q\` — 16 passing (POST round-trip × 5, PATCH PENDING-only gate, list filter × 3, validation × 6 + invalid filter).
- [x] \`uv run pytest packages/tulip-storage/tests/test_migrations.py -q\` — 16 passing (migration round-trip clean; no duplicate-head error).
- [x] \`uv run pytest packages/tulip-api/tests/test_transactions_endpoints.py packages/tulip-api/tests/test_audit_retention_coverage.py -q\` — passing (no regression on existing endpoints).
- [x] \`just lint\` / \`just typecheck\` — clean.
- [ ] CI green on this PR.