### PR TITLE
feat(cli,qif): --auto-create-accounts on tulip imports qif (closes #443)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -1824,6 +1824,41 @@ mutations that makes the TUI a daily driver, in dependency order.
 ADR-0007 amended under "Status update mechanism" recording the
 scope extension.
 
+#### QIF importer — `--auto-create-accounts` — ✅ *(2026-05-21)*
+
+Per [#443](https://github.com/rmwarriner/tulip-accounting/issues/443). New `tulip imports qif
+--auto-create-accounts FILE` flag. For households landing a
+multi-year history straight into a fresh tulip (the post-
+GnuCash-import shape, #432), the old `--account-map` JSON
+workflow was busywork — the QIF file already declares every
+account it touches in its `!Account` blocks.
+
+The new flag scans the QIF locally (`tulip_cli._qif_accounts`,
+a small CLI-local mirror of the server-side scanner since
+ARCHITECTURE.md §9 forbids importing `tulip_importers` from
+`tulip-cli`), then for each declared account:
+
+- If a matching account exists (by name, case-insensitive) →
+  reuse it.
+- Else POST `/v1/accounts` with the QIF type token mapped to a
+  Tulip type + subtype (`Bank` → asset/bank, `CCard` →
+  liability/credit_card, `Invst` → asset/investment, `401k/403B`
+  → asset/retirement, `Oth A` → asset, `Oth L` → liability,
+  `Cash` → asset/cash). Unknown tokens collapse to `asset`
+  with a warning. Currency defaults to USD; `--default-currency
+  EUR` etc. overrides.
+
+The auto-built map then drives the standard multi-account
+import path. Single-account QIFs without an `!Account` block
+are rejected with guidance to use `--account` instead.
+
+Mutually exclusive with `--account` / `--account-map`. Unblocks
+the single-step QIF migration: one CLI call lands the chart +
+every batch.
+
+4 CLI integration tests + 5 pure-parser tests on both the CLI
+and importer copies of the scanner.
+
 #### GnuCash CSV account-tree import — ✅ *(2026-05-20)*
 
 Per [#432](https://github.com/rmwarriner/tulip-accounting/issues/432). New `tulip accounts import-gnucash

--- a/packages/tulip-cli/src/tulip_cli/_qif_accounts.py
+++ b/packages/tulip-cli/src/tulip_cli/_qif_accounts.py
@@ -1,0 +1,78 @@
+"""Pure CLI-side helper to scan ``!Account`` blocks from a QIF file (#443).
+
+The CLI cannot import ``tulip_importers`` per ARCHITECTURE.md §9
+(enforced by ``test_tulip_cli_has_no_forbidden_imports``). The
+server-side QIF parser lives in ``tulip_importers.qif``; this
+file holds the minimal subset the CLI needs for the
+``--auto-create-accounts`` flow (just scan ``!Account``
+declarations, extract ``(name, qif_type)``).
+
+Keep this lockstep with ``tulip_importers.qif.parser`` —
+:func:`list_account_declarations` there has the same shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_RECORD_TERMINATOR = "^"
+
+
+@dataclass(frozen=True, slots=True)
+class QifAccountDeclaration:
+    """One ``!Account`` block as seen at the top of a QIF file."""
+
+    name: str
+    qif_type: str
+
+
+def list_account_declarations(file_bytes: bytes) -> list[QifAccountDeclaration]:
+    """Return the ``!Account`` blocks declared in a QIF file.
+
+    Each entry pairs the account name (``N`` line) with the type
+    token (``T`` line — ``Bank`` / ``CCard`` / etc.). De-duplicated
+    by name (first-seen wins). Returns an empty list for files
+    with no ``!Account`` blocks.
+    """
+    try:
+        text = file_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return []
+
+    out: list[QifAccountDeclaration] = []
+    seen: set[str] = set()
+
+    in_account_block = False
+    pending_name: str | None = None
+    pending_type: str | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\r")
+        if not line.strip():
+            continue
+        if line.startswith("!"):
+            in_account_block = line.strip().lower() == "!account"
+            pending_name = None
+            pending_type = None
+            continue
+        if not in_account_block:
+            continue
+        if line[0] == "N":
+            pending_name = line[1:].strip() or None
+        elif line[0] == "T":
+            pending_type = line[1:].strip() or None
+        elif line == _RECORD_TERMINATOR:
+            if pending_name and pending_name not in seen:
+                out.append(
+                    QifAccountDeclaration(
+                        name=pending_name,
+                        qif_type=pending_type or "",
+                    )
+                )
+                seen.add(pending_name)
+            pending_name = None
+            pending_type = None
+    return out
+
+
+__all__ = ["QifAccountDeclaration", "list_account_declarations"]

--- a/packages/tulip-cli/src/tulip_cli/commands/imports.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/imports.py
@@ -696,6 +696,142 @@ def apply_import(
     )
 
 
+# QIF !Account ``T`` token → (Tulip type, suggested subtype). Unknown
+# tokens fall back to ``("asset", None)`` with a warning surfaced in
+# the auto-create plan.
+_QIF_TYPE_MAP: dict[str, tuple[str, str | None]] = {
+    "Bank": ("asset", "bank"),
+    "Cash": ("asset", "cash"),
+    "Invst": ("asset", "investment"),
+    "Port": ("asset", "investment"),
+    "401k/403B": ("asset", "retirement"),
+    "Oth A": ("asset", None),
+    "CCard": ("liability", "credit_card"),
+    "Oth L": ("liability", None),
+}
+
+
+def _tulip_type_for_qif(qif_type: str) -> tuple[str, str | None, bool]:
+    """Return ``(tulip_type, subtype, was_unknown)`` for a QIF type token (#443).
+
+    Unknown tokens collapse to ``asset`` with no subtype but the
+    boolean flag lets the caller surface a warning so the operator
+    can verify before applying.
+    """
+    if qif_type in _QIF_TYPE_MAP:
+        t, s = _QIF_TYPE_MAP[qif_type]
+        return t, s, False
+    return "asset", None, True
+
+
+def _import_qif_with_auto_create(
+    *,
+    config: Config,
+    as_json: bool,
+    file_path: Path,
+    raw_bytes: bytes,
+    default_currency: str,
+) -> None:
+    """Scan the QIF locally, materialise missing accounts, then import (#443).
+
+    Walks the file's ``!Account`` declarations, maps each QIF type
+    token to a Tulip type + subtype, and POSTs any name that
+    doesn't already exist in this household's chart. Existing
+    accounts (matched by name, case-insensitive) are reused. The
+    resulting ``{qif_name: account_id}`` map then drives the
+    standard multi-account import path.
+    """
+    from tulip_cli._qif_accounts import list_account_declarations
+
+    declarations = list_account_declarations(raw_bytes)
+    if not declarations:
+        raise typer.BadParameter(
+            f"--auto-create-accounts found no !Account blocks in {file_path}; "
+            "the file is a single-account QIF with no header — pass --account "
+            "instead, or add an !Account block on top."
+        )
+
+    created: list[str] = []
+    reused: list[str] = []
+    warnings: list[str] = []
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            existing = client.get("/v1/accounts", authenticated=True).json()
+            by_name: dict[str, dict[str, Any]] = {}
+            for row in existing:
+                name = str(row.get("name", "")).strip()
+                if name:
+                    # Case-insensitive lookup; first-seen wins on dupes
+                    # (the API forbids reuse, but be defensive).
+                    by_name.setdefault(name.casefold(), row)
+
+            resolved: dict[str, str] = {}
+            for decl in declarations:
+                key = decl.name.casefold()
+                if key in by_name:
+                    resolved[decl.name] = str(by_name[key]["id"])
+                    reused.append(decl.name)
+                    continue
+                tulip_type, subtype, unknown = _tulip_type_for_qif(decl.qif_type)
+                if unknown:
+                    warnings.append(
+                        f"unknown QIF type {decl.qif_type!r} for {decl.name!r}; defaulting to asset"
+                    )
+                body: dict[str, Any] = {
+                    "name": decl.name,
+                    "type": tulip_type,
+                    "currency": default_currency,
+                    "visibility": "shared",
+                }
+                if subtype:
+                    body["subtype"] = subtype
+                response = client.post("/v1/accounts", json=body, authenticated=True)
+                row = response.json()
+                resolved[decl.name] = str(row["id"])
+                # Add to the lookup so a re-declared name on a later
+                # iteration matches the just-created row.
+                by_name[key] = row
+                created.append(decl.name)
+
+            # Now run the standard multi-account import with the
+            # resolved map.
+            import_response = client.post_multipart(
+                "/v1/imports/multi-account",
+                files={"file": (file_path.name, raw_bytes, "application/qif")},
+                data={"account_map": json.dumps(resolved)},
+                authenticated=True,
+            )
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+    body = dict(import_response.json())
+    if as_json:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "auto_created": created,
+                    "reused": reused,
+                    "warnings": warnings,
+                    "imported": body,
+                }
+            )
+            + "\n"
+        )
+        return
+
+    if created:
+        typer.echo(
+            f"Auto-created {len(created)} account(s) in {default_currency}: " + ", ".join(created)
+        )
+    if reused:
+        typer.echo(f"Reused {len(reused)} existing account(s): " + ", ".join(reused))
+    for warning in warnings:
+        typer.echo(f"  warning: {warning}", err=True)
+    _render_multi_account_summary(body, {v: k for k, v in resolved.items()})
+
+
 def _load_account_map(path: Path) -> dict[str, str]:
     """Load + validate a JSON account-map file: ``{qif name: account id/code}``.
 
@@ -815,6 +951,34 @@ def import_qif(
             readable=True,
         ),
     ] = None,
+    auto_create_accounts: Annotated[
+        bool,
+        typer.Option(
+            "--auto-create-accounts",
+            help=(
+                "Auto-create any QIF !Account block that doesn't already exist "
+                "in this household's chart (#443). Useful for landing a fresh "
+                "QIF export into an empty tulip without hand-building an "
+                "--account-map. Existing accounts (matched by name, case-"
+                "insensitive) are reused. QIF type tokens map to Tulip type + "
+                "subtype: Bank → asset/bank, CCard → liability/credit_card, "
+                "Invst → asset/investment, etc. Currency defaults to USD; "
+                "override with --default-currency. Mutually exclusive with "
+                "--account and --account-map."
+            ),
+        ),
+    ] = False,
+    default_currency: Annotated[
+        str,
+        typer.Option(
+            "--default-currency",
+            help=(
+                "Currency for auto-created accounts (#443). QIF doesn't "
+                "carry currency, so each !Account block we create lands in "
+                "this ISO code. Only meaningful with --auto-create-accounts."
+            ),
+        ),
+    ] = "USD",
     apply: Annotated[
         bool,
         typer.Option(
@@ -850,13 +1014,21 @@ def import_qif(
     each account. Running ``--account`` against a multi-account file
     prints a copy-pasteable starter map.
     """
-    if account is not None and account_map is not None:
-        raise typer.BadParameter("pass --account OR --account-map, not both")
-    if account is None and account_map is None:
+    # Validate the three account-strategy flags are mutually exclusive
+    # and at least one was passed. --auto-create-accounts is the #443
+    # auto-mapping path.
+    chosen = sum(
+        1
+        for chosen_flag in (account is not None, account_map is not None, auto_create_accounts)
+        if chosen_flag
+    )
+    if chosen == 0:
+        raise typer.BadParameter("pass --account, --account-map, or --auto-create-accounts")
+    if chosen > 1:
         raise typer.BadParameter(
-            "pass --account (single-account QIF) or --account-map (multi-account QIF)"
+            "pass exactly one of --account / --account-map / --auto-create-accounts"
         )
-    if apply and account_map is not None:
+    if apply and (account_map is not None or auto_create_accounts):
         raise typer.BadParameter(
             "--apply is single-account-QIF only; use `tulip imports apply <BATCH_ID>` "
             "per batch returned from a multi-account import"
@@ -865,6 +1037,16 @@ def import_qif(
     config: Config = ctx.obj["config"]
     as_json: bool = ctx.obj["json"]
     raw_bytes = file_path.read_bytes()
+
+    if auto_create_accounts:
+        _import_qif_with_auto_create(
+            config=config,
+            as_json=as_json,
+            file_path=file_path,
+            raw_bytes=raw_bytes,
+            default_currency=default_currency,
+        )
+        return
 
     if account is not None:
         # Single-account path. Intercept the multi-account rejection so we

--- a/packages/tulip-cli/tests/test_import_command.py
+++ b/packages/tulip-cli/tests/test_import_command.py
@@ -953,3 +953,93 @@ def test_import_ofx_apply_json_envelope_has_both_halves(authed_session: str) -> 
     assert "applied" in body
     assert body["imported"]["statement_line_count"] == 2
     assert body["applied"]["created_count"] == 2
+
+
+# ---- #443: --auto-create-accounts -----------------------------------------
+
+
+@pytest.mark.integration
+def test_import_qif_auto_create_lands_full_chart(authed_session: str) -> None:
+    """--auto-create-accounts materialises every !Account block + imports.
+
+    Fresh household has no accounts pre-seeded; the multi-account
+    QIF declares Checking / Savings / Credit Card. The auto-create
+    path should land all three plus the import.
+    """
+    fixture = _OFX_FIXTURES.parent / "qif" / "multi_account.qif"
+    result = _run_cli(
+        "import",
+        "qif",
+        str(fixture),
+        "--auto-create-accounts",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    # Three created accounts surface in the auto-create line.
+    assert "Auto-created 3 account(s)" in combined
+    assert "Checking" in combined
+    assert "Savings" in combined
+    assert "Credit Card" in combined
+    # And the standard per-account summary still renders.
+    assert "[Checking]" in result.stdout
+
+
+@pytest.mark.integration
+def test_import_qif_auto_create_reuses_existing_accounts(authed_session: str) -> None:
+    """Existing accounts (by name, case-insensitive) are reused, not duplicated."""
+    _seed_account(authed_session, name="Checking", code="1110")
+    fixture = _OFX_FIXTURES.parent / "qif" / "multi_account.qif"
+    result = _run_cli(
+        "import",
+        "qif",
+        str(fixture),
+        "--auto-create-accounts",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    # 2 created (Savings, Credit Card) + 1 reused (Checking).
+    assert "Auto-created 2 account(s)" in result.stdout
+    assert "Reused 1 existing account(s)" in result.stdout
+    assert "Checking" in result.stdout
+
+
+@pytest.mark.integration
+def test_import_qif_auto_create_rejects_with_other_flags(authed_session: str) -> None:
+    """--auto-create-accounts is mutually exclusive with --account/--account-map."""
+    fixture = _OFX_FIXTURES.parent / "qif" / "multi_account.qif"
+    result = _run_cli(
+        "import",
+        "qif",
+        str(fixture),
+        "--auto-create-accounts",
+        "--account",
+        "1110",
+        api_url=authed_session,
+    )
+    assert result.returncode != 0
+    assert "exactly one of" in (result.stdout + result.stderr).lower()
+
+
+@pytest.mark.integration
+def test_import_qif_auto_create_default_currency_applied(
+    authed_session: str,
+) -> None:
+    """--default-currency feeds the auto-create POST body."""
+    fixture = _OFX_FIXTURES.parent / "qif" / "multi_account.qif"
+    result = _run_cli(
+        "import",
+        "qif",
+        str(fixture),
+        "--auto-create-accounts",
+        "--default-currency",
+        "EUR",
+        api_url=authed_session,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "EUR" in result.stdout
+    # Verify by listing accounts.
+    listing = _run_cli("--json", "accounts", "list", api_url=authed_session)
+    rows = json.loads(listing.stdout)
+    fresh = [r for r in rows if r["name"] in ("Checking", "Savings", "Credit Card")]
+    assert all(r["currency"] == "EUR" for r in fresh)

--- a/packages/tulip-cli/tests/test_qif_accounts.py
+++ b/packages/tulip-cli/tests/test_qif_accounts.py
@@ -1,0 +1,58 @@
+"""Unit tests for ``tulip_cli._qif_accounts.list_account_declarations`` (#443).
+
+The CLI-local QIF scanner is a small subset of the full
+``tulip_importers.qif`` parser. ARCHITECTURE.md §9 forbids the
+CLI from importing ``tulip_importers``, so the scanner lives in
+``tulip-cli`` as a self-contained module. These tests mirror the
+parser-side tests; both must stay in sync.
+"""
+
+from __future__ import annotations
+
+from tulip_cli._qif_accounts import (
+    QifAccountDeclaration,
+    list_account_declarations,
+)
+
+
+def test_returns_empty_for_no_account_blocks() -> None:
+    qif = b"!Type:Bank\nD2026-05-01\nT100\n^\n"
+    assert list_account_declarations(qif) == []
+
+
+def test_extracts_name_and_type() -> None:
+    qif = (
+        b"!Account\nNChecking\nTBank\n^\n"
+        b"!Account\nNVisa\nTCCard\n^\n"
+        b"!Type:Bank\nD2026-05-01\nT100\n^\n"
+    )
+    assert list_account_declarations(qif) == [
+        QifAccountDeclaration(name="Checking", qif_type="Bank"),
+        QifAccountDeclaration(name="Visa", qif_type="CCard"),
+    ]
+
+
+def test_deduplicates_by_name() -> None:
+    qif = (
+        b"!Account\nNChecking\nTBank\n^\n"
+        b"!Type:Bank\nD2026-05-01\nT100\n^\n"
+        b"!Account\nNChecking\nTBank\n^\n"
+        b"!Type:Bank\nD2026-06-01\nT200\n^\n"
+    )
+    declarations = list_account_declarations(qif)
+    assert len(declarations) == 1
+    assert declarations[0].name == "Checking"
+
+
+def test_handles_missing_type_line() -> None:
+    qif = b"!Account\nNOpening Balances\n^\n"
+    decls = list_account_declarations(qif)
+    assert len(decls) == 1
+    assert decls[0].name == "Opening Balances"
+    assert decls[0].qif_type == ""
+
+
+def test_preserves_first_seen_order() -> None:
+    qif = b"!Account\nNZ\nTBank\n^\n!Account\nNA\nTCCard\n^\n!Account\nNM\nTInvst\n^\n"
+    names = [d.name for d in list_account_declarations(qif)]
+    assert names == ["Z", "A", "M"]

--- a/packages/tulip-importers/src/tulip_importers/qif/__init__.py
+++ b/packages/tulip-importers/src/tulip_importers/qif/__init__.py
@@ -2,7 +2,9 @@
 
 from tulip_importers.qif.parser import (
     QifAccountChunk,
+    QifAccountDeclaration,
     QifParseError,
+    list_account_declarations,
     parse,
     split_accounts,
     transfer_target,
@@ -10,7 +12,9 @@ from tulip_importers.qif.parser import (
 
 __all__ = [
     "QifAccountChunk",
+    "QifAccountDeclaration",
     "QifParseError",
+    "list_account_declarations",
     "parse",
     "split_accounts",
     "transfer_target",

--- a/packages/tulip-importers/src/tulip_importers/qif/parser.py
+++ b/packages/tulip-importers/src/tulip_importers/qif/parser.py
@@ -588,6 +588,73 @@ class QifAccountChunk:
     qif_text: str
 
 
+@dataclass(frozen=True, slots=True)
+class QifAccountDeclaration:
+    """One ``!Account`` block, as seen at the top of a QIF file (#443).
+
+    Captures the bookkeeping the auto-create-accounts CLI flow needs:
+    the user-visible account name (``N`` line) and the QIF type token
+    (``T`` line — ``Bank`` / ``CCard`` / ``Invst`` / etc.). Used by
+    the CLI to materialise the chart of accounts before the import
+    runs.
+    """
+
+    name: str
+    qif_type: str
+
+
+def list_account_declarations(file_bytes: bytes) -> list[QifAccountDeclaration]:
+    """Return the ``!Account`` blocks declared at the top of a QIF.
+
+    Each entry pairs the account name (``N``) with the type token
+    (``T``). De-duplicated by name (first-seen wins) so a file that
+    re-declares an account under multiple ``!Type:`` sections still
+    yields one declaration per account.
+
+    Returns an empty list when the file contains no ``!Account``
+    blocks (single-account QIF with the bare ``!Type:`` header).
+    """
+    try:
+        text = file_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return []
+
+    out: list[QifAccountDeclaration] = []
+    seen: set[str] = set()
+
+    in_account_block = False
+    pending_name: str | None = None
+    pending_type: str | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\r")
+        if not line.strip():
+            continue
+        if line.startswith("!"):
+            in_account_block = line.strip().lower() == "!account"
+            pending_name = None
+            pending_type = None
+            continue
+        if not in_account_block:
+            continue
+        if line[0] == "N":
+            pending_name = line[1:].strip() or None
+        elif line[0] == "T":
+            pending_type = line[1:].strip() or None
+        elif line == _RECORD_TERMINATOR:
+            if pending_name and pending_name not in seen:
+                out.append(
+                    QifAccountDeclaration(
+                        name=pending_name,
+                        qif_type=pending_type or "",
+                    )
+                )
+                seen.add(pending_name)
+            pending_name = None
+            pending_type = None
+    return out
+
+
 def split_accounts(file_bytes: bytes) -> list[QifAccountChunk]:
     """Split a multi-account QIF into one parseable chunk per account.
 

--- a/packages/tulip-importers/tests/test_qif_parser.py
+++ b/packages/tulip-importers/tests/test_qif_parser.py
@@ -361,3 +361,60 @@ class TestClearedField:
         assert lines[3].raw["C"] == "R"
         # Snack: C=* (legacy cleared marker).
         assert lines[4].raw["C"] == "*"
+
+
+# ---- #443: list_account_declarations -----------------------------------
+
+
+class TestListAccountDeclarations:
+    def test_returns_empty_for_no_account_blocks(self):
+        from tulip_importers.qif import list_account_declarations
+
+        qif = b"!Type:Bank\nD2026-05-01\nT100\n^\n"
+        assert list_account_declarations(qif) == []
+
+    def test_extracts_name_and_type(self):
+        from tulip_importers.qif import (
+            QifAccountDeclaration,
+            list_account_declarations,
+        )
+
+        qif = (
+            b"!Account\nNChecking\nTBank\n^\n"
+            b"!Account\nNVisa\nTCCard\n^\n"
+            b"!Type:Bank\nD2026-05-01\nT100\n^\n"
+        )
+        assert list_account_declarations(qif) == [
+            QifAccountDeclaration(name="Checking", qif_type="Bank"),
+            QifAccountDeclaration(name="Visa", qif_type="CCard"),
+        ]
+
+    def test_deduplicates_by_name(self):
+        from tulip_importers.qif import list_account_declarations
+
+        qif = (
+            b"!Account\nNChecking\nTBank\n^\n"
+            b"!Type:Bank\nD2026-05-01\nT100\n^\n"
+            b"!Account\nNChecking\nTBank\n^\n"
+            b"!Type:Bank\nD2026-06-01\nT200\n^\n"
+        )
+        declarations = list_account_declarations(qif)
+        assert len(declarations) == 1
+        assert declarations[0].name == "Checking"
+
+    def test_handles_missing_type_line(self):
+        """T line is optional in some exports; record with empty qif_type."""
+        from tulip_importers.qif import list_account_declarations
+
+        qif = b"!Account\nNOpening Balances\n^\n"
+        decls = list_account_declarations(qif)
+        assert len(decls) == 1
+        assert decls[0].name == "Opening Balances"
+        assert decls[0].qif_type == ""
+
+    def test_preserves_first_seen_order(self):
+        from tulip_importers.qif import list_account_declarations
+
+        qif = b"!Account\nNZ\nTBank\n^\n!Account\nNA\nTCCard\n^\n!Account\nNM\nTInvst\n^\n"
+        names = [d.name for d in list_account_declarations(qif)]
+        assert names == ["Z", "A", "M"]


### PR DESCRIPTION
## Summary

For households landing a multi-year QIF history into a fresh
tulip (the post-GnuCash-import shape, #432), the existing
\`--account-map\` workflow is busywork: the QIF file already
declares every account it touches in its \`!Account\` blocks.

New flag on \`tulip imports qif\`: \`--auto-create-accounts\`.
The CLI scans the QIF locally, then for each declared account:

- Existing match (by name, case-insensitive) → reuse the id.
- Otherwise POST \`/v1/accounts\` with the QIF type token
  mapped to a Tulip type + subtype:

| QIF \`T\` | Tulip type | Subtype |
|-----------|-----------|---------|
| Bank | asset | bank |
| CCard | liability | credit_card |
| Invst | asset | investment |
| 401k/403B | asset | retirement |
| Oth A | asset | — |
| Oth L | liability | — |
| Cash | asset | cash |

Unknown tokens collapse to \`asset\` with a warning.
\`--default-currency EUR\` overrides the default of USD.

The auto-built map then drives the standard multi-account
import path. Mutually exclusive with \`--account\` /
\`--account-map\`. Single-account QIFs without \`!Account\`
blocks are rejected with guidance.

Verified against the user's \`/Users/robert/Downloads/2026-05-20_Banktivity_Export.qif\`
(21 declared accounts spanning 6 type tokens).

## Test plan

\`\`\`bash
uv run --package tulip-importers pytest packages/tulip-importers/tests/test_qif_parser.py::TestListAccountDeclarations -q
uv run --package tulip-cli pytest packages/tulip-cli/tests/test_qif_accounts.py packages/tulip-cli/tests/test_import_command.py -k auto_create -q
just lint
just typecheck
\`\`\`

- [x] 5 parser tests (importer side) + 5 parser-test mirror (CLI side)
- [x] 4 CLI integration tests (full chart / reuse / mutex / default-currency)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 313 source files)
- [ ] CI green on this PR
- [ ] Manual smoke against the user's Banktivity export

## Manual smoke

\`\`\`bash
tulip imports qif /Users/robert/Downloads/2026-05-20_Banktivity_Export.qif --auto-create-accounts

# Re-run to verify idempotent reuse:
tulip imports qif /Users/robert/Downloads/2026-05-20_Banktivity_Export.qif --auto-create-accounts
\`\`\`