### PR TITLE
feat(tui): surface notes + placeholder on AccountEditModal

### DIFF
--- a/packages/tulip-tui/src/tulip_tui/data/account_write.py
+++ b/packages/tulip-tui/src/tulip_tui/data/account_write.py
@@ -24,6 +24,8 @@ class AccountDraft:
     subtype: str | None
     visibility: str  # shared / private
     parent_account_id: str | None
+    notes: str | None = None  # #50: freeform notes (encrypted at rest)
+    is_placeholder: bool = False  # #52: leaf-only postings
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +57,10 @@ def create_account(client: TulipClient, draft: AccountDraft) -> dict[str, object
         body["subtype"] = draft.subtype
     if draft.parent_account_id:
         body["parent_account_id"] = draft.parent_account_id
+    if draft.notes:
+        body["notes"] = draft.notes
+    if draft.is_placeholder:
+        body["is_placeholder"] = True
     resp = client.post("/v1/accounts", authenticated=True, json=body)
     return cast("dict[str, object]", resp.json())
 

--- a/packages/tulip-tui/src/tulip_tui/data/accounts.py
+++ b/packages/tulip-tui/src/tulip_tui/data/accounts.py
@@ -40,6 +40,7 @@ class AccountSummary:
     type: str
     currency: str
     balance: Decimal | None
+    is_placeholder: bool = False  # #52
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,6 +81,7 @@ def load_accounts(client: TulipClient) -> AccountsData:
                 type=str(raw.get("type", "")),
                 currency=str(raw.get("currency", "")),
                 balance=balances_by_id.get(account_id),
+                is_placeholder=bool(raw.get("is_placeholder", False)),
             )
         )
 

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -251,6 +251,7 @@ def _account_edit_action(account_id: str, draft: AccountDraft) -> object:
     patch: dict[str, object] = {
         "name": draft.name,
         "visibility": draft.visibility,
+        "is_placeholder": draft.is_placeholder,
     }
     if draft.code is not None:
         patch["code"] = draft.code
@@ -258,6 +259,8 @@ def _account_edit_action(account_id: str, draft: AccountDraft) -> object:
         patch["subtype"] = draft.subtype
     if draft.parent_account_id is not None:
         patch["parent_account_id"] = draft.parent_account_id
+    if draft.notes is not None:
+        patch["notes"] = draft.notes
     with TulipClient(config, token_store=default_token_store()) as client:
         return update_account(client, account_id, patch)
 

--- a/packages/tulip-tui/src/tulip_tui/screens/account_modal.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/account_modal.py
@@ -90,6 +90,8 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
         initial_subtype: str = "",
         initial_visibility: str = "shared",
         initial_parent_id: str | None = None,
+        initial_notes: str = "",
+        initial_placeholder: bool = False,
     ) -> None:
         """Store prefill values; modal renders on mount."""
         super().__init__()
@@ -101,6 +103,8 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
         self._initial_subtype = initial_subtype
         self._initial_visibility = initial_visibility
         self._initial_parent_id = initial_parent_id
+        self._initial_notes = initial_notes
+        self._initial_placeholder = initial_placeholder
         self._error: str = ""
 
     def compose(self) -> ComposeResult:
@@ -126,11 +130,22 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
                     value=self._initial_visibility == "private",
                     id="acct-private",
                 )
+            with Horizontal(id="acct-placeholder-row"):
+                yield Static(
+                    "placeholder (organisational; rejects postings)?",
+                    classes="label",
+                )
+                yield Switch(
+                    value=self._initial_placeholder,
+                    id="acct-placeholder",
+                )
             yield Static("parent account id (optional)", classes="label")
             yield Input(
                 value=self._initial_parent_id or "",
                 id="acct-parent-id",
             )
+            yield Static("notes (optional, encrypted at rest)", classes="label")
+            yield Input(value=self._initial_notes, id="acct-notes")
             yield Static("", id="acct-error")
             with Horizontal(id="acct-buttons"):
                 yield Button("Cancel", id="acct-cancel")
@@ -156,8 +171,10 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
         code = self.query_one("#acct-code", Input).value.strip() or None
         subtype = self.query_one("#acct-subtype", Input).value.strip() or None
         visibility = "private" if self.query_one("#acct-private", Switch).value else "shared"
+        is_placeholder = self.query_one("#acct-placeholder", Switch).value
         parent_id_raw = self.query_one("#acct-parent-id", Input).value.strip()
         parent_id = parent_id_raw or None
+        notes = self.query_one("#acct-notes", Input).value.strip() or None
 
         if not name:
             self._set_error("name is required")
@@ -177,6 +194,8 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
             subtype=subtype,
             visibility=visibility,
             parent_account_id=parent_id,
+            notes=notes,
+            is_placeholder=is_placeholder,
         )
 
     def _set_error(self, msg: str) -> None:

--- a/packages/tulip-tui/src/tulip_tui/screens/accounts.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/accounts.py
@@ -161,6 +161,7 @@ class AccountsScreen(Screen[None]):
             initial_type=account.type,
             initial_currency=account.currency,
             initial_code=account.code or "",
+            initial_placeholder=account.is_placeholder,
         )
         account_id = account.id
         self.app.push_screen(modal, lambda result: self._on_edit_modal_done(account_id, result))

--- a/packages/tulip-tui/tests/test_account_modal_screen.py
+++ b/packages/tulip-tui/tests/test_account_modal_screen.py
@@ -133,6 +133,42 @@ async def test_modal_builds_draft_on_valid_input() -> None:
 
 
 @pytest.mark.asyncio
+async def test_modal_carries_notes_and_placeholder_in_draft() -> None:
+    """#50 + #52: notes and is_placeholder flow through the modal."""
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = AccountEditModal(
+            initial_name="Current Assets",
+            initial_type="asset",
+            initial_currency="USD",
+            initial_notes="Pre-filled note",
+            initial_placeholder=True,
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        draft = modal.snapshot()
+    assert draft is not None
+    assert draft.notes == "Pre-filled note"
+    assert draft.is_placeholder is True
+
+
+@pytest.mark.asyncio
+async def test_modal_blank_notes_become_none() -> None:
+    """Empty notes input → ``None`` in the draft (omitted from PATCH)."""
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = AccountEditModal(initial_name="X")
+        await app.push_screen(modal)
+        await pilot.pause()
+        draft = modal.snapshot()
+    assert draft is not None
+    assert draft.notes is None
+    assert draft.is_placeholder is False
+
+
+@pytest.mark.asyncio
 async def test_modal_currency_is_uppercased() -> None:
     app = TulipTuiApp(loader=_accounts_loader_empty)
     async with app.run_test() as pilot:

--- a/packages/tulip-tui/tests/test_account_write_data.py
+++ b/packages/tulip-tui/tests/test_account_write_data.py
@@ -75,9 +75,42 @@ def test_create_account_omits_optional_fields() -> None:
     # subtype and parent are omitted when None.
     assert "subtype" not in seen["body"]
     assert "parent_account_id" not in seen["body"]
+    # notes / is_placeholder default to None / False — also omitted.
+    assert "notes" not in seen["body"]
+    assert "is_placeholder" not in seen["body"]
     assert seen["body"]["name"] == "Checking"
     assert seen["body"]["code"] == "1110"
     assert result["id"] == "acc-1"
+
+
+def test_create_account_includes_notes_and_placeholder_when_set() -> None:
+    """#50 + #52: AccountDraft surfaces notes + is_placeholder via POST body."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        seen["body"] = _json.loads(request.content.decode())
+        return httpx.Response(
+            201,
+            json={"id": "acc-3", "name": "X", "type": "asset", "currency": "USD"},
+        )
+
+    draft = AccountDraft(
+        name="Current Assets",
+        type="asset",
+        currency="USD",
+        code=None,
+        subtype=None,
+        visibility="shared",
+        parent_account_id=None,
+        notes="header for the chart",
+        is_placeholder=True,
+    )
+    with _client(httpx.MockTransport(handler)) as client:
+        create_account(client, draft)
+    assert seen["body"]["notes"] == "header for the chart"
+    assert seen["body"]["is_placeholder"] is True
 
 
 def test_create_account_includes_parent_when_set() -> None:


### PR DESCRIPTION
## Summary

Follow-up to PR #436 (the account modal itself), now that #50
(notes field) and #52 (is_placeholder flag) have landed.

- \`AccountDraft\` gains optional \`notes\` and \`is_placeholder\`
  fields; defaults (None / False) keep them out of the POST
  body so the API treats them as unchanged.
- \`AccountEditModal\` renders a notes \`Input\` + a placeholder
  \`Switch\`, with prefill hooks.
- \`AccountsScreen\` prefills \`is_placeholder\` from the focused
  account on \`e\`. \`notes\` is left blank by default (the list
  endpoint deliberately omits the decrypted notes, so prefill
  would need a per-edit \`GET\` round-trip; left as a small
  follow-up if the operator asks for it).
- \`AccountSummary\` carries \`is_placeholder\` for that prefill.
- The PATCH plumbing in \`main.py\` threads both fields through.
- 3 new tests cover the round-trip + the optional-field omit.

## Test plan

\`\`\`bash
uv run --package tulip-tui pytest packages/tulip-tui/tests/test_account_modal_screen.py packages/tulip-tui/tests/test_account_write_data.py -q
just lint
just typecheck
\`\`\`

- [x] 23 tests green locally
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (Success: no issues found in 308 source files)
- [ ] CI green on this PR