### PR TITLE
fix(cli): edit/void/delete fall back to interactive picker (closes #303)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -754,12 +754,16 @@ def show_transaction(
 def void_transaction(
     ctx: typer.Context,
     tx_id: Annotated[
-        str,
+        str | None,
         typer.Argument(
-            help="Transaction UUID or unambiguous hex prefix to void.",
+            help=(
+                "Transaction UUID or unambiguous hex prefix to void. Omit to "
+                "pick interactively from recent transactions (TTY only — "
+                "scripts still get the usage error)."
+            ),
             metavar="TXID",
         ),
-    ],
+    ] = None,
     reason: Annotated[
         str,
         typer.Option(
@@ -767,7 +771,7 @@ def void_transaction(
             "-r",
             help="Reason for the void; surfaced in the reversal's description.",
         ),
-    ],
+    ] = "",
     yes: Annotated[
         bool,
         typer.Option(
@@ -790,6 +794,14 @@ def void_transaction(
     """Void a POSTED transaction by posting a sign-flipped sibling reversal."""
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
+
+    if tx_id is None:
+        tx_id = _pick_tx_id(config, as_json=as_json)
+        if tx_id is None:
+            raise typer.Exit(2)
+
+    if not reason:
+        raise typer.BadParameter("--reason is required (use -r/--reason).")
 
     if reversal_date is not None:
         _validate_iso_date(reversal_date, flag="--date")
@@ -831,12 +843,16 @@ def void_transaction(
 def delete_transaction(
     ctx: typer.Context,
     tx_id: Annotated[
-        str,
+        str | None,
         typer.Argument(
-            help="Transaction UUID or unambiguous hex prefix to delete.",
+            help=(
+                "Transaction UUID or unambiguous hex prefix to delete. Omit "
+                "to pick interactively from recent transactions (TTY only — "
+                "scripts still get the usage error)."
+            ),
             metavar="TXID",
         ),
-    ],
+    ] = None,
     yes: Annotated[
         bool,
         typer.Option(
@@ -849,6 +865,11 @@ def delete_transaction(
     """Hard-delete a PENDING transaction. Use ``void`` for POSTED transactions."""
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
+
+    if tx_id is None:
+        tx_id = _pick_tx_id(config, as_json=as_json)
+        if tx_id is None:
+            raise typer.Exit(2)
 
     try:
         with _client(config, as_json=as_json) as client:
@@ -955,12 +976,16 @@ def _prompt_reconciled_edit(reconciliation_hint: str) -> str:
 def edit_transaction(
     ctx: typer.Context,
     tx_id: Annotated[
-        str,
+        str | None,
         typer.Argument(
-            help="Transaction UUID or unambiguous hex prefix to edit.",
+            help=(
+                "Transaction UUID or unambiguous hex prefix to edit. Omit to "
+                "pick interactively from recent transactions (TTY only — "
+                "scripts still get the usage error)."
+            ),
             metavar="TXID",
         ),
-    ],
+    ] = None,
     force_reconciled_edit: Annotated[
         bool,
         typer.Option(
@@ -997,6 +1022,11 @@ def edit_transaction(
 
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
+
+    if tx_id is None:
+        tx_id = _pick_tx_id(config, as_json=as_json)
+        if tx_id is None:
+            raise typer.Exit(2)
 
     try:
         with _client(config, as_json=as_json) as client:

--- a/packages/tulip-cli/tests/test_picker_integration.py
+++ b/packages/tulip-cli/tests/test_picker_integration.py
@@ -408,3 +408,27 @@ def test_reconcile_show_missing_arg_non_tty_exits_2() -> None:
     result = _run_cli_no_tty("reconcile", "show")
     assert result.returncode == 2, result.stdout + result.stderr
     assert "Missing argument RECONCILIATION_ID" in result.stderr
+
+
+# ---- #303: edit / void / delete fall back to the picker -----------------
+
+
+def test_transactions_void_missing_arg_non_tty_exits_2() -> None:
+    """`tulip transactions void` with no TXID, no TTY → usage error, exit 2."""
+    result = _run_cli_no_tty("transactions", "void", "--reason", "x")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Missing argument TXID" in result.stderr
+
+
+def test_transactions_delete_missing_arg_non_tty_exits_2() -> None:
+    """`tulip transactions delete` with no TXID, no TTY → usage error, exit 2."""
+    result = _run_cli_no_tty("transactions", "delete")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Missing argument TXID" in result.stderr
+
+
+def test_transactions_edit_missing_arg_non_tty_exits_2() -> None:
+    """`tulip transactions edit` with no TXID, no TTY → usage error, exit 2."""
+    result = _run_cli_no_tty("transactions", "edit")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Missing argument TXID" in result.stderr


### PR DESCRIPTION
## Summary

- Mirror the picker fallback shipped by \`tulip transactions show\`:
  when \`TXID\` is omitted at a TTY, prompt the user with a picker of
  recent transactions. Scripts (non-TTY / \`--json\`) still surface the
  \"Missing argument TXID\" usage error and exit 2, so automation
  breaks cleanly.
- Applies to \`tulip transactions {edit, void, delete}\`.
- \`tulip transactions void\` now checks \`--reason\` after the picker so
  an interactive cancel doesn't error on the required flag.

3 new end-to-end picker tests (non-TTY exit-2 paths). Lint + mypy
--strict clean.

## Test plan

\`\`\`bash
uv run --package tulip-cli pytest packages/tulip-cli/tests/test_picker_integration.py -q
just lint
just typecheck
\`\`\`

- [x] picker integration suite green (17 passed)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean
- [ ] CI green on this PR

### Manual smoke test

\`\`\`bash
just dev &
tulip register --household Pick --email me@example.invalid --display-name Me --password-stdin <<<'correct horse battery staple'
tulip auth login --email me@example.invalid --password-stdin <<<'correct horse battery staple'
tulip accounts add --name Checking --type asset --currency USD --code 1110
tulip accounts add --name Food --type expense --currency USD --code 5100
tulip add --date 2026-05-20 --description 'Lunch' --post 1110=-12.50 --post 5100=12.50
\`\`\`

Then run interactively:

\`\`\`bash
tulip transactions void --reason 'wrong amount'  # picker opens
tulip transactions delete                        # picker opens
tulip transactions edit                          # picker opens
\`\`\`

Compare with non-TTY (still errors with exit 2):

\`\`\`bash
echo '' | tulip transactions void --reason 'x'   # exit 2, "Missing argument TXID"
\`\`\`