### PR TITLE
P9.5.a — TUI envelopes browser (closes #400)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-18 · `main` @ **Phase 8 deep security audit complete + Phase 9 v1 shipped (read-only TUI: skeleton + accounts browser + transactions register + reports viewer + reconciliations / imports browse)** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318) and all five P9.0–P9.4 slices merged across PRs #383 / #384 / #385 / #386 against umbrella [#309](https://github.com/rmwarriner/tulip-accounting/issues/309); mutation surfaces (categorize / split / edit / reconcile-action / apply-import) deliberately remain on the CLI for v1 per ADR-0007.
+**Last updated:** 2026-05-18 · `main` @ **Phase 8 deep security audit complete + Phase 9 v1 shipped (read-only TUI: skeleton + accounts browser + transactions register + reports viewer + reconciliations / imports browse) + P9.5.a envelopes browser in flight** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318) and all five P9.0–P9.4 slices merged across PRs #383 / #384 / #385 / #386 against umbrella [#309](https://github.com/rmwarriner/tulip-accounting/issues/309); mutation surfaces (categorize / split / edit / reconcile-action / apply-import) deliberately remain on the CLI for v1 per ADR-0007. Phase 9 v1 read continuation ([#399](https://github.com/rmwarriner/tulip-accounting/issues/399)) opens with three read-only browse slices (envelopes / sinking funds / pending) on the same loader-injection pattern; [#400](https://github.com/rmwarriner/tulip-accounting/issues/400) (envelopes) is the first.
 
 ---
 
@@ -1696,6 +1696,46 @@ the CLI per ADR-0007.
   binding tests for `c` / `i`).
 - **Out of scope (per design pass)** — actioning reconciliations
   (mutation), per-batch line drill-in (later polish if needed).
+
+### P9.5 — TUI read-only continuation (in flight)
+
+Per [#399](https://github.com/rmwarriner/tulip-accounting/issues/399). Three more read-only browse screens (envelopes,
+sinking funds, pending) that complete the v1 read surface — every
+mutation flow still stays on the CLI per ADR-0007.
+
+#### P9.5.a — Envelopes browser — ✅ *(2026-05-18)*
+
+Per [#400](https://github.com/rmwarriner/tulip-accounting/issues/400). New app-wide `e` binding pushes the
+envelopes browser.
+
+- **Data layer** — `tulip_tui/data/envelopes.py` adds
+  `EnvelopeSummary` / `EnvelopesData` (frozen) and
+  `load_envelopes(client)`. Joins `GET /v1/envelopes` with
+  `POST /v1/pools/balances` (the batched balance endpoint from #137).
+  Envelopes that don't come back in the balance response keep
+  `balance = None` so the screen renders `—` instead of `0.00`
+  (same convention as `data/accounts.py`). Empty envelope list
+  short-circuits the POST. Refill-rule summarisation
+  (`fixed: 600.00 USD` / `target: 200.00 USD` / `pct-inflow: 5%`)
+  is duplicated inline rather than reaching into the
+  `tulip_cli.commands._pools._summarize_refill_rule` private.
+- **EnvelopesScreen** — DataTable with seven columns (Name /
+  Currency / Period / Rollover / Budget / Balance / Refill); detail
+  pane below renders the full envelope on cursor highlight.
+  `escape` pops, `r` refreshes. Inline error pane on loader failure.
+- **App wiring** — new `e` binding + `envelopes_loader` constructor
+  seam with a `_no_op_envelopes_loader` default (consistent with the
+  existing per-screen seam pattern). Production `main.run()` installs
+  the loader that opens a fresh `TulipClient` per fetch.
+- **Tests** — 10 data-layer tests (happy join, empty short-circuit,
+  API-error path, refill-summary table for each strategy + None +
+  unknown); 5 pilot-mode screen tests (rows render with formatted
+  amounts + refill summary, cursor follows detail, empty state,
+  inline error, `e` binding pushes the screen).
+- **Out of scope** — period-bucketed "Spent vs Budget" view (no API
+  endpoint exposes it; deferred to a backend slice), Needs / Wants /
+  Bills / Family group headers (no `group` field on the API), every
+  mutation (fund / move / edit stay on the CLI).
 
 ---
 

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -21,10 +21,12 @@ from typing import ClassVar
 from textual.app import App
 from textual.binding import Binding, BindingType
 
+from tulip_tui.data.envelopes import EnvelopesData
 from tulip_tui.data.imports import ImportsData
 from tulip_tui.data.reconciliations import ReconciliationsData
 from tulip_tui.data.reports import ReportPayload, ReportSpec
 from tulip_tui.screens.accounts import AccountsLoader, AccountsScreen
+from tulip_tui.screens.envelopes import EnvelopesScreen
 from tulip_tui.screens.imports import ImportsScreen
 from tulip_tui.screens.reconciliations import ReconciliationsScreen
 from tulip_tui.screens.reports import ReportsScreen
@@ -34,6 +36,7 @@ TransactionsLoaderFactory = Callable[[str | None], TransactionsLoader]
 ReportLoader = Callable[[ReportSpec], ReportPayload]
 ReconciliationsLoader = Callable[[], ReconciliationsData]
 ImportsLoader = Callable[[], ImportsData]
+EnvelopesLoader = Callable[[], EnvelopesData]
 
 
 def _no_op_transactions_factory(_account_id: str | None) -> TransactionsLoader:
@@ -61,6 +64,10 @@ def _no_op_imports_loader() -> ImportsData:
     raise RuntimeError("imports loader not configured")
 
 
+def _no_op_envelopes_loader() -> EnvelopesData:
+    raise RuntimeError("envelopes loader not configured")
+
+
 class TulipTuiApp(App[None]):
     """Tulip TUI shell — boots into the accounts browser."""
 
@@ -71,6 +78,7 @@ class TulipTuiApp(App[None]):
         Binding("p", "open_reports", "reports", show=True),
         Binding("c", "open_reconciliations", "reconcile", show=True),
         Binding("i", "open_imports", "imports", show=True),
+        Binding("e", "open_envelopes", "envelopes", show=True),
     ]
 
     def __init__(
@@ -81,6 +89,7 @@ class TulipTuiApp(App[None]):
         reports_loader: ReportLoader = _no_op_reports_loader,
         reconciliations_loader: ReconciliationsLoader = _no_op_reconciliations_loader,
         imports_loader: ImportsLoader = _no_op_imports_loader,
+        envelopes_loader: EnvelopesLoader = _no_op_envelopes_loader,
     ) -> None:
         """Store the per-screen loaders / factories used at mount and drill-in."""
         super().__init__()
@@ -89,6 +98,7 @@ class TulipTuiApp(App[None]):
         self._reports_loader = reports_loader
         self._reconciliations_loader = reconciliations_loader
         self._imports_loader = imports_loader
+        self._envelopes_loader = envelopes_loader
 
     def on_mount(self) -> None:
         """Push the accounts browser as the initial screen."""
@@ -110,3 +120,7 @@ class TulipTuiApp(App[None]):
     def action_open_imports(self) -> None:
         """Push the import batches browser onto the screen stack."""
         self.push_screen(ImportsScreen(loader=self._imports_loader))
+
+    def action_open_envelopes(self) -> None:
+        """Push the envelopes browser onto the screen stack."""
+        self.push_screen(EnvelopesScreen(loader=self._envelopes_loader))

--- a/packages/tulip-tui/src/tulip_tui/data/envelopes.py
+++ b/packages/tulip-tui/src/tulip_tui/data/envelopes.py
@@ -1,0 +1,130 @@
+"""Envelopes-screen data adapter.
+
+Composes two API reads into one immutable value object:
+
+* ``GET /v1/envelopes`` — every active envelope visible to the caller.
+* ``POST /v1/pools/balances`` — the batched balance endpoint added in
+  #137. One round-trip across every envelope id; the CLI ``envelopes
+  list`` command uses the same pattern.
+
+The join is by envelope id ↔ ``pool_id``. Envelopes with no balance
+row keep ``balance = None`` so the screen renders ``—`` instead of a
+misleading ``0.00`` (same convention as the accounts adapter).
+
+The refill-rule summariser is duplicated from
+``tulip_cli.commands._pools._summarize_refill_rule`` rather than
+reaching into a ``_``-prefixed CLI internal across the package
+boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tulip_cli.http import TulipClient
+
+
+@dataclass(frozen=True, slots=True)
+class EnvelopeSummary:
+    """One row in the envelope browser."""
+
+    id: str
+    name: str
+    currency: str
+    visibility: str
+    is_active: bool
+    budget_period: str
+    rollover_policy: str
+    budget_amount: str | None
+    balance: str | None
+    refill_summary: str
+
+
+@dataclass(frozen=True, slots=True)
+class EnvelopesData:
+    """The full payload the envelopes screen renders."""
+
+    envelopes: tuple[EnvelopeSummary, ...]
+
+
+def load_envelopes(client: TulipClient) -> EnvelopesData:
+    """Fetch + join ``/v1/envelopes`` and ``/v1/pools/balances``."""
+    raw = client.get("/v1/envelopes", authenticated=True).json()
+    if not raw:
+        return EnvelopesData(envelopes=())
+
+    pool_ids = [str(row["id"]) for row in raw]
+    balances_raw = client.post(
+        "/v1/pools/balances",
+        json={"pool_ids": pool_ids},
+        authenticated=True,
+    ).json()
+    balances_by_id = {str(row["pool_id"]): str(row["balance"]) for row in balances_raw}
+
+    summaries = tuple(_to_summary(row, balances_by_id) for row in raw)
+    return EnvelopesData(envelopes=summaries)
+
+
+def _to_summary(row: dict[str, object], balances_by_id: dict[str, str]) -> EnvelopeSummary:
+    envelope_id = str(row.get("id", ""))
+    return EnvelopeSummary(
+        id=envelope_id,
+        name=str(row.get("name", "")),
+        currency=str(row.get("currency", "")),
+        visibility=str(row.get("visibility", "")),
+        is_active=bool(row.get("is_active", False)),
+        budget_period=str(row.get("budget_period", "")),
+        rollover_policy=str(row.get("rollover_policy", "")),
+        budget_amount=_optional_str(row.get("budget_amount")),
+        balance=balances_by_id.get(envelope_id),
+        refill_summary=summarize_refill_rule(_optional_dict(row.get("refill_rule"))),
+    )
+
+
+def summarize_refill_rule(rule: dict[str, object] | None) -> str:
+    """One-line description of an envelope's ``refill_rule``.
+
+    Mirrors ``tulip_cli.commands._pools._summarize_refill_rule`` so the
+    TUI doesn't import a CLI private. Each strategy gets a compact
+    form keyed by what a user actually scans for.
+    """
+    if not rule:
+        return "—"
+    strategy = rule.get("strategy")
+    if strategy == "fixed_amount":
+        amount = rule.get("amount", "?")
+        currency = rule.get("currency", "")
+        return f"fixed: {amount} {currency}".rstrip()
+    if strategy == "fill_to_amount":
+        amount = rule.get("amount", "?")
+        currency = rule.get("currency", "")
+        return f"target: {amount} {currency}".rstrip()
+    if strategy == "percentage_of_income":
+        pct = rule.get("percentage")
+        if pct is None:
+            return "pct-inflow"
+        try:
+            display = f"{float(str(pct)) * 100:g}%"
+        except (TypeError, ValueError):
+            display = str(pct)
+        return f"pct-inflow: {display}"
+    return str(strategy or "—")
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _optional_dict(value: object) -> dict[str, object] | None:
+    return value if isinstance(value, dict) else None
+
+
+__all__: list[str] = [
+    "EnvelopeSummary",
+    "EnvelopesData",
+    "load_envelopes",
+    "summarize_refill_rule",
+]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -13,6 +13,7 @@ from tulip_cli.config import load_config
 from tulip_cli.http import TulipClient
 from tulip_tui.app import TulipTuiApp
 from tulip_tui.data.accounts import AccountsData, load_accounts
+from tulip_tui.data.envelopes import EnvelopesData, load_envelopes
 from tulip_tui.data.imports import ImportsData, load_import_batches
 from tulip_tui.data.reconciliations import ReconciliationsData, load_reconciliations
 from tulip_tui.data.reports import ReportPayload, ReportSpec, load_report
@@ -57,6 +58,12 @@ def _imports_loader() -> ImportsData:
         return load_import_batches(client)
 
 
+def _envelopes_loader() -> EnvelopesData:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return load_envelopes(client)
+
+
 def run() -> None:
     """Launch the Tulip TUI against the configured API."""
     TulipTuiApp(
@@ -65,4 +72,5 @@ def run() -> None:
         reports_loader=_reports_loader,
         reconciliations_loader=_reconciliations_loader,
         imports_loader=_imports_loader,
+        envelopes_loader=_envelopes_loader,
     ).run()

--- a/packages/tulip-tui/src/tulip_tui/screens/envelopes.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/envelopes.py
@@ -1,0 +1,178 @@
+"""Envelopes browser — P9.5.a of [#399](https://github.com/rmwarriner/tulip-accounting/issues/399).
+
+Read-only browse of the household's envelopes with live balances and
+a one-line refill-rule summary. Mutating an envelope (fund / move /
+edit) stays on the ``tulip envelopes`` CLI per ADR-0007.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal, InvalidOperation
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+from tulip_tui.data.envelopes import EnvelopesData, EnvelopeSummary
+
+EnvelopesLoader = Callable[[], EnvelopesData]
+
+
+def _fmt_amount(value: str | None) -> str:
+    if value is None or value == "":
+        return "—"
+    try:
+        return f"{Decimal(value).quantize(Decimal('0.01')):,.2f}"
+    except (InvalidOperation, ValueError):
+        return value
+
+
+def _row_for(env: EnvelopeSummary) -> tuple[str, str, str, str, str, str, str]:
+    return (
+        env.name,
+        env.currency,
+        env.budget_period,
+        env.rollover_policy,
+        _fmt_amount(env.budget_amount),
+        _fmt_amount(env.balance),
+        env.refill_summary,
+    )
+
+
+def _detail_for(env: EnvelopeSummary) -> str:
+    lines = [
+        f"[b]{env.id}[/b]    {env.name}",
+        f"currency:         {env.currency}",
+        f"visibility:       {env.visibility}",
+        f"is_active:        {env.is_active}",
+        f"budget_period:    {env.budget_period}",
+        f"rollover_policy:  {env.rollover_policy}",
+        f"budget_amount:    {_fmt_amount(env.budget_amount)}",
+        f"balance:          {_fmt_amount(env.balance)}",
+        f"refill:           {env.refill_summary}",
+    ]
+    return "\n".join(lines)
+
+
+class EnvelopesScreen(Screen[None]):
+    """Browse the household's envelopes."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "app.pop_screen", "back", show=True),
+        Binding("r", "refresh", "refresh", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    EnvelopesScreen {
+        layout: vertical;
+    }
+
+    EnvelopesScreen #env-status {
+        height: auto;
+        padding: 0 1;
+    }
+
+    EnvelopesScreen #env-table {
+        height: 2fr;
+    }
+
+    EnvelopesScreen #env-detail {
+        height: 1fr;
+        padding: 1 2;
+        border-top: solid $accent;
+    }
+    """
+
+    def __init__(self, loader: EnvelopesLoader) -> None:
+        """Store the loader; the screen populates on mount."""
+        super().__init__()
+        self._loader = loader
+        self._rendered_rows: list[str] = []
+        self._index: list[EnvelopeSummary] = []
+        self._detail: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Lay out the status strip, the envelope table, and the detail pane."""
+        yield Header()
+        with Vertical():
+            yield Static("loading envelopes…", id="env-status")
+            yield DataTable(id="env-table", zebra_stripes=True, cursor_type="row")
+            yield Static("", id="env-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Install column headers and trigger the initial load."""
+        table = self.query_one("#env-table", DataTable)
+        table.add_columns("Name", "Currency", "Period", "Rollover", "Budget", "Balance", "Refill")
+        self._load()
+
+    def action_refresh(self) -> None:
+        """Re-run the loader and rebuild the table in place."""
+        self._load()
+
+    def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
+        """Re-render the detail pane to match the newly-highlighted row."""
+        self._refresh_detail()
+
+    # -- internals -----------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            data = self._loader()
+        except Exception as exc:
+            self._render_error(exc)
+            return
+        self._populate(data)
+
+    def _populate(self, data: EnvelopesData) -> None:
+        table = self.query_one("#env-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        status = self.query_one("#env-status", Static)
+        status.update(f"{len(data.envelopes)} envelopes")
+        if not data.envelopes:
+            self._set_detail("No envelopes yet.")
+            return
+        for env in data.envelopes:
+            cells = _row_for(env)
+            table.add_row(*cells)
+            self._rendered_rows.append(" ".join(cells))
+            self._index.append(env)
+        self._refresh_detail()
+
+    def _refresh_detail(self) -> None:
+        if not self._index:
+            return
+        table = self.query_one("#env-table", DataTable)
+        cursor = max(0, table.cursor_row)
+        if cursor >= len(self._index):
+            return
+        self._set_detail(_detail_for(self._index[cursor]))
+
+    def _render_error(self, exc: BaseException) -> None:
+        table = self.query_one("#env-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        status = self.query_one("#env-status", Static)
+        status.update(f"[red]error:[/red] {exc}")
+        self._set_detail(f"error: {exc}")
+
+    def _set_detail(self, text: str) -> None:
+        self._detail = text
+        self.query_one("#env-detail", Static).update(text)
+
+    # -- introspection used by tests ----------------------------------
+
+    def rendered_rows(self) -> list[str]:
+        """Return a string-only mirror of the table's rows for assertions."""
+        return list(self._rendered_rows)
+
+    def detail_text(self) -> str:
+        """Return the current detail-pane text as a plain string."""
+        return self._detail

--- a/packages/tulip-tui/tests/test_envelopes_data.py
+++ b/packages/tulip-tui/tests/test_envelopes_data.py
@@ -1,0 +1,259 @@
+"""Unit tests for ``tulip_tui.data.envelopes``.
+
+The adapter joins ``GET /v1/envelopes`` (every active envelope visible
+to the caller) with ``POST /v1/pools/balances`` (the batched balance
+endpoint added in #137). Envelopes that don't come back in the
+balance response keep ``balance = None`` so the screen can render
+``—`` instead of a misleading ``0.00`` (same convention as the
+accounts adapter).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+from tulip_tui.data.envelopes import (
+    EnvelopesData,
+    EnvelopeSummary,
+    load_envelopes,
+    summarize_refill_rule,
+)
+
+_GROCERIES_ID = "11111111-1111-1111-1111-111111111111"
+_GAS_ID = "22222222-2222-2222-2222-222222222222"
+_DINING_ID = "33333333-3333-3333-3333-333333333333"
+_NEW_ID = "44444444-4444-4444-4444-444444444444"
+
+
+def _envelopes_response() -> list[dict[str, object]]:
+    return [
+        {
+            "id": _GROCERIES_ID,
+            "name": "Groceries",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "budget_period": "monthly",
+            "rollover_policy": "reset",
+            "budget_amount": "600.00",
+            "refill_rule": {
+                "strategy": "fixed_amount",
+                "amount": "600.00",
+                "currency": "USD",
+            },
+        },
+        {
+            "id": _GAS_ID,
+            "name": "Gas",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "budget_period": "monthly",
+            "rollover_policy": "accumulate",
+            "budget_amount": "200.00",
+            "refill_rule": {
+                "strategy": "fill_to_amount",
+                "amount": "200.00",
+                "currency": "USD",
+            },
+        },
+        {
+            "id": _DINING_ID,
+            "name": "Dining out",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "budget_period": "monthly",
+            "rollover_policy": "cap_at_budget",
+            "budget_amount": None,
+            "refill_rule": {
+                "strategy": "percentage_of_income",
+                "percentage": "0.05",
+            },
+        },
+        {
+            "id": _NEW_ID,
+            "name": "Brand new",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "budget_period": "monthly",
+            "rollover_policy": "reset",
+            "budget_amount": "100.00",
+            "refill_rule": None,
+        },
+    ]
+
+
+def _balances_response() -> list[dict[str, object]]:
+    return [
+        {
+            "pool_id": _GROCERIES_ID,
+            "name": "Groceries",
+            "currency": "USD",
+            "balance": "187.45",
+            "as_of": "2026-05-17",
+        },
+        {
+            "pool_id": _GAS_ID,
+            "name": "Gas",
+            "currency": "USD",
+            "balance": "111.60",
+            "as_of": "2026-05-17",
+        },
+        {
+            "pool_id": _DINING_ID,
+            "name": "Dining out",
+            "currency": "USD",
+            "balance": "34.90",
+            "as_of": "2026-05-17",
+        },
+        # _NEW_ID intentionally absent — brand-new pool, no postings yet.
+    ]
+
+
+class _FakeTokenStore:
+    def load(self, _api_url: str) -> object:
+        return SimpleNamespace(
+            email="t@example.invalid",
+            access_token="fake-access-token",
+            refresh_token="fake-refresh-token",
+            access_expires_at=2**31 - 1,
+        )
+
+    def save(self, _api_url: str, _tokens: object) -> None: ...
+    def clear(self, _api_url: str) -> None: ...
+
+
+def _build_client(handler: httpx.MockTransport) -> TulipClient:
+    return TulipClient(
+        Config(api_url="https://example.invalid"),
+        token_store=_FakeTokenStore(),  # type: ignore[arg-type]
+        transport=handler,
+    )
+
+
+# ---- happy path -----------------------------------------------------
+
+
+def test_load_envelopes_joins_balances_and_refill_summaries() -> None:
+    envelopes_payload = _envelopes_response()
+    balances_payload = _balances_response()
+    recorded: list[tuple[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/envelopes":
+            recorded.append(("get", request.url.path))
+            return httpx.Response(200, json=envelopes_payload)
+        if request.method == "POST" and request.url.path == "/v1/pools/balances":
+            import json as _json
+
+            body = _json.loads(request.content.decode("utf-8"))
+            recorded.append(("post", body))
+            return httpx.Response(200, json=balances_payload)
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_envelopes(client)
+
+    assert isinstance(data, EnvelopesData)
+    assert len(data.envelopes) == 4
+    by_id = {e.id: e for e in data.envelopes}
+
+    groceries = by_id[_GROCERIES_ID]
+    assert isinstance(groceries, EnvelopeSummary)
+    assert groceries.name == "Groceries"
+    assert groceries.currency == "USD"
+    assert groceries.budget_period == "monthly"
+    assert groceries.rollover_policy == "reset"
+    assert groceries.budget_amount == "600.00"
+    assert groceries.balance == "187.45"
+    assert "fixed" in groceries.refill_summary
+
+    gas = by_id[_GAS_ID]
+    assert gas.balance == "111.60"
+    assert "target" in gas.refill_summary
+
+    dining = by_id[_DINING_ID]
+    assert dining.budget_amount is None
+    assert dining.balance == "34.90"
+    assert "pct-inflow" in dining.refill_summary
+    assert "5%" in dining.refill_summary
+
+    brand_new = by_id[_NEW_ID]
+    # Missing from balances → None (so screen renders "—" instead of 0).
+    assert brand_new.balance is None
+    assert brand_new.refill_summary == "—"
+
+    # The POST body carried exactly the pool ids the GET returned, in order.
+    posts = [body for kind, body in recorded if kind == "post"]
+    assert posts == [{"pool_ids": [_GROCERIES_ID, _GAS_ID, _DINING_ID, _NEW_ID]}]
+
+
+def test_load_envelopes_empty_short_circuits_balance_post() -> None:
+    """No envelopes → no /v1/pools/balances POST at all."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        if request.url.path == "/v1/envelopes":
+            return httpx.Response(200, json=[])
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_envelopes(client)
+
+    assert data.envelopes == ()
+    assert seen == ["GET /v1/envelopes"]
+
+
+def test_load_envelopes_raises_cli_error_on_api_failure() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                "type": "/.well-known/errors/internal",
+                "title": "Internal server error",
+                "status": 500,
+                "detail": "boom",
+                "instance": "",
+                "code": "internal",
+            },
+        )
+
+    with (
+        _build_client(httpx.MockTransport(handler)) as client,
+        pytest.raises(CliError),
+    ):
+        load_envelopes(client)
+
+
+# ---- refill-summary helper -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rule", "expected_substring"),
+    [
+        ({"strategy": "fixed_amount", "amount": "100.00", "currency": "USD"}, "fixed: 100.00"),
+        ({"strategy": "fill_to_amount", "amount": "500.00", "currency": "USD"}, "target: 500.00"),
+        ({"strategy": "percentage_of_income", "percentage": "0.05"}, "5%"),
+        ({"strategy": "percentage_of_income", "percentage": "0.125"}, "12.5%"),
+        ({"strategy": "percentage_of_income"}, "pct-inflow"),
+        ({"strategy": "something_new"}, "something_new"),
+    ],
+)
+def test_summarize_refill_rule_strategy_branches(
+    rule: dict[str, object], expected_substring: str
+) -> None:
+    summary = summarize_refill_rule(rule)
+    assert expected_substring in summary
+
+
+def test_summarize_refill_rule_none_returns_dash() -> None:
+    assert summarize_refill_rule(None) == "—"

--- a/packages/tulip-tui/tests/test_envelopes_screen.py
+++ b/packages/tulip-tui/tests/test_envelopes_screen.py
@@ -1,0 +1,141 @@
+"""Pilot-mode tests for ``EnvelopesScreen`` + the app-wide ``e`` binding.
+
+Mirrors the test shape of ``test_recon_imports_screens.py``: the screen
+takes an injected loader, so no API call is involved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
+from tulip_tui.data.envelopes import EnvelopesData, EnvelopeSummary
+from tulip_tui.screens.envelopes import EnvelopesScreen
+
+
+def _accounts_loader() -> AccountsData:
+    return AccountsData(as_of="2026-05-17", accounts=(), groups=())
+
+
+def _sample_envelopes() -> EnvelopesData:
+    return EnvelopesData(
+        envelopes=(
+            EnvelopeSummary(
+                id="env-groceries",
+                name="Groceries",
+                currency="USD",
+                visibility="shared",
+                is_active=True,
+                budget_period="monthly",
+                rollover_policy="reset",
+                budget_amount="600.00",
+                balance="187.45",
+                refill_summary="fixed: 600.00 USD",
+            ),
+            EnvelopeSummary(
+                id="env-dining",
+                name="Dining out",
+                currency="USD",
+                visibility="shared",
+                is_active=True,
+                budget_period="monthly",
+                rollover_policy="cap_at_budget",
+                budget_amount=None,
+                balance="34.90",
+                refill_summary="pct-inflow: 5%",
+            ),
+            EnvelopeSummary(
+                id="env-new",
+                name="Brand new",
+                currency="USD",
+                visibility="shared",
+                is_active=True,
+                budget_period="monthly",
+                rollover_policy="reset",
+                budget_amount="100.00",
+                balance=None,
+                refill_summary="—",
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_envelopes_screen_lists_rows_with_balance_and_refill() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = EnvelopesScreen(loader=lambda: _sample_envelopes())
+        await app.push_screen(screen)
+        await pilot.pause()
+        rendered = screen.rendered_rows()
+
+    assert len(rendered) == 3
+    # Comma-grouped balance formatting + refill summary land in the row text.
+    assert any("Groceries" in row and "187.45" in row and "fixed" in row for row in rendered)
+    assert any("Dining out" in row and "34.90" in row and "pct-inflow" in row for row in rendered)
+    # Missing balance renders as "—" (and missing budget too).
+    assert any("Brand new" in row and "—" in row for row in rendered)
+
+
+@pytest.mark.asyncio
+async def test_envelopes_screen_detail_follows_cursor() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = EnvelopesScreen(loader=lambda: _sample_envelopes())
+        await app.push_screen(screen)
+        await pilot.pause()
+        first = screen.detail_text()
+        assert "env-groceries" in first
+        assert "monthly" in first
+        assert "600.00" in first
+        await pilot.press("down")
+        await pilot.pause()
+        second = screen.detail_text()
+        assert "env-dining" in second
+        assert "pct-inflow" in second
+
+
+@pytest.mark.asyncio
+async def test_envelopes_screen_empty_state() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = EnvelopesScreen(loader=lambda: EnvelopesData(envelopes=()))
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "no envelopes" in screen.detail_text().lower()
+
+
+@pytest.mark.asyncio
+async def test_envelopes_screen_renders_error_inline() -> None:
+    def boom() -> EnvelopesData:
+        raise RuntimeError("api unreachable")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = EnvelopesScreen(loader=boom)
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "api unreachable" in screen.detail_text()
+        # Inline error should not lock the screen — escape + quit still work.
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.press("q")
+    assert app.return_code == 0
+
+
+@pytest.mark.asyncio
+async def test_app_binding_e_pushes_envelopes_screen() -> None:
+    app = TulipTuiApp(
+        loader=_accounts_loader,
+        envelopes_loader=lambda: _sample_envelopes(),
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("e")
+        await pilot.pause()
+        assert isinstance(app.screen, EnvelopesScreen)


### PR DESCRIPTION
## Summary

- First slice of [#399](https://github.com/rmwarriner/tulip-accounting/issues/399) (Phase 9.5 read-only continuation). Adds a Textual envelopes browser reachable via the new app-wide `e` binding, mirroring the data-adapter + Screen + loader-injection pattern P9.1–P9.4 already use.
- `data/envelopes.py` joins `GET /v1/envelopes` with `POST /v1/pools/balances` (the batched endpoint from #137). Envelopes missing from the balance response keep `balance = None` so the screen renders `—` instead of a misleading `0.00`. Refill-rule summariser is duplicated inline rather than importing the `tulip_cli.commands._pools._summarize_refill_rule` private.
- `EnvelopesScreen` renders a 7-column DataTable (Name / Currency / Period / Rollover / Budget / Balance / Refill) with a cursor-following detail pane; `r` refreshes, `escape` pops, loader exceptions render inline (consistent with the existing recon / imports screens).
- App: new `e` binding, `envelopes_loader` constructor seam, `_no_op_envelopes_loader` default; `main.run()` installs the production loader on a fresh `TulipClient` per fetch.
- 15 new tests (10 data-layer with `httpx.MockTransport` + 5 pilot-mode). Full `tulip-tui` suite green (65 tests). `PHASE_STATUS.md` gains a P9.5 subsection.
- Out of scope (deliberately, per [#399](https://github.com/rmwarriner/tulip-accounting/issues/399)): the wireframe's per-period Spent vs Budget bars (no API surface today), Needs / Wants / Bills / Family group headers (no `group` field on the API), and every mutation (fund / move / edit stay on the CLI per ADR-0007).

## Test plan

- [x] `uv run pytest packages/tulip-tui/` — 65/65 pass locally.
- [x] `just lint` clean.
- [x] `just typecheck` (mypy --strict) clean — 293 source files.
- [x] `just test` — 2296/2305 pass; the 9 failures are pre-existing PDF tests that fail without WeasyPrint system libs (`libgobject-2.0-0`) on this Mac; same tests fail on `main` for the same reason; CI on Linux is unaffected.
- [ ] CI green on this PR.
- [ ] Manual smoke against a live API and a real envelope row:
      ```bash
      cd ~/Projects/tulip-accounting
      docker compose up -d
      uv run uvicorn tulip_api.main:app --port 8000 &
      UVICORN_PID=$!
      sleep 2
      uv run tulip register --household 'Smoke Test' --email smoke@example.invalid --password-stdin <<<'correct-horse-battery-staple'
      uv run tulip envelopes add --name 'Groceries' --currency USD --budget-period monthly --rollover-policy reset --budget-amount 600.00
      uv run tulip envelopes add --name 'Gas' --currency USD --budget-period monthly --rollover-policy accumulate --budget-amount 200.00
      uv run tulip-tui
      ```
      In the TUI: press `e` → envelopes browser opens with both rows; arrow keys move the cursor and the detail pane follows; `r` refreshes; `escape` pops back; `q` quits cleanly.

      Cleanup:
      ```bash
      kill $UVICORN_PID
      ```