### PR TITLE
feat(accounts): is_placeholder flag rejects postings (closes #52)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -1824,6 +1824,48 @@ mutations that makes the TUI a daily driver, in dependency order.
 ADR-0007 amended under "Status update mechanism" recording the
 scope extension.
 
+#### Account placeholder flag (`is_placeholder`) — ✅ *(2026-05-20)*
+
+Per [#52](https://github.com/rmwarriner/tulip-accounting/issues/52). Adds a flag to mark non-posting
+organisational nodes in the chart of accounts (e.g.
+`Assets:Current Assets`). The API rejects any posting whose
+target account has `is_placeholder=true` with a typed
+`account.placeholder_posting` Problem Detail (400). Same check
+applies to `POST /v1/transactions`, `/replace`, the
+`PATCH` body, and the `POST /v1/imports/{id}/apply` bulk path.
+
+Flipping an existing account to placeholder refuses when it
+has postings (`account.placeholder_has_postings`, 409, carries
+`posting_count`); unsetting is unconditional.
+
+CLI: `tulip accounts add --placeholder`,
+`tulip accounts edit --placeholder/--no-placeholder`,
+`tulip accounts show` surfaces the flag. New migration adds the
+column (defaults to false; no behaviour change for existing
+chart). Precondition for the GnuCash import (#432) to land its
+`Placeholder` column cleanly.
+
+#### Account freeform notes field — ✅ *(2026-05-20)*
+
+Per [#50](https://github.com/rmwarriner/tulip-accounting/issues/50). The `accounts.notes_encrypted` column
+already existed in storage (field-encrypted under the master
+key) but no CRUD path read or wrote it. This slice plumbs it
+through:
+
+- `POST` / `PATCH /v1/accounts` accept `notes`. `PATCH` with
+  empty string clears; omission leaves unchanged.
+- `GET /v1/accounts/{id}` decrypts and returns `notes`. The
+  list endpoint deliberately omits decryption (notes=null) to
+  keep the bulk read cheap.
+- Audit log carries only a boolean `notes_set` flag, never the
+  contents.
+- CLI: `tulip accounts add --notes "..."`,
+  `tulip accounts edit ACCOUNT --notes "..."`,
+  `tulip accounts show` renders notes with multi-line indent.
+
+Precondition for the GnuCash import (#432) to land the
+`Description` column cleanly.
+
 #### P9.6.c — Add/edit/void transaction modal in the TUI — ✅ *(2026-05-20)*
 
 Per [#423](https://github.com/rmwarriner/tulip-accounting/issues/423). Three new bindings on the transactions

--- a/packages/tulip-api/src/tulip_api/errors.py
+++ b/packages/tulip-api/src/tulip_api/errors.py
@@ -540,6 +540,49 @@ class AccountUnknownError(TulipProblem):
         )
 
 
+class AccountPlaceholderPostingError(TulipProblem):
+    """A transaction posting targeted a placeholder account (#52)."""
+
+    def __init__(self, account_id: str) -> None:
+        """Build the account.placeholder_posting problem.
+
+        ``account_id`` identifies the offending posting's target so the
+        caller knows which leg to fix.
+        """
+        super().__init__(
+            code="account.placeholder_posting",
+            title="Cannot post to a placeholder account",
+            status=400,
+            detail=(
+                f"Account {account_id} is a placeholder (organisational "
+                "node, not a posting target). Pick a leaf account under "
+                "this branch, or clear the placeholder flag first."
+            ),
+            extensions={"account_id": account_id},
+        )
+
+
+class AccountPlaceholderHasPostingsError(TulipProblem):
+    """Attempted to set is_placeholder=True on an account that has postings (#52)."""
+
+    def __init__(self, account_id: str, posting_count: int) -> None:
+        """Build the account.placeholder_has_postings problem."""
+        super().__init__(
+            code="account.placeholder_has_postings",
+            title="Account has postings — can't make it a placeholder",
+            status=409,
+            detail=(
+                f"Account {account_id} has {posting_count} posting(s). "
+                "Placeholder accounts can't receive postings; void or "
+                "re-target those postings before flipping the flag."
+            ),
+            extensions={
+                "account_id": account_id,
+                "posting_count": posting_count,
+            },
+        )
+
+
 class AccountPathInvalidError(TulipProblem):
     """``code`` passed with ``create_parents=true`` failed path validation (#46)."""
 

--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -21,6 +21,7 @@ from tulip_api.errors import (
     AccountParentTypeMismatchError,
     AccountParentVisibilityViolationError,
     AccountPathInvalidError,
+    AccountPlaceholderHasPostingsError,
     ForbiddenError,
     problem_response,
 )
@@ -52,6 +53,7 @@ def _to_read(a: Account) -> AccountRead:
         currency=a.currency,
         visibility=a.visibility,
         is_active=a.is_active,
+        is_placeholder=a.is_placeholder,
         parent_account_id=a.parent_account_id,
     )
 
@@ -276,6 +278,7 @@ def create_account(
         subtype=body.subtype,
         parent_account_id=body.parent_account_id,
         visibility=body.visibility,
+        is_placeholder=body.is_placeholder,
         created_by_user_id=claims.user_id,
     )
     audit.write(
@@ -567,6 +570,29 @@ def update_account(
         a.visibility = body.visibility
     if body.parent_account_id is not None:
         a.parent_account_id = body.parent_account_id
+    if body.is_placeholder is not None:
+        if body.is_placeholder and not a.is_placeholder:
+            # Flipping to placeholder is only safe if the account has no
+            # postings — otherwise placeholder + existing postings would
+            # be a contradiction. Count postings within this household.
+            from sqlalchemy import func
+            from sqlalchemy import select as _select
+
+            from tulip_storage.models import Posting
+
+            posting_count = session.execute(
+                _select(func.count())
+                .select_from(Posting)
+                .where(
+                    Posting.household_id == claims.household_id,
+                    Posting.account_id == a.id,
+                )
+            ).scalar_one()
+            if posting_count > 0:
+                raise AccountPlaceholderHasPostingsError(
+                    account_id=str(a.id), posting_count=int(posting_count)
+                )
+        a.is_placeholder = body.is_placeholder
     session.flush()
 
     AuditLogWriter(session, claims.household_id).write(

--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -72,6 +72,7 @@ from tulip_api.services.import_apply import (
     CategorizeUnknownAccountError,
     LineAlreadyPromotedError,
     LineExcludedError,
+    PlaceholderAccountError,
     apply_batch,
     promote_statement_line,
     serialize_parsed_line_raw_json,
@@ -688,6 +689,7 @@ async def upload_multi_account_qif(
     status_code=status.HTTP_200_OK,
     responses={
         401: problem_response("auth.unauthorized"),
+        400: problem_response("account.placeholder_posting"),
         403: problem_response("auth.forbidden"),
         404: problem_response("import_batch.not_found"),
         409: problem_response(
@@ -764,6 +766,10 @@ async def apply_import(
         raise ImportAlreadyAppliedError(batch_id=str(batch_id)) from exc
     except CategorizeUnknownAccountError as exc:
         raise ImportCategorizeUnknownAccountError(account_code=exc.account_code) from exc
+    except PlaceholderAccountError as exc:
+        from tulip_api.errors import AccountPlaceholderPostingError
+
+        raise AccountPlaceholderPostingError(account_id=exc.account_id) from exc
 
     AuditLogWriter(session, claims.household_id).write(
         action="import_apply",

--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -113,6 +113,7 @@ log = structlog.get_logger("tulip_api.transactions")
     responses={
         400: problem_response(
             "account.unknown",
+            "account.placeholder_posting",
             "transaction.invalid",
             "transaction.unbalanced",
             "period.closed",
@@ -148,6 +149,10 @@ def create_transaction(
         a = accounts_repo.get(p.account_id)
         if a is None:
             raise AccountUnknownError(account_id=str(p.account_id))
+        if a.is_placeholder:
+            from tulip_api.errors import AccountPlaceholderPostingError
+
+            raise AccountPlaceholderPostingError(account_id=str(p.account_id))
         accounts_by_id[p.account_id] = a
 
     # ---- Pool pre-flight checks ------------------------------------
@@ -502,6 +507,10 @@ def replace_transaction(
         a = accounts_repo.get(p.account_id)
         if a is None:
             raise AccountUnknownError(account_id=str(p.account_id))
+        if a.is_placeholder:
+            from tulip_api.errors import AccountPlaceholderPostingError
+
+            raise AccountPlaceholderPostingError(account_id=str(p.account_id))
         accounts_by_id[p.account_id] = a
 
     pool_repo = AllocationPoolRepository(session, claims.household_id)
@@ -713,7 +722,7 @@ def _resolve_notes_patch(body: TransactionUpdate) -> str | None | object:
     "/{tx_id}",
     response_model=TransactionRead,
     responses={
-        400: problem_response("account.unknown", "tag.invalid"),
+        400: problem_response("account.unknown", "account.placeholder_posting", "tag.invalid"),
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
         404: problem_response("transaction.not_found"),
@@ -745,8 +754,13 @@ def patch_transaction(
         # Validate account refs before delegating to the repo.
         accounts_repo = AccountRepository(session, claims.household_id)
         for p in body.postings:
-            if accounts_repo.get(p.account_id) is None:
+            a = accounts_repo.get(p.account_id)
+            if a is None:
                 raise AccountUnknownError(account_id=str(p.account_id))
+            if a.is_placeholder:
+                from tulip_api.errors import AccountPlaceholderPostingError
+
+                raise AccountPlaceholderPostingError(account_id=str(p.account_id))
         new_postings: tuple[DomainPosting, ...] = tuple(
             DomainPosting(
                 id=uuid4(),

--- a/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
+++ b/packages/tulip-api/src/tulip_api/routers/well_known_errors.py
@@ -33,6 +33,11 @@ _PLACEHOLDER_ARGS: dict[str, dict[str, Any]] = {
     "MfaRequiredError": {"mfa_token": "<mfa-challenge-jwt>", "expires_in": 300},
     "AccountPathInvalidError": {"reason": "root segment 'widgets' does not name an account type"},
     "AccountUnknownError": {"account_id": "<account-uuid>"},
+    "AccountPlaceholderPostingError": {"account_id": "<account-uuid>"},
+    "AccountPlaceholderHasPostingsError": {
+        "account_id": "<account-uuid>",
+        "posting_count": 42,
+    },
     "TagInvalidError": {"reason": "tag 'has space' must be 1-64 chars of [A-Za-z0-9_-./:]"},
     "AccountParentTypeMismatchError": {"child_type": "expense", "parent_type": "asset"},
     "AccountParentCurrencyMismatchError": {

--- a/packages/tulip-api/src/tulip_api/schemas/account.py
+++ b/packages/tulip-api/src/tulip_api/schemas/account.py
@@ -21,6 +21,15 @@ class AccountCreate(BaseModel):
     subtype: str | None = Field(default=None, max_length=50)
     parent_account_id: UUID | None = None
     visibility: str = Field(default="shared", pattern=r"^(shared|private)$")
+    is_placeholder: bool = Field(
+        default=False,
+        description=(
+            "When true, marks the account as a non-posting organisational "
+            "node (#52). The API rejects any posting whose target account "
+            "is a placeholder; the operator must create + post to a leaf "
+            "instead. Defaults to false (regular postable account)."
+        ),
+    )
     create_parents: bool = Field(
         default=False,
         description=(
@@ -58,6 +67,14 @@ class AccountUpdate(BaseModel):
             "top-level account instead."
         ),
     )
+    is_placeholder: bool | None = Field(
+        default=None,
+        description=(
+            "Toggle the placeholder flag (#52). Omit to leave unchanged. "
+            "Turning a regular account into a placeholder is rejected if "
+            "it has direct postings — clean those up first."
+        ),
+    )
 
 
 class AccountRead(BaseModel):
@@ -71,6 +88,7 @@ class AccountRead(BaseModel):
     currency: str
     visibility: str
     is_active: bool
+    is_placeholder: bool = False
     parent_account_id: UUID | None
     parents_created: list[AccountRead] | None = Field(
         default=None,

--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -242,6 +242,18 @@ class CategorizeUnknownAccountError(ValueError):
         self.household_id = household_id
 
 
+class PlaceholderAccountError(ValueError):
+    """The target account for a posting is a placeholder (#52)."""
+
+    def __init__(self, account_id: str) -> None:
+        """Build with the offending account id."""
+        super().__init__(
+            f"cannot post to placeholder account {account_id}; pick a leaf "
+            "or clear the placeholder flag"
+        )
+        self.account_id = account_id
+
+
 @dataclass(frozen=True, slots=True)
 class ApplyResult:
     """Summary of a successful ``apply_batch`` call."""
@@ -328,6 +340,12 @@ async def promote_statement_line(
     bank_account = accounts.get(batch.account_id)
     if bank_account is None:  # pragma: no cover - bank account is FK-enforced
         raise LookupError(f"batch.account_id {batch.account_id} not found")
+    if bank_account.is_placeholder:
+        # #52: a batch's bank account can be flipped to placeholder after
+        # the batch is uploaded; reject the apply rather than write a
+        # posting against a placeholder. The router lifts this to the
+        # account.placeholder_posting Problem Detail.
+        raise PlaceholderAccountError(account_id=str(bank_account.id))
 
     splits = _extract_splits_from_raw_json(line.raw_json, currency=line.currency)
     # Status resolution per #279 (see docstring).

--- a/packages/tulip-api/tests/test_accounts_endpoints.py
+++ b/packages/tulip-api/tests/test_accounts_endpoints.py
@@ -238,3 +238,148 @@ class TestTenantIsolation:
         names = {row["name"] for row in rows}
         assert "A's account" not in names
         assert names <= {"Imbalance: Unknown"}
+
+
+# ---- #52: placeholder flag (leaf-only postings) -----------------------------
+
+
+class TestAccountPlaceholder:
+    """The placeholder flag rejects postings against placeholder accounts."""
+
+    def test_create_with_placeholder_default_false(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "X", "type": "asset", "currency": "USD"},
+        )
+        assert r.status_code == 201
+        assert r.json()["is_placeholder"] is False
+
+    def test_create_with_placeholder_true(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Current Assets",
+                "type": "asset",
+                "currency": "USD",
+                "is_placeholder": True,
+            },
+        )
+        assert r.status_code == 201
+        assert r.json()["is_placeholder"] is True
+
+    def test_patch_flips_placeholder(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "X", "type": "asset", "currency": "USD"},
+        ).json()
+        r = client.patch(
+            f"/v1/accounts/{created['id']}",
+            headers=auth_h,
+            json={"is_placeholder": True},
+        )
+        assert r.status_code == 200
+        assert r.json()["is_placeholder"] is True
+
+    def test_posting_to_placeholder_rejected(self, client: TestClient, auth_h: dict[str, str]):
+        # Create a placeholder asset + a real expense.
+        ph = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Current Assets",
+                "type": "asset",
+                "currency": "USD",
+                "is_placeholder": True,
+            },
+        ).json()
+        food = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Food", "type": "expense", "currency": "USD"},
+        ).json()
+
+        # Posting against the placeholder rejects with the typed problem.
+        r = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": "2026-05-20",
+                "description": "lunch",
+                "postings": [
+                    {
+                        "account_id": ph["id"],
+                        "amount": "-10.00",
+                        "currency": "USD",
+                    },
+                    {
+                        "account_id": food["id"],
+                        "amount": "10.00",
+                        "currency": "USD",
+                    },
+                ],
+            },
+        )
+        assert_problem(r, status=400, code="account.placeholder_posting")
+        assert r.json()["account_id"] == ph["id"]
+
+    def test_patch_to_placeholder_rejected_when_postings_exist(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        # Create two real accounts, post a transaction, then try to
+        # flip one of them to placeholder.
+        cash = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Cash", "type": "asset", "currency": "USD"},
+        ).json()
+        food = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Food", "type": "expense", "currency": "USD"},
+        ).json()
+        client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": "2026-05-20",
+                "description": "lunch",
+                "postings": [
+                    {"account_id": cash["id"], "amount": "-10.00", "currency": "USD"},
+                    {"account_id": food["id"], "amount": "10.00", "currency": "USD"},
+                ],
+            },
+        )
+
+        r = client.patch(
+            f"/v1/accounts/{cash['id']}",
+            headers=auth_h,
+            json={"is_placeholder": True},
+        )
+        assert_problem(r, status=409, code="account.placeholder_has_postings")
+        assert r.json()["account_id"] == cash["id"]
+        assert r.json()["posting_count"] >= 1
+
+    def test_unsetting_placeholder_is_unblocked(self, client: TestClient, auth_h: dict[str, str]):
+        # Flipping placeholder → false is unconditional (no postings yet).
+        ph = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "X",
+                "type": "asset",
+                "currency": "USD",
+                "is_placeholder": True,
+            },
+        ).json()
+        r = client.patch(
+            f"/v1/accounts/{ph['id']}",
+            headers=auth_h,
+            json={"is_placeholder": False},
+        )
+        assert r.status_code == 200
+        assert r.json()["is_placeholder"] is False

--- a/packages/tulip-cli/src/tulip_cli/commands/accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/accounts.py
@@ -331,6 +331,8 @@ def _render_account(account: dict[str, Any], parent: dict[str, Any] | None = Non
     typer.echo(f"currency:     {account.get('currency', '')}")
     typer.echo(f"visibility:   {account.get('visibility', '')}")
     typer.echo(f"is_active:    {account.get('is_active', '')}")
+    if account.get("is_placeholder"):
+        typer.echo("placeholder:  true (rejects postings)")
     if account.get("parent_account_id"):
         if parent is not None:
             parent_label = f"{parent.get('code') or '—'} ({parent.get('name', '')})"
@@ -443,6 +445,17 @@ def add_account(
             ),
         ),
     ] = False,
+    placeholder: Annotated[
+        bool,
+        typer.Option(
+            "--placeholder",
+            help=(
+                "Mark this account as a non-posting organisational node "
+                "(#52). The API rejects any posting whose target is a "
+                "placeholder; useful for chart-of-accounts headers."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Create a new account in the logged-in user's household.
 
@@ -483,6 +496,8 @@ def add_account(
         body["code"] = code
     if subtype is not None:
         body["subtype"] = subtype
+    if placeholder:
+        body["is_placeholder"] = True
     if create_parents:
         body["create_parents"] = True
 
@@ -557,6 +572,17 @@ def edit_account(
             ),
         ),
     ] = None,
+    placeholder: Annotated[
+        bool | None,
+        typer.Option(
+            "--placeholder/--no-placeholder",
+            help=(
+                "Toggle the placeholder flag (#52). Flipping to "
+                "placeholder requires the account to have no existing "
+                "postings."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Update mutable fields on an existing account.
 
@@ -576,6 +602,8 @@ def edit_account(
         body["subtype"] = subtype
     if visibility is not None:
         body["visibility"] = visibility
+    if placeholder is not None:
+        body["is_placeholder"] = placeholder
 
     try:
         with _client(config, as_json=as_json) as client:

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260520_2100_a8b3c2d1f4e5_accounts_is_placeholder.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260520_2100_a8b3c2d1f4e5_accounts_is_placeholder.py
@@ -1,0 +1,49 @@
+"""Add ``accounts.is_placeholder`` flag (#52).
+
+A placeholder account is a non-posting node in the chart of accounts
+— typically an organisational header like "Assets:Current Assets"
+that's there to group its children, not to receive postings itself.
+
+Today nothing enforces that distinction; users can post to any
+account and the chart-of-accounts hygiene is on the operator. With
+this column the API can reject any posting whose target account has
+``is_placeholder=true``, prompting the user to pick a leaf instead.
+
+The column defaults to ``false`` for every existing row, so no
+existing behaviour changes — placeholder accounts are opt-in.
+
+Revision ID: a8b3c2d1f4e5
+Revises: f4d8c2a1b9e7
+Create Date: 2026-05-20 21:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a8b3c2d1f4e5"
+down_revision: str | None = "f4d8c2a1b9e7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``is_placeholder BOOLEAN NOT NULL DEFAULT 0`` to ``accounts``."""
+    with op.batch_alter_table("accounts") as batch:
+        batch.add_column(
+            sa.Column(
+                "is_placeholder",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade() -> None:
+    """Drop the column."""
+    with op.batch_alter_table("accounts") as batch:
+        batch.drop_column("is_placeholder")

--- a/packages/tulip-storage/src/tulip_storage/models/account.py
+++ b/packages/tulip-storage/src/tulip_storage/models/account.py
@@ -71,6 +71,9 @@ class Account(Base):
     currency: Mapped[str] = mapped_column(String(3), nullable=False)
     visibility: Mapped[str] = mapped_column(String(10), nullable=False, default="shared")
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    is_placeholder: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
     external_account_number_encrypted: Mapped[bytes | None] = mapped_column(nullable=True)
     notes_encrypted: Mapped[bytes | None] = mapped_column(nullable=True)
     created_by_user_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True)

--- a/packages/tulip-storage/src/tulip_storage/repositories/account.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/account.py
@@ -31,9 +31,15 @@ class AccountRepository:
         subtype: str | None = None,
         parent_account_id: UUID | None = None,
         visibility: str = "shared",
+        is_placeholder: bool = False,
         created_by_user_id: UUID | None = None,
     ) -> Account:
-        """Insert a new Account into this repository's household."""
+        """Insert a new Account into this repository's household.
+
+        ``is_placeholder=True`` marks the account as a non-posting
+        organisational node (#52); the API rejects postings against
+        placeholder accounts.
+        """
         a = Account(
             household_id=self._household_id,
             id=uuid4(),
@@ -44,10 +50,20 @@ class AccountRepository:
             currency=currency,
             visibility=visibility,
             is_active=True,
+            is_placeholder=is_placeholder,
             parent_account_id=parent_account_id,
             created_by_user_id=created_by_user_id,
         )
         self._session.add(a)
+        self._session.flush()
+        return a
+
+    def set_placeholder(self, account_id: UUID, is_placeholder: bool) -> Account:
+        """Toggle the placeholder flag (#52)."""
+        a = self.get(account_id)
+        if a is None:
+            raise LookupError(f"account {account_id} not found in household {self._household_id}")
+        a.is_placeholder = is_placeholder
         self._session.flush()
         return a
 


### PR DESCRIPTION
## Summary

- Adds \`is_placeholder\` to the chart of accounts. Useful for
  chart-of-accounts headers ("Assets:Current Assets") that
  organise the tree but aren't themselves posting targets.
- Precondition for the GnuCash import (#432) to land its
  \`Placeholder\` column cleanly.
- New migration adds the column; defaults to false so nothing
  existing changes.
- POST/PATCH \`/v1/transactions\` and the \`/replace\` endpoint
  reject postings against placeholder accounts with the new
  \`account.placeholder_posting\` Problem Detail (400). Same
  rejection lifts through \`POST /v1/imports/{id}/apply\` for the
  bulk path.
- PATCH \`/v1/accounts/{id}\` with \`is_placeholder=true\` refuses
  when the account has existing postings (409
  \`account.placeholder_has_postings\` with \`posting_count\`).
  Unsetting is unconditional.
- CLI: \`tulip accounts add --placeholder\`, \`tulip accounts edit
  ACCOUNT --placeholder/--no-placeholder\`, \`tulip accounts show\`
  surfaces the flag.

6 new API tests cover every path.

## Test plan

\`\`\`bash
uv run --package tulip-api pytest packages/tulip-api/tests/test_accounts_endpoints.py packages/tulip-api/tests/test_transactions_endpoints.py packages/tulip-api/tests/test_apply_promote_endpoints.py -q
just lint
just typecheck
\`\`\`

- [x] 57 tests pass locally
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (Success: no issues found in 306 source files)
- [ ] CI green on this PR

## Out of scope (deliberately)

- TUI surfacing the flag in AccountEditModal — follow-up commit
  once #436 merges and stabilises.
- Migrating existing placeholder-ish accounts (e.g. ones that
  exist purely as parent nodes today). The operator can toggle
  via CLI \`tulip accounts edit\` once they identify them.