### PR TITLE
P9.6.a — Apply imports inside the TUI (closes #418)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -1814,6 +1814,51 @@ row) → transactions · `escape` pop · `r` refresh. Mutation surfaces
 all remain on the CLI for v1; surfacing them as TUI flows is the
 next phase.
 
+### P9.6 — TUI mutation surfaces, daily-driver wave (in flight)
+
+Per umbrella [#414](https://github.com/rmwarriner/tulip-accounting/issues/414). The read-only TUI shipped through P9.5 made
+every domain navigable but kept every recurring household task —
+log a transaction, accept an import, work a reconciliation, fix a
+category — on the CLI. This wave brings the smallest set of
+mutations that makes the TUI a daily driver, in dependency order.
+ADR-0007 amended under "Status update mechanism" recording the
+scope extension.
+
+#### P9.6.a — Apply imports inside the TUI — ✅ *(2026-05-20)*
+
+Per [#418](https://github.com/rmwarriner/tulip-accounting/issues/418). New `ImportBatchDetailScreen` reachable with
+`enter` on a row in the imports browser. Renders the batch header
+plus a per-line table with status markers (promoted / excluded /
+pending) and three new bindings:
+
+- **`x`** toggles `is_excluded` on the cursor line via the new
+  `PATCH /v1/imports/{batch_id}/lines/{line_id}` endpoint (audit
+  rows `statement_line.excluded` / `statement_line.unexcluded`,
+  idempotent no-op when the flag already matches, 409
+  `import.line.already_promoted` if the line has been promoted).
+- **`p`** promotes the cursor pending line via
+  `POST /v1/imports/{batch_id}/lines/{line_id}/promote`.
+- **`a`** opens an `ApplyConfirmModal` with the three apply-flag
+  toggles (`--as-posted`, `--no-categorize`,
+  `--treat-cleared-as-pending`) and a non-excluded line count.
+  Confirm fires `POST /v1/imports/{batch_id}/apply` with the
+  toggles as query params; on success the detail screen pops back
+  to the imports list with the created count in the notice strip.
+
+Already-promoted lines refuse `x` and `p`; the API enforces both
+and the screen surfaces the `promoted` marker so the user knows.
+
+Cross-cutting changes: `StatementLineRepository.unexclude()` mirror
+of `.exclude()`; the `GET /v1/imports/{batch_id}` response now
+surfaces `promoted_transaction_id` per line so the detail screen
+can derive status without a separate transactions fetch; the
+imports browser's `enter` fires the new drill-in handler. Tests: 1
+new storage round-trip, 8 API endpoint tests (happy / round-trip /
+idempotent / 409 promoted / 404 batch / 404 line / 401 unauth /
+audit-row shape), 9 data-layer tests, 13 pilot-mode screen tests
+covering every binding plus the modal's cancel / confirm /
+no-pending paths.
+
 ---
 
 ## Other shipped fixes

--- a/docs/adrs/0007-terminal-ui.md
+++ b/docs/adrs/0007-terminal-ui.md
@@ -157,3 +157,39 @@ Update this ADR when:
 - A web/desktop GUI is ever scoped — that is a *new* ADR that
   supersedes the "rejected for now" stance here, not an edit to this
   one.
+
+### P9.6 — read-only scope extended to mutation surfaces (2026-05-20)
+
+Umbrella [#414](https://github.com/rmwarriner/tulip-accounting/issues/414).
+After the P9.5 read continuation closed every read-only browser
+([#399](https://github.com/rmwarriner/tulip-accounting/issues/399)),
+the remaining structural friction is that every recurring household
+task (log a transaction, accept an import, work a reconciliation,
+fix a category) still drops out of the TUI to the CLI. P9.6
+introduces a tightly-scoped four-slice wave that surfaces those
+mutations inside the TUI in dependency order. The CLI stays
+first-class; the TUI is no longer the only-read surface.
+
+Slices, in order:
+
+- **P9.6.a — Apply imports inside the TUI** ([#418](https://github.com/rmwarriner/tulip-accounting/issues/418)) — new
+  `ImportBatchDetailScreen` reached by `enter` on the imports list;
+  `x` toggles exclude/un-exclude (new
+  `PATCH /v1/imports/{batch_id}/lines/{line_id}`), `p` promotes a
+  single line, `a` opens the apply confirm modal with the three
+  apply-flag toggles. **Shipped 2026-05-20.**
+- **P9.6.b — Reconcile actioning** — accept-auto-match, confirm-
+  suggested-match, manual-match picker, mark-cleared, carry-
+  forward; no backend change planned.
+- **P9.6.c — Add / edit / void transaction modal** — new transaction
+  modal reachable from the transactions register with `n`/`e`/`x`;
+  splits handled as in-modal "add row" affordances.
+- **P9.6.d — AI-categorize with explicit confirmation** — `c` on a
+  PENDING transaction; multi-select via `space` then batch `c`. Per
+  the wireframes' AI-confirmation lock, every proposal requires an
+  explicit accept.
+
+Backend surface is unchanged except for one P9.6.a endpoint gap-fill
+(`PATCH /v1/imports/.../lines/{id}`); the architecture-boundary
+test remains green. Mutation flows still ride the same HTTP API the
+CLI uses, so the TUI is not a new attack surface.

--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -65,6 +65,7 @@ from tulip_api.schemas.import_batch import (
     MultiAccountImportSummary,
     StatementLinePromoteResponse,
     StatementLineRead,
+    StatementLineUpdate,
 )
 from tulip_api.services.import_apply import (
     BatchAlreadyAppliedError,
@@ -876,6 +877,105 @@ async def promote_line(
     )
 
 
+@router.patch(
+    "/{batch_id}/lines/{line_id}",
+    response_model=StatementLineRead,
+    responses={
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        404: problem_response("import_batch.not_found", "import.line.not_found"),
+        409: problem_response("import.line.already_promoted"),
+    },
+)
+def update_statement_line(
+    batch_id: UUID,
+    line_id: UUID,
+    body: StatementLineUpdate,
+    request: Request,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> StatementLineRead:
+    """Toggle ``is_excluded`` on a single parsed statement line (P9.6.a).
+
+    Idempotent — passing the line's current ``is_excluded`` is a no-op
+    (no audit row, returns the line unchanged). Refuses to mutate an
+    already-promoted line: that line has a ledger transaction and
+    excluding it would orphan the back-reference; edit / void the
+    transaction instead.
+    """
+    batch_repo = ImportBatchRepository(session, claims.household_id)
+    batch = batch_repo.get(batch_id)
+    if batch is None:
+        raise ImportBatchNotFoundError()
+
+    line_repo = StatementLineRepository(session, claims.household_id)
+    line = line_repo.get(line_id)
+    if line is None or line.import_batch_id != batch_id:
+        raise StatementLineNotFoundError()
+
+    if line.promoted_transaction_id is not None:
+        raise StatementLineAlreadyPromotedError(
+            line_id=str(line_id),
+            transaction_id=str(line.promoted_transaction_id),
+        )
+
+    if bool(line.is_excluded) == body.is_excluded:
+        # Idempotent no-op — return current state, no audit row.
+        return StatementLineRead(
+            id=line.id,
+            line_number=line.line_number,
+            posted_date=line.posted_date,
+            amount=line.amount,
+            currency=line.currency,
+            description=line.description,
+            counterparty=line.counterparty,
+            reference=line.reference,
+            fitid=line.fitid,
+            is_excluded=line.is_excluded,
+            reconciliation_match_id=line.reconciliation_match_id,
+            promoted_transaction_id=line.promoted_transaction_id,
+        )
+
+    before = bool(line.is_excluded)
+    if body.is_excluded:
+        line = line_repo.exclude(line_id)
+        action = "statement_line.excluded"
+    else:
+        line = line_repo.unexclude(line_id)
+        action = "statement_line.unexcluded"
+
+    AuditLogWriter(session, claims.household_id).write(
+        action=action,
+        actor_kind="user",
+        actor_user_id=claims.user_id,
+        entity_type="statement_line",
+        entity_id=line.id,
+        before={"is_excluded": before},
+        after={"is_excluded": bool(line.is_excluded)},
+        request_id=_request_uuid(request),
+    )
+    session.commit()
+    log.info(
+        "statement_line.is_excluded_updated",
+        line_id=str(line_id),
+        is_excluded=bool(line.is_excluded),
+    )
+    return StatementLineRead(
+        id=line.id,
+        line_number=line.line_number,
+        posted_date=line.posted_date,
+        amount=line.amount,
+        currency=line.currency,
+        description=line.description,
+        counterparty=line.counterparty,
+        reference=line.reference,
+        fitid=line.fitid,
+        is_excluded=line.is_excluded,
+        reconciliation_match_id=line.reconciliation_match_id,
+        promoted_transaction_id=line.promoted_transaction_id,
+    )
+
+
 _LIST_DEFAULT_LIMIT: Final[int] = 25
 _LIST_MAX_LIMIT: Final[int] = 200
 
@@ -1042,6 +1142,7 @@ def get_import_batch(
                 fitid=line.fitid,
                 is_excluded=line.is_excluded,
                 reconciliation_match_id=line.reconciliation_match_id,
+                promoted_transaction_id=line.promoted_transaction_id,
             )
             for line in lines
         ],

--- a/packages/tulip-api/src/tulip_api/schemas/import_batch.py
+++ b/packages/tulip-api/src/tulip_api/schemas/import_batch.py
@@ -24,6 +24,13 @@ class StatementLineRead(BaseModel):
     fitid: str | None
     is_excluded: bool
     reconciliation_match_id: UUID | None
+    promoted_transaction_id: UUID | None = None
+
+
+class StatementLineUpdate(BaseModel):
+    """``PATCH /v1/imports/{batch_id}/lines/{line_id}`` body (P9.6.a)."""
+
+    is_excluded: bool
 
 
 class ImportBatchSummary(BaseModel):

--- a/packages/tulip-api/tests/test_apply_promote_endpoints.py
+++ b/packages/tulip-api/tests/test_apply_promote_endpoints.py
@@ -319,3 +319,135 @@ class TestApplyExceptionDoesNotLeakLock:
             json={"name": "Post-failure", "type": "expense", "currency": "USD", "code": "5200"},
         )
         assert r3.status_code == 201, r3.text
+
+
+# ---- PATCH /lines/{id} — exclude/un-exclude (P9.6.a) -----------------------
+
+
+class TestPatchStatementLine:
+    """``PATCH /v1/imports/{batch_id}/lines/{line_id}`` toggles ``is_excluded``."""
+
+    def test_exclude_flips_flag_and_persists(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        line_id = _first_line_id(client, auth_h, parsed_batch)
+        r = client.patch(
+            f"/v1/imports/{parsed_batch}/lines/{line_id}",
+            headers=auth_h,
+            json={"is_excluded": True},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["is_excluded"] is True
+
+        follow = client.get(f"/v1/imports/{parsed_batch}", headers=auth_h)
+        assert follow.status_code == 200
+        line = next(line for line in follow.json()["lines"] if line["id"] == line_id)
+        assert line["is_excluded"] is True
+
+    def test_unexclude_round_trip(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        line_id = _first_line_id(client, auth_h, parsed_batch)
+        client.patch(
+            f"/v1/imports/{parsed_batch}/lines/{line_id}",
+            headers=auth_h,
+            json={"is_excluded": True},
+        )
+        r = client.patch(
+            f"/v1/imports/{parsed_batch}/lines/{line_id}",
+            headers=auth_h,
+            json={"is_excluded": False},
+        )
+        assert r.status_code == 200
+        assert r.json()["is_excluded"] is False
+
+    def test_idempotent_noop(self, client: TestClient, auth_h: dict[str, str], parsed_batch: str):
+        line_id = _first_line_id(client, auth_h, parsed_batch)
+        # Default is_excluded=False; passing False is a no-op.
+        r = client.patch(
+            f"/v1/imports/{parsed_batch}/lines/{line_id}",
+            headers=auth_h,
+            json={"is_excluded": False},
+        )
+        assert r.status_code == 200
+        assert r.json()["is_excluded"] is False
+
+    def test_promoted_line_rejected_with_409(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        line_id = _first_line_id(client, auth_h, parsed_batch)
+        # Promote first.
+        promote = client.post(
+            f"/v1/imports/{parsed_batch}/lines/{line_id}/promote",
+            headers=auth_h,
+        )
+        assert promote.status_code == 201
+        # Now PATCH must refuse.
+        r = client.patch(
+            f"/v1/imports/{parsed_batch}/lines/{line_id}",
+            headers=auth_h,
+            json={"is_excluded": True},
+        )
+        assert_problem(r, status=409, code="import.line.already_promoted")
+
+    def test_unknown_batch_returns_404(self, client: TestClient, auth_h: dict[str, str]):
+        from uuid import uuid4
+
+        r = client.patch(
+            f"/v1/imports/{uuid4()}/lines/{uuid4()}",
+            headers=auth_h,
+            json={"is_excluded": True},
+        )
+        assert_problem(r, status=404, code="import_batch.not_found")
+
+    def test_unknown_line_returns_404(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str
+    ):
+        from uuid import uuid4
+
+        r = client.patch(
+            f"/v1/imports/{parsed_batch}/lines/{uuid4()}",
+            headers=auth_h,
+            json={"is_excluded": True},
+        )
+        assert_problem(r, status=404, code="import.line.not_found")
+
+    def test_unauthenticated_returns_401(self, client: TestClient, parsed_batch: str):
+        from uuid import uuid4
+
+        r = client.patch(
+            f"/v1/imports/{parsed_batch}/lines/{uuid4()}",
+            json={"is_excluded": True},
+        )
+        assert r.status_code == 401
+
+    def test_exclude_writes_audit_row(
+        self, client: TestClient, auth_h: dict[str, str], parsed_batch: str, app
+    ):
+        from sqlalchemy import select
+
+        from tulip_api.deps import get_session
+        from tulip_storage.models import AuditLog
+
+        line_id = _first_line_id(client, auth_h, parsed_batch)
+        r = client.patch(
+            f"/v1/imports/{parsed_batch}/lines/{line_id}",
+            headers=auth_h,
+            json={"is_excluded": True},
+        )
+        assert r.status_code == 200
+
+        session_iter = app.dependency_overrides[get_session]()
+        session = next(session_iter)
+        try:
+            rows = list(
+                session.execute(
+                    select(AuditLog).where(AuditLog.action == "statement_line.excluded")
+                ).scalars()
+            )
+        finally:
+            try:
+                next(session_iter)
+            except StopIteration:
+                pass
+        assert any(str(row.entity_id) == line_id for row in rows)

--- a/packages/tulip-storage/src/tulip_storage/repositories/statement_line.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/statement_line.py
@@ -106,6 +106,17 @@ class StatementLineRepository:
         self._session.flush()
         return line
 
+    def unexclude(self, line_id: UUID) -> StatementLine:
+        """Reverse ``exclude`` — line re-enters the unmatched / appliable pool."""
+        line = self.get(line_id)
+        if line is None:
+            raise LookupError(
+                f"statement_line {line_id} not found in household {self._household_id}"
+            )
+        line.is_excluded = False
+        self._session.flush()
+        return line
+
     def mark_promoted(self, line_id: UUID, transaction_id: UUID) -> StatementLine:
         """Link a statement line to the ledger Transaction it was promoted into.
 

--- a/packages/tulip-storage/tests/test_p51_repositories.py
+++ b/packages/tulip-storage/tests/test_p51_repositories.py
@@ -463,6 +463,14 @@ class TestImportBatchAndStatementLine:
         session.commit()
         assert len(line_repo.list_unmatched(batch.id)) == 1
 
+        # Un-excluding it puts it back in the unmatched pool.
+        line_repo.unexclude(unmatched[0].id)
+        session.commit()
+        assert len(line_repo.list_unmatched(batch.id)) == 2
+        line = line_repo.get(unmatched[0].id)
+        assert line is not None
+        assert line.is_excluded is False
+
 
 # ---- Reconciliation + Match ---------------------------------------------
 

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -22,6 +22,7 @@ from textual.app import App
 from textual.binding import Binding, BindingType
 
 from tulip_tui.data.envelopes import EnvelopesData
+from tulip_tui.data.import_batch_detail import ImportBatchDetail
 from tulip_tui.data.imports import ImportsData
 from tulip_tui.data.pending import PendingData
 from tulip_tui.data.reconciliations import ReconciliationsData
@@ -29,6 +30,7 @@ from tulip_tui.data.reports import ReportPayload, ReportSpec
 from tulip_tui.data.sinking_funds import SinkingFundsData
 from tulip_tui.screens.accounts import AccountsLoader, AccountsScreen
 from tulip_tui.screens.envelopes import EnvelopesScreen
+from tulip_tui.screens.import_batch_detail import ImportBatchDetailScreen
 from tulip_tui.screens.imports import ImportsScreen
 from tulip_tui.screens.pending import PendingScreen
 from tulip_tui.screens.reconciliations import ReconciliationsScreen
@@ -40,6 +42,10 @@ TransactionsLoaderFactory = Callable[[str | None], TransactionsLoader]
 ReportLoader = Callable[[ReportSpec], ReportPayload]
 ReconciliationsLoader = Callable[[], ReconciliationsData]
 ImportsLoader = Callable[[], ImportsData]
+ImportBatchDetailLoaderFactory = Callable[[str], Callable[[], ImportBatchDetail]]
+LineExcludeAction = Callable[[str, str, bool], None]
+LinePromoteAction = Callable[[str, str], None]
+BatchApplyAction = Callable[[str, bool, bool, bool], object]
 EnvelopesLoader = Callable[[], EnvelopesData]
 SinkingFundsLoader = Callable[[], SinkingFundsData]
 PendingLoader = Callable[[], PendingData]
@@ -68,6 +74,30 @@ def _no_op_reconciliations_loader() -> ReconciliationsData:
 
 def _no_op_imports_loader() -> ImportsData:
     raise RuntimeError("imports loader not configured")
+
+
+def _no_op_import_batch_detail_factory(_batch_id: str) -> Callable[[], ImportBatchDetail]:
+    def _raise() -> ImportBatchDetail:
+        raise RuntimeError("import batch detail loader not configured")
+
+    return _raise
+
+
+def _no_op_line_exclude(_batch_id: str, _line_id: str, _is_excluded: bool) -> None:
+    raise RuntimeError("line exclude action not configured")
+
+
+def _no_op_line_promote(_batch_id: str, _line_id: str) -> None:
+    raise RuntimeError("line promote action not configured")
+
+
+def _no_op_batch_apply(
+    _batch_id: str,
+    _as_posted: bool,
+    _no_categorize: bool,
+    _treat_cleared_as_pending: bool,
+) -> object:
+    raise RuntimeError("batch apply action not configured")
 
 
 def _no_op_envelopes_loader() -> EnvelopesData:
@@ -105,6 +135,12 @@ class TulipTuiApp(App[None]):
         reports_loader: ReportLoader = _no_op_reports_loader,
         reconciliations_loader: ReconciliationsLoader = _no_op_reconciliations_loader,
         imports_loader: ImportsLoader = _no_op_imports_loader,
+        import_batch_detail_factory: ImportBatchDetailLoaderFactory = (
+            _no_op_import_batch_detail_factory
+        ),
+        line_exclude_action: LineExcludeAction = _no_op_line_exclude,
+        line_promote_action: LinePromoteAction = _no_op_line_promote,
+        batch_apply_action: BatchApplyAction = _no_op_batch_apply,
         envelopes_loader: EnvelopesLoader = _no_op_envelopes_loader,
         sinking_funds_loader: SinkingFundsLoader = _no_op_sinking_funds_loader,
         pending_loader: PendingLoader = _no_op_pending_loader,
@@ -116,6 +152,10 @@ class TulipTuiApp(App[None]):
         self._reports_loader = reports_loader
         self._reconciliations_loader = reconciliations_loader
         self._imports_loader = imports_loader
+        self._import_batch_detail_factory = import_batch_detail_factory
+        self._line_exclude_action = line_exclude_action
+        self._line_promote_action = line_promote_action
+        self._batch_apply_action = batch_apply_action
         self._envelopes_loader = envelopes_loader
         self._sinking_funds_loader = sinking_funds_loader
         self._pending_loader = pending_loader
@@ -139,7 +179,28 @@ class TulipTuiApp(App[None]):
 
     def action_open_imports(self) -> None:
         """Push the import batches browser onto the screen stack."""
-        self.push_screen(ImportsScreen(loader=self._imports_loader))
+        self.push_screen(
+            ImportsScreen(
+                loader=self._imports_loader,
+                on_open_batch=self.open_import_batch_detail,
+            )
+        )
+
+    def open_import_batch_detail(self, batch_id: str) -> None:
+        """Push the per-batch detail / apply screen (P9.6.a)."""
+        loader = self._import_batch_detail_factory(batch_id)
+        self.push_screen(
+            ImportBatchDetailScreen(
+                loader=loader,
+                on_toggle_exclude=lambda line_id, is_excluded: self._line_exclude_action(
+                    batch_id, line_id, is_excluded
+                ),
+                on_promote=lambda line_id: self._line_promote_action(batch_id, line_id),
+                on_apply=lambda as_posted, no_categorize, treat_cleared: self._batch_apply_action(
+                    batch_id, as_posted, no_categorize, treat_cleared
+                ),
+            )
+        )
 
     def action_open_envelopes(self) -> None:
         """Push the envelopes browser onto the screen stack."""

--- a/packages/tulip-tui/src/tulip_tui/data/import_batch_detail.py
+++ b/packages/tulip-tui/src/tulip_tui/data/import_batch_detail.py
@@ -1,0 +1,179 @@
+"""Import-batch detail-view data adapter (P9.6.a).
+
+Wraps ``GET /v1/imports/{batch_id}`` into an immutable
+``ImportBatchDetail`` value object the detail screen renders. Lines
+are sorted in source-file order (already done by the API) and carry a
+derived ``status`` enum string so the table can render
+``excluded`` / ``promoted`` / ``pending`` markers without re-deriving.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import cast
+
+from tulip_cli.http import TulipClient
+
+
+@dataclass(frozen=True, slots=True)
+class StatementLineSummary:
+    """One row in the batch detail table, with display strings precomputed."""
+
+    id: str
+    line_number: int
+    date: str
+    description: str
+    amount_display: str
+    currency: str
+    is_excluded: bool
+    promoted_transaction_id: str | None
+    reconciliation_match_id: str | None
+
+    @property
+    def status(self) -> str:
+        """``promoted`` > ``excluded`` > ``pending`` (display order)."""
+        if self.promoted_transaction_id:
+            return "promoted"
+        if self.is_excluded:
+            return "excluded"
+        return "pending"
+
+
+@dataclass(frozen=True, slots=True)
+class ImportBatchDetail:
+    """One import batch as the detail screen needs it."""
+
+    id: str
+    account_id: str
+    source_format: str
+    source_filename: str
+    status: str
+    imported_count: int
+    skipped_count: int
+    error_count: int
+    created_at: str
+    applied_at: str | None
+    reverted_at: str | None
+    lines: tuple[StatementLineSummary, ...]
+
+    @property
+    def pending_count(self) -> int:
+        """Number of lines that would be promoted by a whole-batch apply."""
+        return sum(1 for ln in self.lines if ln.status == "pending")
+
+    @property
+    def excluded_count(self) -> int:
+        """Number of lines the user has marked excluded."""
+        return sum(1 for ln in self.lines if ln.status == "excluded")
+
+    @property
+    def promoted_count(self) -> int:
+        """Number of lines already promoted to ledger transactions."""
+        return sum(1 for ln in self.lines if ln.status == "promoted")
+
+
+def load_import_batch_detail(client: TulipClient, batch_id: str) -> ImportBatchDetail:
+    """Fetch and parse ``/v1/imports/{batch_id}``."""
+    raw = client.get(f"/v1/imports/{batch_id}", authenticated=True).json()
+    lines_raw = cast("list[dict[str, object]]", raw.get("lines") or [])
+    lines = tuple(_to_line_summary(row) for row in lines_raw)
+    return ImportBatchDetail(
+        id=str(raw.get("id", "")),
+        account_id=str(raw.get("account_id", "")),
+        source_format=str(raw.get("source_format", "")),
+        source_filename=str(raw.get("source_filename", "")),
+        status=str(raw.get("status", "")),
+        imported_count=_optional_int(raw.get("imported_count")),
+        skipped_count=_optional_int(raw.get("skipped_count")),
+        error_count=_optional_int(raw.get("error_count")),
+        created_at=str(raw.get("created_at", "")),
+        applied_at=_optional_str(raw.get("applied_at")),
+        reverted_at=_optional_str(raw.get("reverted_at")),
+        lines=lines,
+    )
+
+
+def patch_line_excluded(
+    client: TulipClient, batch_id: str, line_id: str, *, is_excluded: bool
+) -> None:
+    """Call the ``PATCH /v1/imports/{batch_id}/lines/{line_id}`` toggle."""
+    client.patch(
+        f"/v1/imports/{batch_id}/lines/{line_id}",
+        authenticated=True,
+        json={"is_excluded": is_excluded},
+    )
+
+
+def promote_line(client: TulipClient, batch_id: str, line_id: str) -> None:
+    """Call the ``POST /v1/imports/{batch_id}/lines/{line_id}/promote`` action."""
+    client.post(
+        f"/v1/imports/{batch_id}/lines/{line_id}/promote",
+        authenticated=True,
+    )
+
+
+def apply_batch(
+    client: TulipClient,
+    batch_id: str,
+    *,
+    as_posted: bool = False,
+    no_categorize: bool = False,
+    treat_cleared_as_pending: bool = False,
+) -> dict[str, object]:
+    """Call the ``POST /v1/imports/{batch_id}/apply`` action with the three toggles."""
+    params: dict[str, str] = {}
+    if as_posted:
+        params["as_posted"] = "true"
+    if no_categorize:
+        params["no_categorize"] = "true"
+    if treat_cleared_as_pending:
+        params["treat_cleared_as_pending"] = "true"
+    resp = client.request(
+        "POST",
+        f"/v1/imports/{batch_id}/apply",
+        authenticated=True,
+        params=params,
+    )
+    return cast("dict[str, object]", resp.json())
+
+
+def _to_line_summary(row: dict[str, object]) -> StatementLineSummary:
+    amount = Decimal(str(row.get("amount", "0"))).quantize(Decimal("0.01"))
+    currency = str(row.get("currency", ""))
+    return StatementLineSummary(
+        id=str(row.get("id", "")),
+        line_number=_optional_int(row.get("line_number")),
+        date=str(row.get("posted_date", "")),
+        description=str(row.get("description", "")),
+        amount_display=f"{amount:,.2f}",
+        currency=currency,
+        is_excluded=bool(row.get("is_excluded", False)),
+        promoted_transaction_id=_optional_str(row.get("promoted_transaction_id")),
+        reconciliation_match_id=_optional_str(row.get("reconciliation_match_id")),
+    )
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_int(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+__all__: list[str] = [
+    "ImportBatchDetail",
+    "StatementLineSummary",
+    "apply_batch",
+    "load_import_batch_detail",
+    "patch_line_excluded",
+    "promote_line",
+]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -8,12 +8,21 @@ with their own loaders.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from tulip_cli.auth.tokens import default_token_store
 from tulip_cli.config import load_config
 from tulip_cli.http import TulipClient
 from tulip_tui.app import TulipTuiApp
 from tulip_tui.data.accounts import AccountsData, load_accounts
 from tulip_tui.data.envelopes import EnvelopesData, load_envelopes
+from tulip_tui.data.import_batch_detail import (
+    ImportBatchDetail,
+    load_import_batch_detail,
+    patch_line_excluded,
+    promote_line,
+)
+from tulip_tui.data.import_batch_detail import apply_batch as _apply_batch_call
 from tulip_tui.data.imports import ImportsData, load_import_batches
 from tulip_tui.data.pending import PendingData, load_pending
 from tulip_tui.data.reconciliations import ReconciliationsData, load_reconciliations
@@ -60,6 +69,48 @@ def _imports_loader() -> ImportsData:
         return load_import_batches(client)
 
 
+def _import_batch_detail_factory(
+    batch_id: str,
+) -> Callable[[], ImportBatchDetail]:
+    """Build a loader that pulls one import batch's parsed lines."""
+
+    def _load() -> ImportBatchDetail:
+        config = load_config()
+        with TulipClient(config, token_store=default_token_store()) as client:
+            return load_import_batch_detail(client, batch_id)
+
+    return _load
+
+
+def _line_exclude_action(batch_id: str, line_id: str, is_excluded: bool) -> None:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        patch_line_excluded(client, batch_id, line_id, is_excluded=is_excluded)
+
+
+def _line_promote_action(batch_id: str, line_id: str) -> None:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        promote_line(client, batch_id, line_id)
+
+
+def _batch_apply_action(
+    batch_id: str,
+    as_posted: bool,
+    no_categorize: bool,
+    treat_cleared_as_pending: bool,
+) -> object:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return _apply_batch_call(
+            client,
+            batch_id,
+            as_posted=as_posted,
+            no_categorize=no_categorize,
+            treat_cleared_as_pending=treat_cleared_as_pending,
+        )
+
+
 def _envelopes_loader() -> EnvelopesData:
     config = load_config()
     with TulipClient(config, token_store=default_token_store()) as client:
@@ -86,6 +137,10 @@ def run() -> None:
         reports_loader=_reports_loader,
         reconciliations_loader=_reconciliations_loader,
         imports_loader=_imports_loader,
+        import_batch_detail_factory=_import_batch_detail_factory,
+        line_exclude_action=_line_exclude_action,
+        line_promote_action=_line_promote_action,
+        batch_apply_action=_batch_apply_action,
         envelopes_loader=_envelopes_loader,
         sinking_funds_loader=_sinking_funds_loader,
         pending_loader=_pending_loader,

--- a/packages/tulip-tui/src/tulip_tui/screens/import_batch_detail.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/import_batch_detail.py
@@ -1,0 +1,432 @@
+"""Import-batch detail + apply screen — P9.6.a of [#414](https://github.com/rmwarriner/tulip-accounting/issues/414).
+
+Reachable with ``enter`` on a row in the imports browser. Renders the
+batch header plus a per-line table with status markers
+(promoted / excluded / pending) and offers three line-level actions:
+
+- ``x`` toggles exclude / un-exclude (``PATCH /v1/imports/.../lines/{id}``)
+- ``p`` promotes a single pending line
+  (``POST /v1/imports/.../lines/{id}/promote``)
+- ``a`` opens the apply confirm modal with three flag toggles
+  (``--as-posted``, ``--no-categorize``, ``--treat-cleared-as-pending``).
+  Confirm fires ``POST /v1/imports/{batch_id}/apply`` with the toggles
+  as query params, then pops both screens back to the imports list.
+
+Already-promoted lines refuse `x` and `p` (the API enforces this; the
+screen rendering surfaces the "promoted" marker so the user knows).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Button, DataTable, Footer, Header, Static, Switch
+
+from tulip_tui.data.import_batch_detail import (
+    ImportBatchDetail,
+    StatementLineSummary,
+)
+
+ImportBatchDetailLoader = Callable[[], ImportBatchDetail]
+LineExcludeToggle = Callable[[str, bool], None]
+LinePromote = Callable[[str], None]
+BatchApply = Callable[[bool, bool, bool], object]
+
+
+def _status_marker(status: str) -> str:
+    """Map status enum → display marker.  Kept here so tests can pin display."""
+    return {"promoted": "✓", "excluded": "✗", "pending": "•"}.get(status, "?")
+
+
+def _row_for(line: StatementLineSummary) -> tuple[str, str, str, str, str, str]:
+    amount = f"{line.amount_display} {line.currency}".strip()
+    return (
+        str(line.line_number),
+        line.date,
+        line.description,
+        amount,
+        line.status,
+        _status_marker(line.status),
+    )
+
+
+def _detail_for(line: StatementLineSummary) -> str:
+    out = [
+        f"[b]line {line.line_number}[/b]    {line.date}",
+        f"description:  {line.description}",
+        f"amount:       {line.amount_display} {line.currency}",
+        f"status:       {line.status}",
+    ]
+    if line.promoted_transaction_id:
+        out.append(f"transaction:  {line.promoted_transaction_id}")
+    if line.reconciliation_match_id:
+        out.append(f"matched:      {line.reconciliation_match_id}")
+    out.append(f"id:           {line.id}")
+    return "\n".join(out)
+
+
+class ApplyConfirmModal(ModalScreen[tuple[bool, bool, bool] | None]):
+    """Confirmation modal for ``POST /v1/imports/{id}/apply`` (P9.6.a).
+
+    Renders the three apply-flag toggles. Returns the chosen flags on
+    ``confirm``, or ``None`` if the user cancels. The caller fires the
+    API call after the modal dismisses; keeping the network call out of
+    the modal keeps it pilot-mode testable without a live API.
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "cancel", "cancel", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    ApplyConfirmModal {
+        align: center middle;
+    }
+
+    ApplyConfirmModal #apply-modal {
+        width: 70;
+        max-width: 90%;
+        height: auto;
+        background: $panel;
+        border: thick $primary;
+        padding: 1 2;
+    }
+
+    ApplyConfirmModal .row {
+        height: auto;
+        margin: 1 0 0 0;
+    }
+
+    ApplyConfirmModal .toggle-label {
+        width: 1fr;
+        padding: 1 0 0 0;
+    }
+
+    ApplyConfirmModal #apply-buttons {
+        align-horizontal: right;
+        height: auto;
+        margin-top: 1;
+    }
+
+    ApplyConfirmModal Button {
+        margin-left: 2;
+    }
+    """
+
+    def __init__(self, *, pending_count: int) -> None:
+        """Track the count so the header is concrete (``Apply 12 lines?``)."""
+        super().__init__()
+        self._pending_count = pending_count
+
+    def compose(self) -> ComposeResult:
+        """Lay out title, three toggles, and the confirm/cancel buttons."""
+        with Vertical(id="apply-modal"):
+            yield Static(
+                f"[b]Apply {self._pending_count} line(s) to the ledger?[/b]\n"
+                "Excluded and already-promoted lines are skipped.",
+                id="apply-title",
+            )
+            with Horizontal(classes="row"):
+                yield Static("Land as POSTED (skip PENDING review)", classes="toggle-label")
+                yield Switch(value=False, id="apply-as-posted")
+            with Horizontal(classes="row"):
+                yield Static("Skip AI categorizer (Imbalance:Unknown)", classes="toggle-label")
+                yield Switch(value=False, id="apply-no-categorize")
+            with Horizontal(classes="row"):
+                yield Static("Force everything to PENDING", classes="toggle-label")
+                yield Switch(value=False, id="apply-treat-cleared-as-pending")
+            with Horizontal(id="apply-buttons"):
+                yield Button("Cancel", id="apply-cancel")
+                yield Button("Apply", variant="primary", id="apply-confirm")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Dismiss with the toggle tuple on confirm, or ``None`` on cancel."""
+        if event.button.id == "apply-confirm":
+            self.dismiss(self._snapshot())
+        elif event.button.id == "apply-cancel":
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        """``escape`` key alias for the cancel button."""
+        self.dismiss(None)
+
+    def _snapshot(self) -> tuple[bool, bool, bool]:
+        return (
+            self.query_one("#apply-as-posted", Switch).value,
+            self.query_one("#apply-no-categorize", Switch).value,
+            self.query_one("#apply-treat-cleared-as-pending", Switch).value,
+        )
+
+    # -- test introspection ------------------------------------------------
+
+    def snapshot_flags(self) -> tuple[bool, bool, bool]:
+        """Pilot-mode helper — read the three switches without dismissing."""
+        return self._snapshot()
+
+
+class ImportBatchDetailScreen(Screen[None]):
+    """Per-line review and apply for a parsed import batch (P9.6.a)."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "app.pop_screen", "back", show=True),
+        Binding("r", "refresh", "refresh", show=True),
+        Binding("x", "toggle_exclude", "exclude/un-exclude", show=True),
+        Binding("p", "promote", "promote line", show=True),
+        Binding("a", "open_apply", "apply…", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    ImportBatchDetailScreen {
+        layout: vertical;
+    }
+
+    ImportBatchDetailScreen #ibd-header {
+        height: auto;
+        padding: 0 1;
+    }
+
+    ImportBatchDetailScreen #ibd-status {
+        height: auto;
+        padding: 0 1;
+        color: $accent;
+    }
+
+    ImportBatchDetailScreen #ibd-table {
+        height: 2fr;
+    }
+
+    ImportBatchDetailScreen #ibd-detail {
+        height: 1fr;
+        padding: 1 2;
+        border-top: solid $accent;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        loader: ImportBatchDetailLoader,
+        on_toggle_exclude: LineExcludeToggle,
+        on_promote: LinePromote,
+        on_apply: BatchApply,
+    ) -> None:
+        """Wire the per-action callbacks; the screen does no network itself."""
+        super().__init__()
+        self._loader = loader
+        self._on_toggle_exclude = on_toggle_exclude
+        self._on_promote = on_promote
+        self._on_apply = on_apply
+        self._index: list[StatementLineSummary] = []
+        self._rendered_rows: list[str] = []
+        self._header: str = ""
+        self._status: str = ""
+        self._detail: str = ""
+        self._batch: ImportBatchDetail | None = None
+        self._notice: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Lay out header / status strip / line table / detail pane."""
+        yield Header()
+        with Vertical():
+            yield Static("loading batch…", id="ibd-header")
+            yield Static("", id="ibd-status")
+            yield DataTable(id="ibd-table", zebra_stripes=True, cursor_type="row")
+            yield Static("", id="ibd-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Install column headers and trigger the initial load."""
+        table = self.query_one("#ibd-table", DataTable)
+        table.add_columns("#", "Date", "Description", "Amount", "Status", "M")
+        self._load()
+
+    def action_refresh(self) -> None:
+        """Re-run the loader and rebuild the table in place."""
+        self._load()
+
+    def action_toggle_exclude(self) -> None:
+        """``x`` — flip ``is_excluded`` on the cursor line, then reload."""
+        line = self._cursor_line()
+        if line is None:
+            return
+        if line.status == "promoted":
+            self._set_notice("cannot exclude a promoted line — edit/void the tx instead")
+            return
+        new_state = not line.is_excluded
+        try:
+            self._on_toggle_exclude(line.id, new_state)
+        except Exception as exc:
+            self._set_notice(f"[red]exclude failed:[/red] {exc}")
+            return
+        self._set_notice("excluded" if new_state else "un-excluded")
+        self._load()
+
+    def action_promote(self) -> None:
+        """``p`` — promote the cursor line to a ledger transaction, then reload."""
+        line = self._cursor_line()
+        if line is None:
+            return
+        if line.status != "pending":
+            self._set_notice(f"line is {line.status}; only pending lines can promote")
+            return
+        try:
+            self._on_promote(line.id)
+        except Exception as exc:
+            self._set_notice(f"[red]promote failed:[/red] {exc}")
+            return
+        self._set_notice("promoted")
+        self._load()
+
+    def action_open_apply(self) -> None:
+        """``a`` — push the apply confirm modal."""
+        if self._batch is None:
+            return
+        pending = self._batch.pending_count
+        if pending == 0:
+            self._set_notice("nothing to apply — all lines are excluded or already promoted")
+            return
+
+        modal = ApplyConfirmModal(pending_count=pending)
+        self.app.push_screen(modal, self._on_apply_modal_done)
+
+    def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
+        """Re-render the detail pane to match the newly-highlighted row."""
+        self._refresh_detail()
+
+    # -- internals -----------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            data = self._loader()
+        except Exception as exc:
+            self._render_error(exc)
+            return
+        self._populate(data)
+
+    def _populate(self, data: ImportBatchDetail) -> None:
+        self._batch = data
+        table = self.query_one("#ibd-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        header_text = (
+            f"[b]{data.source_format.upper()}[/b] {data.source_filename}    "
+            f"id={data.id[:8] if data.id else '—'}    status={data.status}"
+        )
+        self._set_header(header_text)
+        self._set_status(
+            f"{data.pending_count} pending · "
+            f"{data.excluded_count} excluded · "
+            f"{data.promoted_count} promoted"
+            + (f"    [dim]{self._notice}[/dim]" if self._notice else "")
+        )
+        if not data.lines:
+            self._set_detail("No statement lines.")
+            return
+        for line in data.lines:
+            cells = _row_for(line)
+            table.add_row(*cells)
+            self._rendered_rows.append(" ".join(cells))
+            self._index.append(line)
+        self._refresh_detail()
+
+    def _refresh_detail(self) -> None:
+        if not self._index:
+            return
+        table = self.query_one("#ibd-table", DataTable)
+        cursor = max(0, table.cursor_row)
+        if cursor >= len(self._index):
+            return
+        self._set_detail(_detail_for(self._index[cursor]))
+
+    def _cursor_line(self) -> StatementLineSummary | None:
+        if not self._index:
+            return None
+        table = self.query_one("#ibd-table", DataTable)
+        cursor = max(0, table.cursor_row)
+        if cursor >= len(self._index):
+            return None
+        return self._index[cursor]
+
+    def _on_apply_modal_done(self, result: tuple[bool, bool, bool] | None) -> None:
+        if result is None:
+            self._set_notice("apply cancelled")
+            self._refresh_status_with_notice()
+            return
+        as_posted, no_categorize, treat_cleared = result
+        try:
+            response = self._on_apply(as_posted, no_categorize, treat_cleared)
+        except Exception as exc:
+            self._set_notice(f"[red]apply failed:[/red] {exc}")
+            self._refresh_status_with_notice()
+            return
+        # Show the created count when the API returned the standard body.
+        created = response.get("created_count") if isinstance(response, dict) else None
+        if isinstance(created, int):
+            self._set_notice(f"applied — {created} transaction(s) created")
+        else:
+            self._set_notice("applied")
+        self.app.pop_screen()
+
+    def _render_error(self, exc: BaseException) -> None:
+        table = self.query_one("#ibd-table", DataTable)
+        table.clear()
+        self._rendered_rows = []
+        self._index = []
+        self._batch = None
+        self._set_header("[red]error loading batch[/red]")
+        self._set_status(f"[red]error:[/red] {exc}")
+        self._set_detail(f"error: {exc}")
+
+    def _set_header(self, text: str) -> None:
+        self._header = text
+        self.query_one("#ibd-header", Static).update(text)
+
+    def _set_status(self, text: str) -> None:
+        self._status = text
+        self.query_one("#ibd-status", Static).update(text)
+
+    def _set_detail(self, text: str) -> None:
+        self._detail = text
+        self.query_one("#ibd-detail", Static).update(text)
+
+    def _set_notice(self, text: str) -> None:
+        self._notice = text
+
+    def _refresh_status_with_notice(self) -> None:
+        if self._batch is None:
+            return
+        data = self._batch
+        self._set_status(
+            f"{data.pending_count} pending · "
+            f"{data.excluded_count} excluded · "
+            f"{data.promoted_count} promoted"
+            + (f"    [dim]{self._notice}[/dim]" if self._notice else "")
+        )
+
+    # -- introspection used by tests ----------------------------------
+
+    def rendered_rows(self) -> list[str]:
+        """Return a string-only mirror of the table's rows for assertions."""
+        return list(self._rendered_rows)
+
+    def header_text(self) -> str:
+        """Return the current header text as plain string."""
+        return self._header
+
+    def status_text(self) -> str:
+        """Return the current status-strip text as a plain string."""
+        return self._status
+
+    def detail_text(self) -> str:
+        """Return the current detail-pane text as a plain string."""
+        return self._detail
+
+    def notice(self) -> str:
+        """Return the last action notice (set by exclude/promote/apply)."""
+        return self._notice

--- a/packages/tulip-tui/src/tulip_tui/screens/imports.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/imports.py
@@ -19,6 +19,11 @@ from textual.widgets import DataTable, Footer, Header, Static
 from tulip_tui.data.imports import ImportBatchSummary, ImportsData
 
 ImportsLoader = Callable[[], ImportsData]
+OpenBatchHandler = Callable[[str], None]
+
+
+def _noop_open_batch(_batch_id: str) -> None:
+    """Default drill-in handler — used when no detail screen is wired."""
 
 
 def _row_for(batch: ImportBatchSummary) -> tuple[str, str, str, str, str]:
@@ -83,10 +88,16 @@ class ImportsScreen(Screen[None]):
     }
     """
 
-    def __init__(self, loader: ImportsLoader) -> None:
-        """Store the loader; the screen populates on mount."""
+    def __init__(
+        self,
+        loader: ImportsLoader,
+        *,
+        on_open_batch: OpenBatchHandler = _noop_open_batch,
+    ) -> None:
+        """Store the loader and the drill-in callback used by ``enter``."""
         super().__init__()
         self._loader = loader
+        self._on_open_batch = on_open_batch
         self._rendered_rows: list[str] = []
         self._index: list[ImportBatchSummary] = []
         self._detail: str = ""
@@ -113,6 +124,16 @@ class ImportsScreen(Screen[None]):
     def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
         """Re-render the detail pane to match the newly-highlighted row."""
         self._refresh_detail()
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """``enter`` drills into the per-batch detail screen (P9.6.a)."""
+        index = event.cursor_row
+        if index < 0 or index >= len(self._index):
+            return
+        batch = self._index[index]
+        if not batch.id:
+            return
+        self._on_open_batch(batch.id)
 
     # -- internals -----------------------------------------------------
 

--- a/packages/tulip-tui/tests/test_import_batch_detail_data.py
+++ b/packages/tulip-tui/tests/test_import_batch_detail_data.py
@@ -1,0 +1,285 @@
+"""Unit tests for ``tulip_tui.data.import_batch_detail`` (P9.6.a).
+
+Covers the per-batch detail loader plus the three action wrappers
+(``patch_line_excluded`` / ``promote_line`` / ``apply_batch``). All
+tests use ``httpx.MockTransport`` so the live API is never touched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tulip_cli.config import Config
+from tulip_cli.http import TulipClient
+from tulip_tui.data.import_batch_detail import (
+    ImportBatchDetail,
+    StatementLineSummary,
+    apply_batch,
+    load_import_batch_detail,
+    patch_line_excluded,
+    promote_line,
+)
+
+
+class _FakeTokenStore:
+    def load(self, _api_url: str) -> object:
+        return SimpleNamespace(
+            email="t@example.invalid",
+            access_token="fake-access-token",
+            refresh_token="fake-refresh-token",
+            access_expires_at=2**31 - 1,
+        )
+
+    def save(self, _api_url: str, _tokens: object) -> None: ...
+    def clear(self, _api_url: str) -> None: ...
+
+
+def _build_client(handler: httpx.MockTransport) -> TulipClient:
+    return TulipClient(
+        Config(api_url="https://example.invalid"),
+        token_store=_FakeTokenStore(),  # type: ignore[arg-type]
+        transport=handler,
+    )
+
+
+_BATCH_PAYLOAD: dict[str, object] = {
+    "id": "batch-1",
+    "account_id": "acc-1",
+    "source_format": "ofx",
+    "source_filename": "april.qfx",
+    "status": "parsed",
+    "imported_count": 3,
+    "skipped_count": 0,
+    "error_count": 0,
+    "created_at": "2026-05-01T12:00:00Z",
+    "applied_at": None,
+    "reverted_at": None,
+    "lines": [
+        {
+            "id": "line-1",
+            "line_number": 1,
+            "posted_date": "2026-05-01",
+            "amount": "-42.17",
+            "currency": "USD",
+            "description": "AMAZON",
+            "counterparty": None,
+            "reference": None,
+            "fitid": "F1",
+            "is_excluded": False,
+            "reconciliation_match_id": None,
+            "promoted_transaction_id": None,
+        },
+        {
+            "id": "line-2",
+            "line_number": 2,
+            "posted_date": "2026-05-02",
+            "amount": "-12.50",
+            "currency": "USD",
+            "description": "LUNCH",
+            "counterparty": None,
+            "reference": None,
+            "fitid": "F2",
+            "is_excluded": True,
+            "reconciliation_match_id": None,
+            "promoted_transaction_id": None,
+        },
+        {
+            "id": "line-3",
+            "line_number": 3,
+            "posted_date": "2026-05-03",
+            "amount": "100.00",
+            "currency": "USD",
+            "description": "PAYCHECK",
+            "counterparty": None,
+            "reference": None,
+            "fitid": "F3",
+            "is_excluded": False,
+            "reconciliation_match_id": None,
+            "promoted_transaction_id": "tx-99",
+        },
+    ],
+}
+
+
+def test_load_import_batch_detail_round_trips() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/imports/batch-1"
+        return httpx.Response(200, json=_BATCH_PAYLOAD)
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_import_batch_detail(client, "batch-1")
+
+    assert isinstance(data, ImportBatchDetail)
+    assert data.id == "batch-1"
+    assert data.source_format == "ofx"
+    assert len(data.lines) == 3
+    assert isinstance(data.lines[0], StatementLineSummary)
+
+
+def test_load_import_batch_detail_classifies_statuses() -> None:
+    with _build_client(
+        httpx.MockTransport(lambda _r: httpx.Response(200, json=_BATCH_PAYLOAD))
+    ) as client:
+        data = load_import_batch_detail(client, "batch-1")
+
+    by_id = {line.id: line for line in data.lines}
+    assert by_id["line-1"].status == "pending"
+    assert by_id["line-2"].status == "excluded"
+    assert by_id["line-3"].status == "promoted"
+
+    assert data.pending_count == 1
+    assert data.excluded_count == 1
+    assert data.promoted_count == 1
+
+
+def test_load_import_batch_detail_handles_empty_lines() -> None:
+    payload = dict(_BATCH_PAYLOAD)
+    payload["lines"] = []
+    with _build_client(httpx.MockTransport(lambda _r: httpx.Response(200, json=payload))) as client:
+        data = load_import_batch_detail(client, "batch-1")
+    assert data.lines == ()
+    assert data.pending_count == 0
+
+
+def test_load_import_batch_detail_amount_display_formatted() -> None:
+    with _build_client(
+        httpx.MockTransport(lambda _r: httpx.Response(200, json=_BATCH_PAYLOAD))
+    ) as client:
+        data = load_import_batch_detail(client, "batch-1")
+    assert data.lines[0].amount_display == "-42.17"
+    assert data.lines[2].amount_display == "100.00"
+
+
+def test_load_import_batch_detail_raises_on_404() -> None:
+    from tulip_cli.errors import CliError
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            404,
+            json={
+                "type": "/.well-known/errors/import_batch.not_found",
+                "title": "Not found",
+                "status": 404,
+                "detail": "x",
+                "instance": "",
+                "code": "import_batch.not_found",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client, pytest.raises(CliError):
+        load_import_batch_detail(client, "missing")
+
+
+def test_patch_line_excluded_sends_body() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        import json
+
+        seen["body"] = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "id": "line-1",
+                "line_number": 1,
+                "posted_date": "2026-05-01",
+                "amount": "-42.17",
+                "currency": "USD",
+                "description": "AMAZON",
+                "counterparty": None,
+                "reference": None,
+                "fitid": None,
+                "is_excluded": True,
+                "reconciliation_match_id": None,
+                "promoted_transaction_id": None,
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        patch_line_excluded(client, "batch-1", "line-1", is_excluded=True)
+
+    assert seen["method"] == "PATCH"
+    assert seen["path"] == "/v1/imports/batch-1/lines/line-1"
+    assert seen["body"] == {"is_excluded": True}
+
+
+def test_promote_line_calls_promote_endpoint() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(
+            201,
+            json={
+                "statement_line_id": "line-1",
+                "transaction_id": "tx-new",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        promote_line(client, "batch-1", "line-1")
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/imports/batch-1/lines/line-1/promote"
+
+
+def test_apply_batch_passes_flags_as_query_params() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["query"] = dict(request.url.params)
+        return httpx.Response(
+            200,
+            json={
+                "batch_id": "batch-1",
+                "status": "applied",
+                "created_count": 3,
+                "skipped_count": 0,
+                "transaction_ids": ["t1", "t2", "t3"],
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        result = apply_batch(
+            client,
+            "batch-1",
+            as_posted=True,
+            no_categorize=False,
+            treat_cleared_as_pending=True,
+        )
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/imports/batch-1/apply"
+    # ``no_categorize=False`` must NOT appear in the query string.
+    assert seen["query"] == {"as_posted": "true", "treat_cleared_as_pending": "true"}
+    assert result["created_count"] == 3
+
+
+def test_apply_batch_with_no_flags_omits_params() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["query"] = dict(request.url.params)
+        return httpx.Response(
+            200,
+            json={
+                "batch_id": "batch-1",
+                "status": "applied",
+                "created_count": 0,
+                "skipped_count": 0,
+                "transaction_ids": [],
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        apply_batch(client, "batch-1")
+
+    assert seen["query"] == {}

--- a/packages/tulip-tui/tests/test_import_batch_detail_screen.py
+++ b/packages/tulip-tui/tests/test_import_batch_detail_screen.py
@@ -1,0 +1,482 @@
+"""Pilot-mode tests for the import-batch detail screen (P9.6.a).
+
+Covers the row rendering, the `x`/`p`/`a` action bindings, the apply
+confirm modal, refresh, error rendering, and the `i` → `enter` drill-in
+from the list screen.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
+from tulip_tui.data.import_batch_detail import (
+    ImportBatchDetail,
+    StatementLineSummary,
+)
+from tulip_tui.data.imports import ImportBatchSummary, ImportsData
+from tulip_tui.screens.import_batch_detail import (
+    ApplyConfirmModal,
+    ImportBatchDetailScreen,
+)
+
+
+def _accounts_loader() -> AccountsData:
+    return AccountsData(as_of="2026-05-17", accounts=(), groups=())
+
+
+def _sample_detail() -> ImportBatchDetail:
+    return ImportBatchDetail(
+        id="batch-1",
+        account_id="acc-1",
+        source_format="ofx",
+        source_filename="april.qfx",
+        status="parsed",
+        imported_count=3,
+        skipped_count=0,
+        error_count=0,
+        created_at="2026-05-01T12:00:00Z",
+        applied_at=None,
+        reverted_at=None,
+        lines=(
+            StatementLineSummary(
+                id="line-1",
+                line_number=1,
+                date="2026-05-01",
+                description="AMAZON",
+                amount_display="-42.17",
+                currency="USD",
+                is_excluded=False,
+                promoted_transaction_id=None,
+                reconciliation_match_id=None,
+            ),
+            StatementLineSummary(
+                id="line-2",
+                line_number=2,
+                date="2026-05-02",
+                description="LUNCH",
+                amount_display="-12.50",
+                currency="USD",
+                is_excluded=True,
+                promoted_transaction_id=None,
+                reconciliation_match_id=None,
+            ),
+            StatementLineSummary(
+                id="line-3",
+                line_number=3,
+                date="2026-05-03",
+                description="PAYCHECK",
+                amount_display="100.00",
+                currency="USD",
+                is_excluded=False,
+                promoted_transaction_id="tx-99",
+                reconciliation_match_id=None,
+            ),
+        ),
+    )
+
+
+def _empty_detail() -> ImportBatchDetail:
+    return ImportBatchDetail(
+        id="batch-0",
+        account_id="acc-1",
+        source_format="csv",
+        source_filename="empty.csv",
+        status="parsed",
+        imported_count=0,
+        skipped_count=0,
+        error_count=0,
+        created_at="2026-05-01T12:00:00Z",
+        applied_at=None,
+        reverted_at=None,
+        lines=(),
+    )
+
+
+def _noop_exclude(_line_id: str, _is_excluded: bool) -> None: ...
+
+
+def _noop_promote(_line_id: str) -> None: ...
+
+
+def _noop_apply(*_args: object, **_kwargs: object) -> dict[str, object]:
+    return {"created_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_detail_screen_renders_lines_with_status_markers() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_sample_detail,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=_noop_promote,
+            on_apply=_noop_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        rows = screen.rendered_rows()
+
+    assert len(rows) == 3
+    assert "AMAZON" in rows[0] and "pending" in rows[0]
+    assert "LUNCH" in rows[1] and "excluded" in rows[1]
+    assert "PAYCHECK" in rows[2] and "promoted" in rows[2]
+
+
+@pytest.mark.asyncio
+async def test_detail_screen_status_strip_counts() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_sample_detail,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=_noop_promote,
+            on_apply=_noop_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        status = screen.status_text()
+
+    assert "1 pending" in status
+    assert "1 excluded" in status
+    assert "1 promoted" in status
+
+
+@pytest.mark.asyncio
+async def test_detail_screen_empty_state() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_empty_detail,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=_noop_promote,
+            on_apply=_noop_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "No statement lines" in screen.detail_text()
+
+
+@pytest.mark.asyncio
+async def test_detail_screen_error_path() -> None:
+    def _boom() -> ImportBatchDetail:
+        raise RuntimeError("offline")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_boom,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=_noop_promote,
+            on_apply=_noop_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        status = screen.status_text()
+
+    assert "error" in status.lower()
+    assert "offline" in status
+
+
+@pytest.mark.asyncio
+async def test_exclude_binding_calls_action_and_reloads() -> None:
+    calls: list[tuple[str, bool]] = []
+
+    def on_toggle(line_id: str, is_excluded: bool) -> None:
+        calls.append((line_id, is_excluded))
+
+    state = {"data": _sample_detail()}
+
+    def loader() -> ImportBatchDetail:
+        return state["data"]
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=loader,
+            on_toggle_exclude=on_toggle,
+            on_promote=_noop_promote,
+            on_apply=_noop_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        # Cursor at row 0 (line-1, pending) — `x` should exclude.
+        await pilot.press("x")
+        await pilot.pause()
+
+    assert calls == [("line-1", True)]
+    assert "excluded" in screen.notice()
+
+
+@pytest.mark.asyncio
+async def test_exclude_binding_refuses_promoted_line() -> None:
+    calls: list[tuple[str, bool]] = []
+
+    def on_toggle(line_id: str, is_excluded: bool) -> None:
+        calls.append((line_id, is_excluded))
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_sample_detail,
+            on_toggle_exclude=on_toggle,
+            on_promote=_noop_promote,
+            on_apply=_noop_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        # Move cursor to line-3 (promoted), then `x`.
+        await pilot.press("down", "down")
+        await pilot.pause()
+        await pilot.press("x")
+        await pilot.pause()
+
+    # No action call should fire; notice tells the user why.
+    assert calls == []
+    assert "promoted" in screen.notice().lower()
+
+
+@pytest.mark.asyncio
+async def test_promote_binding_calls_action_and_reloads() -> None:
+    calls: list[str] = []
+
+    def on_promote(line_id: str) -> None:
+        calls.append(line_id)
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_sample_detail,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=on_promote,
+            on_apply=_noop_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("p")
+        await pilot.pause()
+
+    assert calls == ["line-1"]
+    assert "promoted" in screen.notice()
+
+
+@pytest.mark.asyncio
+async def test_promote_binding_refuses_excluded_line() -> None:
+    calls: list[str] = []
+
+    def on_promote(line_id: str) -> None:
+        calls.append(line_id)
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_sample_detail,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=on_promote,
+            on_apply=_noop_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        # Move to line-2 (excluded), then `p`.
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("p")
+        await pilot.pause()
+
+    assert calls == []
+    assert "excluded" in screen.notice().lower()
+
+
+@pytest.mark.asyncio
+async def test_apply_modal_renders_with_pending_count() -> None:
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_sample_detail,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=_noop_promote,
+            on_apply=_noop_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+        # Modal is now on top — find it.
+        modals = [s for s in app.screen_stack if isinstance(s, ApplyConfirmModal)]
+        assert len(modals) == 1
+        # Pending count from _sample_detail = 1.
+        title_widget = modals[0].query_one("#apply-title")
+        title_str = str(title_widget.render())
+        assert "Apply 1 line(s)" in title_str
+
+
+@pytest.mark.asyncio
+async def test_apply_modal_cancel_clears_notice() -> None:
+    apply_calls: list[tuple[bool, bool, bool]] = []
+
+    def on_apply(a: bool, b: bool, c: bool) -> dict[str, object]:
+        apply_calls.append((a, b, c))
+        return {"created_count": 99}
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_sample_detail,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=_noop_promote,
+            on_apply=on_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+        await pilot.press("escape")  # cancel
+        await pilot.pause()
+
+    assert apply_calls == []
+    assert "cancel" in screen.notice().lower()
+
+
+@pytest.mark.asyncio
+async def test_apply_modal_confirm_fires_action() -> None:
+    apply_calls: list[tuple[bool, bool, bool]] = []
+
+    def on_apply(a: bool, b: bool, c: bool) -> dict[str, object]:
+        apply_calls.append((a, b, c))
+        return {"created_count": 5}
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=_sample_detail,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=_noop_promote,
+            on_apply=on_apply,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+        modal = next(s for s in app.screen_stack if isinstance(s, ApplyConfirmModal))
+        # Dismiss programmatically with all defaults (all False).
+        modal.dismiss(modal.snapshot_flags())
+        await pilot.pause()
+
+    assert apply_calls == [(False, False, False)]
+
+
+@pytest.mark.asyncio
+async def test_apply_blocked_when_nothing_pending() -> None:
+    # Detail with every line already promoted.
+    detail = ImportBatchDetail(
+        id="batch-2",
+        account_id="acc-1",
+        source_format="ofx",
+        source_filename="x.qfx",
+        status="parsed",
+        imported_count=1,
+        skipped_count=0,
+        error_count=0,
+        created_at="2026-05-01T12:00:00Z",
+        applied_at=None,
+        reverted_at=None,
+        lines=(
+            StatementLineSummary(
+                id="line-x",
+                line_number=1,
+                date="2026-05-01",
+                description="X",
+                amount_display="1.00",
+                currency="USD",
+                is_excluded=False,
+                promoted_transaction_id="tx-1",
+                reconciliation_match_id=None,
+            ),
+        ),
+    )
+    apply_calls: list[object] = []
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ImportBatchDetailScreen(
+            loader=lambda: detail,
+            on_toggle_exclude=_noop_exclude,
+            on_promote=_noop_promote,
+            on_apply=lambda *_args: apply_calls.append(_args) or {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+
+    modals = [s for s in app.screen_stack if isinstance(s, ApplyConfirmModal)]
+    assert modals == []
+    assert "nothing to apply" in screen.notice().lower()
+
+
+@pytest.mark.asyncio
+async def test_imports_screen_enter_drills_into_detail() -> None:
+    drilled: list[str] = []
+
+    imports = ImportsData(
+        batches=(
+            ImportBatchSummary(
+                id="batch-1",
+                account_id="acc-1",
+                source_format="ofx",
+                source_filename="april.qfx",
+                status="parsed",
+                imported_count=1,
+                skipped_count=0,
+                error_count=0,
+                created_at="2026-05-01T12:00:00Z",
+                applied_at=None,
+                reverted_at=None,
+            ),
+        ),
+    )
+
+    app = TulipTuiApp(
+        loader=_accounts_loader,
+        imports_loader=lambda: imports,
+        import_batch_detail_factory=lambda batch_id: lambda: _sample_detail(),
+        line_exclude_action=lambda *_args: None,
+        line_promote_action=lambda *_args: None,
+        batch_apply_action=lambda *_args: {},
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("i")  # open imports screen
+        await pilot.pause()
+        # Patch the imports-screen handler to capture the batch id.
+        from tulip_tui.screens.imports import ImportsScreen
+
+        imports_screen = next(s for s in app.screen_stack if isinstance(s, ImportsScreen))
+        original = imports_screen._on_open_batch  # type: ignore[attr-defined]
+
+        def _capture(batch_id: str) -> None:
+            drilled.append(batch_id)
+            original(batch_id)
+
+        imports_screen._on_open_batch = _capture  # type: ignore[attr-defined]
+        await pilot.press("enter")
+        await pilot.pause()
+        # Detail screen should now be on top of the stack — check inside the
+        # async-test context so the app is still live.
+        detail_present = any(isinstance(s, ImportBatchDetailScreen) for s in app.screen_stack)
+
+    assert drilled == ["batch-1"]
+    assert detail_present


### PR DESCRIPTION
## Summary

- First slice of the P9.6 mutation wave (umbrella #414). Adds the
  smallest mutation surface that removes a CLI→TUI bounce: a per-batch
  detail screen with line review + the apply flow inline.
- New `PATCH /v1/imports/{batch_id}/lines/{line_id}` endpoint toggles
  `is_excluded` (idempotent no-op when the flag matches; 409
  `import.line.already_promoted` if the line has been promoted; audit
  rows `statement_line.excluded` / `statement_line.unexcluded`).
- New `ImportBatchDetailScreen` reachable with `enter` on the imports
  browser. Bindings: `x` toggle exclude/un-exclude · `p` promote one
  line · `a` apply confirm modal with the three apply-flag toggles
  (`--as-posted`, `--no-categorize`, `--treat-cleared-as-pending`).
- ADR-0007 amended under "Status update mechanism" recording the
  scope extension; PHASE_STATUS.md gains a P9.6 section + P9.6.a
  subsection.

31 new tests (1 storage / 8 API / 9 data / 13 pilot-mode screen).

## Test plan

\`\`\`bash
uv run --package tulip-storage pytest packages/tulip-storage/tests/test_p51_repositories.py -q
uv run --package tulip-api pytest packages/tulip-api/tests/test_apply_promote_endpoints.py -q
uv run --package tulip-tui pytest packages/tulip-tui/tests/ -q
just lint
just typecheck
\`\`\`

- [x] storage suite green locally (29 passed)
- [x] API apply/promote tests green (32 passed incl. 8 new)
- [x] TUI suite green (106 passed incl. 22 new)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (Success: no issues found in 301 source files)
- [ ] CI green on this PR

### Manual smoke test (against a local API + parsed batch)

\`\`\`bash
just dev
\`\`\`

In a second terminal:

\`\`\`bash
tulip register --household Smoke --email me@example.invalid --display-name Me --password-stdin <<<'correct horse battery staple'
tulip auth login --email me@example.invalid --password-stdin <<<'correct horse battery staple'
tulip accounts add --name Checking --type asset --currency USD --code 1110
tulip imports ofx \$(tulip accounts show 1110 --json | jq -r '.id') docs/quickstart-fixtures/sample-statement.ofx
tulip-tui
\`\`\`

Inside the TUI:

1. Press \`i\` to open the imports browser.
2. \`enter\` on the row to drill into the detail screen.
3. Verify the line table renders with pending markers; cursor down
   the rows and confirm the detail pane follows.
4. Press \`x\` on the first row — status flips to \"excluded\", notice
   strip shows \`excluded\`.
5. Press \`x\` again — flips back to \"pending\", notice shows
   \`un-excluded\`.
6. Press \`p\` on a pending line — status flips to \"promoted\", notice
   shows \`promoted\`.
7. Press \`p\` again on the same row — refuses (\"line is promoted\").
8. Press \`a\` — modal appears with \"Apply N line(s)?\"; toggle one or
   more switches, click \"Apply\". Modal dismisses and the detail
   screen pops back to the imports list with the created count in the
   notice.