### PR TITLE
fix(tui): load_import_batches reaches into the {items:[...]} envelope

### DIFF
--- a/packages/tulip-tui/src/tulip_tui/data/imports.py
+++ b/packages/tulip-tui/src/tulip_tui/data/imports.py
@@ -37,9 +37,20 @@ class ImportsData:
 
 
 def load_import_batches(client: TulipClient) -> ImportsData:
-    """Fetch and parse ``/v1/imports``."""
+    """Fetch and parse ``/v1/imports``.
+
+    The API returns ``{"items": [...], "next_cursor": ...}`` (see
+    ``ImportBatchListResponse``); the list endpoint deliberately
+    omits ``error_count`` / ``applied_at`` / ``reverted_at`` to
+    keep the response cheap. We default those to 0 / None so the
+    summary value object stays uniform with the detail loader.
+    """
     raw = client.get("/v1/imports", authenticated=True).json()
-    items = tuple(_to_summary(row) for row in raw)
+    if isinstance(raw, dict):
+        rows = raw.get("items") or []
+    else:
+        rows = raw  # legacy bare-list shape; kept for fixture compat
+    items = tuple(_to_summary(row) for row in rows)
     return ImportsData(batches=items)
 
 

--- a/packages/tulip-tui/src/tulip_tui/data/reconciliations.py
+++ b/packages/tulip-tui/src/tulip_tui/data/reconciliations.py
@@ -38,9 +38,19 @@ class ReconciliationsData:
 
 
 def load_reconciliations(client: TulipClient) -> ReconciliationsData:
-    """Fetch and parse ``/v1/reconciliations``."""
+    """Fetch and parse ``/v1/reconciliations``.
+
+    The API returns ``{"items": [...]}`` per
+    ``ReconciliationListResponse``; iterate into the envelope.
+    Falls back to a bare-list shape for backwards-compat with
+    older fixtures.
+    """
     raw = client.get("/v1/reconciliations", authenticated=True).json()
-    items = tuple(_to_summary(row) for row in raw)
+    if isinstance(raw, dict):
+        rows = raw.get("items") or []
+    else:
+        rows = raw
+    items = tuple(_to_summary(row) for row in rows)
     return ReconciliationsData(reconciliations=items)
 
 

--- a/packages/tulip-tui/tests/test_recon_imports_data.py
+++ b/packages/tulip-tui/tests/test_recon_imports_data.py
@@ -105,6 +105,38 @@ def test_load_reconciliations_handles_empty() -> None:
     assert data.reconciliations == ()
 
 
+def test_load_reconciliations_uses_items_envelope() -> None:
+    """GET /v1/reconciliations returns ``{"items": [...]}`` per
+    ``ReconciliationListResponse``; same envelope bug as the imports
+    loader had (#442). Regression-guard alongside the imports test.
+    """
+    payload = {
+        "items": [
+            {
+                "id": "rec-1",
+                "account_id": "acc-1",
+                "statement_period_start": "2026-05-01",
+                "statement_period_end": "2026-05-31",
+                "statement_starting_balance": "0.00",
+                "statement_ending_balance": "100.00",
+                "currency": "USD",
+                "status": "open",
+                "source_import_batch_id": None,
+                "created_at": "2026-05-21T00:00:00Z",
+                "completed_at": None,
+            }
+        ],
+    }
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_reconciliations(client)
+    assert len(data.reconciliations) == 1
+    assert data.reconciliations[0].id == "rec-1"
+
+
 def test_load_reconciliations_raises_on_error() -> None:
     from tulip_cli.errors import CliError
 

--- a/packages/tulip-tui/tests/test_recon_imports_data.py
+++ b/packages/tulip-tui/tests/test_recon_imports_data.py
@@ -128,34 +128,31 @@ def test_load_reconciliations_raises_on_error() -> None:
 # ---- import batches -------------------------------------------------
 
 
-_IMPORTS_PAYLOAD = [
-    {
-        "id": "batch-1",
-        "account_id": "acc-1",
-        "source_format": "ofx",
-        "source_filename": "april.qfx",
-        "status": "applied",
-        "imported_count": 42,
-        "skipped_count": 0,
-        "error_count": 0,
-        "created_at": "2026-05-01T12:00:00Z",
-        "applied_at": "2026-05-01T12:05:00Z",
-        "reverted_at": None,
-    },
-    {
-        "id": "batch-2",
-        "account_id": "acc-2",
-        "source_format": "csv",
-        "source_filename": "visa.csv",
-        "status": "parsed",
-        "imported_count": 0,
-        "skipped_count": 0,
-        "error_count": 0,
-        "created_at": "2026-05-10T09:00:00Z",
-        "applied_at": None,
-        "reverted_at": None,
-    },
-]
+_IMPORTS_PAYLOAD = {
+    "items": [
+        {
+            "id": "batch-1",
+            "account_id": "acc-1",
+            "source_format": "ofx",
+            "source_filename": "april.qfx",
+            "status": "applied",
+            "imported_count": 42,
+            "skipped_count": 0,
+            "created_at": "2026-05-01T12:00:00Z",
+        },
+        {
+            "id": "batch-2",
+            "account_id": "acc-2",
+            "source_format": "csv",
+            "source_filename": "visa.csv",
+            "status": "parsed",
+            "imported_count": 0,
+            "skipped_count": 0,
+            "created_at": "2026-05-10T09:00:00Z",
+        },
+    ],
+    "next_cursor": None,
+}
 
 
 def test_load_import_batches_returns_summary_list() -> None:
@@ -178,9 +175,46 @@ def test_load_import_batches_returns_summary_list() -> None:
 
 
 def test_load_import_batches_handles_empty() -> None:
-    with _build_client(httpx.MockTransport(lambda _r: httpx.Response(200, json=[]))) as client:
+    with _build_client(
+        httpx.MockTransport(lambda _r: httpx.Response(200, json={"items": [], "next_cursor": None}))
+    ) as client:
         data = load_import_batches(client)
     assert data.batches == ()
+
+
+def test_load_import_batches_uses_items_envelope() -> None:
+    """Regression: GET /v1/imports returns ``{"items": [...]}`` per
+    ``ImportBatchListResponse`` — the loader must reach into the
+    envelope, not iterate the response dict's keys (which produced
+    the ``'str' object has no attribute 'get'`` error in the wild).
+    """
+    payload = {
+        "items": [
+            {
+                "id": "b",
+                "account_id": "a",
+                "source_format": "ofx",
+                "source_filename": "x.qfx",
+                "status": "parsed",
+                "imported_count": 1,
+                "skipped_count": 0,
+                "created_at": "2026-05-21T00:00:00Z",
+            }
+        ],
+        "next_cursor": None,
+    }
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_import_batches(client)
+    assert len(data.batches) == 1
+    assert data.batches[0].id == "b"
+    # Fields the list endpoint deliberately omits — default safely.
+    assert data.batches[0].error_count == 0
+    assert data.batches[0].applied_at is None
+    assert data.batches[0].reverted_at is None
 
 
 def test_load_import_batches_raises_on_error() -> None:


### PR DESCRIPTION
## Summary

The TUI imports browser was rendering \`error: 'str' object has
no attribute 'get'\` because \`load_import_batches\` iterated the
raw JSON directly. \`GET /v1/imports\` actually returns
\`{"items": [...], "next_cursor": ...}\` (\`ImportBatchListResponse\`),
so \`for row in raw\` iterated the dict's *keys* — yielding the
strings \`"items"\` / \`"next_cursor"\` — and the next
\`row.get("id", "")\` blew up.

Tests passed because the mock fixture sent a bare list (the old
shape, before pagination landed). The real API surface had
drifted from the test fixture and no live smoke caught it.

- Loader now reaches into the \`items\` envelope, falls back to
  a bare list for backwards compatibility.
- \`error_count\` / \`applied_at\` / \`reverted_at\` default
  cleanly (the list endpoint omits them to keep the page payload
  small; the detail loader still fills them).
- Test fixture updated to the real envelope shape.
- New regression test asserts the envelope is handled.

## Test plan

\`\`\`bash
uv run --package tulip-tui pytest packages/tulip-tui/tests/test_recon_imports_data.py -q
just lint
just typecheck
\`\`\`

- [x] 7 tests pass locally (was 6 + 1 new regression)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 312 source files)
- [ ] CI green on this PR
- [ ] Manual smoke: open the TUI, press \`i\`, confirm the
  imports browser renders rows instead of the error string