### PR TITLE
fix(docker): bind-mount permission + phantom-file troubleshooting (closes #429)

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -52,6 +52,34 @@ TULIP_ATTACHMENT_ROOT="$ATT_VOL" \
 (`tulip-docker_` is compose's per-project volume prefix; replace if you renamed
 the project.)
 
+## Troubleshooting
+
+### Container starts unhealthy with `sqlite3.OperationalError: unable to open database file`
+
+The DB path is a host bind mount (`./data/db`) so the project-scoped
+sqlite MCP server can read live state. Two failure modes:
+
+1. **First boot on macOS** — Docker Desktop's virtio-fs silently no-ops
+   `chown` on bind mounts, so the entrypoint's `chown -R tulip` doesn't
+   actually take effect. The entrypoint compensates with a follow-up
+   `chmod 0777` on the bind-mount dir; if you see this error anyway,
+   verify the host-side `data/db` is writable (`ls -la deploy/docker/data/db`).
+
+2. **Phantom file from a pre-#397 named-volume run** — if you originally
+   ran an older revision that used a named `tulip-db` volume, Docker
+   Desktop's bind-mount cache can carry a stale ghost entry for
+   `tulip.db` even after the volume is removed. Symptom: from inside the
+   container, `os.path.exists("/var/lib/tulip/db/tulip.db")` returns
+   True but `open()` fails with `FileNotFoundError`. Recover by
+   recreating the host directory:
+
+   ```bash
+   docker compose -f deploy/docker/compose.yml down
+   rm -rf deploy/docker/data/db
+   mkdir -p deploy/docker/data/db
+   docker compose -f deploy/docker/compose.yml up --build --wait
+   ```
+
 ## What's deliberately not here
 
 - TLS termination — internal-beta is localhost-bound. Put it behind Caddy /

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -40,12 +40,18 @@ fi
 
 # ---- 1.5. Reclaim ownership of bind-mounted data dirs --------------------
 # The Dockerfile chowns /var/lib/tulip to uid 1000 at image-build time, but
-# a bind mount overlays that with the host directory's ownership (typically
-# the host user's uid on Linux, often 501 on macOS Docker Desktop). Without
-# this, `gosu tulip alembic upgrade head` below fails with EACCES on the
-# very first boot against an empty bind mount. Idempotent — a no-op once
-# the dirs are already tulip-owned.
+# a bind mount overlays that with the host directory's ownership. Linux
+# hosts let `chown` rewrite the bind-mount uid/gid; macOS Docker Desktop's
+# virtio-fs silently no-ops chown on bind mounts, leaving the dir
+# permanently visible as root:root inside the container regardless of what
+# the host owner is. Belt-and-braces: chown first (Linux path), then chmod
+# the bind-mount dir to 0777 (macOS path) so `gosu tulip alembic upgrade
+# head` below can create `tulip.db` from an empty mount. Idempotent on
+# subsequent boots. The attachments dir is a named Docker volume, so
+# chown alone is enough there; the chmod widening applies only to the
+# bind mount.
 chown -R tulip:tulip /var/lib/tulip/db /var/lib/tulip/attachments
+chmod 0777 /var/lib/tulip/db
 
 # ---- 2. Migrate as the tulip user (writes to the tulip-owned volume) -----
 # Skip migration when TULIP_SKIP_MIGRATION=1 — used by tests or by


### PR DESCRIPTION
## Summary

- After [#397](https://github.com/rmwarriner/tulip-accounting/pull/397) moved the API container's SQLite
  DB from a named volume to a host bind mount, the container
  fails to boot on macOS Docker Desktop with
  \`sqlite3.OperationalError: unable to open database file\`
  during \`alembic upgrade head\`.
- Two stacked causes:
  1. \`chown\` is silently a no-op on virtio-fs bind mounts, so
     the entrypoint's chown leaves the dir as
     \`root:root mode 0755\` inside the container; uid 1000
     can't write.
  2. (Secondary) Docker Desktop's bind-mount cache can carry a
     phantom \`tulip.db\` entry from a pre-#397 named-volume run;
     symptom is \`os.path.exists()\` disagreeing with \`open()\`.
- Fix \`entrypoint.sh\` to follow the chown with a \`chmod 0777\`
  on the bind-mount dir — no-op on already-tulip-owned Linux
  setups, the load-bearing line on macOS.
- Document the phantom-file recovery (rm -rf + mkdir the host
  bind dir) in \`deploy/docker/README.md\` so anyone who hits
  the second failure mode has a clear path out.

## Test plan

\`\`\`bash
docker compose -f deploy/docker/compose.yml down
rm -rf deploy/docker/data/db && mkdir -p deploy/docker/data/db
docker compose -f deploy/docker/compose.yml up --build --wait
curl -s http://127.0.0.1:8000/health
curl -s -X POST http://127.0.0.1:8000/v1/auth/register -H "Content-Type: application/json" \\
  -d '{"email":"smoke@example.com","password":"correct horse battery staple","display_name":"Smoke","household_name":"SmokeTest"}'
\`\`\`

- [x] \`docker compose up --build --wait\` reports \`Container tulip-api Healthy\` on macOS
- [x] \`/health\` returns \`{"status":"ok"}\`
- [x] \`/v1/auth/register\` returns 201 with a fresh household
- [ ] CI green on this PR