### PR TITLE
P9.5.b — TUI sinking funds browser (closes #408)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-18 · `main` @ **Phase 8 deep security audit complete + Phase 9 v1 shipped (read-only TUI: skeleton + accounts browser + transactions register + reports viewer + reconciliations / imports browse) + P9.5.a envelopes browser in flight** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318) and all five P9.0–P9.4 slices merged across PRs #383 / #384 / #385 / #386 against umbrella [#309](https://github.com/rmwarriner/tulip-accounting/issues/309); mutation surfaces (categorize / split / edit / reconcile-action / apply-import) deliberately remain on the CLI for v1 per ADR-0007. Phase 9 v1 read continuation ([#399](https://github.com/rmwarriner/tulip-accounting/issues/399)) opens with three read-only browse slices (envelopes / sinking funds / pending) on the same loader-injection pattern; [#400](https://github.com/rmwarriner/tulip-accounting/issues/400) (envelopes) is the first.
+**Last updated:** 2026-05-18 · `main` @ **Phase 8 deep security audit complete + Phase 9 v1 shipped (read-only TUI: skeleton + accounts browser + transactions register + reports viewer + reconciliations / imports browse) + P9.5.a envelopes browser shipped + P9.5.b sinking funds browser in flight** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318) and all five P9.0–P9.4 slices merged across PRs #383 / #384 / #385 / #386 against umbrella [#309](https://github.com/rmwarriner/tulip-accounting/issues/309); mutation surfaces (categorize / split / edit / reconcile-action / apply-import) deliberately remain on the CLI for v1 per ADR-0007. Phase 9 v1 read continuation ([#399](https://github.com/rmwarriner/tulip-accounting/issues/399)) opens with three read-only browse slices (envelopes / sinking funds / pending) on the same loader-injection pattern; [#400](https://github.com/rmwarriner/tulip-accounting/issues/400) (envelopes) is the first.
 
 ---
 
@@ -1736,6 +1736,38 @@ envelopes browser.
   endpoint exposes it; deferred to a backend slice), Needs / Wants /
   Bills / Family group headers (no `group` field on the API), every
   mutation (fund / move / edit stay on the CLI).
+
+#### P9.5.b — Sinking funds browser — ✅ *(2026-05-18)*
+
+Per [#408](https://github.com/rmwarriner/tulip-accounting/issues/408). New app-wide `s` binding pushes the
+sinking funds browser. Mirrors the P9.5.a envelopes pattern almost
+exactly — pools are pools, so the data layer reuses the same
+`POST /v1/pools/balances` plumbing.
+
+- **Data layer** — `tulip_tui/data/sinking_funds.py` adds
+  `SinkingFundSummary` / `SinkingFundsData` (frozen) and
+  `load_sinking_funds(client)`. Joins `GET /v1/sinking-funds` with
+  `POST /v1/pools/balances`. Funds missing from the balance response
+  keep `balance = None` so the screen renders `—` instead of `0.00`.
+  Empty fund list short-circuits the POST.
+- **SinkingFundsScreen** — DataTable with seven columns (Name /
+  Currency / Target / Target date / Strategy / Contribution /
+  Balance); detail pane below renders the full fund on cursor
+  highlight. `escape` pops, `r` refreshes. Inline error pane on
+  loader failure.
+- **App wiring** — new `s` binding + `sinking_funds_loader`
+  constructor seam with a `_no_op_sinking_funds_loader` default.
+  Production `main.run()` installs the loader that opens a fresh
+  `TulipClient` per fetch.
+- **Tests** — 3 data-layer tests (happy join, empty short-circuit,
+  API-error path); 5 pilot-mode screen tests (rows render with
+  comma-grouped amounts, cursor follows detail, empty state, inline
+  error, `s` binding pushes the screen).
+- **Out of scope** — progress bars (e.g. `$1,200 / $3,000 ▓▓░`)
+  deferred until a reusable progress widget can serve envelopes +
+  sinking funds together; goal-date math ("on track / behind by
+  N days") needs backend support; every mutation (contribute / edit /
+  deactivate) stays on the CLI per ADR-0007.
 
 ---
 

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -25,11 +25,13 @@ from tulip_tui.data.envelopes import EnvelopesData
 from tulip_tui.data.imports import ImportsData
 from tulip_tui.data.reconciliations import ReconciliationsData
 from tulip_tui.data.reports import ReportPayload, ReportSpec
+from tulip_tui.data.sinking_funds import SinkingFundsData
 from tulip_tui.screens.accounts import AccountsLoader, AccountsScreen
 from tulip_tui.screens.envelopes import EnvelopesScreen
 from tulip_tui.screens.imports import ImportsScreen
 from tulip_tui.screens.reconciliations import ReconciliationsScreen
 from tulip_tui.screens.reports import ReportsScreen
+from tulip_tui.screens.sinking_funds import SinkingFundsScreen
 from tulip_tui.screens.transactions import TransactionsLoader, TransactionsScreen
 
 TransactionsLoaderFactory = Callable[[str | None], TransactionsLoader]
@@ -37,6 +39,7 @@ ReportLoader = Callable[[ReportSpec], ReportPayload]
 ReconciliationsLoader = Callable[[], ReconciliationsData]
 ImportsLoader = Callable[[], ImportsData]
 EnvelopesLoader = Callable[[], EnvelopesData]
+SinkingFundsLoader = Callable[[], SinkingFundsData]
 
 
 def _no_op_transactions_factory(_account_id: str | None) -> TransactionsLoader:
@@ -68,6 +71,10 @@ def _no_op_envelopes_loader() -> EnvelopesData:
     raise RuntimeError("envelopes loader not configured")
 
 
+def _no_op_sinking_funds_loader() -> SinkingFundsData:
+    raise RuntimeError("sinking funds loader not configured")
+
+
 class TulipTuiApp(App[None]):
     """Tulip TUI shell — boots into the accounts browser."""
 
@@ -79,6 +86,7 @@ class TulipTuiApp(App[None]):
         Binding("c", "open_reconciliations", "reconcile", show=True),
         Binding("i", "open_imports", "imports", show=True),
         Binding("e", "open_envelopes", "envelopes", show=True),
+        Binding("s", "open_sinking_funds", "sinking funds", show=True),
     ]
 
     def __init__(
@@ -90,6 +98,7 @@ class TulipTuiApp(App[None]):
         reconciliations_loader: ReconciliationsLoader = _no_op_reconciliations_loader,
         imports_loader: ImportsLoader = _no_op_imports_loader,
         envelopes_loader: EnvelopesLoader = _no_op_envelopes_loader,
+        sinking_funds_loader: SinkingFundsLoader = _no_op_sinking_funds_loader,
     ) -> None:
         """Store the per-screen loaders / factories used at mount and drill-in."""
         super().__init__()
@@ -99,6 +108,7 @@ class TulipTuiApp(App[None]):
         self._reconciliations_loader = reconciliations_loader
         self._imports_loader = imports_loader
         self._envelopes_loader = envelopes_loader
+        self._sinking_funds_loader = sinking_funds_loader
 
     def on_mount(self) -> None:
         """Push the accounts browser as the initial screen."""
@@ -124,3 +134,7 @@ class TulipTuiApp(App[None]):
     def action_open_envelopes(self) -> None:
         """Push the envelopes browser onto the screen stack."""
         self.push_screen(EnvelopesScreen(loader=self._envelopes_loader))
+
+    def action_open_sinking_funds(self) -> None:
+        """Push the sinking funds browser onto the screen stack."""
+        self.push_screen(SinkingFundsScreen(loader=self._sinking_funds_loader))

--- a/packages/tulip-tui/src/tulip_tui/data/sinking_funds.py
+++ b/packages/tulip-tui/src/tulip_tui/data/sinking_funds.py
@@ -1,0 +1,91 @@
+"""Sinking-funds-screen data adapter.
+
+Composes two API reads into one immutable value object:
+
+* ``GET /v1/sinking-funds`` — every active sinking fund visible to the
+  caller.
+* ``POST /v1/pools/balances`` — the batched balance endpoint added in
+  #137. Same endpoint envelopes use; pools are pools.
+
+The join is by sinking-fund id ↔ ``pool_id``. Funds with no balance
+row keep ``balance = None`` so the screen renders ``—`` instead of a
+misleading ``0.00`` (same convention as ``data/envelopes.py`` and
+``data/accounts.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tulip_cli.http import TulipClient
+
+
+@dataclass(frozen=True, slots=True)
+class SinkingFundSummary:
+    """One row in the sinking-funds browser."""
+
+    id: str
+    name: str
+    currency: str
+    visibility: str
+    is_active: bool
+    target_amount: str
+    target_date: str
+    contribution_strategy: str
+    contribution_amount: str | None
+    balance: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SinkingFundsData:
+    """The full payload the sinking-funds screen renders."""
+
+    sinking_funds: tuple[SinkingFundSummary, ...]
+
+
+def load_sinking_funds(client: TulipClient) -> SinkingFundsData:
+    """Fetch + join ``/v1/sinking-funds`` and ``/v1/pools/balances``."""
+    raw = client.get("/v1/sinking-funds", authenticated=True).json()
+    if not raw:
+        return SinkingFundsData(sinking_funds=())
+
+    pool_ids = [str(row["id"]) for row in raw]
+    balances_raw = client.post(
+        "/v1/pools/balances",
+        json={"pool_ids": pool_ids},
+        authenticated=True,
+    ).json()
+    balances_by_id = {str(row["pool_id"]): str(row["balance"]) for row in balances_raw}
+
+    summaries = tuple(_to_summary(row, balances_by_id) for row in raw)
+    return SinkingFundsData(sinking_funds=summaries)
+
+
+def _to_summary(row: dict[str, object], balances_by_id: dict[str, str]) -> SinkingFundSummary:
+    fund_id = str(row.get("id", ""))
+    return SinkingFundSummary(
+        id=fund_id,
+        name=str(row.get("name", "")),
+        currency=str(row.get("currency", "")),
+        visibility=str(row.get("visibility", "")),
+        is_active=bool(row.get("is_active", False)),
+        target_amount=str(row.get("target_amount", "")),
+        target_date=str(row.get("target_date", "")),
+        contribution_strategy=str(row.get("contribution_strategy", "")),
+        contribution_amount=_optional_str(row.get("contribution_amount")),
+        balance=balances_by_id.get(fund_id),
+    )
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+__all__: list[str] = [
+    "SinkingFundSummary",
+    "SinkingFundsData",
+    "load_sinking_funds",
+]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -17,6 +17,7 @@ from tulip_tui.data.envelopes import EnvelopesData, load_envelopes
 from tulip_tui.data.imports import ImportsData, load_import_batches
 from tulip_tui.data.reconciliations import ReconciliationsData, load_reconciliations
 from tulip_tui.data.reports import ReportPayload, ReportSpec, load_report
+from tulip_tui.data.sinking_funds import SinkingFundsData, load_sinking_funds
 from tulip_tui.data.transactions import TransactionsData, load_transactions
 from tulip_tui.screens.transactions import TransactionsLoader
 
@@ -64,6 +65,12 @@ def _envelopes_loader() -> EnvelopesData:
         return load_envelopes(client)
 
 
+def _sinking_funds_loader() -> SinkingFundsData:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return load_sinking_funds(client)
+
+
 def run() -> None:
     """Launch the Tulip TUI against the configured API."""
     TulipTuiApp(
@@ -73,4 +80,5 @@ def run() -> None:
         reconciliations_loader=_reconciliations_loader,
         imports_loader=_imports_loader,
         envelopes_loader=_envelopes_loader,
+        sinking_funds_loader=_sinking_funds_loader,
     ).run()

--- a/packages/tulip-tui/src/tulip_tui/screens/sinking_funds.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/sinking_funds.py
@@ -1,0 +1,187 @@
+"""Sinking funds browser — P9.5.b of [#399](https://github.com/rmwarriner/tulip-accounting/issues/399).
+
+Read-only browse of the household's sinking funds with goal frame
+(target / target date), contribution schedule, and live balance.
+Mutating a fund (contribute / edit / deactivate) stays on the
+``tulip sinking-funds`` CLI per ADR-0007.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal, InvalidOperation
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+from tulip_tui.data.sinking_funds import SinkingFundsData, SinkingFundSummary
+
+SinkingFundsLoader = Callable[[], SinkingFundsData]
+
+
+def _fmt_amount(value: str | None) -> str:
+    if value is None or value == "":
+        return "—"
+    try:
+        return f"{Decimal(value).quantize(Decimal('0.01')):,.2f}"
+    except (InvalidOperation, ValueError):
+        return value
+
+
+def _row_for(fund: SinkingFundSummary) -> tuple[str, str, str, str, str, str, str]:
+    return (
+        fund.name,
+        fund.currency,
+        _fmt_amount(fund.target_amount),
+        fund.target_date,
+        fund.contribution_strategy,
+        _fmt_amount(fund.contribution_amount),
+        _fmt_amount(fund.balance),
+    )
+
+
+def _detail_for(fund: SinkingFundSummary) -> str:
+    lines = [
+        f"[b]{fund.id}[/b]    {fund.name}",
+        f"currency:              {fund.currency}",
+        f"visibility:            {fund.visibility}",
+        f"is_active:             {fund.is_active}",
+        f"target_amount:         {_fmt_amount(fund.target_amount)}",
+        f"target_date:           {fund.target_date}",
+        f"contribution_strategy: {fund.contribution_strategy}",
+        f"contribution_amount:   {_fmt_amount(fund.contribution_amount)}",
+        f"balance:               {_fmt_amount(fund.balance)}",
+    ]
+    return "\n".join(lines)
+
+
+class SinkingFundsScreen(Screen[None]):
+    """Browse the household's sinking funds."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "app.pop_screen", "back", show=True),
+        Binding("r", "refresh", "refresh", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    SinkingFundsScreen {
+        layout: vertical;
+    }
+
+    SinkingFundsScreen #sf-status {
+        height: auto;
+        padding: 0 1;
+    }
+
+    SinkingFundsScreen #sf-table {
+        height: 2fr;
+    }
+
+    SinkingFundsScreen #sf-detail {
+        height: 1fr;
+        padding: 1 2;
+        border-top: solid $accent;
+    }
+    """
+
+    def __init__(self, loader: SinkingFundsLoader) -> None:
+        """Store the loader; the screen populates on mount."""
+        super().__init__()
+        self._loader = loader
+        self._rendered_rows: list[str] = []
+        self._index: list[SinkingFundSummary] = []
+        self._detail: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Lay out the status strip, the sinking-fund table, and the detail pane."""
+        yield Header()
+        with Vertical():
+            yield Static("loading sinking funds…", id="sf-status")
+            yield DataTable(id="sf-table", zebra_stripes=True, cursor_type="row")
+            yield Static("", id="sf-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Install column headers and trigger the initial load."""
+        table = self.query_one("#sf-table", DataTable)
+        table.add_columns(
+            "Name",
+            "Currency",
+            "Target",
+            "Target date",
+            "Strategy",
+            "Contribution",
+            "Balance",
+        )
+        self._load()
+
+    def action_refresh(self) -> None:
+        """Re-run the loader and rebuild the table in place."""
+        self._load()
+
+    def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
+        """Re-render the detail pane to match the newly-highlighted row."""
+        self._refresh_detail()
+
+    # -- internals -----------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            data = self._loader()
+        except Exception as exc:
+            self._render_error(exc)
+            return
+        self._populate(data)
+
+    def _populate(self, data: SinkingFundsData) -> None:
+        table = self.query_one("#sf-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        status = self.query_one("#sf-status", Static)
+        status.update(f"{len(data.sinking_funds)} sinking funds")
+        if not data.sinking_funds:
+            self._set_detail("No sinking funds yet.")
+            return
+        for fund in data.sinking_funds:
+            cells = _row_for(fund)
+            table.add_row(*cells)
+            self._rendered_rows.append(" ".join(cells))
+            self._index.append(fund)
+        self._refresh_detail()
+
+    def _refresh_detail(self) -> None:
+        if not self._index:
+            return
+        table = self.query_one("#sf-table", DataTable)
+        cursor = max(0, table.cursor_row)
+        if cursor >= len(self._index):
+            return
+        self._set_detail(_detail_for(self._index[cursor]))
+
+    def _render_error(self, exc: BaseException) -> None:
+        table = self.query_one("#sf-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        status = self.query_one("#sf-status", Static)
+        status.update(f"[red]error:[/red] {exc}")
+        self._set_detail(f"error: {exc}")
+
+    def _set_detail(self, text: str) -> None:
+        self._detail = text
+        self.query_one("#sf-detail", Static).update(text)
+
+    # -- introspection used by tests ----------------------------------
+
+    def rendered_rows(self) -> list[str]:
+        """Return a string-only mirror of the table's rows for assertions."""
+        return list(self._rendered_rows)
+
+    def detail_text(self) -> str:
+        """Return the current detail-pane text as a plain string."""
+        return self._detail

--- a/packages/tulip-tui/tests/test_sinking_funds_data.py
+++ b/packages/tulip-tui/tests/test_sinking_funds_data.py
@@ -1,0 +1,196 @@
+"""Unit tests for ``tulip_tui.data.sinking_funds``.
+
+The adapter joins ``GET /v1/sinking-funds`` (every active fund visible
+to the caller) with ``POST /v1/pools/balances`` (the batched balance
+endpoint added in #137). Sinking funds that don't come back in the
+balance response keep ``balance = None`` so the screen renders ``—``
+instead of ``0.00`` (same convention as the envelopes / accounts
+adapters).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+from tulip_tui.data.sinking_funds import (
+    SinkingFundsData,
+    SinkingFundSummary,
+    load_sinking_funds,
+)
+
+_CAR_REPAIR_ID = "11111111-1111-1111-1111-111111111111"
+_VACATION_ID = "22222222-2222-2222-2222-222222222222"
+_NEW_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def _sinking_funds_response() -> list[dict[str, object]]:
+    return [
+        {
+            "id": _CAR_REPAIR_ID,
+            "name": "Car repair",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "target_amount": "3000.00",
+            "target_date": "2027-01-01",
+            "contribution_strategy": "manual",
+            "contribution_amount": None,
+        },
+        {
+            "id": _VACATION_ID,
+            "name": "Vacation",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "target_amount": "5000.00",
+            "target_date": "2026-12-15",
+            "contribution_strategy": "even_split",
+            "contribution_amount": "250.00",
+        },
+        {
+            "id": _NEW_ID,
+            "name": "Brand new fund",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "target_amount": "1000.00",
+            "target_date": "2027-06-01",
+            "contribution_strategy": "manual",
+            "contribution_amount": None,
+        },
+    ]
+
+
+def _balances_response() -> list[dict[str, object]]:
+    return [
+        {
+            "pool_id": _CAR_REPAIR_ID,
+            "name": "Car repair",
+            "currency": "USD",
+            "balance": "1200.00",
+            "as_of": "2026-05-18",
+        },
+        {
+            "pool_id": _VACATION_ID,
+            "name": "Vacation",
+            "currency": "USD",
+            "balance": "650.00",
+            "as_of": "2026-05-18",
+        },
+        # _NEW_ID intentionally absent — brand-new pool with no postings yet.
+    ]
+
+
+class _FakeTokenStore:
+    def load(self, _api_url: str) -> object:
+        return SimpleNamespace(
+            email="t@example.invalid",
+            access_token="fake-access-token",
+            refresh_token="fake-refresh-token",
+            access_expires_at=2**31 - 1,
+        )
+
+    def save(self, _api_url: str, _tokens: object) -> None: ...
+    def clear(self, _api_url: str) -> None: ...
+
+
+def _build_client(handler: httpx.MockTransport) -> TulipClient:
+    return TulipClient(
+        Config(api_url="https://example.invalid"),
+        token_store=_FakeTokenStore(),  # type: ignore[arg-type]
+        transport=handler,
+    )
+
+
+# ---- happy path -----------------------------------------------------
+
+
+def test_load_sinking_funds_joins_balances() -> None:
+    funds_payload = _sinking_funds_response()
+    balances_payload = _balances_response()
+    recorded: list[tuple[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/sinking-funds":
+            recorded.append(("get", request.url.path))
+            return httpx.Response(200, json=funds_payload)
+        if request.method == "POST" and request.url.path == "/v1/pools/balances":
+            import json as _json
+
+            body = _json.loads(request.content.decode("utf-8"))
+            recorded.append(("post", body))
+            return httpx.Response(200, json=balances_payload)
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_sinking_funds(client)
+
+    assert isinstance(data, SinkingFundsData)
+    assert len(data.sinking_funds) == 3
+    by_id = {sf.id: sf for sf in data.sinking_funds}
+
+    car = by_id[_CAR_REPAIR_ID]
+    assert isinstance(car, SinkingFundSummary)
+    assert car.name == "Car repair"
+    assert car.currency == "USD"
+    assert car.target_amount == "3000.00"
+    assert car.target_date == "2027-01-01"
+    assert car.contribution_strategy == "manual"
+    assert car.contribution_amount is None
+    assert car.balance == "1200.00"
+
+    vacation = by_id[_VACATION_ID]
+    assert vacation.contribution_strategy == "even_split"
+    assert vacation.contribution_amount == "250.00"
+    assert vacation.balance == "650.00"
+
+    brand_new = by_id[_NEW_ID]
+    # Missing from balances → None (screen renders "—" instead of 0.00).
+    assert brand_new.balance is None
+
+    posts = [body for kind, body in recorded if kind == "post"]
+    assert posts == [{"pool_ids": [_CAR_REPAIR_ID, _VACATION_ID, _NEW_ID]}]
+
+
+def test_load_sinking_funds_empty_short_circuits_balance_post() -> None:
+    """No funds → no /v1/pools/balances POST at all."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        if request.url.path == "/v1/sinking-funds":
+            return httpx.Response(200, json=[])
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_sinking_funds(client)
+
+    assert data.sinking_funds == ()
+    assert seen == ["GET /v1/sinking-funds"]
+
+
+def test_load_sinking_funds_raises_cli_error_on_api_failure() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                "type": "/.well-known/errors/internal",
+                "title": "Internal server error",
+                "status": 500,
+                "detail": "boom",
+                "instance": "",
+                "code": "internal",
+            },
+        )
+
+    with (
+        _build_client(httpx.MockTransport(handler)) as client,
+        pytest.raises(CliError),
+    ):
+        load_sinking_funds(client)

--- a/packages/tulip-tui/tests/test_sinking_funds_screen.py
+++ b/packages/tulip-tui/tests/test_sinking_funds_screen.py
@@ -1,0 +1,148 @@
+"""Pilot-mode tests for ``SinkingFundsScreen`` + the app-wide ``s`` binding.
+
+Mirrors the test shape of ``test_envelopes_screen.py``: the screen takes
+an injected loader, so no API call is involved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
+from tulip_tui.data.sinking_funds import SinkingFundsData, SinkingFundSummary
+from tulip_tui.screens.sinking_funds import SinkingFundsScreen
+
+
+def _accounts_loader() -> AccountsData:
+    return AccountsData(as_of="2026-05-18", accounts=(), groups=())
+
+
+def _sample_sinking_funds() -> SinkingFundsData:
+    return SinkingFundsData(
+        sinking_funds=(
+            SinkingFundSummary(
+                id="sf-car",
+                name="Car repair",
+                currency="USD",
+                visibility="shared",
+                is_active=True,
+                target_amount="3000.00",
+                target_date="2027-01-01",
+                contribution_strategy="manual",
+                contribution_amount=None,
+                balance="1200.00",
+            ),
+            SinkingFundSummary(
+                id="sf-vacation",
+                name="Vacation",
+                currency="USD",
+                visibility="shared",
+                is_active=True,
+                target_amount="5000.00",
+                target_date="2026-12-15",
+                contribution_strategy="even_split",
+                contribution_amount="250.00",
+                balance="650.00",
+            ),
+            SinkingFundSummary(
+                id="sf-new",
+                name="Brand new fund",
+                currency="USD",
+                visibility="shared",
+                is_active=True,
+                target_amount="1000.00",
+                target_date="2027-06-01",
+                contribution_strategy="manual",
+                contribution_amount=None,
+                balance=None,
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_sinking_funds_screen_lists_rows() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = SinkingFundsScreen(loader=lambda: _sample_sinking_funds())
+        await app.push_screen(screen)
+        await pilot.pause()
+        rendered = screen.rendered_rows()
+
+    assert len(rendered) == 3
+    # Comma-grouped amount formatting and strategy land in the row text.
+    assert any(
+        "Car repair" in row and "3,000.00" in row and "1,200.00" in row and "manual" in row
+        for row in rendered
+    )
+    assert any(
+        "Vacation" in row and "5,000.00" in row and "650.00" in row and "even_split" in row
+        for row in rendered
+    )
+    # Missing balance renders as "—".
+    assert any("Brand new fund" in row and "—" in row for row in rendered)
+
+
+@pytest.mark.asyncio
+async def test_sinking_funds_screen_detail_follows_cursor() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = SinkingFundsScreen(loader=lambda: _sample_sinking_funds())
+        await app.push_screen(screen)
+        await pilot.pause()
+        first = screen.detail_text()
+        assert "sf-car" in first
+        assert "2027-01-01" in first
+        assert "1,200.00" in first
+        await pilot.press("down")
+        await pilot.pause()
+        second = screen.detail_text()
+        assert "sf-vacation" in second
+        assert "even_split" in second
+        assert "250.00" in second
+
+
+@pytest.mark.asyncio
+async def test_sinking_funds_screen_empty_state() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = SinkingFundsScreen(loader=lambda: SinkingFundsData(sinking_funds=()))
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "no sinking funds" in screen.detail_text().lower()
+
+
+@pytest.mark.asyncio
+async def test_sinking_funds_screen_renders_error_inline() -> None:
+    def boom() -> SinkingFundsData:
+        raise RuntimeError("api unreachable")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = SinkingFundsScreen(loader=boom)
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "api unreachable" in screen.detail_text()
+        # Inline error should not lock the screen — escape + quit still work.
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.press("q")
+    assert app.return_code == 0
+
+
+@pytest.mark.asyncio
+async def test_app_binding_s_pushes_sinking_funds_screen() -> None:
+    app = TulipTuiApp(
+        loader=_accounts_loader,
+        sinking_funds_loader=lambda: _sample_sinking_funds(),
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("s")
+        await pilot.pause()
+        assert isinstance(app.screen, SinkingFundsScreen)


### PR DESCRIPTION
## Summary

- Second slice of [#399](https://github.com/rmwarriner/tulip-accounting/issues/399), following P9.5.a (envelopes, [#401](https://github.com/rmwarriner/tulip-accounting/pull/401)). Adds a sinking funds browser reachable via the new app-wide `s` binding. Mirrors P9.5.a almost line-for-line — pools are pools, so the data layer reuses the same `POST /v1/pools/balances` plumbing.
- `data/sinking_funds.py` joins `GET /v1/sinking-funds` with `POST /v1/pools/balances`. Funds missing from the balance response keep `balance = None` so the screen renders `—` instead of a misleading `0.00`. Empty fund list short-circuits the POST.
- `SinkingFundsScreen` renders a 7-column DataTable (Name / Currency / Target / Target date / Strategy / Contribution / Balance) with a cursor-following detail pane; `r` refreshes, `escape` pops, loader exceptions render inline.
- App: new `s` binding, `sinking_funds_loader` constructor seam, `_no_op_sinking_funds_loader` default. `main.run()` installs the production loader on a fresh `TulipClient` per fetch.
- 8 new tests (3 data-layer + 5 pilot-mode). Full `tulip-tui` suite green (73 tests). `PHASE_STATUS.md` gains a P9.5.b subsection.
- Out of scope (deliberately, per [#399](https://github.com/rmwarriner/tulip-accounting/issues/399)): progress bars (`$1,200 / $3,000 ▓▓░`) — deferred until a reusable progress widget can serve envelopes + sinking funds together; goal-date math ("on track / behind by N days") — needs backend support; every mutation (contribute / edit / deactivate) stays on the CLI per ADR-0007.

## Test plan

- [x] `uv run pytest packages/tulip-tui/` — 73/73 pass locally.
- [x] `just lint` clean.
- [x] `just typecheck` (mypy --strict) clean — 295 source files.
- [ ] CI green on this PR.
- [ ] Manual smoke against a live API and a real sinking-fund row:
      ```bash
      cd ~/Projects/tulip-accounting
      docker compose up -d
      uv run uvicorn tulip_api.main:app --port 8000 &
      UVICORN_PID=\$!
      sleep 2
      uv run tulip register --household 'Smoke Test' --email smoke@example.invalid --password-stdin <<<'correct-horse-battery-staple'
      uv run tulip sinking-funds add --name 'Car repair' --currency USD --target-amount 3000.00 --target-date 2027-01-01 --contribution-strategy manual
      uv run tulip sinking-funds add --name 'Vacation' --currency USD --target-amount 5000.00 --target-date 2026-12-15 --contribution-strategy even_split --contribution-amount 250.00
      uv run tulip-tui
      ```
      In the TUI: press \`s\` → sinking funds browser opens with both rows; arrow keys move the cursor and the detail pane follows; \`r\` refreshes; \`escape\` pops back; \`q\` quits cleanly.

      Cleanup:
      ```bash
      kill \$UVICORN_PID
      ```