### PR TITLE
fix(qif): $ with no preceding S is not a split-amount error (closes #445)

### DIFF
--- a/packages/tulip-importers/src/tulip_importers/qif/parser.py
+++ b/packages/tulip-importers/src/tulip_importers/qif/parser.py
@@ -483,12 +483,20 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
             rec.pending_split_memo = None
             rec.splits.append(split)
         elif code == "$":
-            if not rec.splits:
-                raise QifParseError(
-                    f"line {source_line_number}: $ split-amount line appeared "
-                    "before any S split-category line"
-                )
-            rec.splits[-1].amount_str = value
+            if rec.splits:
+                # Bank-section ``$`` partners the preceding ``S`` (split
+                # amount). Standard bookkeeping shape.
+                rec.splits[-1].amount_str = value
+            else:
+                # No preceding ``S``: this isn't a split-amount line at
+                # all. Investment sections use ``$`` as the transfer
+                # amount on Cash/MiscInc/MiscExp records that move money
+                # to/from another account via ``L[<account>]``. Banktivity
+                # also emits it on some non-split bank records. Store it
+                # in ``raw`` so downstream code can recover the value;
+                # rejecting outright (the pre-fix behaviour) lost whole
+                # accounts to a single record with an investment shape.
+                rec.raw[code] = value
         elif code == "E":
             # ``E`` is the split memo. Banktivity emits it *before* its
             # ``S<category>`` partner; we buffer it on the record and the

--- a/packages/tulip-importers/tests/test_qif_parser.py
+++ b/packages/tulip-importers/tests/test_qif_parser.py
@@ -418,3 +418,37 @@ class TestListAccountDeclarations:
         qif = b"!Account\nNZ\nTBank\n^\n!Account\nNA\nTCCard\n^\n!Account\nNM\nTInvst\n^\n"
         names = [d.name for d in list_account_declarations(qif)]
         assert names == ["Z", "A", "M"]
+
+
+# ---- #445: $ without preceding S (investment-section transfer) -----------
+
+
+class TestDollarWithoutSplit:
+    def test_dollar_without_split_does_not_raise(self):
+        """Banktivity emits ``$`` as the transfer amount on Invst Cash
+        records — no ``S`` precedes it. The parser must not reject the
+        file (#445)."""
+        qif = (
+            b"!Type:Invst\n"
+            b"D1/7/26\n"
+            b"NCash\n"
+            b"T147.56\n"
+            b"O0.00\n"
+            b"PEmployer Payroll\n"
+            b"L[Checking]\n"
+            b"$2589.83\n"
+            b"^\n"
+        )
+        lines = parse(qif, currency="USD")
+        assert len(lines) == 1
+        # Value lands in raw so consumers can recover it.
+        assert lines[0].raw.get("$") == "2589.83"
+        # And no splits were created from this record.
+        assert lines[0].splits == ()
+
+    def test_dollar_with_preceding_split_still_works(self):
+        """The bank-section case (S then $) is unchanged."""
+        qif = b"!Type:Bank\nD2026-05-01\nT-100\nSGroceries\n$-60\nSFuel\n$-40\n^\n"
+        lines = parse(qif, currency="USD")
+        assert len(lines) == 1
+        assert len(lines[0].splits) == 2


### PR DESCRIPTION
## Summary

Discovered while smoke-testing PR #444's
\`--auto-create-accounts\` against the user's real Banktivity
export. The parser rejected the file with:

\`\`\`
QIF file could not be parsed
  account 'BNSF 401(k)': line 28: \$ split-amount line appeared
  before any S split-category line
\`\`\`

The triggering record (BNSF 401(k) \`!Type:Invst\` section) is a
valid Banktivity export shape — investment Cash records use
\`\$\` as the transfer amount to/from the \`L[<account>]\`
referenced on the same record. There is no preceding \`S\` and
this isn't a split, it's an investment-section transfer.

Bank-section \`\$\` (the split-amount case) still partners the
preceding \`S\` as before. Without a preceding \`S\`, \`\$\` now
lands in the record's \`raw\` dict so downstream code can
recover the value rather than losing the whole batch.

## Test plan

\`\`\`bash
uv run --package tulip-importers pytest packages/tulip-importers/tests/test_qif_parser.py -q
just lint
just typecheck
\`\`\`

- [x] 43 parser tests pass (41 existing + 2 new for #445)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean
- [ ] CI green on this PR
- [ ] Re-run \`tulip imports qif Banktivity_Export.qif
  --auto-create-accounts\` post-merge + post-image-rebuild