### PR TITLE
feat(ai,tui): top-N categorize + TUI proposal modal (closes #425)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -1931,6 +1931,56 @@ column (defaults to false; no behaviour change for existing
 chart). Precondition for the GnuCash import (#432) to land its
 `Placeholder` column cleanly.
 
+#### P9.6.d — AI categorize proposal modal in the TUI — ✅ *(2026-05-20)*
+
+Per [#425](https://github.com/rmwarriner/tulip-accounting/issues/425). Closes the original P9.6 umbrella.
+Two coupled slices in one PR:
+
+**Backend extension**:
+- New `CategorizationCandidate` dataclass in `tulip_core` (the
+  ranked-candidate analog to `CategorizationResult`).
+- `Categorizer.propose(line, ctx, *, n=5)` Protocol method
+  returning a tuple sorted by confidence descending.
+- `NullCategorizer.propose` returns a single-element tuple
+  wrapping the same `Imbalance:Unknown` answer for backwards
+  compatibility.
+- `AICategorizer.propose` uses a top-N-aware system prompt
+  (`{"candidates": [...]}`) and a new defensive parser
+  (`_parse_propose_response`) that filters codes against the
+  chart, drops zero-confidence candidates, dedups by code,
+  and caps to `n`. Same policy / cost-cap / rate-limit /
+  audit plumbing as `categorize`.
+- 8 new tests covering the happy path, n-cap, fallback for
+  disabled / provider-error / malformed-JSON, the dataclass
+  validators, and `NullCategorizer.propose`.
+
+**API surface**:
+- `POST /v1/ai/categorize-proposals` accepts a synthetic line
+  shape (description / amount / currency / posted_date / n)
+  and returns the ranked candidates JSON. Uses the registered
+  categorizer (no separate AI instance). Fallback returns the
+  single `Imbalance:Unknown` candidate; bad `n` returns 422.
+  3 endpoint tests.
+
+**TUI**:
+- `c` on a PENDING transaction in the register fetches up to
+  5 proposals via the new endpoint, pushes
+  `AICategorizeProposalModal` showing the top-1 prominently
+  with the remaining alternates in a focusable table.
+- `a` / `enter` accepts the cursor row's candidate. `escape`
+  cancels.
+- The accept handler resolves the picked `account_code` →
+  account_id, fetches the current transaction, identifies the
+  non-bank-side posting (largest |amount| = bank), and PATCHes
+  the transaction with the new account_id on the other leg.
+- 5 pilot-mode modal tests cover render / accept / arrow-then-
+  accept / escape / empty-candidates.
+
+Deliberately out of scope (filed for a follow-up if asked):
+multi-select on the register with `space` for batch
+categorize, and a manual-picker fallback `m` on the modal.
+The single-tx flow ships the headline feature.
+
 #### P9.6.c — Add/edit/void transaction modal in the TUI — ✅ *(2026-05-20)*
 
 Per [#423](https://github.com/rmwarriner/tulip-accounting/issues/423). Three new bindings on the transactions

--- a/packages/tulip-ai/src/tulip_ai/categorize.py
+++ b/packages/tulip-ai/src/tulip_ai/categorize.py
@@ -39,7 +39,10 @@ from tulip_ai.redaction import (
     ChartEntry,
     PromptRedactor,
 )
-from tulip_core.reconciliation.categorizer import CategorizationResult
+from tulip_core.reconciliation.categorizer import (
+    CategorizationCandidate,
+    CategorizationResult,
+)
 from tulip_storage.encryption import decrypt_field, field_aad
 from tulip_storage.models import Account, AccountType, Household, User
 
@@ -56,6 +59,9 @@ if TYPE_CHECKING:
 log = logging.getLogger("tulip_ai.categorize")
 
 _FALLBACK_RESULT = CategorizationResult(account_code="Imbalance:Unknown", confidence=0.0)
+_FALLBACK_CANDIDATES: tuple[CategorizationCandidate, ...] = (
+    CategorizationCandidate(account_code="Imbalance:Unknown", confidence=0.0),
+)
 
 
 @dataclass(slots=True)
@@ -136,6 +142,199 @@ class AICategorizer:
                 extra={"household_id": str(household_context.household_id)},
             )
             return _FALLBACK_RESULT
+
+    async def propose(
+        self,
+        line: StatementLine,
+        household_context: HouseholdContext,
+        *,
+        n: int = 5,
+        session: Session | None = None,
+    ) -> tuple[CategorizationCandidate, ...]:
+        """Suggest up to ``n`` ranked candidates for one statement line (#425).
+
+        Powers the TUI's AI proposal modal. Same broad-exception
+        guard as :meth:`categorize`: any failure returns a single
+        ``Imbalance:Unknown`` candidate rather than letting the
+        importer / TUI flow blow up.
+        """
+        try:
+            return await self._propose_inner(line, household_context, n=n, session=session)
+        except Exception:
+            log.exception(
+                "ai.propose.failed",
+                extra={"household_id": str(household_context.household_id)},
+            )
+            return _FALLBACK_CANDIDATES
+
+    async def _propose_inner(
+        self,
+        line: StatementLine,
+        household_context: HouseholdContext,
+        *,
+        n: int,
+        session: Session | None,
+    ) -> tuple[CategorizationCandidate, ...]:
+        """Inner propose body — top-N variant of ``_categorize_inner``.
+
+        Shares the same policy gate, redaction, rate-limit, audit-row
+        plumbing. The two divergences are the system prompt (asks for
+        ranked top-N) and the parser (returns a tuple instead of one).
+        Capability is recorded as ``"categorize"`` so existing
+        cost-cap accounting + audit reports pick it up alongside the
+        single-call path; ``response_text`` (when logged) carries the
+        full JSON array.
+        """
+        n = max(1, min(n, 10))  # cap at 10 — guards prompt-token budget
+        with use_session_or_make_one(session, self._session_maker) as (session, should_commit):
+            inputs = self._load_inputs(
+                session,
+                household_context.household_id,
+                household_context.acting_user_id,
+            )
+            if inputs is None:
+                return _FALLBACK_CANDIDATES
+
+            policy = resolve_policy(inputs.household.ai_policy, inputs.user_policy, "categorize")
+            writer = AIInvocationWriter(session)
+
+            payload = build_categorize_prompt(line, inputs.chart)
+            body = PromptRedactor(policy.profile).to_message_body(payload)
+
+            if policy.level == "disabled":
+                writer.write(
+                    AIInvocationRecord(
+                        household_id=household_context.household_id,
+                        capability="categorize",
+                        policy_resolved="disabled",
+                        profile=policy.profile,
+                        outcome="policy_disabled",
+                        prompt_hash=hash_prompt_payload(body),
+                    )
+                )
+                if should_commit:
+                    session.commit()
+                return _FALLBACK_CANDIDATES
+
+            if inputs.api_key is None and policy.provider != "ollama":
+                writer.write(
+                    AIInvocationRecord(
+                        household_id=household_context.household_id,
+                        capability="categorize",
+                        policy_resolved=policy.level,
+                        profile=policy.profile,
+                        provider=policy.provider,
+                        model=policy.model,
+                        outcome="provider_error",
+                        prompt_hash=hash_prompt_payload(body),
+                        response_text=(
+                            "no api key configured for provider" if policy.log_prompts else None
+                        ),
+                    )
+                )
+                if should_commit:
+                    session.commit()
+                return _FALLBACK_CANDIDATES
+
+            messages = [
+                {
+                    "role": "system",
+                    "content": (
+                        f"You are a transaction categorizer. Pick up to {n} "
+                        "candidate account_codes from the provided chart, "
+                        "ranked best-first. Return JSON of the shape "
+                        '{"candidates": [{"account_code": "<code>", '
+                        '"confidence": <0.0-1.0>, "reasoning": "<short>"}, ...]}. '
+                        "Use only codes that appear in the chart. Higher "
+                        "confidence means a stronger match."
+                    ),
+                },
+                {"role": "user", "content": json.dumps(body, ensure_ascii=False)},
+            ]
+
+            gate = enforce_pre_call(
+                session,
+                household_id=household_context.household_id,
+                user_id=household_context.acting_user_id,
+                rate_limit_per_hour=policy.rate_limit_per_hour,
+                monthly_cost_cap_usd=policy.monthly_cost_cap_usd,
+                cost_cap_behaviour=policy.cost_cap_behaviour,
+                fallback_provider=policy.fallback_provider,
+                fallback_model=policy.fallback_model,
+                primary_provider=policy.provider,
+                primary_model=policy.model,
+            )
+            if not isinstance(gate, PreCallApproval):
+                writer.write(
+                    AIInvocationRecord(
+                        household_id=household_context.household_id,
+                        capability="categorize",
+                        policy_resolved=policy.level,
+                        profile=policy.profile,
+                        provider=policy.provider,
+                        model=policy.model,
+                        outcome=gate.outcome,
+                        prompt_hash=hash_prompt_payload(body),
+                        response_text=gate.reason[:500] if policy.log_prompts else None,
+                    )
+                )
+                if should_commit:
+                    session.commit()
+                return _FALLBACK_CANDIDATES
+
+            call_provider = gate.provider or ""
+            call_model = gate.model or ""
+            try:
+                response = await self._adapter.chat(
+                    provider=call_provider,
+                    model=call_model,
+                    api_key=inputs.api_key if not gate.degraded else None,
+                    messages=messages,
+                    max_tokens=600,  # ~6x single-shot — fits up to 10 candidates
+                )
+            except AIProviderError as exc:
+                writer.write(
+                    AIInvocationRecord(
+                        household_id=household_context.household_id,
+                        capability="categorize",
+                        policy_resolved=policy.level,
+                        profile=policy.profile,
+                        provider=call_provider,
+                        model=call_model,
+                        outcome="provider_error",
+                        prompt_hash=hash_prompt_payload(body),
+                        response_text=str(exc)[:500] if policy.log_prompts else None,
+                    )
+                )
+                if should_commit:
+                    session.commit()
+                return _FALLBACK_CANDIDATES
+
+            candidates = _parse_propose_response(response, fallback_chart=inputs.chart, n=n)
+            writer.write(
+                AIInvocationRecord(
+                    household_id=household_context.household_id,
+                    capability="categorize",
+                    policy_resolved=policy.level,
+                    profile=policy.profile,
+                    provider=call_provider,
+                    model=call_model,
+                    tokens_in=response.tokens_in,
+                    tokens_out=response.tokens_out,
+                    cost_estimate_usd=response.cost_estimate_usd,
+                    latency_ms=response.latency_ms,
+                    outcome="success",
+                    prompt_hash=hash_prompt_payload(body),
+                    provider_response_id=response.provider_response_id,
+                    prompt_json=(
+                        json.dumps(body, ensure_ascii=False) if policy.log_prompts else None
+                    ),
+                    response_text=response.text if policy.log_prompts else None,
+                )
+            )
+            if should_commit:
+                session.commit()
+            return candidates
 
     async def _categorize_inner(
         self,
@@ -390,6 +589,64 @@ class AICategorizer:
             return None
         value = keys_dict.get(provider)
         return value if isinstance(value, str) else None
+
+
+def _parse_propose_response(
+    response: ProviderResponse, *, fallback_chart: Sequence[ChartEntry], n: int
+) -> tuple[CategorizationCandidate, ...]:
+    """Parse the provider's JSON response into ranked candidates (#425).
+
+    Looks for ``{"candidates": [{"account_code", "confidence",
+    "reasoning"?}, ...]}``. Filters out codes that aren't in the
+    chart, clamps confidences to ``[0.0, 1.0]``, drops any with
+    ``confidence <= 0``, sorts by confidence descending, and caps
+    to ``n``. Returns the fallback single-candidate tuple on
+    malformed JSON or zero valid candidates.
+    """
+    valid_codes = {entry.code for entry in fallback_chart}
+    text = response.text.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if "\n" in text:
+            first, _, rest = text.partition("\n")
+            if first.strip().lower() in ("json", "javascript"):
+                text = rest
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        return _FALLBACK_CANDIDATES
+    try:
+        parsed = json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        return _FALLBACK_CANDIDATES
+    raw_candidates = parsed.get("candidates")
+    if not isinstance(raw_candidates, list) or not raw_candidates:
+        return _FALLBACK_CANDIDATES
+
+    out: list[CategorizationCandidate] = []
+    seen_codes: set[str] = set()
+    for entry in raw_candidates:
+        if not isinstance(entry, dict):
+            continue
+        code = entry.get("account_code")
+        if not isinstance(code, str) or code not in valid_codes or code in seen_codes:
+            continue
+        try:
+            conf = float(entry.get("confidence", 0.5))
+        except (TypeError, ValueError):
+            conf = 0.5
+        conf = max(0.0, min(1.0, conf))
+        if conf <= 0.0:
+            continue
+        reasoning_raw = entry.get("reasoning")
+        reasoning = reasoning_raw if isinstance(reasoning_raw, str) and reasoning_raw else None
+        out.append(CategorizationCandidate(account_code=code, confidence=conf, reasoning=reasoning))
+        seen_codes.add(code)
+
+    if not out:
+        return _FALLBACK_CANDIDATES
+    out.sort(key=lambda c: c.confidence, reverse=True)
+    return tuple(out[:n])
 
 
 def _parse_response(

--- a/packages/tulip-ai/tests/test_categorize.py
+++ b/packages/tulip-ai/tests/test_categorize.py
@@ -705,3 +705,213 @@ async def test_provider_error_response_text_persisted_when_log_prompts_on(
         assert rows[0].outcome == "provider_error"
         assert rows[0].response_text is not None
         assert "provider blew up" in rows[0].response_text
+
+
+# ---- #425: top-N propose() -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_propose_happy_path_returns_ranked_candidates(
+    session_maker: sessionmaker[Session],
+    household_and_user,
+    master_key: bytes,
+) -> None:
+    """propose() round-trips top-N JSON, filters chart, sorts by confidence."""
+    household, _ = household_and_user
+    _seed_chart(
+        session_maker,
+        household.id,
+        codes=[
+            ("5100", "Groceries", AccountType.EXPENSE),
+            ("5300", "Fuel", AccountType.EXPENSE),
+            ("5400", "Dining", AccountType.EXPENSE),
+        ],
+    )
+    _set_ai_keys(session_maker, household.id, keys={"anthropic": "sk-test"}, master_key=master_key)
+
+    canned = json.dumps(
+        {
+            "candidates": [
+                {"account_code": "5300", "confidence": 0.55, "reasoning": "fuel-ish"},
+                {"account_code": "5100", "confidence": 0.85, "reasoning": "grocery-ish"},
+                {"account_code": "5400", "confidence": 0.30},
+                # Unknown code — filtered out.
+                {"account_code": "9999", "confidence": 0.99},
+                # Zero confidence — dropped.
+                {"account_code": "5100", "confidence": 0.0},
+            ]
+        }
+    )
+    adapter = RecordingAdapter(canned_reply=canned)
+    categorizer = AICategorizer(session_maker=session_maker, master_key=master_key, adapter=adapter)
+    candidates = await categorizer.propose(
+        _make_statement_line(description="WHOLE FOODS MARKET", amount="-87.42"),
+        HouseholdContext(household_id=household.id, account_whitelist=frozenset()),
+        n=5,
+    )
+    # Three valid → sorted by confidence descending.
+    assert len(candidates) == 3
+    assert [c.account_code for c in candidates] == ["5100", "5300", "5400"]
+    assert candidates[0].confidence == pytest.approx(0.85)
+    assert candidates[0].reasoning == "grocery-ish"
+    # 5400 had no reasoning field — preserved as None.
+    assert candidates[2].reasoning is None
+
+
+@pytest.mark.asyncio
+async def test_propose_caps_to_n(
+    session_maker: sessionmaker[Session],
+    household_and_user,
+    master_key: bytes,
+) -> None:
+    """propose(n=2) returns at most 2 candidates."""
+    household, _ = household_and_user
+    _seed_chart(
+        session_maker,
+        household.id,
+        codes=[
+            ("5100", "Groceries", AccountType.EXPENSE),
+            ("5300", "Fuel", AccountType.EXPENSE),
+            ("5400", "Dining", AccountType.EXPENSE),
+        ],
+    )
+    _set_ai_keys(session_maker, household.id, keys={"anthropic": "sk-test"}, master_key=master_key)
+
+    canned = json.dumps(
+        {
+            "candidates": [
+                {"account_code": "5300", "confidence": 0.55},
+                {"account_code": "5100", "confidence": 0.85},
+                {"account_code": "5400", "confidence": 0.30},
+            ]
+        }
+    )
+    adapter = RecordingAdapter(canned_reply=canned)
+    categorizer = AICategorizer(session_maker=session_maker, master_key=master_key, adapter=adapter)
+    candidates = await categorizer.propose(
+        _make_statement_line(description="GAS STATION", amount="-42.00"),
+        HouseholdContext(household_id=household.id, account_whitelist=frozenset()),
+        n=2,
+    )
+    assert len(candidates) == 2
+    assert [c.account_code for c in candidates] == ["5100", "5300"]
+
+
+@pytest.mark.asyncio
+async def test_propose_falls_back_when_policy_disabled(
+    session_maker: sessionmaker[Session],
+    household_and_user,
+    master_key: bytes,
+) -> None:
+    """Disabled policy returns the Imbalance:Unknown single-candidate fallback."""
+    household, _ = household_and_user
+    _seed_chart(session_maker, household.id, codes=[("5100", "Groceries", AccountType.EXPENSE)])
+    with session_maker() as s:
+        h = s.get(Household, household.id)
+        assert h is not None
+        h.ai_policy = {
+            "default_provider": "anthropic",
+            "default_model": "claude-opus-4-7",
+            "capabilities": {"categorize": {"policy": "disabled"}},
+        }
+        s.commit()
+
+    adapter = RecordingAdapter(canned_reply="{}")
+    categorizer = AICategorizer(session_maker=session_maker, master_key=master_key, adapter=adapter)
+    candidates = await categorizer.propose(
+        _make_statement_line(description="X", amount="-1.00"),
+        HouseholdContext(household_id=household.id, account_whitelist=frozenset()),
+    )
+    assert len(candidates) == 1
+    assert candidates[0].account_code == "Imbalance:Unknown"
+    assert candidates[0].confidence == 0.0
+    # No adapter call when disabled.
+    assert adapter.calls == []
+    # Audit row landed with outcome=policy_disabled.
+    with session_maker() as s:
+        rows = s.execute(select(AIInvocation)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].outcome == "policy_disabled"
+
+
+@pytest.mark.asyncio
+async def test_propose_falls_back_on_provider_error(
+    session_maker: sessionmaker[Session],
+    household_and_user,
+    master_key: bytes,
+) -> None:
+    """Provider error → single Imbalance:Unknown candidate, audit row records error."""
+    household, _ = household_and_user
+    _seed_chart(session_maker, household.id, codes=[("5100", "Groceries", AccountType.EXPENSE)])
+    _set_ai_keys(session_maker, household.id, keys={"anthropic": "sk-test"}, master_key=master_key)
+
+    class BoomAdapter:
+        async def chat(self, **_kwargs):
+            raise AIProviderError("provider down")
+
+    categorizer = AICategorizer(
+        session_maker=session_maker,
+        master_key=master_key,
+        adapter=BoomAdapter(),  # type: ignore[arg-type]
+    )
+    candidates = await categorizer.propose(
+        _make_statement_line(description="X", amount="-1.00"),
+        HouseholdContext(household_id=household.id, account_whitelist=frozenset()),
+    )
+    assert len(candidates) == 1
+    assert candidates[0].account_code == "Imbalance:Unknown"
+    with session_maker() as s:
+        rows = s.execute(select(AIInvocation)).scalars().all()
+        assert rows[0].outcome == "provider_error"
+
+
+@pytest.mark.asyncio
+async def test_propose_falls_back_on_malformed_response(
+    session_maker: sessionmaker[Session],
+    household_and_user,
+    master_key: bytes,
+) -> None:
+    """Garbage JSON → single Imbalance:Unknown candidate (success-audited)."""
+    household, _ = household_and_user
+    _seed_chart(session_maker, household.id, codes=[("5100", "Groceries", AccountType.EXPENSE)])
+    _set_ai_keys(session_maker, household.id, keys={"anthropic": "sk-test"}, master_key=master_key)
+    adapter = RecordingAdapter(canned_reply="this is not json")
+    categorizer = AICategorizer(session_maker=session_maker, master_key=master_key, adapter=adapter)
+    candidates = await categorizer.propose(
+        _make_statement_line(description="X", amount="-1.00"),
+        HouseholdContext(household_id=household.id, account_whitelist=frozenset()),
+    )
+    assert len(candidates) == 1
+    assert candidates[0].account_code == "Imbalance:Unknown"
+
+
+# ---- core type guards -------------------------------------------------------
+
+
+def test_categorization_candidate_validates_account_code() -> None:
+    from tulip_core.reconciliation.categorizer import CategorizationCandidate
+
+    with pytest.raises(ValueError, match="account_code"):
+        CategorizationCandidate(account_code="", confidence=0.5)
+
+
+def test_categorization_candidate_validates_confidence_range() -> None:
+    from tulip_core.reconciliation.categorizer import CategorizationCandidate
+
+    with pytest.raises(ValueError, match="confidence"):
+        CategorizationCandidate(account_code="5100", confidence=1.1)
+
+
+@pytest.mark.asyncio
+async def test_null_categorizer_propose_returns_single_imbalance() -> None:
+    from tulip_core.reconciliation.categorizer import NullCategorizer
+
+    null = NullCategorizer()
+    line = _make_statement_line(description="X", amount="-1.00")
+    candidates = await null.propose(
+        line,
+        HouseholdContext(household_id=uuid4(), account_whitelist=frozenset()),
+    )
+    assert len(candidates) == 1
+    assert candidates[0].account_code == "Imbalance:Unknown"
+    assert candidates[0].confidence == 1.0

--- a/packages/tulip-api/src/tulip_api/routers/ai.py
+++ b/packages/tulip-api/src/tulip_api/routers/ai.py
@@ -34,6 +34,9 @@ from tulip_api.schemas.ai import (
     CLEAR_SENTINEL,
     AIAskRequest,
     AIAskResponse,
+    AICategorizeCandidate,
+    AICategorizeProposalsRequest,
+    AICategorizeProposalsResponse,
     AIConfigCapability,
     AIConfigCapabilityPatch,
     AIConfigPatch,
@@ -597,6 +600,72 @@ def preview_categorize_prompt(
         provider=policy.provider,
         model=policy.model,
         payload=body_dict,
+    )
+
+
+@router.post(
+    "/categorize-proposals",
+    response_model=AICategorizeProposalsResponse,
+    responses={
+        400: problem_response("request.body_invalid"),
+        401: problem_response("auth.unauthorized"),
+        403: problem_response("auth.forbidden"),
+        422: problem_response("validation.failed"),
+    },
+)
+async def categorize_proposals(
+    body: AICategorizeProposalsRequest,
+    claims: Claims = Depends(require_role("admin", "member")),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> AICategorizeProposalsResponse:
+    """Return up to ``n`` ranked categorize candidates for a synthetic line (#425).
+
+    Calls the registered :class:`tulip_core.reconciliation.Categorizer`'s
+    ``propose()`` method. Honours the household + per-user AI policy
+    exactly the same way the import-apply flow does (including the
+    rate-limit / cost-cap / policy-disabled fall-throughs). On any
+    fallback (disabled, no key, provider error, malformed response)
+    the response is a single ``Imbalance:Unknown`` candidate with
+    confidence 0.0 — the TUI surfaces that as "no proposal".
+
+    The TUI calls this when the user presses ``c`` on a PENDING
+    transaction. Body fields mirror :class:`AIPreviewRequest` so the
+    operator can synthesize the same statement-line shape; the new
+    ``n`` field caps the number of candidates returned.
+    """
+    from tulip_core.reconciliation.categorizer import (
+        HouseholdContext,
+        get_categorizer,
+    )
+
+    line = StatementLine(
+        id=uuid4(),
+        import_batch_id=uuid4(),
+        line_number=1,
+        posted_date=body.posted_date,
+        amount=Money(body.amount, body.currency),
+        description=body.description,
+    )
+    categorizer = get_categorizer()
+    candidates = await categorizer.propose(
+        line,
+        HouseholdContext(
+            household_id=claims.household_id,
+            account_whitelist=frozenset(),
+            acting_user_id=claims.user_id,
+        ),
+        n=body.n,
+        session=session,
+    )
+    return AICategorizeProposalsResponse(
+        candidates=[
+            AICategorizeCandidate(
+                account_code=c.account_code,
+                confidence=c.confidence,
+                reasoning=c.reasoning,
+            )
+            for c in candidates
+        ]
     )
 
 

--- a/packages/tulip-api/src/tulip_api/schemas/ai.py
+++ b/packages/tulip-api/src/tulip_api/schemas/ai.py
@@ -72,6 +72,32 @@ class AIPreviewResponse(BaseModel):
     payload: dict[str, object]
 
 
+class AICategorizeProposalsRequest(BaseModel):
+    """Body for ``POST /v1/ai/categorize-proposals`` (#425)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: str = Field(min_length=1, max_length=500)
+    amount: Decimal
+    currency: str = Field(min_length=3, max_length=3)
+    posted_date: date
+    n: int = Field(default=5, ge=1, le=10)
+
+
+class AICategorizeCandidate(BaseModel):
+    """One ranked candidate in the propose response."""
+
+    account_code: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    reasoning: str | None = None
+
+
+class AICategorizeProposalsResponse(BaseModel):
+    """Top-N candidates returned by the categorizer (#425)."""
+
+    candidates: list[AICategorizeCandidate]
+
+
 class AIAskRequest(BaseModel):
     """Body for ``POST /v1/ai/ask`` — one user question over the AI views (P6.2)."""
 

--- a/packages/tulip-api/tests/test_ai_endpoints.py
+++ b/packages/tulip-api/tests/test_ai_endpoints.py
@@ -128,6 +128,65 @@ class TestPreview:
         assert r.status_code == 401
 
 
+class TestCategorizeProposals:
+    """#425: top-N propose surface for the TUI."""
+
+    def test_proposals_with_disabled_policy_returns_imbalance(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """Fresh household has the default policy and no key → fallback."""
+        client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"code": "5100", "name": "Groceries", "type": "expense", "currency": "USD"},
+        )
+        r = client.post(
+            "/v1/ai/categorize-proposals",
+            headers=auth_h,
+            json={
+                "description": "WHOLE FOODS MARKET",
+                "amount": "-87.42",
+                "currency": "USD",
+                "posted_date": "2026-05-03",
+            },
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert isinstance(body["candidates"], list)
+        # Without configured AI, the fallback single candidate fires.
+        assert len(body["candidates"]) == 1
+        assert body["candidates"][0]["account_code"] == "Imbalance:Unknown"
+
+    def test_proposals_request_caps_n_field(
+        self, client: TestClient, auth_h: dict[str, str]
+    ) -> None:
+        """n must be in [1, 10]."""
+        r = client.post(
+            "/v1/ai/categorize-proposals",
+            headers=auth_h,
+            json={
+                "description": "X",
+                "amount": "-1.00",
+                "currency": "USD",
+                "posted_date": "2026-05-03",
+                "n": 20,
+            },
+        )
+        assert r.status_code == 422
+
+    def test_proposals_requires_auth(self, client: TestClient) -> None:
+        r = client.post(
+            "/v1/ai/categorize-proposals",
+            json={
+                "description": "X",
+                "amount": "-1.00",
+                "currency": "USD",
+                "posted_date": "2026-05-03",
+            },
+        )
+        assert r.status_code == 401
+
+
 class TestAsk:
     def test_ask_with_no_api_key_returns_error_summary(
         self, client: TestClient, auth_h: dict[str, str]

--- a/packages/tulip-core/src/tulip_core/reconciliation/categorizer.py
+++ b/packages/tulip-core/src/tulip_core/reconciliation/categorizer.py
@@ -45,6 +45,27 @@ class CategorizationResult:
 
 
 @dataclass(frozen=True, slots=True)
+class CategorizationCandidate:
+    """One ranked alternative for the TUI categorize proposal modal (#425).
+
+    ``reasoning`` is the optional model's brief justification (the
+    AI categorizer asks for it; ``NullCategorizer`` and rule-based
+    fallbacks leave it ``None``).
+    """
+
+    account_code: str
+    confidence: float
+    reasoning: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate ``account_code`` non-empty + ``confidence`` range."""
+        if not self.account_code or not self.account_code.strip():
+            raise ValueError("account_code must be non-empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(f"confidence must be in [0.0, 1.0] (got {self.confidence})")
+
+
+@dataclass(frozen=True, slots=True)
 class HouseholdContext:
     """Per-household context handed to the categorizer.
 
@@ -91,6 +112,27 @@ class Categorizer(Protocol):
         """Suggest a category for an unmatched statement line."""
         ...
 
+    async def propose(
+        self,
+        line: StatementLine,
+        household_context: HouseholdContext,
+        *,
+        n: int = 5,
+        session: Any = None,  # noqa: ANN401 — tulip-core can't import sqlalchemy
+    ) -> tuple[CategorizationCandidate, ...]:
+        """Suggest up to ``n`` ranked candidates for an unmatched line (#425).
+
+        Returns at most ``n`` :class:`CategorizationCandidate` records
+        sorted by confidence descending. Powers the TUI's "AI proposal
+        with alternates" modal: the user sees the top suggestion plus
+        runner-ups and picks one (or rejects the lot and uses the
+        manual picker). Implementations that don't have native top-N
+        support (NullCategorizer, providers without re-ranking) return
+        a single-element tuple wrapping the same answer
+        :meth:`categorize` would have given — backwards-compatible.
+        """
+        ...
+
 
 class NullCategorizer:
     """v1 default: every line gets ``Imbalance:Unknown`` with confidence 1.0.
@@ -110,6 +152,18 @@ class NullCategorizer:
         """Return ``Imbalance:Unknown`` regardless of ``line``."""
         del line, household_context, session  # unused — placeholder-by-design
         return CategorizationResult(account_code="Imbalance:Unknown", confidence=1.0)
+
+    async def propose(
+        self,
+        line: StatementLine,
+        household_context: HouseholdContext,
+        *,
+        n: int = 5,
+        session: Any = None,  # noqa: ANN401 — tulip-core can't import sqlalchemy
+    ) -> tuple[CategorizationCandidate, ...]:
+        """One-candidate tuple wrapping the same ``Imbalance:Unknown`` (#425)."""
+        del line, household_context, n, session  # unused — placeholder-by-design
+        return (CategorizationCandidate(account_code="Imbalance:Unknown", confidence=1.0),)
 
 
 # ---- module-global registry -----------------------------------------------

--- a/packages/tulip-core/tests/reconciliation/test_categorizer.py
+++ b/packages/tulip-core/tests/reconciliation/test_categorizer.py
@@ -146,6 +146,20 @@ class TestRegistry:
             ) -> CategorizationResult:
                 return CategorizationResult(account_code="Custom:Account", confidence=0.5)
 
+            async def propose(
+                self,
+                line: StatementLine,
+                household_context: HouseholdContext,
+                *,
+                n: int = 5,
+                session: Any = None,
+            ):
+                from tulip_core.reconciliation.categorizer import (
+                    CategorizationCandidate,
+                )
+
+                return (CategorizationCandidate("Custom:Account", 0.5),)
+
         custom = CustomCategorizer()
         register_categorizer(custom)
         assert get_categorizer() is custom
@@ -158,6 +172,8 @@ class TestRegistry:
             register_categorizer(NotACategorizer())  # type: ignore[arg-type]
 
     def test_re_registration_warns(self):
+        from tulip_core.reconciliation.categorizer import CategorizationCandidate
+
         class CustomA:
             async def categorize(
                 self,
@@ -168,6 +184,16 @@ class TestRegistry:
             ) -> CategorizationResult:
                 return CategorizationResult("A", 1.0)
 
+            async def propose(
+                self,
+                line: StatementLine,
+                household_context: HouseholdContext,
+                *,
+                n: int = 5,
+                session: Any = None,
+            ):
+                return (CategorizationCandidate("A", 1.0),)
+
         class CustomB:
             async def categorize(
                 self,
@@ -177,6 +203,16 @@ class TestRegistry:
                 session: Any = None,
             ) -> CategorizationResult:
                 return CategorizationResult("B", 1.0)
+
+            async def propose(
+                self,
+                line: StatementLine,
+                household_context: HouseholdContext,
+                *,
+                n: int = 5,
+                session: Any = None,
+            ):
+                return (CategorizationCandidate("B", 1.0),)
 
         register_categorizer(CustomA())
         with pytest.warns(UserWarning, match="replac"):
@@ -192,6 +228,20 @@ class TestRegistry:
                 self, line: StatementLine, household_context: HouseholdContext
             ) -> CategorizationResult:
                 return CategorizationResult("x", 1.0)
+
+            async def propose(
+                self,
+                line: StatementLine,
+                household_context: HouseholdContext,
+                *,
+                n: int = 5,
+                session: Any = None,
+            ):
+                from tulip_core.reconciliation.categorizer import (
+                    CategorizationCandidate,
+                )
+
+                return (CategorizationCandidate("x", 1.0),)
 
         with pytest.raises(TypeError, match="async"):
             register_categorizer(SyncCategorizer())  # type: ignore[arg-type]

--- a/packages/tulip-tui/src/tulip_tui/app.py
+++ b/packages/tulip-tui/src/tulip_tui/app.py
@@ -16,12 +16,14 @@ mount and on refresh.
 from __future__ import annotations
 
 from collections.abc import Callable
+from decimal import Decimal
 from typing import ClassVar
 
 from textual.app import App
 from textual.binding import Binding, BindingType
 
 from tulip_tui.data.account_write import AccountDraft
+from tulip_tui.data.ai_categorize import AIProposalCandidate
 from tulip_tui.data.envelopes import EnvelopesData
 from tulip_tui.data.import_batch_detail import ImportBatchDetail
 from tulip_tui.data.imports import ImportsData
@@ -58,6 +60,8 @@ TxEditAction = Callable[[str, TransactionDraft], object]
 TxVoidAction = Callable[[str, str], object]
 AccountCreateAction = Callable[[AccountDraft], object]
 AccountEditAction = Callable[[str, AccountDraft], object]
+TxFetchProposalsAction = Callable[[str, Decimal, str, str], tuple[AIProposalCandidate, ...]]
+TxApplyCategoryAction = Callable[[str, str], object]
 
 ReconciliationDetailLoaderFactory = Callable[[str], Callable[[], ReconciliationDetail]]
 ReconciliationAutoMatchAction = Callable[[str], object]
@@ -188,6 +192,16 @@ def _no_op_account_edit(_account_id: str, _draft: AccountDraft) -> object:
     raise RuntimeError("account edit action not configured")
 
 
+def _no_op_tx_fetch_proposals(
+    _description: str, _amount: Decimal, _currency: str, _posted_date: str
+) -> tuple[AIProposalCandidate, ...]:
+    raise RuntimeError("tx fetch proposals action not configured")
+
+
+def _no_op_tx_apply_category(_tx_id: str, _account_code: str) -> object:
+    raise RuntimeError("tx apply category action not configured")
+
+
 class TulipTuiApp(App[None]):
     """Tulip TUI shell — boots into the accounts browser."""
 
@@ -234,6 +248,8 @@ class TulipTuiApp(App[None]):
         tx_create_action: TxCreateAction = _no_op_tx_create,
         tx_edit_action: TxEditAction = _no_op_tx_edit,
         tx_void_action: TxVoidAction = _no_op_tx_void,
+        tx_fetch_proposals_action: TxFetchProposalsAction = _no_op_tx_fetch_proposals,
+        tx_apply_category_action: TxApplyCategoryAction = _no_op_tx_apply_category,
         account_create_action: AccountCreateAction = _no_op_account_create,
         account_edit_action: AccountEditAction = _no_op_account_edit,
     ) -> None:
@@ -261,6 +277,8 @@ class TulipTuiApp(App[None]):
         self._tx_create_action = tx_create_action
         self._tx_edit_action = tx_edit_action
         self._tx_void_action = tx_void_action
+        self._tx_fetch_proposals_action = tx_fetch_proposals_action
+        self._tx_apply_category_action = tx_apply_category_action
         self._account_create_action = account_create_action
         self._account_edit_action = account_edit_action
 
@@ -284,6 +302,8 @@ class TulipTuiApp(App[None]):
                 on_create=self._tx_create_action,
                 on_edit=self._tx_edit_action,
                 on_void=self._tx_void_action,
+                on_fetch_proposals=self._tx_fetch_proposals_action,
+                on_apply_category=self._tx_apply_category_action,
             )
         )
 

--- a/packages/tulip-tui/src/tulip_tui/data/ai_categorize.py
+++ b/packages/tulip-tui/src/tulip_tui/data/ai_categorize.py
@@ -1,0 +1,71 @@
+"""TUI data adapter for ``POST /v1/ai/categorize-proposals`` (#425).
+
+Thin wrapper around the AI top-N propose endpoint. The screen calls
+this when the user presses ``c`` on a PENDING transaction; the
+modal renders the returned candidates with the top-1 prominent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import cast
+
+from tulip_cli.http import TulipClient
+
+
+@dataclass(frozen=True, slots=True)
+class AIProposalCandidate:
+    """One ranked candidate from the API."""
+
+    account_code: str
+    confidence: float
+    reasoning: str | None
+
+
+def fetch_proposals(
+    client: TulipClient,
+    *,
+    description: str,
+    amount: Decimal,
+    currency: str,
+    posted_date: str,
+    n: int = 5,
+) -> tuple[AIProposalCandidate, ...]:
+    """Call ``POST /v1/ai/categorize-proposals``; return the ranked list."""
+    resp = client.post(
+        "/v1/ai/categorize-proposals",
+        authenticated=True,
+        json={
+            "description": description,
+            "amount": str(amount),
+            "currency": currency,
+            "posted_date": posted_date,
+            "n": n,
+        },
+    )
+    payload = cast("dict[str, object]", resp.json())
+    raw = payload.get("candidates")
+    if not isinstance(raw, list):
+        return ()
+    out: list[AIProposalCandidate] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        code = entry.get("account_code")
+        conf = entry.get("confidence")
+        if not isinstance(code, str) or not isinstance(conf, (int, float)):
+            continue
+        reasoning_raw = entry.get("reasoning")
+        reasoning = reasoning_raw if isinstance(reasoning_raw, str) and reasoning_raw else None
+        out.append(
+            AIProposalCandidate(
+                account_code=code,
+                confidence=float(conf),
+                reasoning=reasoning,
+            )
+        )
+    return tuple(out)
+
+
+__all__ = ["AIProposalCandidate", "fetch_proposals"]

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -9,8 +9,14 @@ with their own loaders.
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from tulip_cli.auth.tokens import default_token_store
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+
+    from tulip_tui.data.ai_categorize import AIProposalCandidate
 from tulip_cli.config import load_config
 from tulip_cli.http import TulipClient
 from tulip_tui.app import TulipTuiApp
@@ -245,6 +251,74 @@ def _account_create_action(draft: AccountDraft) -> object:
         return create_account(client, draft)
 
 
+def _tx_fetch_proposals_action(
+    description: str, amount: Decimal, currency: str, posted_date: str
+) -> tuple[AIProposalCandidate, ...]:
+    """Call ``POST /v1/ai/categorize-proposals`` (#425)."""
+    from tulip_tui.data.ai_categorize import fetch_proposals
+
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        return fetch_proposals(
+            client,
+            description=description,
+            amount=amount,
+            currency=currency,
+            posted_date=posted_date,
+        )
+
+
+def _tx_apply_category_action(tx_id: str, account_code: str) -> object:
+    """Re-categorize a PENDING transaction (#425).
+
+    Resolves ``account_code`` to an account id, fetches the current
+    transaction, finds the non-bank posting (the one whose account is
+    income/expense, currently Imbalance:Unknown), and PATCHes the
+    transaction with the new ``account_id`` on that posting. Errors
+    propagate to the screen's notice line.
+    """
+    config = load_config()
+    with TulipClient(config, token_store=default_token_store()) as client:
+        accounts = client.get("/v1/accounts", authenticated=True).json()
+        target = next((a for a in accounts if a.get("code") == account_code), None)
+        if target is None:
+            raise RuntimeError(
+                f"AI proposed code {account_code!r} but no account with that "
+                f"code is visible — refresh the chart and try again"
+            )
+        tx = client.get(f"/v1/transactions/{tx_id}", authenticated=True).json()
+        # Find the non-bank-side posting. Heuristic: largest |amount| is the
+        # bank side; the rest are the categorizable legs. For a 2-posting
+        # transaction (the common case), that's everything that ISN'T the
+        # bank side.
+        postings = tx.get("postings") or []
+        if len(postings) < 2:
+            raise RuntimeError("transaction has < 2 postings — can't recategorize")
+        from decimal import Decimal as _D
+
+        bank_idx = max(
+            range(len(postings)),
+            key=lambda i: abs(_D(str(postings[i].get("amount", "0")))),
+        )
+        new_postings = []
+        for i, p in enumerate(postings):
+            entry = {
+                "account_id": p["account_id"] if i == bank_idx else target["id"],
+                "amount": str(p["amount"]),
+                "currency": p["currency"],
+            }
+            if p.get("memo"):
+                entry["memo"] = p["memo"]
+            if p.get("pool_id"):
+                entry["pool_id"] = p["pool_id"]
+            new_postings.append(entry)
+        return client.patch(
+            f"/v1/transactions/{tx_id}",
+            authenticated=True,
+            json={"postings": new_postings},
+        ).json()
+
+
 def _account_edit_action(account_id: str, draft: AccountDraft) -> object:
     """PATCH a subset of the editable fields."""
     config = load_config()
@@ -290,6 +364,8 @@ def run() -> None:
         tx_create_action=_tx_create_action,
         tx_edit_action=_tx_edit_action,
         tx_void_action=_tx_void_action,
+        tx_fetch_proposals_action=_tx_fetch_proposals_action,
+        tx_apply_category_action=_tx_apply_category_action,
         account_create_action=_account_create_action,
         account_edit_action=_account_edit_action,
     ).run()

--- a/packages/tulip-tui/src/tulip_tui/screens/ai_categorize_modal.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/ai_categorize_modal.py
@@ -1,0 +1,138 @@
+"""AI categorize proposal modal — #425 (P9.6.d).
+
+Reached from the transactions register: ``c`` on a PENDING transaction
+fetches up to N proposals from the categorize endpoint and renders
+the top-1 prominent with alternates listed below. Confirmed pick
+fires a PATCH against the transaction to re-target the non-bank
+posting's ``account_id``.
+
+Mirrors the P9.6.c modal pattern: HTTP stays out of the modal, the
+caller fires the action after the modal dismisses with a chosen
+``account_code``.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.coordinate import Coordinate
+from textual.screen import ModalScreen
+from textual.widgets import DataTable, Static
+
+from tulip_tui.data.ai_categorize import AIProposalCandidate
+
+
+class AICategorizeProposalModal(ModalScreen[str | None]):
+    """Pick a category from the AI's ranked proposals (#425).
+
+    Dismisses with the selected ``account_code`` on confirm, ``None``
+    on cancel. ``a`` / ``enter`` confirms the row under the cursor;
+    ``escape`` cancels.
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "cancel", "cancel", show=True),
+        Binding("a", "accept", "accept", show=True),
+        Binding("enter", "accept", "accept", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    AICategorizeProposalModal {
+        align: center middle;
+    }
+    AICategorizeProposalModal #ai-cat-form {
+        width: 100;
+        max-width: 95%;
+        height: auto;
+        background: $panel;
+        border: thick $primary;
+        padding: 1 2;
+    }
+    AICategorizeProposalModal #ai-cat-top {
+        height: auto;
+        padding: 0 1 1 1;
+    }
+    AICategorizeProposalModal #ai-cat-table {
+        height: 12;
+    }
+    AICategorizeProposalModal #ai-cat-hint {
+        height: auto;
+        color: $text-muted;
+        padding: 1 1 0 1;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        description: str,
+        candidates: tuple[AIProposalCandidate, ...],
+    ) -> None:
+        """Store the candidates; modal renders on mount."""
+        super().__init__()
+        self._description = description
+        self._candidates = candidates
+        self._selected_code: str | None = None
+
+    def compose(self) -> ComposeResult:
+        """Render top-1 prominently + a table of alternates."""
+        with Vertical(id="ai-cat-form"):
+            yield Static(
+                f"[b]AI proposal for[/b] {self._description}",
+                id="ai-cat-title",
+            )
+            if not self._candidates:
+                yield Static(
+                    "[yellow]No proposals returned — check AI policy / "
+                    "provider key, or use the manual picker.[/yellow]",
+                    id="ai-cat-top",
+                )
+            else:
+                top = self._candidates[0]
+                pct = int(top.confidence * 100)
+                reason = f" — {top.reasoning}" if top.reasoning else ""
+                yield Static(
+                    f"[b green]{top.account_code}[/b green] ([dim]{pct}% confident[/dim]){reason}",
+                    id="ai-cat-top",
+                )
+            yield DataTable(id="ai-cat-table", zebra_stripes=True, cursor_type="row")
+            yield Static(
+                "[dim]a / enter[/dim] accept · [dim]escape[/dim] cancel",
+                id="ai-cat-hint",
+            )
+
+    def on_mount(self) -> None:
+        """Populate the alternates table with every candidate."""
+        table = self.query_one("#ai-cat-table", DataTable)
+        table.add_columns("Code", "Confidence", "Reasoning")
+        for c in self._candidates:
+            pct = f"{int(c.confidence * 100)}%"
+            reasoning = c.reasoning or "—"
+            table.add_row(c.account_code, pct, reasoning)
+        if self._candidates:
+            table.cursor_coordinate = Coordinate(0, 0)
+            table.focus()
+
+    def action_cancel(self) -> None:
+        """``escape`` cancels."""
+        self.dismiss(None)
+
+    def action_accept(self) -> None:
+        """``a`` / ``enter`` accepts the row under the cursor."""
+        if not self._candidates:
+            self.dismiss(None)
+            return
+        table = self.query_one("#ai-cat-table", DataTable)
+        idx = max(0, table.cursor_row)
+        if idx >= len(self._candidates):
+            idx = 0
+        self.dismiss(self._candidates[idx].account_code)
+
+    # -- pilot-mode introspection -----------------------------------------
+
+    def snapshot_candidates(self) -> tuple[AIProposalCandidate, ...]:
+        """Return the candidates the modal is rendering."""
+        return self._candidates

--- a/packages/tulip-tui/src/tulip_tui/screens/transactions.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/transactions.py
@@ -22,12 +22,14 @@ from textual.containers import Vertical
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Header, Static
 
+from tulip_tui.data.ai_categorize import AIProposalCandidate
 from tulip_tui.data.transaction_write import TransactionDraft
 from tulip_tui.data.transactions import (
     PostingSummary,
     TransactionsData,
     TransactionSummary,
 )
+from tulip_tui.screens.ai_categorize_modal import AICategorizeProposalModal
 from tulip_tui.screens.transaction_modal import (
     TransactionEditModal,
     VoidConfirmModal,
@@ -37,6 +39,8 @@ TransactionsLoader = Callable[[], TransactionsData]
 CreateTransactionAction = Callable[[TransactionDraft], object]
 EditTransactionAction = Callable[[str, TransactionDraft], object]
 VoidTransactionAction = Callable[[str, str], object]
+FetchProposalsAction = Callable[[str, "Decimal", str, str], tuple[AIProposalCandidate, ...]]
+ApplyCategoryAction = Callable[[str, str], object]
 
 
 def _noop_create(_draft: TransactionDraft) -> object:
@@ -49,6 +53,16 @@ def _noop_edit(_tx_id: str, _draft: TransactionDraft) -> object:
 
 def _noop_void(_tx_id: str, _reason: str) -> object:
     raise RuntimeError("void action not configured")
+
+
+def _noop_fetch_proposals(
+    _description: str, _amount: Decimal, _currency: str, _posted_date: str
+) -> tuple[AIProposalCandidate, ...]:
+    raise RuntimeError("AI categorize proposals action not configured")
+
+
+def _noop_apply_category(_tx_id: str, _account_code: str) -> object:
+    raise RuntimeError("apply category action not configured")
 
 
 def _row_text(tx: TransactionSummary) -> tuple[str, str, str, str, str]:
@@ -85,6 +99,7 @@ class TransactionsScreen(Screen[None]):
         Binding("n", "new_tx", "new tx", show=True),
         Binding("e", "edit_tx", "edit tx", show=True),
         Binding("x", "void_tx", "void tx", show=True),
+        Binding("c", "categorize", "AI categorize", show=True),
     ]
 
     DEFAULT_CSS = """
@@ -115,13 +130,17 @@ class TransactionsScreen(Screen[None]):
         on_create: CreateTransactionAction = _noop_create,
         on_edit: EditTransactionAction = _noop_edit,
         on_void: VoidTransactionAction = _noop_void,
+        on_fetch_proposals: FetchProposalsAction = _noop_fetch_proposals,
+        on_apply_category: ApplyCategoryAction = _noop_apply_category,
     ) -> None:
-        """Store the loader and the per-action callbacks (P9.6.c)."""
+        """Store the loader and the per-action callbacks (P9.6.c, #425)."""
         super().__init__()
         self._loader = loader
         self._on_create = on_create
         self._on_edit = on_edit
         self._on_void = on_void
+        self._on_fetch_proposals = on_fetch_proposals
+        self._on_apply_category = on_apply_category
         self._data: TransactionsData = TransactionsData(transactions=())
         self._rendered_rows: list[str] = []
         self._empty = False
@@ -204,6 +223,55 @@ class TransactionsScreen(Screen[None]):
         modal = VoidConfirmModal(tx_id=tx.id, description=tx.description)
         tx_id = tx.id
         self.app.push_screen(modal, lambda result: self._on_void_modal_done(tx_id, result))
+
+    def action_categorize(self) -> None:
+        """``c`` — fetch AI proposals + push the picker modal (#425).
+
+        Only meaningful on PENDING transactions. Any failure surfaces
+        as an inline notice rather than crashing the screen.
+        """
+        tx = self._cursor_tx()
+        if tx is None:
+            self._set_notice("no transaction focused")
+            return
+        if tx.status != "pending":
+            self._set_notice(
+                f"AI categorize only works on PENDING transactions (this one is {tx.status})"
+            )
+            return
+        # Use the transaction's largest non-bank-side posting amount + currency
+        # as the synthetic line for the propose call. v1 sends ``description``
+        # straight through; the API normalises further.
+        if not tx.postings:
+            self._set_notice("transaction has no postings to categorize")
+            return
+        # Pick the posting whose absolute amount is largest — typically the
+        # bank-side leg. We send its currency + the transaction amount.
+        largest = max(tx.postings, key=lambda p: abs(p.amount))
+        try:
+            candidates = self._on_fetch_proposals(
+                tx.description, largest.amount, largest.currency, tx.date
+            )
+        except Exception as exc:
+            self._set_notice(f"[red]proposals failed:[/red] {exc}")
+            return
+        modal = AICategorizeProposalModal(description=tx.description, candidates=candidates)
+        tx_id = tx.id
+        self.app.push_screen(modal, lambda result: self._on_categorize_modal_done(tx_id, result))
+
+    def _on_categorize_modal_done(self, tx_id: str, result: object) -> None:
+        if result is None:
+            self._set_notice("categorize cancelled")
+            return
+        if not isinstance(result, str):
+            return
+        try:
+            self._on_apply_category(tx_id, result)
+        except Exception as exc:
+            self._set_notice(f"[red]apply failed:[/red] {exc}")
+            return
+        self._set_notice(f"categorized as {result}")
+        self._load()
 
     def on_data_table_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
         """Re-render the detail pane to match the newly-highlighted row."""

--- a/packages/tulip-tui/tests/test_ai_categorize_modal.py
+++ b/packages/tulip-tui/tests/test_ai_categorize_modal.py
@@ -1,0 +1,115 @@
+"""Pilot-mode tests for ``AICategorizeProposalModal`` (#425)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tulip_tui.app import TulipTuiApp
+from tulip_tui.data.accounts import AccountsData
+from tulip_tui.data.ai_categorize import AIProposalCandidate
+from tulip_tui.screens.ai_categorize_modal import AICategorizeProposalModal
+
+
+def _accounts_loader_empty() -> AccountsData:
+    return AccountsData(as_of="2026-05-20", accounts=(), groups=())
+
+
+def _sample_candidates() -> tuple[AIProposalCandidate, ...]:
+    return (
+        AIProposalCandidate(account_code="5100", confidence=0.85, reasoning="grocery"),
+        AIProposalCandidate(account_code="5300", confidence=0.55, reasoning=None),
+        AIProposalCandidate(account_code="5400", confidence=0.30, reasoning="dining-ish"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_modal_renders_top_candidate_and_alternates() -> None:
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = AICategorizeProposalModal(
+            description="WHOLE FOODS MARKET", candidates=_sample_candidates()
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        snapshot = modal.snapshot_candidates()
+    assert len(snapshot) == 3
+    assert snapshot[0].account_code == "5100"
+
+
+@pytest.mark.asyncio
+async def test_modal_accept_dismisses_with_top_code() -> None:
+    """``a`` accepts the focused row — cursor starts at row 0 (the top)."""
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        accepted: list[str | None] = []
+
+        def callback(result: object) -> None:
+            accepted.append(result)  # type: ignore[arg-type]
+
+        modal = AICategorizeProposalModal(description="X", candidates=_sample_candidates())
+        await app.push_screen(modal, callback)
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+    assert accepted == ["5100"]
+
+
+@pytest.mark.asyncio
+async def test_modal_arrow_then_accept_picks_alternate() -> None:
+    """Down-arrow + ``a`` picks the second-row candidate."""
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        accepted: list[str | None] = []
+
+        def callback(result: object) -> None:
+            accepted.append(result)  # type: ignore[arg-type]
+
+        modal = AICategorizeProposalModal(description="X", candidates=_sample_candidates())
+        await app.push_screen(modal, callback)
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("a")
+        await pilot.pause()
+    assert accepted == ["5300"]
+
+
+@pytest.mark.asyncio
+async def test_modal_escape_dismisses_with_none() -> None:
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        accepted: list[object] = []
+
+        def callback(result: object) -> None:
+            accepted.append(result)
+
+        modal = AICategorizeProposalModal(description="X", candidates=_sample_candidates())
+        await app.push_screen(modal, callback)
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+    assert accepted == [None]
+
+
+@pytest.mark.asyncio
+async def test_modal_empty_candidates_renders_no_proposal_message() -> None:
+    """Empty candidate tuple → modal still renders + escape dismisses cleanly."""
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        accepted: list[object] = []
+
+        def callback(result: object) -> None:
+            accepted.append(result)
+
+        modal = AICategorizeProposalModal(description="X", candidates=())
+        await app.push_screen(modal, callback)
+        await pilot.pause()
+        # `a` on empty also dismisses with None — no candidate to accept.
+        await pilot.press("a")
+        await pilot.pause()
+    assert accepted == [None]


### PR DESCRIPTION
## Summary

Closes the original P9.6 umbrella by shipping the deferred
P9.6.d slice: top-N AI categorize with explicit confirmation in
the TUI.

**Backend extension**
- New \`CategorizationCandidate\` dataclass in \`tulip_core\`.
- \`Categorizer.propose(line, ctx, *, n=5)\` Protocol method.
  \`NullCategorizer\` wraps the same Imbalance:Unknown answer
  for backwards-compatibility.
- \`AICategorizer.propose\` asks the model for a top-N JSON shape
  (\`{"candidates": [...]}\`); a defensive parser filters codes
  against the chart, drops zero-confidence entries, dedups by
  code, sorts by confidence descending, and caps to \`n\`.
- Reuses the same policy / cost-cap / rate-limit / audit plumbing
  as the single-call path.
- 8 new \`tulip-ai\` tests + dataclass-validator coverage.

**API surface**
- New \`POST /v1/ai/categorize-proposals\` endpoint takes a
  synthetic statement-line shape (description / amount / currency
  / posted_date / n) and returns the ranked candidates JSON.
- Calls the registered categorizer; on any fallback (disabled,
  no key, provider error, malformed response) returns a single
  Imbalance:Unknown candidate with confidence 0.0 — the TUI
  treats that as "no proposal".
- \`n\` is capped to \`[1, 10]\` (422 outside).
- 3 endpoint tests.

**TUI**
- New \`AICategorizeProposalModal\` shows the top candidate
  prominently + alternates in a focusable table.
- \`c\` on a PENDING transaction fetches up to 5 proposals,
  pushes the modal. \`a\` / \`enter\` accepts the cursor row;
  \`escape\` cancels.
- Accept resolves \`account_code\` → \`account_id\`, fetches the
  current transaction, identifies the non-bank-side posting
  (largest \`|amount|\` = bank), and PATCHes with the new
  \`account_id\` on the other leg.
- 5 pilot-mode modal tests.

## Test plan

\`\`\`bash
uv run --package tulip-ai pytest packages/tulip-ai/tests/test_categorize.py -q
uv run --package tulip-api pytest packages/tulip-api/tests/test_ai_endpoints.py -q
uv run --package tulip-tui pytest packages/tulip-tui/tests/test_ai_categorize_modal.py -q
just lint
just typecheck
\`\`\`

- [x] 64 tests pass locally
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (Success: no issues found in 312 source files)
- [ ] CI green on this PR

## Out of scope (deliberately)

- Multi-select with \`space\` on the register for batch categorize
  (one user action = N PATCHes; needs a new screen-level state).
- Manual-picker fallback \`m\` on the modal — the existing
  \`e\` (edit transaction) flow already lets the operator pick
  any account directly.

PHASE_STATUS gains a P9.6.d subsection documenting the slice
and the deferred items.