### PR TITLE
feat(accounts): expose the notes field through API + CLI (closes #50)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -11,6 +11,7 @@ import structlog
 from fastapi import APIRouter, Depends, Query, Request, status
 
 from tulip_api.auth.deps import get_current_claims, require_role
+from tulip_api.config import get_settings
 from tulip_api.deps import get_session
 from tulip_api.errors import (
     AccountNotFoundError,
@@ -42,7 +43,7 @@ router = APIRouter(prefix="/v1/accounts", tags=["accounts"])
 log = structlog.get_logger("tulip_api.accounts")
 
 
-def _to_read(a: Account) -> AccountRead:
+def _to_read(a: Account, *, notes: str | None = None) -> AccountRead:
     return AccountRead(
         id=a.id,
         code=a.code,
@@ -53,6 +54,7 @@ def _to_read(a: Account) -> AccountRead:
         visibility=a.visibility,
         is_active=a.is_active,
         parent_account_id=a.parent_account_id,
+        notes=notes,
     )
 
 
@@ -234,7 +236,8 @@ def create_account(
     takes the body's ``name`` / ``subtype`` / ``visibility``; parents
     take their segment as the name and inherit currency from the body.
     """
-    repo = AccountRepository(session, claims.household_id)
+    settings = get_settings()
+    repo = AccountRepository(session, claims.household_id, master_key=settings.master_key)
     audit = AuditLogWriter(session, claims.household_id)
     request_id = _request_uuid(request)
 
@@ -276,20 +279,31 @@ def create_account(
         subtype=body.subtype,
         parent_account_id=body.parent_account_id,
         visibility=body.visibility,
+        notes=body.notes,
         created_by_user_id=claims.user_id,
     )
+    after_snapshot: dict[str, object] = {
+        "name": a.name,
+        "type": a.type.value,
+        "currency": a.currency,
+    }
+    if body.notes:
+        # Don't write the notes contents into the audit log (#50 — the
+        # column is encrypted at rest precisely because the operator
+        # may put PII in there). Boolean signal is enough for the audit.
+        after_snapshot["notes_set"] = True
     audit.write(
         action="create",
         actor_kind="user",
         actor_user_id=claims.user_id,
         entity_type="account",
         entity_id=a.id,
-        after={"name": a.name, "type": a.type.value, "currency": a.currency},
+        after=after_snapshot,
         request_id=request_id,
     )
     session.commit()
     log.info("account.created", account_id=str(a.id))
-    return _to_read(a)
+    return _to_read(a, notes=body.notes)
 
 
 def _create_with_parents(
@@ -492,10 +506,12 @@ def get_account(
     session: Session = Depends(get_session),  # noqa: B008
 ) -> AccountRead:
     """Fetch an account by id (404 if not in this household or not visible)."""
-    a = AccountRepository(session, claims.household_id).get(account_id)
+    settings = get_settings()
+    repo = AccountRepository(session, claims.household_id, master_key=settings.master_key)
+    a = repo.get(account_id)
     if a is None or not _filter_for_role(a, claims):
         raise AccountNotFoundError()
-    return _to_read(a)
+    return _to_read(a, notes=repo.decrypt_notes(a))
 
 
 @router.patch(
@@ -523,7 +539,8 @@ def update_account(
     session: Session = Depends(get_session),  # noqa: B008
 ) -> AccountRead:
     """Update mutable fields. Member cannot edit private accounts they didn't create."""
-    repo = AccountRepository(session, claims.household_id)
+    settings = get_settings()
+    repo = AccountRepository(session, claims.household_id, master_key=settings.master_key)
     a = repo.get(account_id)
     if a is None or not _filter_for_role(a, claims):
         raise AccountNotFoundError()
@@ -567,8 +584,24 @@ def update_account(
         a.visibility = body.visibility
     if body.parent_account_id is not None:
         a.parent_account_id = body.parent_account_id
+    notes_changed = False
+    if body.notes is not None:
+        # `notes=""` clears; `notes="..."` updates. Omitting the key
+        # entirely (Pydantic gives None default) leaves it unchanged —
+        # so we distinguish "not in body" from "explicitly empty" via
+        # the pre-flush before snapshot.
+        repo.set_notes(a.id, body.notes if body.notes else None)
+        notes_changed = True
     session.flush()
 
+    after_snapshot: dict[str, object] = {
+        "name": a.name,
+        "code": a.code,
+        "visibility": a.visibility,
+        "parent_account_id": (str(a.parent_account_id) if a.parent_account_id else None),
+    }
+    if notes_changed:
+        after_snapshot["notes_set"] = a.notes_encrypted is not None
     AuditLogWriter(session, claims.household_id).write(
         action="update",
         actor_kind="user",
@@ -576,16 +609,11 @@ def update_account(
         entity_type="account",
         entity_id=a.id,
         before=before,
-        after={
-            "name": a.name,
-            "code": a.code,
-            "visibility": a.visibility,
-            "parent_account_id": str(a.parent_account_id) if a.parent_account_id else None,
-        },
+        after=after_snapshot,
         request_id=_request_uuid(request),
     )
     session.commit()
-    return _to_read(a)
+    return _to_read(a, notes=repo.decrypt_notes(a))
 
 
 @router.get(

--- a/packages/tulip-api/src/tulip_api/schemas/account.py
+++ b/packages/tulip-api/src/tulip_api/schemas/account.py
@@ -21,6 +21,16 @@ class AccountCreate(BaseModel):
     subtype: str | None = Field(default=None, max_length=50)
     parent_account_id: UUID | None = None
     visibility: str = Field(default="shared", pattern=r"^(shared|private)$")
+    notes: str | None = Field(
+        default=None,
+        description=(
+            "Freeform notes / comments — opaque to Tulip, stored "
+            "field-encrypted at rest under the household master key "
+            "(#50). Useful for capturing why the account exists, "
+            "external references, account-number tail digits, or "
+            "the source description from a chart-of-accounts import."
+        ),
+    )
     create_parents: bool = Field(
         default=False,
         description=(
@@ -58,6 +68,14 @@ class AccountUpdate(BaseModel):
             "top-level account instead."
         ),
     )
+    notes: str | None = Field(
+        default=None,
+        description=(
+            "Freeform notes / comments. Pass an empty string to clear "
+            "an existing note; omit the key entirely to leave it "
+            "unchanged. Encrypted at rest (#50)."
+        ),
+    )
 
 
 class AccountRead(BaseModel):
@@ -72,6 +90,13 @@ class AccountRead(BaseModel):
     visibility: str
     is_active: bool
     parent_account_id: UUID | None
+    notes: str | None = Field(
+        default=None,
+        description=(
+            "Freeform notes / comments (#50). Decrypted server-side "
+            "for the caller. Null when no note is set."
+        ),
+    )
     parents_created: list[AccountRead] | None = Field(
         default=None,
         description=(

--- a/packages/tulip-api/tests/test_accounts_endpoints.py
+++ b/packages/tulip-api/tests/test_accounts_endpoints.py
@@ -238,3 +238,132 @@ class TestTenantIsolation:
         names = {row["name"] for row in rows}
         assert "A's account" not in names
         assert names <= {"Imbalance: Unknown"}
+
+
+# ---- #50: freeform notes field --------------------------------------------
+
+
+class TestAccountNotes:
+    """``notes`` is field-encrypted at rest; round-trips via POST/GET/PATCH."""
+
+    def test_create_with_notes_round_trip(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Checking",
+                "type": "asset",
+                "currency": "USD",
+                "code": "1110",
+                "notes": "Opened Mar 2018; primary household checking.",
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["notes"] == "Opened Mar 2018; primary household checking."
+
+        # GET round-trip surfaces the decrypted notes.
+        r2 = client.get(f"/v1/accounts/{body['id']}", headers=auth_h)
+        assert r2.status_code == 200
+        assert r2.json()["notes"] == "Opened Mar 2018; primary household checking."
+
+    def test_create_without_notes_is_null(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "X", "type": "asset", "currency": "USD"},
+        )
+        assert r.status_code == 201
+        # Notes default null when omitted.
+        assert r.json()["notes"] is None
+        r2 = client.get(f"/v1/accounts/{r.json()['id']}", headers=auth_h)
+        assert r2.json()["notes"] is None
+
+    def test_patch_sets_notes(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "X", "type": "asset", "currency": "USD"},
+        ).json()
+        r = client.patch(
+            f"/v1/accounts/{created['id']}",
+            headers=auth_h,
+            json={"notes": "Added later"},
+        )
+        assert r.status_code == 200
+        assert r.json()["notes"] == "Added later"
+
+    def test_patch_clears_notes_with_empty_string(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "X",
+                "type": "asset",
+                "currency": "USD",
+                "notes": "to clear",
+            },
+        ).json()
+        assert created["notes"] == "to clear"
+        r = client.patch(
+            f"/v1/accounts/{created['id']}",
+            headers=auth_h,
+            json={"notes": ""},
+        )
+        assert r.status_code == 200
+        assert r.json()["notes"] is None
+
+    def test_list_endpoint_omits_notes(self, client: TestClient, auth_h: dict[str, str]):
+        """The list endpoint returns notes=null to avoid N decrypts.
+        Per-account GET is where the decrypted notes surface."""
+        client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "X",
+                "type": "asset",
+                "currency": "USD",
+                "notes": "ignore on list",
+            },
+        )
+        rows = client.get("/v1/accounts", headers=auth_h).json()
+        for row in rows:
+            assert row["notes"] is None
+
+    def test_audit_log_does_not_carry_notes_content(
+        self, client: TestClient, auth_h: dict[str, str], app
+    ):
+        from sqlalchemy import select
+
+        from tulip_api.deps import get_session
+        from tulip_storage.models import AuditLog
+
+        client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "X",
+                "type": "asset",
+                "currency": "USD",
+                "notes": "SECRET-MARKER-12345",
+            },
+        )
+        session_iter = app.dependency_overrides[get_session]()
+        session = next(session_iter)
+        try:
+            rows = list(
+                session.execute(select(AuditLog).where(AuditLog.action == "create")).scalars()
+            )
+        finally:
+            try:
+                next(session_iter)
+            except StopIteration:
+                pass
+        for row in rows:
+            after = row.after_snapshot or {}
+            for v in after.values():
+                if isinstance(v, str):
+                    assert "SECRET-MARKER-12345" not in v
+            # The bool flag is what the audit row carries.
+            if "notes_set" in after:
+                assert after["notes_set"] is True

--- a/packages/tulip-cli/src/tulip_cli/commands/accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/accounts.py
@@ -337,6 +337,13 @@ def _render_account(account: dict[str, Any], parent: dict[str, Any] | None = Non
             typer.echo(f"parent:       {parent_label} [{account['parent_account_id']}]")
         else:
             typer.echo(f"parent:       {account['parent_account_id']}")
+    notes = account.get("notes")
+    if notes:
+        # Multi-line indent so long notes still read cleanly.
+        first, *rest = notes.splitlines() or [""]
+        typer.echo(f"notes:        {first}")
+        for line in rest:
+            typer.echo(f"              {line}")
 
 
 @accounts_app.command("list")
@@ -443,6 +450,16 @@ def add_account(
             ),
         ),
     ] = False,
+    notes: Annotated[
+        str | None,
+        typer.Option(
+            "--notes",
+            help=(
+                "Optional freeform comment / context (#50). Stored "
+                "field-encrypted under the household master key."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Create a new account in the logged-in user's household.
 
@@ -483,6 +500,8 @@ def add_account(
         body["code"] = code
     if subtype is not None:
         body["subtype"] = subtype
+    if notes is not None:
+        body["notes"] = notes
     if create_parents:
         body["create_parents"] = True
 
@@ -557,6 +576,16 @@ def edit_account(
             ),
         ),
     ] = None,
+    notes: Annotated[
+        str | None,
+        typer.Option(
+            "--notes",
+            help=(
+                "Set the freeform notes / comments field (#50). Pass "
+                "an empty string to clear an existing note."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Update mutable fields on an existing account.
 
@@ -576,6 +605,8 @@ def edit_account(
         body["subtype"] = subtype
     if visibility is not None:
         body["visibility"] = visibility
+    if notes is not None:
+        body["notes"] = notes
 
     try:
         with _client(config, as_json=as_json) as client:

--- a/packages/tulip-storage/src/tulip_storage/repositories/account.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/account.py
@@ -7,19 +7,80 @@ from uuid import UUID, uuid4
 
 from sqlalchemy import select
 
+from tulip_storage.encryption import decrypt_field, encrypt_field, field_aad
 from tulip_storage.models import Account, AccountType
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
+class AccountMasterKeyRequiredError(RuntimeError):
+    """Raised when a notes write is attempted without a master key configured."""
+
+
 class AccountRepository:
     """CRUD for accounts within a single household."""
 
-    def __init__(self, session: Session, household_id: UUID) -> None:
-        """Bind the repository to a session and a tenant scope."""
+    def __init__(
+        self,
+        session: Session,
+        household_id: UUID,
+        *,
+        master_key: bytes | None = None,
+    ) -> None:
+        """Bind the repository to a session and a tenant scope.
+
+        ``master_key`` is required only when ``notes`` plaintext is
+        passed to ``create`` / ``set_notes`` (or read back via
+        :meth:`decrypt_notes`). The pre-existing CRUD surface stays
+        intact without it.
+        """
         self._session = session
         self._household_id = household_id
+        self._master_key = master_key
+
+    def _require_master_key(self) -> bytes:
+        if self._master_key is None:
+            raise AccountMasterKeyRequiredError(
+                "AccountRepository requires a master_key to encrypt or "
+                "decrypt account notes; construct with master_key=..."
+            )
+        return self._master_key
+
+    def _notes_aad(self, account_id: UUID) -> bytes:
+        return field_aad(
+            table="accounts",
+            column="notes_encrypted",
+            household_id=self._household_id,
+            row_id=account_id,
+        )
+
+    def decrypt_notes(self, account: Account) -> str | None:
+        """Return the plaintext notes for ``account`` or None when unset.
+
+        Decoded as UTF-8. Requires a configured master key.
+        """
+        if account.notes_encrypted is None:
+            return None
+        key = self._require_master_key()
+        return decrypt_field(account.notes_encrypted, key, aad=self._notes_aad(account.id)).decode(
+            "utf-8"
+        )
+
+    def set_notes(self, account_id: UUID, notes: str | None) -> Account:
+        """Encrypt + persist a freeform notes string, or clear with None."""
+        account = self.get(account_id)
+        if account is None:
+            raise LookupError(f"account {account_id} not found in household {self._household_id}")
+        if notes is None or notes == "":
+            account.notes_encrypted = None
+        else:
+            key = self._require_master_key()
+            account.notes_encrypted = encrypt_field(
+                notes.encode("utf-8"), key, aad=self._notes_aad(account_id)
+            )
+        self._session.flush()
+        return account
 
     def create(
         self,
@@ -31,9 +92,14 @@ class AccountRepository:
         subtype: str | None = None,
         parent_account_id: UUID | None = None,
         visibility: str = "shared",
+        notes: str | None = None,
         created_by_user_id: UUID | None = None,
     ) -> Account:
-        """Insert a new Account into this repository's household."""
+        """Insert a new Account into this repository's household.
+
+        When ``notes`` is provided, the repository must have been
+        constructed with a master key — see :meth:`__init__`.
+        """
         a = Account(
             household_id=self._household_id,
             id=uuid4(),
@@ -47,6 +113,9 @@ class AccountRepository:
             parent_account_id=parent_account_id,
             created_by_user_id=created_by_user_id,
         )
+        if notes:
+            key = self._require_master_key()
+            a.notes_encrypted = encrypt_field(notes.encode("utf-8"), key, aad=self._notes_aad(a.id))
         self._session.add(a)
         self._session.flush()
         return a

--- a/packages/tulip-storage/tests/test_repositories.py
+++ b/packages/tulip-storage/tests/test_repositories.py
@@ -96,6 +96,51 @@ class TestAccountRepository:
         # but get() still finds it
         assert repo.get(a.id) is not None
 
+    def test_notes_round_trip(self, session: Session, household: Household):
+        # 32-byte deterministic test key.
+        master_key = b"\x00" * 32
+        repo = AccountRepository(session, household.id, master_key=master_key)
+        a = repo.create(
+            code="1110",
+            name="Checking",
+            type=AccountType.ASSET,
+            currency="USD",
+            notes="Opened Mar 2018; primary household checking.",
+        )
+        session.commit()
+
+        # Encrypted at rest — no plaintext in the column.
+        assert a.notes_encrypted is not None
+        assert b"primary household checking" not in a.notes_encrypted
+
+        # Read back via the same key decrypts cleanly.
+        assert repo.decrypt_notes(a) == "Opened Mar 2018; primary household checking."
+
+        # Update via set_notes round-trips.
+        repo.set_notes(a.id, "Updated note.")
+        session.commit()
+        assert repo.decrypt_notes(repo.get(a.id)) == "Updated note."
+
+        # Clearing via None nulls the column.
+        repo.set_notes(a.id, None)
+        session.commit()
+        assert repo.get(a.id).notes_encrypted is None
+        assert repo.decrypt_notes(repo.get(a.id)) is None
+
+    def test_notes_requires_master_key(self, session: Session, household: Household):
+        from tulip_storage.repositories.account import AccountMasterKeyRequiredError
+
+        # No master key configured.
+        repo = AccountRepository(session, household.id)
+        with pytest.raises(AccountMasterKeyRequiredError):
+            repo.create(
+                code="1110",
+                name="X",
+                type=AccountType.ASSET,
+                currency="USD",
+                notes="non-empty",
+            )
+
     def test_get_by_code_returns_match(self, session: Session, household: Household):
         repo = AccountRepository(session, household.id)
         a = repo.create(


### PR DESCRIPTION
## Summary

- The \`accounts.notes_encrypted\` column existed in storage but
  no CRUD path read or wrote it. This PR plumbs it through:
  storage repo + API schemas + CLI flags.
- Notes are field-encrypted at rest with \`field_aad\` bound to
  row id (same pattern as transaction notes).
- API: \`POST /v1/accounts\` accepts \`notes\`; \`PATCH /v1/accounts/{id}\`
  takes \`notes\` (empty string clears, omission leaves unchanged);
  \`GET /v1/accounts/{id}\` returns decrypted notes. The list
  endpoint deliberately omits decryption to keep bulk reads
  cheap.
- Audit log records only a boolean \`notes_set\` flag, never the
  contents.
- CLI: \`tulip accounts add --notes "..."\`,
  \`tulip accounts edit ACCOUNT --notes "..."\`,
  \`tulip accounts show\` renders notes with multi-line indent.

Precondition for #432 (GnuCash import) — the importer can now
land the GnuCash CSV's \`Description\` column into Tulip's
\`notes\` field without a workaround.

8 new tests (2 storage / 6 API). All 51 account tests green.

## Test plan

\`\`\`bash
uv run --package tulip-storage pytest packages/tulip-storage/tests/test_repositories.py -q -k Account
uv run --package tulip-api pytest packages/tulip-api/tests/test_accounts_endpoints.py -q
just lint
just typecheck
\`\`\`

- [x] Storage tests green (17 + 2 new)
- [x] API tests green (40 + 6 new)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (Success: no issues found in 305 source files)
- [ ] CI green on this PR

## Out of scope (deliberately)

- TUI surfacing — adding a \`notes\` input to \`AccountEditModal\`
  conflicts with PR #436 (#431) which adds the modal itself.
  Will land as a small follow-up commit after #436 merges.