### PR TITLE
fix(api): document 400 request.body_invalid on body-accepting endpoints (closes #410)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -14,6 +14,7 @@ from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.config import get_settings
 from tulip_api.deps import get_session
 from tulip_api.errors import (
+    FRAMEWORK_BODY_RESPONSES,
     AccountUnknownError,
     PeriodClosedError,
     PoolCurrencyMismatchError,
@@ -823,11 +824,11 @@ def patch_transaction(
     "/{tx_id}/description",
     response_model=TransactionRead,
     responses={
+        **FRAMEWORK_BODY_RESPONSES,
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
         404: problem_response("transaction.not_found"),
         409: problem_response("transaction.not_rectifiable"),
-        422: problem_response("validation.failed"),
     },
 )
 def rectify_transaction_description(

--- a/packages/tulip-api/src/tulip_api/routers/users.py
+++ b/packages/tulip-api/src/tulip_api/routers/users.py
@@ -27,6 +27,7 @@ from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.auth.passwords import verify_password
 from tulip_api.deps import get_session
 from tulip_api.errors import (
+    FRAMEWORK_BODY_RESPONSES,
     DuplicateEmailError,
     InvalidCredentialsError,
     LastAdminDeletionError,
@@ -151,11 +152,11 @@ def delete_user(
     "/me",
     response_model=UserMeRead,
     responses={
+        **FRAMEWORK_BODY_RESPONSES,
         401: problem_response(
             "auth.unauthorized", "auth.invalid_credentials", "auth.reauth_required"
         ),
         409: problem_response("auth.duplicate_email"),
-        422: problem_response("validation.failed"),
     },
 )
 def patch_own_profile(
@@ -268,8 +269,8 @@ def _apply_ai_policy(
     "/me/ai-policy",
     response_model=UserAIPolicyRead,
     responses={
+        **FRAMEWORK_BODY_RESPONSES,
         401: problem_response("auth.unauthorized"),
-        422: problem_response("validation.failed"),
     },
 )
 def put_own_ai_policy(
@@ -300,10 +301,10 @@ def put_own_ai_policy(
     "/{user_id}/ai-policy",
     response_model=UserAIPolicyRead,
     responses={
+        **FRAMEWORK_BODY_RESPONSES,
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
         404: problem_response("user.not_found"),
-        422: problem_response("validation.failed"),
     },
 )
 def put_user_ai_policy(


### PR DESCRIPTION
## Summary

- Fixes the schemathesis flake that intermittently failed `test_api_conforms_to_schema[PUT /v1/users/me/ai-policy]` on PRs touching unrelated code (#401, #409 both hit it). Diagnosed as a real OpenAPI contract drift, not runner noise: the endpoint correctly returns `400 request.body_invalid` on malformed JSON but didn't declare 400 in its `responses=`. Hypothesis explores garbage payloads so ~50% of CI runs surfaced it.
- The codebase already had the right primitive — `FRAMEWORK_BODY_RESPONSES` in `packages/tulip-api/src/tulip_api/errors.py:1149`, whose comment literally says "Documents the framework-level errors (400 bad body, 422 validation) that schemathesis can trigger with random inputs". It just wasn't applied consistently.
- An AST audit (POST/PUT/PATCH operations that accept a Pydantic body and lack 400 in `responses=`) found **4** affected routes:
  - `users.py / patch_own_profile` (PATCH `/v1/users/me`)
  - `users.py / put_own_ai_policy` (PUT `/v1/users/me/ai-policy`) ← the one schemathesis hit
  - `users.py / put_user_ai_policy` (PUT `/v1/users/{user_id}/ai-policy`)
  - `transactions.py / rectify_transaction_description` (PATCH `/v1/transactions/{tx_id}/description`)
- Each now spreads `**FRAMEWORK_BODY_RESPONSES` (400 + 422) at the top of its `responses=` and drops the redundant `422: validation.failed` entry. Pure OpenAPI declaration tightening — no runtime behaviour changes; the 400 was always being returned, it just wasn't documented.
- The original audit in #410 listed 15 routes but most are POST/PUT/PATCH endpoints without bodies (admin redactions, period close/reopen, ack actions) — they can't return `request.body_invalid` so the declaration would be inaccurate. Limited to the 4 that actually accept a body.

## Test plan

- [x] Targeted contract sweep `uv run pytest packages/tulip-api/tests/test_openapi_contract.py -k "ai-policy or description"`: 3/3 pass.
- [x] Full contract test file: 120 passed / 6 skipped.
- [x] Full tulip-api suite: 942 passed (8 PDF-render failures are pre-existing local-env weasyprint/libgobject issues — unrelated to this fix; same failures on `main`).
- [x] `just lint`, `just typecheck` clean.
- [ ] CI green on this PR — especially `Test (tulip-api)`, which has been the canary.

## Out of scope

- Adding 4xx documentation for other framework-level errors (404 method, 405 method-not-allowed, 415 unsupported-media-type) — separate bug if schemathesis surfaces them. The audit above only checks for 400.