### PR TITLE
P9.5.c — TUI pending transactions browser (closes #412, closes #399)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what's shipped, what's in flight, and what's queued. The phase definitions live in [ARCHITECTURE.md §10](ARCHITECTURE.md); this file just tracks the state.
 
-**Last updated:** 2026-05-18 · `main` @ **Phase 8 deep security audit complete + Phase 9 v1 shipped (read-only TUI: skeleton + accounts browser + transactions register + reports viewer + reconciliations / imports browse) + P9.5.a envelopes browser shipped + P9.5.b sinking funds browser in flight** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318) and all five P9.0–P9.4 slices merged across PRs #383 / #384 / #385 / #386 against umbrella [#309](https://github.com/rmwarriner/tulip-accounting/issues/309); mutation surfaces (categorize / split / edit / reconcile-action / apply-import) deliberately remain on the CLI for v1 per ADR-0007. Phase 9 v1 read continuation ([#399](https://github.com/rmwarriner/tulip-accounting/issues/399)) opens with three read-only browse slices (envelopes / sinking funds / pending) on the same loader-injection pattern; [#400](https://github.com/rmwarriner/tulip-accounting/issues/400) (envelopes) is the first.
+**Last updated:** 2026-05-18 · `main` @ **Phase 8 deep security audit complete + Phase 9 v1 shipped (read-only TUI: skeleton + accounts browser + transactions register + reports viewer + reconciliations / imports browse) + P9.5 read continuation shipped (envelopes + sinking funds + pending browsers)** — security + privacy Wave-1 follow-ups landing (#239 per-user AI policy + keys, #242 GDPR Art. 16 rectification, #244 THREAT_MODEL §2 refresh, #245 audit-log tiered retention + backup-leak warning, #246 IP+UA redaction whitelist, #247 ai.consent_changed audit, #248 litellm telemetry pin, #249 USER_RIGHTS.md operator map merged), plus a CLI/importers usability bundle. Phase 9 (terminal UI) design questions resolved (#318) and all five P9.0–P9.4 slices merged across PRs #383 / #384 / #385 / #386 against umbrella [#309](https://github.com/rmwarriner/tulip-accounting/issues/309); mutation surfaces (categorize / split / edit / reconcile-action / apply-import) deliberately remain on the CLI for v1 per ADR-0007. Phase 9 v1 read continuation ([#399](https://github.com/rmwarriner/tulip-accounting/issues/399)) opens with three read-only browse slices (envelopes / sinking funds / pending) on the same loader-injection pattern; [#400](https://github.com/rmwarriner/tulip-accounting/issues/400) (envelopes) is the first.
 
 ---
 
@@ -1737,7 +1737,7 @@ envelopes browser.
   Bills / Family group headers (no `group` field on the API), every
   mutation (fund / move / edit stay on the CLI).
 
-#### P9.5.b — Sinking funds browser — ✅ *(2026-05-18)*
+#### P9.5.b — Sinking funds browser — ✅ *(2026-05-18, [#409](https://github.com/rmwarriner/tulip-accounting/pull/409))*
 
 Per [#408](https://github.com/rmwarriner/tulip-accounting/issues/408). New app-wide `s` binding pushes the
 sinking funds browser. Mirrors the P9.5.a envelopes pattern almost
@@ -1768,6 +1768,51 @@ exactly — pools are pools, so the data layer reuses the same
   sinking funds together; goal-date math ("on track / behind by
   N days") needs backend support; every mutation (contribute / edit /
   deactivate) stays on the CLI per ADR-0007.
+
+#### P9.5.c — Pending transactions browser — ✅ *(2026-05-18)*
+
+Per [#412](https://github.com/rmwarriner/tulip-accounting/issues/412). Final slice of [#399](https://github.com/rmwarriner/tulip-accounting/issues/399).
+New app-wide `n` binding pushes the pending browser (`p` is reports).
+
+- **Data layer** — `tulip_tui/data/pending.py` adds `PendingTransaction`
+  / `PendingData` (frozen). `load_pending(client, *, today=None,
+  stale_days=14)` joins `GET /v1/transactions?status=pending` with
+  `GET /v1/accounts` for label resolution, computes per-row `age_days`
+  from `today - tx.date`, and pre-splits into **Stale (>14d)** and
+  **Recent** (the stale threshold default is pinned in
+  [TUI_WIREFRAMES.md § Cross-cutting decisions § 3](TUI_WIREFRAMES.md#3-stale-thresholds)).
+  Strict boundary: age=14 is recent; age=15 is stale. `today` is
+  injectable so tests don't depend on wall-clock; production uses
+  `datetime.now(UTC).date()`.
+- **PendingScreen** — two stacked DataTables with group headers
+  (Stale / Recent), six columns each (Date / Description / Account /
+  Ref / Amount / Age). Detail pane below renders the full transaction
+  on cursor highlight, with a focus-aware handler so cross-table
+  navigation (tab between stale + recent) drives the right row. `r`
+  refreshes, `escape` pops, loader exceptions render inline.
+- **App wiring** — new `n` binding + `pending_loader` constructor seam
+  with a `_no_op_pending_loader` default. Production `main.run()`
+  installs the loader that opens a fresh `TulipClient` per fetch.
+- **Tests** — 5 data-layer tests (split at boundary, empty groups,
+  API-error path, unknown-account → `—` fallback, custom
+  `stale_days` threshold); 6 pilot-mode screen tests (rows render in
+  both groups, group counts in status strip, detail follows cursor
+  across tab-traversal, empty state, inline error, `n` binding pushes
+  the screen).
+- **Out of scope** — per-type filters (chk / hold / ach / xfer; the API
+  doesn't structure transaction types), paired-transfer `↔` marker
+  ([`paired_shadow_tx_id`](TUI_WIREFRAMES.md) exists but surfacing it
+  is post-v1 polish), real-liquid vitals strip (not a v1 thing), all
+  mutations (mark cleared / void / reissue / match-to-bank stay on
+  the CLI per ADR-0007).
+
+With this slice [#399](https://github.com/rmwarriner/tulip-accounting/issues/399) closes — every read-only domain surface
+the wireframes mock now has a TUI browser. App-wide bindings as
+shipped: `q` quit · `p` reports · `c` reconcile · `i` imports · `e`
+envelopes · `s` sinking funds · `n` pending · `enter` (on account
+row) → transactions · `escape` pop · `r` refresh. Mutation surfaces
+all remain on the CLI for v1; surfacing them as TUI flows is the
+next phase.
 
 ---
 

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -23,12 +23,14 @@ from textual.binding import Binding, BindingType
 
 from tulip_tui.data.envelopes import EnvelopesData
 from tulip_tui.data.imports import ImportsData
+from tulip_tui.data.pending import PendingData
 from tulip_tui.data.reconciliations import ReconciliationsData
 from tulip_tui.data.reports import ReportPayload, ReportSpec
 from tulip_tui.data.sinking_funds import SinkingFundsData
 from tulip_tui.screens.accounts import AccountsLoader, AccountsScreen
 from tulip_tui.screens.envelopes import EnvelopesScreen
 from tulip_tui.screens.imports import ImportsScreen
+from tulip_tui.screens.pending import PendingScreen
 from tulip_tui.screens.reconciliations import ReconciliationsScreen
 from tulip_tui.screens.reports import ReportsScreen
 from tulip_tui.screens.sinking_funds import SinkingFundsScreen
@@ -40,6 +42,7 @@ ReconciliationsLoader = Callable[[], ReconciliationsData]
 ImportsLoader = Callable[[], ImportsData]
 EnvelopesLoader = Callable[[], EnvelopesData]
 SinkingFundsLoader = Callable[[], SinkingFundsData]
+PendingLoader = Callable[[], PendingData]
 
 
 def _no_op_transactions_factory(_account_id: str | None) -> TransactionsLoader:
@@ -75,6 +78,10 @@ def _no_op_sinking_funds_loader() -> SinkingFundsData:
     raise RuntimeError("sinking funds loader not configured")
 
 
+def _no_op_pending_loader() -> PendingData:
+    raise RuntimeError("pending loader not configured")
+
+
 class TulipTuiApp(App[None]):
     """Tulip TUI shell — boots into the accounts browser."""
 
@@ -87,6 +94,7 @@ class TulipTuiApp(App[None]):
         Binding("i", "open_imports", "imports", show=True),
         Binding("e", "open_envelopes", "envelopes", show=True),
         Binding("s", "open_sinking_funds", "sinking funds", show=True),
+        Binding("n", "open_pending", "pending", show=True),
     ]
 
     def __init__(
@@ -99,6 +107,7 @@ class TulipTuiApp(App[None]):
         imports_loader: ImportsLoader = _no_op_imports_loader,
         envelopes_loader: EnvelopesLoader = _no_op_envelopes_loader,
         sinking_funds_loader: SinkingFundsLoader = _no_op_sinking_funds_loader,
+        pending_loader: PendingLoader = _no_op_pending_loader,
     ) -> None:
         """Store the per-screen loaders / factories used at mount and drill-in."""
         super().__init__()
@@ -109,6 +118,7 @@ class TulipTuiApp(App[None]):
         self._imports_loader = imports_loader
         self._envelopes_loader = envelopes_loader
         self._sinking_funds_loader = sinking_funds_loader
+        self._pending_loader = pending_loader
 
     def on_mount(self) -> None:
         """Push the accounts browser as the initial screen."""
@@ -138,3 +148,7 @@ class TulipTuiApp(App[None]):
     def action_open_sinking_funds(self) -> None:
         """Push the sinking funds browser onto the screen stack."""
         self.push_screen(SinkingFundsScreen(loader=self._sinking_funds_loader))
+
+    def action_open_pending(self) -> None:
+        """Push the pending transactions browser onto the screen stack."""
+        self.push_screen(PendingScreen(loader=self._pending_loader))

--- a/packages/tulip-tui/src/tulip_tui/data/pending.py
+++ b/packages/tulip-tui/src/tulip_tui/data/pending.py
@@ -1,0 +1,136 @@
+"""Pending transactions data adapter.
+
+Joins ``GET /v1/transactions?status=pending`` with ``GET /v1/accounts``
+(UUID → friendly name) and splits the result into two groups at the
+stale-day boundary — 14 days by default, per
+``TUI_WIREFRAMES.md § Cross-cutting decisions § 3``. ``today`` is an
+injected argument so tests don't depend on wall-clock.
+
+The split rule is strict: ``age > stale_days`` is stale; ``age <= stale_days``
+is recent. Recent rows sort oldest-first to match the wireframe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import cast
+
+from tulip_cli.http import TulipClient
+
+STALE_DAYS_DEFAULT: int = 14
+
+
+@dataclass(frozen=True, slots=True)
+class PendingTransaction:
+    """One row in the pending browser, with age + label pre-resolved."""
+
+    id: str
+    date: str
+    age_days: int
+    description: str
+    reference: str | None
+    account_label: str
+    amount_display: str
+
+
+@dataclass(frozen=True, slots=True)
+class PendingData:
+    """Pending transactions pre-split into Stale (>threshold) and Recent."""
+
+    stale: tuple[PendingTransaction, ...]
+    recent: tuple[PendingTransaction, ...]
+
+
+def load_pending(
+    client: TulipClient,
+    *,
+    today: date | None = None,
+    stale_days: int = STALE_DAYS_DEFAULT,
+) -> PendingData:
+    """Fetch pending transactions, join account labels, group by staleness."""
+    as_of = today if today is not None else datetime.now(UTC).date()
+
+    accounts_raw = client.get("/v1/accounts", authenticated=True).json()
+    label_by_id = {str(a["id"]): _account_label(a) for a in accounts_raw}
+
+    tx_raw = client.get(
+        "/v1/transactions",
+        authenticated=True,
+        params={"status": "pending"},
+    ).json()
+
+    summaries: list[PendingTransaction] = []
+    for row in tx_raw:
+        summaries.append(_to_summary(row, label_by_id, as_of))
+
+    stale_list = [s for s in summaries if s.age_days > stale_days]
+    recent_list = [s for s in summaries if s.age_days <= stale_days]
+
+    # Stale: oldest first (largest age first). Recent: oldest first too —
+    # matches the wireframe's "Stale (>14d)" then "Recent" ordering from
+    # the most-actionable item downward.
+    stale_list.sort(key=lambda s: s.age_days, reverse=True)
+    recent_list.sort(key=lambda s: s.age_days, reverse=True)
+
+    return PendingData(stale=tuple(stale_list), recent=tuple(recent_list))
+
+
+def _account_label(account: dict[str, object]) -> str:
+    """Use the friendly ``name`` (matches the wireframe); fall back to ``code``."""
+    name = account.get("name")
+    if isinstance(name, str) and name:
+        return name
+    code = account.get("code")
+    return code if isinstance(code, str) and code else "—"
+
+
+def _to_summary(
+    row: dict[str, object],
+    label_by_id: dict[str, str],
+    as_of: date,
+) -> PendingTransaction:
+    raw_postings = cast("list[dict[str, object]]", row.get("postings") or [])
+
+    # Pick the negative leg first (the account that paid) — same convention
+    # as ``data/transactions.py``. Falls back to the first posting if there
+    # are no negatives.
+    negatives = [p for p in raw_postings if Decimal(str(p.get("amount", "0"))) < 0]
+    chosen = negatives[0] if negatives else (raw_postings[0] if raw_postings else None)
+
+    account_label = "—"
+    amount_display = ""
+    if chosen is not None:
+        account_id = str(chosen.get("account_id", ""))
+        account_label = label_by_id.get(account_id, "—")
+        amount = Decimal(str(chosen.get("amount", "0"))).quantize(Decimal("0.01"))
+        amount_display = f"{amount:,.2f} {chosen.get('currency', '')}"
+
+    tx_date_raw = row.get("date", "")
+    tx_date = (
+        date.fromisoformat(tx_date_raw) if isinstance(tx_date_raw, str) and tx_date_raw else as_of
+    )
+    age_days = (as_of - tx_date).days
+
+    return PendingTransaction(
+        id=str(row.get("id", "")),
+        date=str(tx_date_raw),
+        age_days=age_days,
+        description=str(row.get("description", "")),
+        reference=_optional_str(row.get("reference")),
+        account_label=account_label,
+        amount_display=amount_display,
+    )
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+__all__: list[str] = [
+    "STALE_DAYS_DEFAULT",
+    "PendingData",
+    "PendingTransaction",
+    "load_pending",
+]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -15,6 +15,7 @@ from tulip_tui.app import TulipTuiApp
 from tulip_tui.data.accounts import AccountsData, load_accounts
 from tulip_tui.data.envelopes import EnvelopesData, load_envelopes
 from tulip_tui.data.imports import ImportsData, load_import_batches
+from tulip_tui.data.pending import PendingData, load_pending
 from tulip_tui.data.reconciliations import ReconciliationsData, load_reconciliations
 from tulip_tui.data.reports import ReportPayload, ReportSpec, load_report
 from tulip_tui.data.sinking_funds import SinkingFundsData, load_sinking_funds
@@ -71,6 +72,12 @@ def _sinking_funds_loader() -> SinkingFundsData:
         return load_sinking_funds(client)
 
 
+def _pending_loader() -> PendingData:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return load_pending(client)
+
+
 def run() -> None:
     """Launch the Tulip TUI against the configured API."""
     TulipTuiApp(
@@ -81,4 +88,5 @@ def run() -> None:
         imports_loader=_imports_loader,
         envelopes_loader=_envelopes_loader,
         sinking_funds_loader=_sinking_funds_loader,
+        pending_loader=_pending_loader,
     ).run()

--- a/packages/tulip-tui/src/tulip_tui/screens/pending.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/pending.py
@@ -1,0 +1,232 @@
+"""Pending transactions browser — P9.5.c of [#399](https://github.com/rmwarriner/tulip-accounting/issues/399).
+
+Read-only browse of uncleared transactions split into two visual
+groups: **Stale (>14d)** and **Recent**. Per ``TUI_WIREFRAMES.md
+§ Pending`` and the cross-cutting decision on stale thresholds —
+stale is strictly older than 14 days; the boundary day (14d) is recent.
+
+Mutating a pending transaction (mark cleared / void / reissue /
+match-to-bank) stays on the ``tulip transactions`` /
+``tulip reconcile`` CLIs per ADR-0007.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import ClassVar
+
+from textual import events
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+from tulip_tui.data.pending import PendingData, PendingTransaction
+
+PendingLoader = Callable[[], PendingData]
+
+
+def _row_for(tx: PendingTransaction) -> tuple[str, str, str, str, str, str]:
+    return (
+        tx.date,
+        tx.description,
+        tx.account_label,
+        tx.reference or "—",
+        tx.amount_display or "—",
+        f"{tx.age_days}d",
+    )
+
+
+def _detail_for(tx: PendingTransaction) -> str:
+    lines = [
+        f"[b]{tx.id}[/b]    {tx.description}",
+        f"date:         {tx.date}    ({tx.age_days}d outstanding)",
+        f"account:      {tx.account_label}",
+        f"amount:       {tx.amount_display or '—'}",
+    ]
+    if tx.reference:
+        lines.append(f"reference:    {tx.reference}")
+    return "\n".join(lines)
+
+
+class PendingScreen(Screen[None]):
+    """Browse uncleared / pending transactions."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "app.pop_screen", "back", show=True),
+        Binding("r", "refresh", "refresh", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    PendingScreen {
+        layout: vertical;
+    }
+
+    PendingScreen #pending-status {
+        height: auto;
+        padding: 0 1;
+    }
+
+    PendingScreen .group-header {
+        height: auto;
+        padding: 0 1;
+        color: $accent;
+    }
+
+    PendingScreen #pending-stale-table,
+    PendingScreen #pending-recent-table {
+        height: 1fr;
+    }
+
+    PendingScreen #pending-detail {
+        height: auto;
+        min-height: 5;
+        padding: 1 2;
+        border-top: solid $accent;
+    }
+    """
+
+    def __init__(self, loader: PendingLoader) -> None:
+        """Store the loader; the screen populates on mount."""
+        super().__init__()
+        self._loader = loader
+        self._rendered_rows: list[str] = []
+        self._stale_index: list[PendingTransaction] = []
+        self._recent_index: list[PendingTransaction] = []
+        self._status: str = ""
+        self._detail: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Lay out the status strip, two grouped tables, and the detail pane."""
+        yield Header()
+        with Vertical():
+            yield Static("loading pending…", id="pending-status")
+            yield Static("[b]Stale (>14d)[/b]", classes="group-header", id="pending-stale-header")
+            yield DataTable(id="pending-stale-table", zebra_stripes=True, cursor_type="row")
+            yield Static("[b]Recent[/b]", classes="group-header", id="pending-recent-header")
+            yield DataTable(id="pending-recent-table", zebra_stripes=True, cursor_type="row")
+            yield Static("", id="pending-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Install column headers and trigger the initial load."""
+        for table_id in ("#pending-stale-table", "#pending-recent-table"):
+            table = self.query_one(table_id, DataTable)
+            table.add_columns("Date", "Description", "Account", "Ref", "Amount", "Age")
+        self._load()
+
+    def action_refresh(self) -> None:
+        """Re-run the loader and rebuild both tables in place."""
+        self._load()
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Re-render the detail pane for the focused table's cursor.
+
+        Both tables fire ``RowHighlighted`` on populate; without this focus
+        guard the recent-table's initial event would clobber the stale-table
+        detail at boot. Once the user moves the cursor, focus is on whichever
+        table they're in and the right detail follows.
+        """
+        which = event.data_table.id
+        if self.focused is not None and getattr(self.focused, "id", None) != which:
+            return
+        cursor = max(0, event.cursor_row)
+        if which == "pending-stale-table" and cursor < len(self._stale_index):
+            self._set_detail(_detail_for(self._stale_index[cursor]))
+        elif which == "pending-recent-table" and cursor < len(self._recent_index):
+            self._set_detail(_detail_for(self._recent_index[cursor]))
+
+    def on_descendant_focus(self, event: events.DescendantFocus) -> None:
+        """When focus shifts between the two tables, re-render detail.
+
+        Tabbing from stale → recent (or vice versa) doesn't fire a fresh
+        ``RowHighlighted`` because the cursor was already on row 0. Refresh
+        from whatever the focused table's cursor currently points at.
+        """
+        widget = event.widget
+        widget_id = getattr(widget, "id", None)
+        if widget_id == "pending-stale-table" and self._stale_index:
+            cursor = max(0, getattr(widget, "cursor_row", 0))
+            cursor = min(cursor, len(self._stale_index) - 1)
+            self._set_detail(_detail_for(self._stale_index[cursor]))
+        elif widget_id == "pending-recent-table" and self._recent_index:
+            cursor = max(0, getattr(widget, "cursor_row", 0))
+            cursor = min(cursor, len(self._recent_index) - 1)
+            self._set_detail(_detail_for(self._recent_index[cursor]))
+
+    # -- internals -----------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            data = self._loader()
+        except Exception as exc:
+            self._render_error(exc)
+            return
+        self._populate(data)
+
+    def _populate(self, data: PendingData) -> None:
+        stale_table = self.query_one("#pending-stale-table", DataTable)
+        recent_table = self.query_one("#pending-recent-table", DataTable)
+        stale_table.clear()
+        recent_table.clear()
+        self._rendered_rows = []
+        self._stale_index = []
+        self._recent_index = []
+
+        self._set_status(f"{len(data.stale)} stale (>14d) · {len(data.recent)} recent")
+
+        if not data.stale and not data.recent:
+            self._set_detail("No pending transactions.")
+            return
+
+        for tx in data.stale:
+            cells = _row_for(tx)
+            stale_table.add_row(*cells)
+            self._rendered_rows.append(" ".join(cells))
+            self._stale_index.append(tx)
+        for tx in data.recent:
+            cells = _row_for(tx)
+            recent_table.add_row(*cells)
+            self._rendered_rows.append(" ".join(cells))
+            self._recent_index.append(tx)
+
+        # Focus the table the user lands on first (stale takes priority).
+        # The matching ``RowHighlighted`` event then drives the detail pane;
+        # the other table's spurious initial event is suppressed by the
+        # focus guard in ``on_data_table_row_highlighted``.
+        if data.stale:
+            stale_table.focus()
+        else:
+            recent_table.focus()
+
+    def _render_error(self, exc: BaseException) -> None:
+        for table_id in ("#pending-stale-table", "#pending-recent-table"):
+            self.query_one(table_id, DataTable).clear()
+        self._rendered_rows = []
+        self._stale_index = []
+        self._recent_index = []
+        self._set_status(f"[red]error:[/red] {exc}")
+        self._set_detail(f"error: {exc}")
+
+    def _set_status(self, text: str) -> None:
+        self._status = text
+        self.query_one("#pending-status", Static).update(text)
+
+    def _set_detail(self, text: str) -> None:
+        self._detail = text
+        self.query_one("#pending-detail", Static).update(text)
+
+    # -- introspection used by tests ----------------------------------
+
+    def rendered_rows(self) -> list[str]:
+        """Return a string-only mirror of both tables' rows for assertions."""
+        return list(self._rendered_rows)
+
+    def status_text(self) -> str:
+        """Return the current status-strip text as a plain string."""
+        return self._status
+
+    def detail_text(self) -> str:
+        """Return the current detail-pane text as a plain string."""
+        return self._detail

--- a/packages/tulip-tui/tests/test_pending_data.py
+++ b/packages/tulip-tui/tests/test_pending_data.py
@@ -1,0 +1,325 @@
+"""Unit tests for ``tulip_tui.data.pending``.
+
+The adapter joins ``GET /v1/transactions?status=pending`` with
+``GET /v1/accounts`` (UUID → name) and splits the result into two
+groups at the stale-day boundary (14d default, per
+`TUI_WIREFRAMES.md § Cross-cutting decisions § 3`). ``today`` is an
+injected argument so tests don't depend on wall-clock.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tulip_cli.config import Config
+from tulip_cli.errors import CliError
+from tulip_cli.http import TulipClient
+from tulip_tui.data.pending import (
+    PendingData,
+    PendingTransaction,
+    load_pending,
+)
+
+_CHECKING_ID = "11111111-1111-1111-1111-111111111111"
+_VISA_ID = "22222222-2222-2222-2222-222222222222"
+_GROCERIES_ID = "33333333-3333-3333-3333-333333333333"
+
+_TODAY = date(2026, 5, 15)
+
+
+def _accounts_response() -> list[dict[str, object]]:
+    return [
+        {
+            "id": _CHECKING_ID,
+            "code": "assets:checking",
+            "name": "Checking",
+            "type": "asset",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+        },
+        {
+            "id": _VISA_ID,
+            "code": "liabilities:visa",
+            "name": "Visa",
+            "type": "liability",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+        },
+        {
+            "id": _GROCERIES_ID,
+            "code": "expenses:groceries",
+            "name": "Groceries",
+            "type": "expense",
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+        },
+    ]
+
+
+def _pending_response() -> list[dict[str, object]]:
+    return [
+        {
+            # 23 days old → stale
+            "id": "tx-old-check",
+            "date": "2026-04-22",
+            "description": "Check #1042 — Smith",
+            "reference": "1042",
+            "notes": None,
+            "status": "pending",
+            "postings": [
+                {
+                    "id": "p-1",
+                    "account_id": _CHECKING_ID,
+                    "amount": "-240.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+                {
+                    "id": "p-2",
+                    "account_id": _GROCERIES_ID,
+                    "amount": "240.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+            ],
+            "paired_shadow_tx_id": None,
+            "voided_by_transaction_id": None,
+            "voided_at": None,
+            "tags": [],
+        },
+        {
+            # 1 day old → recent
+            "id": "tx-card-hold",
+            "date": "2026-05-14",
+            "description": "Card hold — Shell",
+            "reference": None,
+            "notes": None,
+            "status": "pending",
+            "postings": [
+                {
+                    "id": "p-3",
+                    "account_id": _VISA_ID,
+                    "amount": "-42.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+                {
+                    "id": "p-4",
+                    "account_id": _GROCERIES_ID,
+                    "amount": "42.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+            ],
+            "paired_shadow_tx_id": None,
+            "voided_by_transaction_id": None,
+            "voided_at": None,
+            "tags": [],
+        },
+        {
+            # exactly 14 days old → recent (boundary: stale is *strictly* >14d)
+            "id": "tx-boundary",
+            "date": "2026-05-01",
+            "description": "ACH out — IRA",
+            "reference": None,
+            "notes": None,
+            "status": "pending",
+            "postings": [
+                {
+                    "id": "p-5",
+                    "account_id": _CHECKING_ID,
+                    "amount": "-500.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+                {
+                    "id": "p-6",
+                    "account_id": _GROCERIES_ID,
+                    "amount": "500.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+            ],
+            "paired_shadow_tx_id": None,
+            "voided_by_transaction_id": None,
+            "voided_at": None,
+            "tags": [],
+        },
+    ]
+
+
+class _FakeTokenStore:
+    def load(self, _api_url: str) -> object:
+        return SimpleNamespace(
+            email="t@example.invalid",
+            access_token="fake-access-token",
+            refresh_token="fake-refresh-token",
+            access_expires_at=2**31 - 1,
+        )
+
+    def save(self, _api_url: str, _tokens: object) -> None: ...
+    def clear(self, _api_url: str) -> None: ...
+
+
+def _build_client(handler: httpx.MockTransport) -> TulipClient:
+    return TulipClient(
+        Config(api_url="https://example.invalid"),
+        token_store=_FakeTokenStore(),  # type: ignore[arg-type]
+        transport=handler,
+    )
+
+
+# ---- happy path -----------------------------------------------------
+
+
+def test_load_pending_splits_at_stale_boundary() -> None:
+    accounts_payload = _accounts_response()
+    pending_payload = _pending_response()
+    recorded: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded.append((request.method, str(request.url)))
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts_payload)
+        if request.url.path == "/v1/transactions":
+            assert request.url.params.get("status") == "pending"
+            return httpx.Response(200, json=pending_payload)
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_pending(client, today=_TODAY)
+
+    assert isinstance(data, PendingData)
+    assert len(data.stale) == 1
+    assert len(data.recent) == 2
+
+    stale = data.stale[0]
+    assert isinstance(stale, PendingTransaction)
+    assert stale.id == "tx-old-check"
+    assert stale.age_days == 23
+    assert stale.description == "Check #1042 — Smith"
+    assert stale.reference == "1042"
+    assert stale.account_label == "Checking"
+    assert "-240.00" in stale.amount_display
+    assert "USD" in stale.amount_display
+
+    recent_ids = [t.id for t in data.recent]
+    # Recent is sorted oldest-first within group (boundary 14d before card-hold 1d).
+    assert recent_ids == ["tx-boundary", "tx-card-hold"]
+    # exactly 14d → recent (stale is strict >14)
+    assert data.recent[0].age_days == 14
+    assert data.recent[1].age_days == 1
+
+
+def test_load_pending_empty_returns_empty_groups() -> None:
+    accounts_payload = _accounts_response()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts_payload)
+        if request.url.path == "/v1/transactions":
+            return httpx.Response(200, json=[])
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_pending(client, today=_TODAY)
+
+    assert data.stale == ()
+    assert data.recent == ()
+
+
+def test_load_pending_raises_cli_error_on_api_failure() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                "type": "/.well-known/errors/internal",
+                "title": "Internal server error",
+                "status": 500,
+                "detail": "boom",
+                "instance": "",
+                "code": "internal",
+            },
+        )
+
+    with (
+        _build_client(httpx.MockTransport(handler)) as client,
+        pytest.raises(CliError),
+    ):
+        load_pending(client, today=_TODAY)
+
+
+def test_load_pending_unknown_account_renders_dash() -> None:
+    """A posting referencing an account not in /v1/accounts → label '—'."""
+    accounts_payload: list[dict[str, object]] = []  # empty lookup
+    pending_payload = [
+        {
+            "id": "tx-orphan",
+            "date": "2026-05-10",
+            "description": "Mystery",
+            "reference": None,
+            "notes": None,
+            "status": "pending",
+            "postings": [
+                {
+                    "id": "p-x",
+                    "account_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                    "amount": "-10.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+            ],
+            "paired_shadow_tx_id": None,
+            "voided_by_transaction_id": None,
+            "voided_at": None,
+            "tags": [],
+        }
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts_payload)
+        if request.url.path == "/v1/transactions":
+            return httpx.Response(200, json=pending_payload)
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_pending(client, today=_TODAY)
+
+    assert len(data.recent) == 1
+    assert data.recent[0].account_label == "—"
+
+
+def test_load_pending_custom_stale_days_threshold() -> None:
+    """Caller can override the 14-day default for testing / alt config."""
+    accounts_payload = _accounts_response()
+    pending_payload = _pending_response()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts_payload)
+        if request.url.path == "/v1/transactions":
+            return httpx.Response(200, json=pending_payload)
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        # threshold=2 → both boundary (14d) and old-check (23d) are stale.
+        data = load_pending(client, today=_TODAY, stale_days=2)
+
+    assert len(data.stale) == 2
+    assert len(data.recent) == 1
+    assert data.recent[0].id == "tx-card-hold"

--- a/packages/tulip-tui/tests/test_pending_screen.py
+++ b/packages/tulip-tui/tests/test_pending_screen.py
@@ -1,0 +1,163 @@
+"""Pilot-mode tests for ``PendingScreen`` + the app-wide ``n`` binding.
+
+Mirrors the test shape of ``test_envelopes_screen.py`` /
+``test_sinking_funds_screen.py``: the screen takes an injected loader,
+no API call is involved. Two table groups (Stale / Recent) make the
+rendered-row assertions look slightly different — both groups are
+flattened with a marker into one ``rendered_rows()`` list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
+from tulip_tui.data.pending import PendingData, PendingTransaction
+from tulip_tui.screens.pending import PendingScreen
+
+
+def _accounts_loader() -> AccountsData:
+    return AccountsData(as_of="2026-05-15", accounts=(), groups=())
+
+
+def _sample_pending() -> PendingData:
+    return PendingData(
+        stale=(
+            PendingTransaction(
+                id="tx-old-check",
+                date="2026-04-22",
+                age_days=23,
+                description="Check #1042 — Smith",
+                reference="1042",
+                account_label="Checking",
+                amount_display="-240.00 USD",
+            ),
+        ),
+        recent=(
+            PendingTransaction(
+                id="tx-boundary",
+                date="2026-05-01",
+                age_days=14,
+                description="ACH out — IRA",
+                reference=None,
+                account_label="Checking",
+                amount_display="-500.00 USD",
+            ),
+            PendingTransaction(
+                id="tx-card-hold",
+                date="2026-05-14",
+                age_days=1,
+                description="Card hold — Shell",
+                reference=None,
+                account_label="Visa",
+                amount_display="-42.00 USD",
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_pending_screen_lists_both_groups() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = PendingScreen(loader=lambda: _sample_pending())
+        await app.push_screen(screen)
+        await pilot.pause()
+        rendered = screen.rendered_rows()
+
+    assert any(
+        "Check #1042" in row and "Checking" in row and "23" in row and "-240.00" in row
+        for row in rendered
+    )
+    assert any(
+        "Card hold" in row and "Visa" in row and "1" in row and "-42.00" in row for row in rendered
+    )
+    assert any("ACH out" in row and "14" in row and "-500.00" in row for row in rendered)
+
+
+@pytest.mark.asyncio
+async def test_pending_screen_group_headers_present() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = PendingScreen(loader=lambda: _sample_pending())
+        await app.push_screen(screen)
+        await pilot.pause()
+        status = screen.status_text()
+
+    # Status strip names the count totals from both groups.
+    assert "1" in status  # stale count
+    assert "2" in status  # recent count
+
+
+@pytest.mark.asyncio
+async def test_pending_screen_detail_follows_cursor() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = PendingScreen(loader=lambda: _sample_pending())
+        await app.push_screen(screen)
+        await pilot.pause()
+        first = screen.detail_text()
+        # Initial focus is on the stale table → first row is Check #1042.
+        assert "tx-old-check" in first
+        assert "1042" in first
+        assert "Checking" in first
+        # ``tab`` moves focus to the recent table (Textual default focus
+        # traversal); its highlighted row becomes the detail.
+        await pilot.press("tab")
+        await pilot.pause()
+        second = screen.detail_text()
+        # Recent table's first row in the fixture is the boundary ACH txn.
+        assert "tx-boundary" in second
+        assert "ACH out" in second
+        # Move down inside the recent table → second recent row (card hold).
+        await pilot.press("down")
+        await pilot.pause()
+        third = screen.detail_text()
+        assert "tx-card-hold" in third
+        assert "Card hold" in third
+
+
+@pytest.mark.asyncio
+async def test_pending_screen_empty_state() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = PendingScreen(loader=lambda: PendingData(stale=(), recent=()))
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "no pending" in screen.detail_text().lower()
+
+
+@pytest.mark.asyncio
+async def test_pending_screen_renders_error_inline() -> None:
+    def boom() -> PendingData:
+        raise RuntimeError("api unreachable")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = PendingScreen(loader=boom)
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "api unreachable" in screen.detail_text()
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.press("q")
+    assert app.return_code == 0
+
+
+@pytest.mark.asyncio
+async def test_app_binding_n_pushes_pending_screen() -> None:
+    app = TulipTuiApp(
+        loader=_accounts_loader,
+        pending_loader=lambda: _sample_pending(),
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("n")
+        await pilot.pause()
+        assert isinstance(app.screen, PendingScreen)


### PR DESCRIPTION
## Summary

- Third and final slice of [#399](https://github.com/rmwarriner/tulip-accounting/issues/399), following P9.5.a (envelopes, [#401](https://github.com/rmwarriner/tulip-accounting/pull/401)) and P9.5.b (sinking funds, [#409](https://github.com/rmwarriner/tulip-accounting/pull/409)). Closes the read-only TUI surface: every domain in the wireframes now has a browser.
- `data/pending.py` joins `GET /v1/transactions?status=pending` with `GET /v1/accounts` for label resolution, computes per-row `age_days` from `today - tx.date`, then pre-splits into **Stale (>14d, strict)** and **Recent**. `today` is injectable so tests don't depend on wall-clock; production uses `datetime.now(UTC).date()`. `stale_days` threshold is configurable (default 14 per [TUI_WIREFRAMES.md § Cross-cutting decisions § 3](../blob/main/docs/TUI_WIREFRAMES.md#3-stale-thresholds)).
- `PendingScreen` renders two stacked DataTables with group headers (Stale / Recent), six columns each (Date / Description / Account / Ref / Amount / Age). Detail pane is focus-aware: tab between the two tables updates the detail from the focused table's cursor (avoids the spurious populate-time `RowHighlighted` clobber that initially showed the wrong group).
- App: new `n` binding (`p` is reports), `pending_loader` constructor seam, `_no_op_pending_loader` default. `main.run()` installs the production loader on a fresh `TulipClient` per fetch.
- 11 new tests (5 data-layer with `httpx.MockTransport` + 6 pilot-mode). Full `tulip-tui` suite green (84 tests). `PHASE_STATUS.md` gains a P9.5.c subsection and a closing paragraph noting #399 is shipped.
- Out of scope (per [#399](https://github.com/rmwarriner/tulip-accounting/issues/399)): per-type filters (chk/hold/ach/xfer — API doesn't structure transaction types), paired-transfer ↔ marker (post-v1 polish), real-liquid vitals strip (not v1), all mutations stay on the CLI per ADR-0007.

## App-wide bindings as shipped after this PR

`q` quit · `p` reports · `c` reconcile · `i` imports · `e` envelopes · `s` sinking funds · `n` pending · `enter` (on account row) → transactions · `escape` pop · `r` refresh

## Test plan

- [x] `uv run pytest packages/tulip-tui/` — 84/84 pass locally.
- [x] `just lint` clean.
- [x] `just typecheck` (mypy --strict) clean — 297 source files.
- [ ] CI green on this PR.
- [ ] Manual smoke against a pending transaction:
      ```bash
      cd ~/Projects/tulip-accounting
      docker compose up -d
      uv run uvicorn tulip_api.main:app --port 8000 &
      UVICORN_PID=$!
      sleep 2
      uv run tulip register --household 'Smoke Test' --email smoke@example.invalid --password-stdin <<<'correct-horse-battery-staple'
      uv run tulip accounts add --code assets:checking --name Checking --type asset --currency USD
      uv run tulip accounts add --code expenses:groceries --name Groceries --type expense --currency USD
      uv run tulip add --date 2026-04-22 --description 'Check #1042 — Smith' --reference 1042 --status pending --debit expenses:groceries:240.00 USD --credit assets:checking:240.00 USD
      uv run tulip add --date 2026-05-14 --description 'Card hold — Shell' --status pending --debit expenses:groceries:42.00 USD --credit assets:checking:42.00 USD
      uv run tulip-tui
      ```
      In the TUI: press `n` → pending browser opens; the 23-day-old check appears under Stale (>14d), the 4-day-old card hold appears under Recent (relative to 2026-05-18); arrow keys move cursor within a table; `tab` switches focus between Stale and Recent and the detail pane follows; `r` refreshes; `escape` pops; `q` quits cleanly.

      Cleanup:
      ```bash
      kill $UVICORN_PID
      ```