### PR TITLE
P9.6.b — Reconcile actioning in the TUI (closes #420)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -1824,6 +1824,43 @@ mutations that makes the TUI a daily driver, in dependency order.
 ADR-0007 amended under "Status update mechanism" recording the
 scope extension.
 
+#### P9.6.b — Reconcile actioning in the TUI — ✅ *(2026-05-20)*
+
+Per [#420](https://github.com/rmwarriner/tulip-accounting/issues/420). New `ReconciliationDetailScreen` reachable with
+`enter` on a row in the reconciliations browser. Renders three
+stacked tables — Matches / Unmatched Lines / Unmatched
+Transactions — plus a header (period / opening + closing balances /
+paper-or-imported marker / status) and a cursor-driven detail pane.
+Six new bindings turn the whole reconciliation workflow into
+in-TUI actions:
+
+- **`a`** runs auto-match via
+  `POST /v1/reconciliations/{id}/auto-match` (refused if matches
+  already exist; reject one first to re-run).
+- **`x`** rejects the focused match (matches-table-only) via
+  `POST /v1/reconciliations/{id}/matches/{id}/reject`.
+- **`m`** opens a `ManualMatchPickerModal` listing the unmatched
+  ledger transactions; user picks one to pair with the focused
+  unmatched line. Amount + currency default to the line's. Fires
+  `POST /v1/reconciliations/{id}/matches`.
+- **`k`** mark-cleared via
+  `POST /v1/reconciliations/{id}/paper-matches` on paper recons
+  only (the API enforces; the screen renders a notice on imported
+  recons rather than calling the endpoint).
+- **`f`** carry-forward the focused unmatched tx via
+  `POST /v1/reconciliations/{id}/carry-forward`.
+- **`c`** completes the reconciliation via
+  `POST /v1/reconciliations/{id}/complete` (the server's balance
+  check surfaces inline if the envelope isn't balanced).
+
+No backend changes — every endpoint shipped with P5.4.a/b/c/d.
+Tests: 11 data-layer tests (loader + classify match-kind +
+paper-flag + amount-fmt + 404 + the six action wrappers' wire
+shapes), 16 pilot-mode screen tests (rendering across the three
+tables, every binding's happy + refuse path, modal open + confirm,
+inline error on load failure, drill-in from the reconciliations
+list).
+
 #### P9.6.a — Apply imports inside the TUI — ✅ *(2026-05-20)*
 
 Per [#418](https://github.com/rmwarriner/tulip-accounting/issues/418). New `ImportBatchDetailScreen` reachable with

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -25,6 +25,7 @@ from tulip_tui.data.envelopes import EnvelopesData
 from tulip_tui.data.import_batch_detail import ImportBatchDetail
 from tulip_tui.data.imports import ImportsData
 from tulip_tui.data.pending import PendingData
+from tulip_tui.data.reconciliation_detail import ReconciliationDetail
 from tulip_tui.data.reconciliations import ReconciliationsData
 from tulip_tui.data.reports import ReportPayload, ReportSpec
 from tulip_tui.data.sinking_funds import SinkingFundsData
@@ -33,6 +34,7 @@ from tulip_tui.screens.envelopes import EnvelopesScreen
 from tulip_tui.screens.import_batch_detail import ImportBatchDetailScreen
 from tulip_tui.screens.imports import ImportsScreen
 from tulip_tui.screens.pending import PendingScreen
+from tulip_tui.screens.reconciliation_detail import ReconciliationDetailScreen
 from tulip_tui.screens.reconciliations import ReconciliationsScreen
 from tulip_tui.screens.reports import ReportsScreen
 from tulip_tui.screens.sinking_funds import SinkingFundsScreen
@@ -49,6 +51,14 @@ BatchApplyAction = Callable[[str, bool, bool, bool], object]
 EnvelopesLoader = Callable[[], EnvelopesData]
 SinkingFundsLoader = Callable[[], SinkingFundsData]
 PendingLoader = Callable[[], PendingData]
+
+ReconciliationDetailLoaderFactory = Callable[[str], Callable[[], ReconciliationDetail]]
+ReconciliationAutoMatchAction = Callable[[str], object]
+ReconciliationRejectAction = Callable[[str, str], None]
+ReconciliationManualMatchAction = Callable[[str, str, str, str, str], object]
+ReconciliationPaperMatchAction = Callable[[str, str], object]
+ReconciliationCarryForwardAction = Callable[[str, str], object]
+ReconciliationCompleteAction = Callable[[str], object]
 
 
 def _no_op_transactions_factory(_account_id: str | None) -> TransactionsLoader:
@@ -112,6 +122,45 @@ def _no_op_pending_loader() -> PendingData:
     raise RuntimeError("pending loader not configured")
 
 
+def _no_op_recon_detail_factory(
+    _reconciliation_id: str,
+) -> Callable[[], ReconciliationDetail]:
+    def _raise() -> ReconciliationDetail:
+        raise RuntimeError("reconciliation detail loader not configured")
+
+    return _raise
+
+
+def _no_op_recon_auto_match(_reconciliation_id: str) -> object:
+    raise RuntimeError("auto-match action not configured")
+
+
+def _no_op_recon_reject(_reconciliation_id: str, _match_id: str) -> None:
+    raise RuntimeError("reject action not configured")
+
+
+def _no_op_recon_manual_match(
+    _reconciliation_id: str,
+    _line_id: str,
+    _tx_id: str,
+    _amount: str,
+    _currency: str,
+) -> object:
+    raise RuntimeError("manual match action not configured")
+
+
+def _no_op_recon_paper_match(_reconciliation_id: str, _tx_id: str) -> object:
+    raise RuntimeError("paper match action not configured")
+
+
+def _no_op_recon_carry_forward(_reconciliation_id: str, _tx_id: str) -> object:
+    raise RuntimeError("carry-forward action not configured")
+
+
+def _no_op_recon_complete(_reconciliation_id: str) -> object:
+    raise RuntimeError("complete action not configured")
+
+
 class TulipTuiApp(App[None]):
     """Tulip TUI shell — boots into the accounts browser."""
 
@@ -144,6 +193,17 @@ class TulipTuiApp(App[None]):
         envelopes_loader: EnvelopesLoader = _no_op_envelopes_loader,
         sinking_funds_loader: SinkingFundsLoader = _no_op_sinking_funds_loader,
         pending_loader: PendingLoader = _no_op_pending_loader,
+        reconciliation_detail_factory: ReconciliationDetailLoaderFactory = (
+            _no_op_recon_detail_factory
+        ),
+        reconciliation_auto_match: ReconciliationAutoMatchAction = _no_op_recon_auto_match,
+        reconciliation_reject: ReconciliationRejectAction = _no_op_recon_reject,
+        reconciliation_manual_match: ReconciliationManualMatchAction = (_no_op_recon_manual_match),
+        reconciliation_paper_match: ReconciliationPaperMatchAction = _no_op_recon_paper_match,
+        reconciliation_carry_forward: ReconciliationCarryForwardAction = (
+            _no_op_recon_carry_forward
+        ),
+        reconciliation_complete: ReconciliationCompleteAction = _no_op_recon_complete,
     ) -> None:
         """Store the per-screen loaders / factories used at mount and drill-in."""
         super().__init__()
@@ -159,6 +219,13 @@ class TulipTuiApp(App[None]):
         self._envelopes_loader = envelopes_loader
         self._sinking_funds_loader = sinking_funds_loader
         self._pending_loader = pending_loader
+        self._reconciliation_detail_factory = reconciliation_detail_factory
+        self._reconciliation_auto_match = reconciliation_auto_match
+        self._reconciliation_reject = reconciliation_reject
+        self._reconciliation_manual_match = reconciliation_manual_match
+        self._reconciliation_paper_match = reconciliation_paper_match
+        self._reconciliation_carry_forward = reconciliation_carry_forward
+        self._reconciliation_complete = reconciliation_complete
 
     def on_mount(self) -> None:
         """Push the accounts browser as the initial screen."""
@@ -175,7 +242,30 @@ class TulipTuiApp(App[None]):
 
     def action_open_reconciliations(self) -> None:
         """Push the reconciliations browser onto the screen stack."""
-        self.push_screen(ReconciliationsScreen(loader=self._reconciliations_loader))
+        self.push_screen(
+            ReconciliationsScreen(
+                loader=self._reconciliations_loader,
+                on_open_reconciliation=self.open_reconciliation_detail,
+            )
+        )
+
+    def open_reconciliation_detail(self, reconciliation_id: str) -> None:
+        """Push the per-reconciliation actioning screen (P9.6.b)."""
+        loader = self._reconciliation_detail_factory(reconciliation_id)
+        rid = reconciliation_id
+        self.push_screen(
+            ReconciliationDetailScreen(
+                loader=loader,
+                on_auto_match=lambda: self._reconciliation_auto_match(rid),
+                on_reject=lambda match_id: self._reconciliation_reject(rid, match_id),
+                on_manual_match=lambda line_id, tx_id, amt, cur: self._reconciliation_manual_match(
+                    rid, line_id, tx_id, amt, cur
+                ),
+                on_paper_match=lambda tx_id: self._reconciliation_paper_match(rid, tx_id),
+                on_carry_forward=lambda tx_id: self._reconciliation_carry_forward(rid, tx_id),
+                on_complete=lambda: self._reconciliation_complete(rid),
+            )
+        )
 
     def action_open_imports(self) -> None:
         """Push the import batches browser onto the screen stack."""

--- a/packages/tulip-tui/src/tulip_tui/data/reconciliation_detail.py
+++ b/packages/tulip-tui/src/tulip_tui/data/reconciliation_detail.py
@@ -1,0 +1,273 @@
+"""Reconciliation-detail / inbox data adapter (P9.6.b).
+
+Wraps ``GET /v1/reconciliations/{id}`` into an immutable
+``ReconciliationDetail`` value object. Also provides thin wrappers
+around the per-action endpoints (auto-match, reject, manual match,
+paper match, carry-forward, complete) so the TUI screen just makes
+``Callable`` calls and never touches HTTP plumbing directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import cast
+
+from tulip_cli.http import TulipClient
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationEnvelope:
+    """Top-level reconciliation header — period + balances + status."""
+
+    id: str
+    account_id: str
+    statement_period_start: str
+    statement_period_end: str
+    statement_starting_balance: str
+    statement_ending_balance: str
+    currency: str
+    status: str
+    source_import_batch_id: str | None
+    created_at: str
+    completed_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class MatchSummary:
+    """One reconciliation match — line ↔ ledger transaction pair."""
+
+    id: str
+    statement_line_id: str | None
+    ledger_transaction_id: str
+    match_amount: str
+    currency: str
+    confidence: str | None
+    created_by_user_id: str | None
+    is_manual: bool
+
+
+@dataclass(frozen=True, slots=True)
+class UnmatchedLine:
+    """A statement line that has no match in this reconciliation yet."""
+
+    id: str
+    line_number: int
+    posted_date: str
+    amount_display: str
+    currency: str
+    description: str
+    reference: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class UnmatchedTransaction:
+    """A ledger transaction inside the statement period not yet matched."""
+
+    id: str
+    date: str
+    description: str
+    reference: str | None
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationDetail:
+    """Full inbox payload: envelope + matches + two unmatched lists."""
+
+    envelope: ReconciliationEnvelope
+    matches: tuple[MatchSummary, ...]
+    unmatched_lines: tuple[UnmatchedLine, ...]
+    unmatched_transactions: tuple[UnmatchedTransaction, ...]
+
+    @property
+    def is_paper(self) -> bool:
+        """A paper-statement reconciliation has no imported batch."""
+        return self.envelope.source_import_batch_id is None
+
+
+def load_reconciliation_detail(client: TulipClient, reconciliation_id: str) -> ReconciliationDetail:
+    """Fetch and parse ``/v1/reconciliations/{id}`` (the inbox view)."""
+    raw = client.get(f"/v1/reconciliations/{reconciliation_id}", authenticated=True).json()
+    return ReconciliationDetail(
+        envelope=_to_envelope(cast("dict[str, object]", raw.get("reconciliation", {}))),
+        matches=tuple(
+            _to_match(m) for m in cast("list[dict[str, object]]", raw.get("matches") or [])
+        ),
+        unmatched_lines=tuple(
+            _to_unmatched_line(line)
+            for line in cast("list[dict[str, object]]", raw.get("unmatched_statement_lines") or [])
+        ),
+        unmatched_transactions=tuple(
+            _to_unmatched_tx(tx)
+            for tx in cast(
+                "list[dict[str, object]]",
+                raw.get("unmatched_ledger_transactions") or [],
+            )
+        ),
+    )
+
+
+def auto_match(client: TulipClient, reconciliation_id: str) -> dict[str, object]:
+    """Call ``POST /v1/reconciliations/{id}/auto-match``."""
+    resp = client.post(
+        f"/v1/reconciliations/{reconciliation_id}/auto-match",
+        authenticated=True,
+    )
+    return cast("dict[str, object]", resp.json())
+
+
+def reject_match(client: TulipClient, reconciliation_id: str, match_id: str) -> None:
+    """Call ``POST /v1/reconciliations/{id}/matches/{match_id}/reject``."""
+    client.post(
+        f"/v1/reconciliations/{reconciliation_id}/matches/{match_id}/reject",
+        authenticated=True,
+    )
+
+
+def manual_match(
+    client: TulipClient,
+    reconciliation_id: str,
+    *,
+    statement_line_id: str,
+    ledger_transaction_id: str,
+    match_amount: str,
+    currency: str,
+) -> dict[str, object]:
+    """Call ``POST /v1/reconciliations/{id}/matches``."""
+    resp = client.post(
+        f"/v1/reconciliations/{reconciliation_id}/matches",
+        authenticated=True,
+        json={
+            "statement_line_id": statement_line_id,
+            "ledger_transaction_id": ledger_transaction_id,
+            "match_amount": match_amount,
+            "currency": currency,
+        },
+    )
+    return cast("dict[str, object]", resp.json())
+
+
+def paper_match(
+    client: TulipClient,
+    reconciliation_id: str,
+    *,
+    ledger_transaction_id: str,
+) -> dict[str, object]:
+    """Call ``POST /v1/reconciliations/{id}/paper-matches`` (mark-cleared)."""
+    resp = client.post(
+        f"/v1/reconciliations/{reconciliation_id}/paper-matches",
+        authenticated=True,
+        json={"ledger_transaction_id": ledger_transaction_id},
+    )
+    return cast("dict[str, object]", resp.json())
+
+
+def carry_forward(
+    client: TulipClient,
+    reconciliation_id: str,
+    *,
+    transaction_ids: list[str],
+) -> dict[str, object]:
+    """Call ``POST /v1/reconciliations/{id}/carry-forward``."""
+    resp = client.post(
+        f"/v1/reconciliations/{reconciliation_id}/carry-forward",
+        authenticated=True,
+        json={"transaction_ids": transaction_ids},
+    )
+    return cast("dict[str, object]", resp.json())
+
+
+def complete(client: TulipClient, reconciliation_id: str) -> dict[str, object]:
+    """Call ``POST /v1/reconciliations/{id}/complete``."""
+    resp = client.post(
+        f"/v1/reconciliations/{reconciliation_id}/complete",
+        authenticated=True,
+    )
+    return cast("dict[str, object]", resp.json())
+
+
+def _to_envelope(row: dict[str, object]) -> ReconciliationEnvelope:
+    return ReconciliationEnvelope(
+        id=str(row.get("id", "")),
+        account_id=str(row.get("account_id", "")),
+        statement_period_start=str(row.get("statement_period_start", "")),
+        statement_period_end=str(row.get("statement_period_end", "")),
+        statement_starting_balance=str(row.get("statement_starting_balance", "")),
+        statement_ending_balance=str(row.get("statement_ending_balance", "")),
+        currency=str(row.get("currency", "")),
+        status=str(row.get("status", "")),
+        source_import_batch_id=_optional_str(row.get("source_import_batch_id")),
+        created_at=str(row.get("created_at", "")),
+        completed_at=_optional_str(row.get("completed_at")),
+    )
+
+
+def _to_match(row: dict[str, object]) -> MatchSummary:
+    confidence = _optional_str(row.get("confidence"))
+    created_by = _optional_str(row.get("created_by_user_id"))
+    amount = Decimal(str(row.get("match_amount", "0"))).quantize(Decimal("0.01"))
+    return MatchSummary(
+        id=str(row.get("id", "")),
+        statement_line_id=_optional_str(row.get("statement_line_id")),
+        ledger_transaction_id=str(row.get("ledger_transaction_id", "")),
+        match_amount=f"{amount:,.2f}",
+        currency=str(row.get("currency", "")),
+        confidence=confidence,
+        created_by_user_id=created_by,
+        is_manual=confidence is None and created_by is not None,
+    )
+
+
+def _to_unmatched_line(row: dict[str, object]) -> UnmatchedLine:
+    amount = Decimal(str(row.get("amount", "0"))).quantize(Decimal("0.01"))
+    return UnmatchedLine(
+        id=str(row.get("id", "")),
+        line_number=_optional_int(row.get("line_number")),
+        posted_date=str(row.get("posted_date", "")),
+        amount_display=f"{amount:,.2f}",
+        currency=str(row.get("currency", "")),
+        description=str(row.get("description", "")),
+        reference=_optional_str(row.get("reference")),
+    )
+
+
+def _to_unmatched_tx(row: dict[str, object]) -> UnmatchedTransaction:
+    return UnmatchedTransaction(
+        id=str(row.get("id", "")),
+        date=str(row.get("date", "")),
+        description=str(row.get("description", "")),
+        reference=_optional_str(row.get("reference")),
+        status=str(row.get("status", "")),
+    )
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_int(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+__all__: list[str] = [
+    "MatchSummary",
+    "ReconciliationDetail",
+    "ReconciliationEnvelope",
+    "UnmatchedLine",
+    "UnmatchedTransaction",
+    "auto_match",
+    "carry_forward",
+    "complete",
+    "load_reconciliation_detail",
+    "manual_match",
+    "paper_match",
+    "reject_match",
+]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -25,6 +25,16 @@ from tulip_tui.data.import_batch_detail import (
 from tulip_tui.data.import_batch_detail import apply_batch as _apply_batch_call
 from tulip_tui.data.imports import ImportsData, load_import_batches
 from tulip_tui.data.pending import PendingData, load_pending
+from tulip_tui.data.reconciliation_detail import (
+    ReconciliationDetail,
+    auto_match,
+    carry_forward,
+    complete,
+    load_reconciliation_detail,
+    manual_match,
+    paper_match,
+    reject_match,
+)
 from tulip_tui.data.reconciliations import ReconciliationsData, load_reconciliations
 from tulip_tui.data.reports import ReportPayload, ReportSpec, load_report
 from tulip_tui.data.sinking_funds import SinkingFundsData, load_sinking_funds
@@ -129,6 +139,66 @@ def _pending_loader() -> PendingData:
         return load_pending(client)
 
 
+def _reconciliation_detail_factory(
+    reconciliation_id: str,
+) -> Callable[[], ReconciliationDetail]:
+    def _load() -> ReconciliationDetail:
+        config = load_config()
+        with TulipClient(config, token_store=default_token_store()) as client:
+            return load_reconciliation_detail(client, reconciliation_id)
+
+    return _load
+
+
+def _reconciliation_auto_match(reconciliation_id: str) -> object:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return auto_match(client, reconciliation_id)
+
+
+def _reconciliation_reject(reconciliation_id: str, match_id: str) -> None:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        reject_match(client, reconciliation_id, match_id)
+
+
+def _reconciliation_manual_match(
+    reconciliation_id: str,
+    statement_line_id: str,
+    ledger_transaction_id: str,
+    match_amount: str,
+    currency: str,
+) -> object:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return manual_match(
+            client,
+            reconciliation_id,
+            statement_line_id=statement_line_id,
+            ledger_transaction_id=ledger_transaction_id,
+            match_amount=match_amount,
+            currency=currency,
+        )
+
+
+def _reconciliation_paper_match(reconciliation_id: str, ledger_transaction_id: str) -> object:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return paper_match(client, reconciliation_id, ledger_transaction_id=ledger_transaction_id)
+
+
+def _reconciliation_carry_forward(reconciliation_id: str, transaction_id: str) -> object:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return carry_forward(client, reconciliation_id, transaction_ids=[transaction_id])
+
+
+def _reconciliation_complete(reconciliation_id: str) -> object:
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return complete(client, reconciliation_id)
+
+
 def run() -> None:
     """Launch the Tulip TUI against the configured API."""
     TulipTuiApp(
@@ -144,4 +214,11 @@ def run() -> None:
         envelopes_loader=_envelopes_loader,
         sinking_funds_loader=_sinking_funds_loader,
         pending_loader=_pending_loader,
+        reconciliation_detail_factory=_reconciliation_detail_factory,
+        reconciliation_auto_match=_reconciliation_auto_match,
+        reconciliation_reject=_reconciliation_reject,
+        reconciliation_manual_match=_reconciliation_manual_match,
+        reconciliation_paper_match=_reconciliation_paper_match,
+        reconciliation_carry_forward=_reconciliation_carry_forward,
+        reconciliation_complete=_reconciliation_complete,
     ).run()

--- a/packages/tulip-tui/src/tulip_tui/screens/reconciliation_detail.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/reconciliation_detail.py
@@ -1,0 +1,562 @@
+"""Reconciliation detail / actioning screen — P9.6.b of [#414](https://github.com/rmwarriner/2014).
+
+Reached with ``enter`` on a row in the reconciliations browser.
+Renders three stacked tables — Matches / Unmatched Lines / Unmatched
+Transactions — and exposes the daily-driver actions inline:
+
+- ``a`` run auto-match (when matches list is empty)
+- ``x`` reject the highlighted match (matches table only)
+- ``m`` manual match: picker modal lists unmatched txs; user picks
+  one to pair with the highlighted unmatched line. Amount + currency
+  default to the line's.
+- ``k`` mark-cleared: paper-match the highlighted unmatched tx
+  (paper-statement reconciliations only — the API enforces this).
+- ``f`` carry-forward the highlighted unmatched tx.
+- ``c`` complete the reconciliation (errors surface inline if the
+  envelope isn't balanced).
+
+Already-complete reconciliations show actions in a "view-only"
+state — refresh / escape still work; mutation keys produce a
+notice rather than calling the API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import ClassVar
+
+from textual import events
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Button, DataTable, Footer, Header, Static
+
+from tulip_tui.data.reconciliation_detail import (
+    MatchSummary,
+    ReconciliationDetail,
+    UnmatchedLine,
+    UnmatchedTransaction,
+)
+
+ReconciliationDetailLoader = Callable[[], ReconciliationDetail]
+AutoMatchAction = Callable[[], object]
+RejectAction = Callable[[str], None]
+ManualMatchAction = Callable[[str, str, str, str], object]
+PaperMatchAction = Callable[[str], object]
+CarryForwardAction = Callable[[str], object]
+CompleteAction = Callable[[], object]
+
+
+def _match_row(m: MatchSummary) -> tuple[str, str, str, str, str]:
+    return (
+        m.confidence or ("manual" if m.is_manual else "—"),
+        m.statement_line_id[:8] if m.statement_line_id else "—",
+        m.ledger_transaction_id[:8],
+        f"{m.match_amount} {m.currency}",
+        m.id[:8],
+    )
+
+
+def _line_row(line: UnmatchedLine) -> tuple[str, str, str, str, str]:
+    return (
+        str(line.line_number),
+        line.posted_date,
+        line.description,
+        f"{line.amount_display} {line.currency}",
+        line.id[:8],
+    )
+
+
+def _tx_row(tx: UnmatchedTransaction) -> tuple[str, str, str, str, str]:
+    return (
+        tx.date,
+        tx.description,
+        tx.reference or "—",
+        tx.status,
+        tx.id[:8],
+    )
+
+
+class ManualMatchPickerModal(ModalScreen[str | None]):
+    """Picker modal — choose a ledger tx to pair with a given line (P9.6.b)."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "cancel", "cancel", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    ManualMatchPickerModal {
+        align: center middle;
+    }
+    ManualMatchPickerModal #picker-panel {
+        width: 90%;
+        height: 80%;
+        background: $panel;
+        border: thick $primary;
+        padding: 1 2;
+    }
+    ManualMatchPickerModal #picker-table {
+        height: 1fr;
+    }
+    ManualMatchPickerModal #picker-buttons {
+        align-horizontal: right;
+        height: auto;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        line: UnmatchedLine,
+        candidates: tuple[UnmatchedTransaction, ...],
+    ) -> None:
+        """Store the line + candidate list for rendering."""
+        super().__init__()
+        self._line = line
+        self._candidates = candidates
+
+    def compose(self) -> ComposeResult:
+        """Lay out title, candidate picker, and the confirm/cancel buttons."""
+        with Vertical(id="picker-panel"):
+            yield Static(
+                f"[b]Pair line {self._line.line_number}[/b]  "
+                f"{self._line.posted_date}  "
+                f"{self._line.description}  "
+                f"({self._line.amount_display} {self._line.currency})\n"
+                f"Pick the ledger transaction it matches:",
+                id="picker-title",
+            )
+            yield DataTable(id="picker-table", zebra_stripes=True, cursor_type="row")
+            with Horizontal(id="picker-buttons"):
+                yield Button("Cancel", id="picker-cancel")
+                yield Button("Confirm", variant="primary", id="picker-confirm")
+
+    def on_mount(self) -> None:
+        """Install columns and populate the picker on mount."""
+        table = self.query_one("#picker-table", DataTable)
+        table.add_columns("Date", "Description", "Ref", "Status", "Id")
+        for tx in self._candidates:
+            table.add_row(*_tx_row(tx))
+        if self._candidates:
+            table.focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Confirm with the chosen tx id, or cancel."""
+        if event.button.id == "picker-confirm":
+            self.dismiss(self._chosen_id())
+        elif event.button.id == "picker-cancel":
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        """``escape`` cancels."""
+        self.dismiss(None)
+
+    def _chosen_id(self) -> str | None:
+        if not self._candidates:
+            return None
+        table = self.query_one("#picker-table", DataTable)
+        cursor = max(0, table.cursor_row)
+        if cursor >= len(self._candidates):
+            return None
+        return self._candidates[cursor].id
+
+
+class ReconciliationDetailScreen(Screen[None]):
+    """Per-reconciliation action surface (P9.6.b)."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "app.pop_screen", "back", show=True),
+        Binding("r", "refresh", "refresh", show=True),
+        Binding("a", "auto_match", "auto-match", show=True),
+        Binding("x", "reject", "reject match", show=True),
+        Binding("m", "manual_match", "manual match", show=True),
+        Binding("k", "mark_cleared", "mark cleared", show=True),
+        Binding("f", "carry_forward", "carry-forward", show=True),
+        Binding("c", "complete", "complete", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    ReconciliationDetailScreen { layout: vertical; }
+    ReconciliationDetailScreen #rcd-header { height: auto; padding: 0 1; }
+    ReconciliationDetailScreen #rcd-status { height: auto; padding: 0 1; color: $accent; }
+    ReconciliationDetailScreen .group-header { height: auto; padding: 0 1; color: $accent; }
+    ReconciliationDetailScreen #rcd-matches,
+    ReconciliationDetailScreen #rcd-lines,
+    ReconciliationDetailScreen #rcd-txs { height: 1fr; }
+    ReconciliationDetailScreen #rcd-detail {
+        height: auto;
+        min-height: 4;
+        padding: 1 2;
+        border-top: solid $accent;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        loader: ReconciliationDetailLoader,
+        on_auto_match: AutoMatchAction,
+        on_reject: RejectAction,
+        on_manual_match: ManualMatchAction,
+        on_paper_match: PaperMatchAction,
+        on_carry_forward: CarryForwardAction,
+        on_complete: CompleteAction,
+    ) -> None:
+        """Wire the per-action callbacks; the screen makes no HTTP calls itself."""
+        super().__init__()
+        self._loader = loader
+        self._on_auto_match = on_auto_match
+        self._on_reject = on_reject
+        self._on_manual_match = on_manual_match
+        self._on_paper_match = on_paper_match
+        self._on_carry_forward = on_carry_forward
+        self._on_complete = on_complete
+        self._data: ReconciliationDetail | None = None
+        self._matches_index: list[MatchSummary] = []
+        self._lines_index: list[UnmatchedLine] = []
+        self._txs_index: list[UnmatchedTransaction] = []
+        self._notice: str = ""
+        self._header: str = ""
+        self._status: str = ""
+        self._detail: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Lay out header + three stacked tables + detail pane."""
+        yield Header()
+        with Vertical():
+            yield Static("loading reconciliation…", id="rcd-header")
+            yield Static("", id="rcd-status")
+            yield Static("[b]Matches[/b]", classes="group-header", id="rcd-matches-header")
+            yield DataTable(id="rcd-matches", zebra_stripes=True, cursor_type="row")
+            yield Static("[b]Unmatched lines[/b]", classes="group-header", id="rcd-lines-header")
+            yield DataTable(id="rcd-lines", zebra_stripes=True, cursor_type="row")
+            yield Static(
+                "[b]Unmatched transactions[/b]", classes="group-header", id="rcd-txs-header"
+            )
+            yield DataTable(id="rcd-txs", zebra_stripes=True, cursor_type="row")
+            yield Static("", id="rcd-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Install columns and trigger the initial load."""
+        self.query_one("#rcd-matches", DataTable).add_columns(
+            "Conf.", "Line", "Tx", "Amount", "Match"
+        )
+        self.query_one("#rcd-lines", DataTable).add_columns(
+            "#", "Date", "Description", "Amount", "Id"
+        )
+        self.query_one("#rcd-txs", DataTable).add_columns(
+            "Date", "Description", "Ref", "Status", "Id"
+        )
+        self._load()
+
+    def action_refresh(self) -> None:
+        """Re-run the loader and rebuild every table in place."""
+        self._load()
+
+    def action_auto_match(self) -> None:
+        """``a`` — run the matcher (when no matches exist yet)."""
+        if self._data is None:
+            return
+        if self._data.matches:
+            self._set_notice("matches already exist — reject one with `x` to re-run")
+            return
+        try:
+            result = self._on_auto_match()
+        except Exception as exc:
+            self._set_notice(f"[red]auto-match failed:[/red] {exc}")
+            return
+        created = result.get("matches_created") if isinstance(result, dict) else None
+        if isinstance(created, int):
+            self._set_notice(f"auto-matched — {created} new match(es)")
+        else:
+            self._set_notice("auto-matched")
+        self._load()
+
+    def action_reject(self) -> None:
+        """``x`` — reject the highlighted match (matches table only)."""
+        match = self._cursor_match()
+        if match is None:
+            self._set_notice("focus a match row (top table) before pressing `x`")
+            return
+        try:
+            self._on_reject(match.id)
+        except Exception as exc:
+            self._set_notice(f"[red]reject failed:[/red] {exc}")
+            return
+        self._set_notice(f"rejected match {match.id[:8]}")
+        self._load()
+
+    def action_manual_match(self) -> None:
+        """``m`` — open the picker modal to pair the focused line with a tx."""
+        line = self._cursor_line()
+        if line is None:
+            self._set_notice("focus an unmatched line before pressing `m`")
+            return
+        if self._data is None or not self._data.unmatched_transactions:
+            self._set_notice("no unmatched ledger transactions to pair")
+            return
+
+        modal = ManualMatchPickerModal(line=line, candidates=self._data.unmatched_transactions)
+        self.app.push_screen(
+            modal,
+            lambda result: self._on_manual_match_chosen(line, result),
+        )
+
+    def action_mark_cleared(self) -> None:
+        """``k`` — paper-match the highlighted unmatched tx (paper recons)."""
+        tx = self._cursor_tx()
+        if tx is None:
+            self._set_notice("focus an unmatched transaction before pressing `k`")
+            return
+        if self._data is None or not self._data.is_paper:
+            self._set_notice("mark-cleared is only valid on paper reconciliations")
+            return
+        try:
+            self._on_paper_match(tx.id)
+        except Exception as exc:
+            self._set_notice(f"[red]mark-cleared failed:[/red] {exc}")
+            return
+        self._set_notice(f"marked cleared: {tx.description}")
+        self._load()
+
+    def action_carry_forward(self) -> None:
+        """``f`` — carry the highlighted unmatched tx to the next reconciliation."""
+        tx = self._cursor_tx()
+        if tx is None:
+            self._set_notice("focus an unmatched transaction before pressing `f`")
+            return
+        try:
+            self._on_carry_forward(tx.id)
+        except Exception as exc:
+            self._set_notice(f"[red]carry-forward failed:[/red] {exc}")
+            return
+        self._set_notice(f"carried forward: {tx.description}")
+        self._load()
+
+    def action_complete(self) -> None:
+        """``c`` — finalise the reconciliation (server checks balance)."""
+        if self._data is None:
+            return
+        if self._data.envelope.status == "complete":
+            self._set_notice("already complete")
+            return
+        try:
+            self._on_complete()
+        except Exception as exc:
+            self._set_notice(f"[red]complete failed:[/red] {exc}")
+            return
+        self._set_notice("reconciliation complete")
+        self._load()
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Re-render the detail pane for the focused table's cursor."""
+        widget = event.data_table
+        widget_id = widget.id
+        cursor = max(0, event.cursor_row)
+        if widget_id == "rcd-matches" and cursor < len(self._matches_index):
+            self._set_detail(_detail_for_match(self._matches_index[cursor]))
+        elif widget_id == "rcd-lines" and cursor < len(self._lines_index):
+            self._set_detail(_detail_for_line(self._lines_index[cursor]))
+        elif widget_id == "rcd-txs" and cursor < len(self._txs_index):
+            self._set_detail(_detail_for_tx(self._txs_index[cursor]))
+
+    def on_descendant_focus(self, event: events.DescendantFocus) -> None:
+        """When focus shifts between tables, re-render detail from that cursor."""
+        widget_id = getattr(event.widget, "id", None)
+        cursor = max(0, getattr(event.widget, "cursor_row", 0))
+        if widget_id == "rcd-matches" and self._matches_index:
+            cursor = min(cursor, len(self._matches_index) - 1)
+            self._set_detail(_detail_for_match(self._matches_index[cursor]))
+        elif widget_id == "rcd-lines" and self._lines_index:
+            cursor = min(cursor, len(self._lines_index) - 1)
+            self._set_detail(_detail_for_line(self._lines_index[cursor]))
+        elif widget_id == "rcd-txs" and self._txs_index:
+            cursor = min(cursor, len(self._txs_index) - 1)
+            self._set_detail(_detail_for_tx(self._txs_index[cursor]))
+
+    # -- internals -------------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            data = self._loader()
+        except Exception as exc:
+            self._render_error(exc)
+            return
+        self._populate(data)
+
+    def _populate(self, data: ReconciliationDetail) -> None:
+        self._data = data
+        m_table = self.query_one("#rcd-matches", DataTable)
+        l_table = self.query_one("#rcd-lines", DataTable)
+        t_table = self.query_one("#rcd-txs", DataTable)
+        m_table.clear()
+        l_table.clear()
+        t_table.clear()
+        self._matches_index = []
+        self._lines_index = []
+        self._txs_index = []
+
+        env = data.envelope
+        recon_kind = "paper" if data.is_paper else "imported"
+        self._set_header(
+            f"[b]{env.statement_period_start} → {env.statement_period_end}[/b]    "
+            f"{env.statement_starting_balance} → {env.statement_ending_balance} "
+            f"{env.currency}    status={env.status}    [{recon_kind}]"
+        )
+        self._set_status(
+            f"{len(data.matches)} matches · "
+            f"{len(data.unmatched_lines)} unmatched lines · "
+            f"{len(data.unmatched_transactions)} unmatched txs"
+            + (f"    [dim]{self._notice}[/dim]" if self._notice else "")
+        )
+
+        for m in data.matches:
+            m_table.add_row(*_match_row(m))
+            self._matches_index.append(m)
+        for line in data.unmatched_lines:
+            l_table.add_row(*_line_row(line))
+            self._lines_index.append(line)
+        for tx in data.unmatched_transactions:
+            t_table.add_row(*_tx_row(tx))
+            self._txs_index.append(tx)
+
+        # Focus the first non-empty table so the cursor binds somewhere
+        # sensible. Most useful default is the unmatched-lines table —
+        # that's where most user actions originate.
+        if data.unmatched_lines:
+            l_table.focus()
+        elif data.matches:
+            m_table.focus()
+        elif data.unmatched_transactions:
+            t_table.focus()
+
+    def _cursor_match(self) -> MatchSummary | None:
+        if self.focused is None or self.focused.id != "rcd-matches":
+            return None
+        cursor = max(0, getattr(self.focused, "cursor_row", 0))
+        if cursor >= len(self._matches_index):
+            return None
+        return self._matches_index[cursor]
+
+    def _cursor_line(self) -> UnmatchedLine | None:
+        if self.focused is None or self.focused.id != "rcd-lines":
+            return None
+        cursor = max(0, getattr(self.focused, "cursor_row", 0))
+        if cursor >= len(self._lines_index):
+            return None
+        return self._lines_index[cursor]
+
+    def _cursor_tx(self) -> UnmatchedTransaction | None:
+        if self.focused is None or self.focused.id != "rcd-txs":
+            return None
+        cursor = max(0, getattr(self.focused, "cursor_row", 0))
+        if cursor >= len(self._txs_index):
+            return None
+        return self._txs_index[cursor]
+
+    def _on_manual_match_chosen(self, line: UnmatchedLine, tx_id: str | None) -> None:
+        if tx_id is None:
+            self._set_notice("manual match cancelled")
+            return
+        try:
+            self._on_manual_match(
+                line.id,
+                tx_id,
+                line.amount_display.replace(",", ""),
+                line.currency,
+            )
+        except Exception as exc:
+            self._set_notice(f"[red]manual match failed:[/red] {exc}")
+            return
+        self._set_notice(f"matched line {line.line_number} ↔ tx {tx_id[:8]}")
+        self._load()
+
+    def _render_error(self, exc: BaseException) -> None:
+        for tid in ("#rcd-matches", "#rcd-lines", "#rcd-txs"):
+            self.query_one(tid, DataTable).clear()
+        self._matches_index = []
+        self._lines_index = []
+        self._txs_index = []
+        self._data = None
+        self._set_header("[red]error loading reconciliation[/red]")
+        self._set_status(f"[red]error:[/red] {exc}")
+        self._set_detail(f"error: {exc}")
+
+    def _set_header(self, text: str) -> None:
+        self._header = text
+        self.query_one("#rcd-header", Static).update(text)
+
+    def _set_status(self, text: str) -> None:
+        self._status = text
+        self.query_one("#rcd-status", Static).update(text)
+
+    def _set_detail(self, text: str) -> None:
+        self._detail = text
+        self.query_one("#rcd-detail", Static).update(text)
+
+    def _set_notice(self, text: str) -> None:
+        self._notice = text
+        # Re-render the status strip so the notice surfaces immediately.
+        if self._data is not None:
+            data = self._data
+            self.query_one("#rcd-status", Static).update(
+                f"{len(data.matches)} matches · "
+                f"{len(data.unmatched_lines)} unmatched lines · "
+                f"{len(data.unmatched_transactions)} unmatched txs"
+                + (f"    [dim]{self._notice}[/dim]" if self._notice else "")
+            )
+
+    # -- introspection used by tests ------------------------------------
+
+    def header_text(self) -> str:
+        """Return the current header text."""
+        return self._header
+
+    def status_text(self) -> str:
+        """Return the current status-strip text."""
+        return self._status
+
+    def detail_text(self) -> str:
+        """Return the current detail-pane text."""
+        return self._detail
+
+    def notice(self) -> str:
+        """Return the last action notice."""
+        return self._notice
+
+
+def _detail_for_match(m: MatchSummary) -> str:
+    lines = [
+        f"[b]match {m.id}[/b]",
+        f"line:        {m.statement_line_id or '—'}",
+        f"tx:          {m.ledger_transaction_id}",
+        f"amount:      {m.match_amount} {m.currency}",
+        f"confidence:  {m.confidence or ('manual' if m.is_manual else '—')}",
+    ]
+    return "\n".join(lines)
+
+
+def _detail_for_line(line: UnmatchedLine) -> str:
+    out = [
+        f"[b]line {line.line_number}[/b]    {line.posted_date}",
+        f"description: {line.description}",
+        f"amount:      {line.amount_display} {line.currency}",
+    ]
+    if line.reference:
+        out.append(f"reference:   {line.reference}")
+    out.append(f"id:          {line.id}")
+    return "\n".join(out)
+
+
+def _detail_for_tx(tx: UnmatchedTransaction) -> str:
+    out = [
+        f"[b]{tx.date}[/b]    {tx.description}",
+        f"status:      {tx.status}",
+    ]
+    if tx.reference:
+        out.append(f"reference:   {tx.reference}")
+    out.append(f"id:          {tx.id}")
+    return "\n".join(out)

--- a/packages/tulip-tui/src/tulip_tui/screens/reconciliations.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/reconciliations.py
@@ -21,6 +21,11 @@ from textual.widgets import DataTable, Footer, Header, Static
 from tulip_tui.data.reconciliations import ReconciliationsData, ReconciliationSummary
 
 ReconciliationsLoader = Callable[[], ReconciliationsData]
+OpenReconciliationHandler = Callable[[str], None]
+
+
+def _noop_open_reconciliation(_reconciliation_id: str) -> None:
+    """Default drill-in handler — used when no detail screen is wired."""
 
 
 def _fmt_balance(value: str) -> str:
@@ -81,10 +86,16 @@ class ReconciliationsScreen(Screen[None]):
     }
     """
 
-    def __init__(self, loader: ReconciliationsLoader) -> None:
-        """Store the loader; the screen populates on mount."""
+    def __init__(
+        self,
+        loader: ReconciliationsLoader,
+        *,
+        on_open_reconciliation: OpenReconciliationHandler = _noop_open_reconciliation,
+    ) -> None:
+        """Store the loader and the drill-in handler used by ``enter``."""
         super().__init__()
         self._loader = loader
+        self._on_open_reconciliation = on_open_reconciliation
         self._rendered_rows: list[str] = []
         self._index: list[ReconciliationSummary] = []
         self._detail: str = ""
@@ -111,6 +122,16 @@ class ReconciliationsScreen(Screen[None]):
     def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
         """Re-render the detail pane to match the newly-highlighted row."""
         self._refresh_detail()
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """``enter`` drills into the per-reconciliation actioning screen (P9.6.b)."""
+        index = event.cursor_row
+        if index < 0 or index >= len(self._index):
+            return
+        rec = self._index[index]
+        if not rec.id:
+            return
+        self._on_open_reconciliation(rec.id)
 
     # -- internals -----------------------------------------------------
 

--- a/packages/tulip-tui/tests/test_reconciliation_detail_data.py
+++ b/packages/tulip-tui/tests/test_reconciliation_detail_data.py
@@ -1,0 +1,338 @@
+"""Unit tests for ``tulip_tui.data.reconciliation_detail`` (P9.6.b)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tulip_cli.config import Config
+from tulip_cli.http import TulipClient
+from tulip_tui.data.reconciliation_detail import (
+    ReconciliationDetail,
+    auto_match,
+    carry_forward,
+    complete,
+    load_reconciliation_detail,
+    manual_match,
+    paper_match,
+    reject_match,
+)
+
+
+class _FakeTokenStore:
+    def load(self, _api_url: str) -> object:
+        return SimpleNamespace(
+            email="t@example.invalid",
+            access_token="fake-access-token",
+            refresh_token="fake-refresh-token",
+            access_expires_at=2**31 - 1,
+        )
+
+    def save(self, _api_url: str, _tokens: object) -> None: ...
+    def clear(self, _api_url: str) -> None: ...
+
+
+def _build_client(handler: httpx.MockTransport) -> TulipClient:
+    return TulipClient(
+        Config(api_url="https://example.invalid"),
+        token_store=_FakeTokenStore(),  # type: ignore[arg-type]
+        transport=handler,
+    )
+
+
+_INBOX_PAYLOAD = {
+    "reconciliation": {
+        "id": "rec-1",
+        "account_id": "acc-1",
+        "statement_period_start": "2026-04-01",
+        "statement_period_end": "2026-04-30",
+        "statement_starting_balance": "1000.00",
+        "statement_ending_balance": "1234.56",
+        "currency": "USD",
+        "status": "open",
+        "source_import_batch_id": "batch-9",
+        "created_at": "2026-05-01T12:00:00Z",
+        "completed_at": None,
+    },
+    "matches": [
+        {
+            "id": "match-1",
+            "reconciliation_id": "rec-1",
+            "statement_line_id": "line-1",
+            "ledger_transaction_id": "tx-1",
+            "match_amount": "100.00",
+            "currency": "USD",
+            "confidence": "HIGH",
+            "matcher_version": "v1",
+            "created_by_user_id": None,
+            "created_at": "2026-05-01T12:00:00Z",
+        },
+        {
+            "id": "match-2",
+            "reconciliation_id": "rec-1",
+            "statement_line_id": "line-2",
+            "ledger_transaction_id": "tx-2",
+            "match_amount": "50.00",
+            "currency": "USD",
+            "confidence": None,
+            "matcher_version": None,
+            "created_by_user_id": "user-1",
+            "created_at": "2026-05-01T12:00:00Z",
+        },
+    ],
+    "unmatched_statement_lines": [
+        {
+            "id": "line-3",
+            "line_number": 3,
+            "posted_date": "2026-04-15",
+            "amount": "-25.50",
+            "currency": "USD",
+            "description": "AMAZON",
+            "counterparty": None,
+            "reference": None,
+            "fitid": "F3",
+        }
+    ],
+    "unmatched_ledger_transactions": [
+        {
+            "id": "tx-3",
+            "date": "2026-04-15",
+            "description": "Amazon order",
+            "reference": None,
+            "status": "posted",
+        }
+    ],
+}
+
+
+def test_load_reconciliation_detail_parses_full_payload() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/reconciliations/rec-1"
+        return httpx.Response(200, json=_INBOX_PAYLOAD)
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_reconciliation_detail(client, "rec-1")
+
+    assert isinstance(data, ReconciliationDetail)
+    assert data.envelope.id == "rec-1"
+    assert data.envelope.status == "open"
+    assert len(data.matches) == 2
+    assert len(data.unmatched_lines) == 1
+    assert len(data.unmatched_transactions) == 1
+
+
+def test_load_reconciliation_detail_classifies_match_kind() -> None:
+    with _build_client(
+        httpx.MockTransport(lambda _r: httpx.Response(200, json=_INBOX_PAYLOAD))
+    ) as client:
+        data = load_reconciliation_detail(client, "rec-1")
+
+    assert data.matches[0].confidence == "HIGH"
+    assert data.matches[0].is_manual is False
+    assert data.matches[1].confidence is None
+    assert data.matches[1].is_manual is True
+
+
+def test_load_reconciliation_detail_paper_recon_flag() -> None:
+    payload = {**_INBOX_PAYLOAD, "reconciliation": dict(_INBOX_PAYLOAD["reconciliation"])}
+    payload["reconciliation"]["source_import_batch_id"] = None
+    with _build_client(httpx.MockTransport(lambda _r: httpx.Response(200, json=payload))) as client:
+        data = load_reconciliation_detail(client, "rec-1")
+    assert data.is_paper is True
+
+
+def test_load_reconciliation_detail_formats_amounts() -> None:
+    with _build_client(
+        httpx.MockTransport(lambda _r: httpx.Response(200, json=_INBOX_PAYLOAD))
+    ) as client:
+        data = load_reconciliation_detail(client, "rec-1")
+    assert data.matches[0].match_amount == "100.00"
+    assert data.unmatched_lines[0].amount_display == "-25.50"
+
+
+def test_load_reconciliation_detail_raises_on_404() -> None:
+    from tulip_cli.errors import CliError
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            404,
+            json={
+                "type": "/.well-known/errors/reconciliation.not_found",
+                "title": "Not found",
+                "status": 404,
+                "detail": "x",
+                "instance": "",
+                "code": "reconciliation.not_found",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client, pytest.raises(CliError):
+        load_reconciliation_detail(client, "missing")
+
+
+def test_auto_match_calls_endpoint() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(
+            200,
+            json={
+                "reconciliation_id": "rec-1",
+                "matches_created": 5,
+                "candidate_summary": {"high": 3, "medium": 1, "low": 1},
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        result = auto_match(client, "rec-1")
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/reconciliations/rec-1/auto-match"
+    assert result["matches_created"] == 5
+
+
+def test_reject_match_calls_endpoint() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(204)
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        reject_match(client, "rec-1", "match-1")
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/reconciliations/rec-1/matches/match-1/reject"
+
+
+def test_manual_match_sends_body() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content.decode())
+        return httpx.Response(
+            201,
+            json={
+                "id": "match-new",
+                "reconciliation_id": "rec-1",
+                "statement_line_id": "line-3",
+                "ledger_transaction_id": "tx-3",
+                "match_amount": "25.50",
+                "currency": "USD",
+                "confidence": None,
+                "matcher_version": None,
+                "created_by_user_id": "user-1",
+                "created_at": "2026-05-01T12:00:00Z",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        result = manual_match(
+            client,
+            "rec-1",
+            statement_line_id="line-3",
+            ledger_transaction_id="tx-3",
+            match_amount="25.50",
+            currency="USD",
+        )
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/reconciliations/rec-1/matches"
+    assert seen["body"] == {
+        "statement_line_id": "line-3",
+        "ledger_transaction_id": "tx-3",
+        "match_amount": "25.50",
+        "currency": "USD",
+    }
+    assert result["id"] == "match-new"
+
+
+def test_paper_match_sends_body() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content.decode())
+        return httpx.Response(
+            201,
+            json={
+                "id": "match-paper",
+                "reconciliation_id": "rec-1",
+                "statement_line_id": None,
+                "ledger_transaction_id": "tx-3",
+                "match_amount": "25.50",
+                "currency": "USD",
+                "confidence": None,
+                "matcher_version": None,
+                "created_by_user_id": "user-1",
+                "created_at": "2026-05-01T12:00:00Z",
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        paper_match(client, "rec-1", ledger_transaction_id="tx-3")
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/reconciliations/rec-1/paper-matches"
+    assert seen["body"] == {"ledger_transaction_id": "tx-3"}
+
+
+def test_carry_forward_sends_body() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content.decode())
+        return httpx.Response(
+            201,
+            json={
+                "reconciliation_id": "rec-1",
+                "transaction_ids": ["tx-3"],
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        carry_forward(client, "rec-1", transaction_ids=["tx-3"])
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/reconciliations/rec-1/carry-forward"
+    assert seen["body"] == {"transaction_ids": ["tx-3"]}
+
+
+def test_complete_calls_endpoint() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(
+            200,
+            json={
+                "reconciliation_id": "rec-1",
+                "status": "complete",
+                "completed_at": "2026-05-01T12:00:00Z",
+                "affected_transaction_count": 5,
+            },
+        )
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        result = complete(client, "rec-1")
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/reconciliations/rec-1/complete"
+    assert result["affected_transaction_count"] == 5

--- a/packages/tulip-tui/tests/test_reconciliation_detail_screen.py
+++ b/packages/tulip-tui/tests/test_reconciliation_detail_screen.py
@@ -1,0 +1,564 @@
+"""Pilot-mode tests for the reconciliation detail screen (P9.6.b).
+
+Covers row rendering, every binding (`a`/`x`/`m`/`k`/`f`/`c`), the
+manual-match picker modal, the drill-in from the reconciliations list,
+and the error rendering path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
+from tulip_tui.data.reconciliation_detail import (
+    MatchSummary,
+    ReconciliationDetail,
+    ReconciliationEnvelope,
+    UnmatchedLine,
+    UnmatchedTransaction,
+)
+from tulip_tui.data.reconciliations import (
+    ReconciliationsData,
+    ReconciliationSummary,
+)
+from tulip_tui.screens.reconciliation_detail import (
+    ManualMatchPickerModal,
+    ReconciliationDetailScreen,
+)
+
+
+def _accounts_loader() -> AccountsData:
+    return AccountsData(as_of="2026-05-17", accounts=(), groups=())
+
+
+def _envelope(
+    *,
+    source_batch: str | None = "batch-9",
+    status: str = "open",
+) -> ReconciliationEnvelope:
+    return ReconciliationEnvelope(
+        id="rec-1",
+        account_id="acc-1",
+        statement_period_start="2026-04-01",
+        statement_period_end="2026-04-30",
+        statement_starting_balance="1000.00",
+        statement_ending_balance="1234.56",
+        currency="USD",
+        status=status,
+        source_import_batch_id=source_batch,
+        created_at="2026-05-01T12:00:00Z",
+        completed_at=None,
+    )
+
+
+def _detail(
+    *,
+    matches: tuple[MatchSummary, ...] = (),
+    lines: tuple[UnmatchedLine, ...] = (),
+    txs: tuple[UnmatchedTransaction, ...] = (),
+    source_batch: str | None = "batch-9",
+    status: str = "open",
+) -> ReconciliationDetail:
+    return ReconciliationDetail(
+        envelope=_envelope(source_batch=source_batch, status=status),
+        matches=matches,
+        unmatched_lines=lines,
+        unmatched_transactions=txs,
+    )
+
+
+def _match(idx: int = 1, *, manual: bool = False) -> MatchSummary:
+    return MatchSummary(
+        id=f"match-{idx}",
+        statement_line_id=f"line-{idx}",
+        ledger_transaction_id=f"tx-{idx}",
+        match_amount="100.00",
+        currency="USD",
+        confidence=None if manual else "HIGH",
+        created_by_user_id="user-1" if manual else None,
+        is_manual=manual,
+    )
+
+
+def _line(idx: int = 3) -> UnmatchedLine:
+    return UnmatchedLine(
+        id=f"line-{idx}",
+        line_number=idx,
+        posted_date="2026-04-15",
+        amount_display="-25.50",
+        currency="USD",
+        description=f"VENDOR {idx}",
+        reference=None,
+    )
+
+
+def _tx(idx: int = 3) -> UnmatchedTransaction:
+    return UnmatchedTransaction(
+        id=f"tx-{idx}",
+        date="2026-04-15",
+        description=f"Tx desc {idx}",
+        reference=None,
+        status="posted",
+    )
+
+
+# --- happy-path renders --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_renders_all_three_tables() -> None:
+    detail = _detail(
+        matches=(_match(1),),
+        lines=(_line(2),),
+        txs=(_tx(3),),
+    )
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {"matches_created": 0},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {"id": "m"},
+            on_paper_match=lambda _t: {"id": "m"},
+            on_carry_forward=lambda _t: {"transaction_ids": ["tx-3"]},
+            on_complete=lambda: {"affected_transaction_count": 0},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        status = screen.status_text()
+
+    assert "1 matches" in status
+    assert "1 unmatched lines" in status
+    assert "1 unmatched txs" in status
+
+
+@pytest.mark.asyncio
+async def test_header_shows_period_and_balances() -> None:
+    detail = _detail()
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        header = screen.header_text()
+
+    assert "2026-04-01" in header
+    assert "2026-04-30" in header
+    assert "1000.00" in header
+    assert "1234.56" in header
+    assert "imported" in header  # source_batch is set → "imported"
+
+
+@pytest.mark.asyncio
+async def test_paper_recon_shows_paper_in_header() -> None:
+    detail = _detail(source_batch=None)
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert "paper" in screen.header_text()
+
+
+# --- bindings ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_match_binding_calls_action() -> None:
+    calls: list[str] = []
+    state = {"data": _detail(lines=(_line(),), txs=(_tx(),))}
+
+    def on_auto_match() -> dict[str, object]:
+        calls.append("auto")
+        state["data"] = _detail(matches=(_match(1),), lines=(_line(),), txs=(_tx(),))
+        return {"matches_created": 1}
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: state["data"],
+            on_auto_match=on_auto_match,
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+
+    assert calls == ["auto"]
+    assert "auto-matched" in screen.notice()
+
+
+@pytest.mark.asyncio
+async def test_auto_match_refuses_when_matches_exist() -> None:
+    calls: list[str] = []
+    detail = _detail(matches=(_match(1),), lines=(_line(),), txs=(_tx(),))
+
+    def on_auto_match() -> dict[str, object]:
+        calls.append("auto")
+        return {}
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=on_auto_match,
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+
+    assert calls == []
+    assert "matches already exist" in screen.notice()
+
+
+@pytest.mark.asyncio
+async def test_reject_binding_calls_action_with_focused_match() -> None:
+    calls: list[str] = []
+    detail = _detail(matches=(_match(1), _match(2)), lines=(_line(),))
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda match_id: calls.append(match_id),
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        # Move focus into matches table (it's the first one).
+        screen.query_one("#rcd-matches").focus()
+        await pilot.pause()
+        await pilot.press("x")
+        await pilot.pause()
+
+    assert calls == ["match-1"]
+
+
+@pytest.mark.asyncio
+async def test_reject_refuses_without_match_focus() -> None:
+    calls: list[str] = []
+    detail = _detail(matches=(_match(1),), lines=(_line(),))
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda match_id: calls.append(match_id),
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        # Default focus is on the unmatched-lines table.
+        await pilot.press("x")
+        await pilot.pause()
+
+    assert calls == []
+    assert "focus a match row" in screen.notice()
+
+
+@pytest.mark.asyncio
+async def test_manual_match_opens_picker_modal() -> None:
+    detail = _detail(lines=(_line(3),), txs=(_tx(7),))
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {"id": "m"},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("m")
+        await pilot.pause()
+        modal_present = any(isinstance(s, ManualMatchPickerModal) for s in app.screen_stack)
+
+    assert modal_present
+
+
+@pytest.mark.asyncio
+async def test_manual_match_picker_dismiss_fires_action() -> None:
+    calls: list[tuple[str, str, str, str]] = []
+    detail = _detail(lines=(_line(3),), txs=(_tx(7),))
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda a, b, c, d: calls.append((a, b, c, d)) or {"id": "m"},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("m")
+        await pilot.pause()
+        modal = next(s for s in app.screen_stack if isinstance(s, ManualMatchPickerModal))
+        modal.dismiss("tx-7")
+        await pilot.pause()
+
+    assert calls == [("line-3", "tx-7", "-25.50", "USD")]
+
+
+@pytest.mark.asyncio
+async def test_paper_match_only_on_paper_recon() -> None:
+    calls: list[str] = []
+    # Imported reconciliation — k should refuse.
+    detail = _detail(txs=(_tx(),), source_batch="batch-9")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda t: calls.append(t) or {"id": "m"},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        # Focus the txs table.
+        screen.query_one("#rcd-txs").focus()
+        await pilot.pause()
+        await pilot.press("k")
+        await pilot.pause()
+
+    assert calls == []
+    assert "paper" in screen.notice()
+
+
+@pytest.mark.asyncio
+async def test_paper_match_fires_on_paper_recon() -> None:
+    calls: list[str] = []
+    detail = _detail(txs=(_tx(),), source_batch=None)
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda t: calls.append(t) or {"id": "m"},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen.query_one("#rcd-txs").focus()
+        await pilot.pause()
+        await pilot.press("k")
+        await pilot.pause()
+
+    assert calls == ["tx-3"]
+
+
+@pytest.mark.asyncio
+async def test_carry_forward_fires_action() -> None:
+    calls: list[str] = []
+    detail = _detail(txs=(_tx(),))
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda t: calls.append(t) or {"transaction_ids": [t]},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen.query_one("#rcd-txs").focus()
+        await pilot.pause()
+        await pilot.press("f")
+        await pilot.pause()
+
+    assert calls == ["tx-3"]
+
+
+@pytest.mark.asyncio
+async def test_complete_fires_action() -> None:
+    calls: list[str] = []
+    detail = _detail()
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: calls.append("done") or {"affected_transaction_count": 5},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("c")
+        await pilot.pause()
+
+    assert calls == ["done"]
+
+
+@pytest.mark.asyncio
+async def test_complete_refuses_on_already_complete_recon() -> None:
+    calls: list[str] = []
+    detail = _detail(status="complete")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=lambda: detail,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: calls.append("done") or {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("c")
+        await pilot.pause()
+
+    assert calls == []
+    assert "already complete" in screen.notice()
+
+
+@pytest.mark.asyncio
+async def test_inline_error_on_load_failure() -> None:
+    def _boom() -> ReconciliationDetail:
+        raise RuntimeError("offline")
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ReconciliationDetailScreen(
+            loader=_boom,
+            on_auto_match=lambda: {},
+            on_reject=lambda _m: None,
+            on_manual_match=lambda *_a: {},
+            on_paper_match=lambda _t: {},
+            on_carry_forward=lambda _t: {},
+            on_complete=lambda: {},
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+
+    assert "offline" in screen.status_text()
+
+
+@pytest.mark.asyncio
+async def test_reconciliations_screen_enter_drills_into_detail() -> None:
+    drilled: list[str] = []
+    recs = ReconciliationsData(
+        reconciliations=(
+            ReconciliationSummary(
+                id="rec-1",
+                account_id="acc-1",
+                statement_period_start="2026-04-01",
+                statement_period_end="2026-04-30",
+                statement_starting_balance="1000.00",
+                statement_ending_balance="1234.56",
+                currency="USD",
+                status="open",
+                source_import_batch_id="batch-9",
+                created_at="2026-05-01T12:00:00Z",
+                completed_at=None,
+            ),
+        ),
+    )
+
+    app = TulipTuiApp(
+        loader=_accounts_loader,
+        reconciliations_loader=lambda: recs,
+        reconciliation_detail_factory=lambda _rid: lambda: _detail(),
+        reconciliation_auto_match=lambda _r: {},
+        reconciliation_reject=lambda _r, _m: None,
+        reconciliation_manual_match=lambda *_a: {},
+        reconciliation_paper_match=lambda _r, _t: {},
+        reconciliation_carry_forward=lambda _r, _t: {},
+        reconciliation_complete=lambda _r: {},
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("c")  # open reconciliations browser
+        await pilot.pause()
+
+        from tulip_tui.screens.reconciliations import ReconciliationsScreen
+
+        recs_screen = next(s for s in app.screen_stack if isinstance(s, ReconciliationsScreen))
+        original = recs_screen._on_open_reconciliation  # type: ignore[attr-defined]
+
+        def _capture(rid: str) -> None:
+            drilled.append(rid)
+            original(rid)
+
+        recs_screen._on_open_reconciliation = _capture  # type: ignore[attr-defined]
+        await pilot.press("enter")
+        await pilot.pause()
+        detail_present = any(isinstance(s, ReconciliationDetailScreen) for s in app.screen_stack)
+
+    assert drilled == ["rec-1"]
+    assert detail_present


### PR DESCRIPTION
## Summary

- Second slice of the P9.6 mutation wave (umbrella #414). Surfaces
  the full daily-driver reconciliation flow inside the TUI; the CLI
  (\`tulip reconcile\`) remains the scripting surface.
- New \`ReconciliationDetailScreen\` reached with \`enter\` on the
  reconciliations browser. Three stacked tables (Matches / Unmatched
  Lines / Unmatched Transactions) + a header with period, balances,
  paper-or-imported marker, and status.
- Six new bindings: \`a\` auto-match · \`x\` reject the focused match
  (matches-table-only) · \`m\` manual-match picker modal · \`k\`
  mark-cleared (paper recons only) · \`f\` carry-forward · \`c\` complete.
- No backend changes — every endpoint shipped with P5.4.a/b/c/d.

27 new tests (11 data / 16 pilot-mode). PHASE_STATUS gains a
P9.6.b subsection.

## Test plan

\`\`\`bash
uv run --package tulip-tui pytest packages/tulip-tui/tests/ -q
just lint
just typecheck
\`\`\`

- [x] TUI suite green (133 passed)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean
- [ ] CI green on this PR

### Manual smoke test

\`\`\`bash
just dev &
tulip register --household RecSmoke --email me@example.invalid --display-name Me --password-stdin <<<'correct horse battery staple'
tulip auth login --email me@example.invalid --password-stdin <<<'correct horse battery staple'
tulip accounts add --name Checking --type asset --currency USD --code 1110
tulip accounts add --name Food --type expense --currency USD --code 5100
tulip imports ofx \$(tulip accounts show 1110 --json | jq -r '.id') docs/quickstart-fixtures/sample-statement.ofx
tulip imports apply \$(tulip imports list --status parsed --json | jq -r '.items[0].id')
tulip reconcile start --account 1110 --period 2026-05 --starting 0.00 --ending 3611.88
tulip-tui
\`\`\`

Inside the TUI:

1. Press \`c\` to open the reconciliations browser.
2. \`enter\` on the row to drill into the detail screen.
3. Press \`a\` — auto-match runs; matches appear in the top table.
4. Cursor down to a match in the matches table, \`x\` to reject; row
   leaves the matches table, re-appears in unmatched.
5. Focus an unmatched line; \`m\` opens the picker modal listing
   unmatched ledger txs. Pick one and confirm — pair appears in
   matches.
6. \`f\` on an unmatched ledger tx — carries forward.
7. \`c\` — completes (or reports the balance error if not zeroed).