### PR TITLE
chore(just): docker-reset recipes for bind-mounted SQLite DB

### DIFF
--- a/justfile
+++ b/justfile
@@ -95,6 +95,36 @@ mutate:
 mutate-results:
     uv run mutmut results
 
+# ---------------------------------------------------------------------------
+# Docker dev stack
+# ---------------------------------------------------------------------------
+
+# The DB lives in a host bind mount (./deploy/docker/data/db), so `down -v`
+# does not touch it — Docker only manages named volumes. This stops the
+# stack, removes the SQLite file + its WAL sidecars, then brings the stack
+# back up; the entrypoint re-runs `alembic upgrade head` against the empty
+# dir, leaving a schema-current DB.
+#
+# Pass extra flags through to `up`, e.g. after a Dockerfile or source change:
+#     just docker-reset --build
+# If just refuses the leading dash, separate with --:
+#     just docker-reset -- --build
+#
+# Attachments (still a named volume) are preserved; use docker-reset-all to
+# wipe those too.
+
+# Reset the local Docker stack's SQLite DB for a clean regression-test run.
+docker-reset *FLAGS:
+    docker compose -f deploy/docker/compose.yml down
+    rm -f deploy/docker/data/db/tulip.db deploy/docker/data/db/tulip.db-wal deploy/docker/data/db/tulip.db-shm
+    docker compose -f deploy/docker/compose.yml up --wait -d {{FLAGS}}
+
+# Same as docker-reset but also wipes the attachments named volume.
+docker-reset-all *FLAGS:
+    docker compose -f deploy/docker/compose.yml down -v
+    rm -f deploy/docker/data/db/tulip.db deploy/docker/data/db/tulip.db-wal deploy/docker/data/db/tulip.db-shm
+    docker compose -f deploy/docker/compose.yml up --wait -d {{FLAGS}}
+
 # Replay the docs/QUICKSTART.md flow end-to-end against a fresh stack
 # (#138). Intent is to surface drift between the doc and the code:
 # if any of the commands in the walkthrough stop returning a 0 exit


### PR DESCRIPTION
## Summary
- Follow-up to #397 — `docker compose down -v` no longer wipes the DB now that it lives in a host bind mount (Docker only manages named volumes), so the manual reset became a three-step dance: `down`, `rm` the SQLite + WAL sidecars, `up`.
- New `just docker-reset` bundles it; takes `*FLAGS` so `just docker-reset --build` forwards `--build` to `docker compose up` for the after-Dockerfile-change case.
- New `just docker-reset-all` does the same but also passes `-v` to `down` to clear the attachments named volume in one shot.
- New `# Docker dev stack` section header in the justfile groups these (and is the right home for `quickstart-smoke` too, conceptually — left in place to keep the diff scoped).

## Test plan
- [x] `just --list` shows both recipes with a sensible one-line summary.
- [x] `just --dry-run docker-reset --build` prints the expected three commands with `--build` spliced onto `up`:
```bash
just --dry-run docker-reset --build
```
- [ ] End-to-end on a fresh stack: bring it up, write something, reset, verify the DB file was recreated empty and the schema is current:
```bash
docker compose -f deploy/docker/compose.yml up --build --wait -d
sqlite3 deploy/docker/data/db/tulip.db "SELECT name FROM sqlite_master WHERE type='table' AND name='alembic_version';"
sqlite3 deploy/docker/data/db/tulip.db "CREATE TABLE smoke_marker (x INTEGER);"
just docker-reset
sqlite3 deploy/docker/data/db/tulip.db "SELECT name FROM sqlite_master WHERE type='table' AND name='smoke_marker';"
sqlite3 deploy/docker/data/db/tulip.db "SELECT name FROM sqlite_master WHERE type='table' AND name='alembic_version';"
docker compose -f deploy/docker/compose.yml down
```
Expected: the first `alembic_version` query returns the table, the `smoke_marker` lookup after reset returns nothing (wiped), and the post-reset `alembic_version` query returns the table again (entrypoint re-migrated the empty DB).
- [ ] CI green on this PR (justfile-only change — `lint` and `secrets-scan` only per the path-conditional jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)