### PR TITLE
chore(docker): bind-mount sqlite DB for MCP access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,14 @@ junit.xml
 # Databases (SQLite / SQLCipher)
 *.db
 *.db-journal
+*.db-wal
+*.db-shm
 *.sqlite
 *.sqlite3
+
+# Docker bind-mount data dirs (compose.yml mounts ./deploy/docker/data/db
+# into the API container; runtime state, never committed).
+/deploy/docker/data/
 
 # IDE / editor
 # Team-shared VS Code config (extensions, workspace settings, debug

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
       "args": [
         "mcp-server-sqlite",
         "--db-path",
-        "./tulip.db"
+        "./deploy/docker/data/db/tulip.db"
       ]
     }
   }

--- a/deploy/docker/compose.yml
+++ b/deploy/docker/compose.yml
@@ -68,7 +68,14 @@ services:
       - tulip-master-key
       - tulip-jwt-secret
     volumes:
-      - tulip-db:/var/lib/tulip/db
+      # DB is a host bind mount so the project-scoped `sqlite` MCP server
+      # (.mcp.json) can read the live container DB. Named volumes live in
+      # Docker's internal storage and aren't reachable from the host.
+      # Attachments stay on a named volume — the MCP doesn't read them
+      # and the bind-mount portability tradeoffs (uid 1000 on Linux,
+      # see entrypoint.sh's chown step) only matter for files we need
+      # to inspect off-container.
+      - ./data/db:/var/lib/tulip/db
       - tulip-attachments:/var/lib/tulip/attachments
     healthcheck:
       test:
@@ -82,7 +89,6 @@ services:
       start_period: 30s
 
 volumes:
-  tulip-db:
   tulip-attachments:
 
 secrets:

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -38,6 +38,15 @@ if [ -n "${TULIP_JWT_SECRET_FILE:-}" ] && [ -f "${TULIP_JWT_SECRET_FILE}" ]; the
     unset TULIP_JWT_SECRET_FILE
 fi
 
+# ---- 1.5. Reclaim ownership of bind-mounted data dirs --------------------
+# The Dockerfile chowns /var/lib/tulip to uid 1000 at image-build time, but
+# a bind mount overlays that with the host directory's ownership (typically
+# the host user's uid on Linux, often 501 on macOS Docker Desktop). Without
+# this, `gosu tulip alembic upgrade head` below fails with EACCES on the
+# very first boot against an empty bind mount. Idempotent — a no-op once
+# the dirs are already tulip-owned.
+chown -R tulip:tulip /var/lib/tulip/db /var/lib/tulip/attachments
+
 # ---- 2. Migrate as the tulip user (writes to the tulip-owned volume) -----
 # Skip migration when TULIP_SKIP_MIGRATION=1 — used by tests or by
 # operators running `docker compose run` for one-off commands.


### PR DESCRIPTION
## Summary
- Swap the `tulip-db` named volume for a host bind mount at `./deploy/docker/data/db`, so the project-scoped `sqlite` MCP can read what the API container actually wrote — the named volume lived in Docker's internal storage and was invisible to the host, leaving the MCP querying an unrelated stale `./tulip.db` from non-Docker dev runs.
- Update `.mcp.json` to point at the bind-mounted file.
- Add a root-time `chown -R tulip:tulip /var/lib/tulip/{db,attachments}` to `entrypoint.sh` — the Dockerfile's image-time chown is overlaid by the bind mount, and without this the `gosu tulip alembic upgrade head` step fails with EACCES on a fresh host-owned dir. Idempotent on subsequent boots.
- Attachments stay on a named volume; the MCP doesn't read them and the uid-portability tradeoff only matters for files we actually want to inspect off the container.
- Gitignore the bind-mount dir; add `*.db-wal` / `*.db-shm` so SQLite WAL sidecars never sneak in.

## Test plan
- [ ] Secrets in place (one-time, per the `compose.yml` header comment):
```bash
mkdir -p deploy/docker/secrets
python -c 'import base64, secrets; print(base64.b64encode(secrets.token_bytes(32)).decode())' > deploy/docker/secrets/master-key
python -c 'import secrets; print(secrets.token_urlsafe(48))' > deploy/docker/secrets/jwt-secret
chmod 0400 deploy/docker/secrets/*
```
- [ ] Wipe any prior named-volume data, boot against the bind mount, verify the DB file lands on the host, verify the host can read it (simulating the MCP's access pattern), verify the API is healthy, then tear down preserving the bind-mount data:
```bash
docker compose -f deploy/docker/compose.yml down -v
docker compose -f deploy/docker/compose.yml up --build --wait -d
ls -la deploy/docker/data/db/
sqlite3 deploy/docker/data/db/tulip.db ".tables"
curl -fsS http://127.0.0.1:8000/health
docker compose -f deploy/docker/compose.yml down
ls -la deploy/docker/data/db/
```
Expected: `ls` shows `tulip.db` (possibly with `-wal` / `-shm` sidecars) on the host; `sqlite3 .tables` lists `alembic_version` plus the migrated schema; `curl` returns 200; a plain `down` (no `-v`) leaves the bind-mount data intact for the next session.
- [ ] Restart the Claude Code session so the `sqlite` MCP server respawns against the new `--db-path`, then run a sanity MCP query against `list_tables`.
- [ ] CI green on this PR (paths only hit `lint` + `secrets-scan` per the `changes` job in `.github/workflows/ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)