### PR TITLE
feat(storage): normalised tag registry (ADR-0009, PR A)

### DIFF
--- a/docs/adrs/0009-tag-redesign.md
+++ b/docs/adrs/0009-tag-redesign.md
@@ -1,0 +1,268 @@
+# ADR-0009: Normalised tags with posting / transaction / account scopes and inherited resolution
+
+**Status:** Proposed (2026-05-21).
+
+**Phase:** Decision lands during the Phase 9 follow-up wave alongside the
+chart-of-accounts mutation surface (#431, #432, #443, #447). The
+**implementation** is sequenced into three PRs — see *Phasing* below.
+
+**Supersedes:** [#39](https://github.com/rmwarriner/tulip-accounting/issues/39)
+("v1 labels-only tags surface"), which deliberately shipped the smallest
+useful tag slice and explicitly deferred posting tags, account tags,
+cascade semantics, and key=value pairs. This ADR closes that deferral
+window.
+
+---
+
+## Context
+
+The v1 tag surface that shipped under #39 is:
+
+- One table: `transaction_tags(household_id, transaction_id, tag)`.
+  Tag is a freeform `String(64)` with composite PK; no separate `tags`
+  table.
+- Tags exist only at the **transaction level**. Postings cannot carry
+  tags; accounts cannot carry tags.
+- The string is the identity — renaming a tag means a multi-row UPDATE
+  across every transaction that uses it. There is no "tag exists in
+  the household but isn't used yet" concept.
+
+Two pressures forced reopening the design:
+
+1. **QIF import** (#447): Banktivity (and Quicken-derived exporters)
+   embed tags in the category field on split lines:
+
+   ```
+   SWants:Personal:Gifts/Birthday:Walter
+   ```
+
+   Category is `Wants:Personal:Gifts`, tags are `Birthday`, `Walter`.
+   Tags are emitted **per split**, not per transaction. Tulip's
+   per-transaction model can only land the *union* of split tags up to
+   the parent — losing the per-leg attribution that the source data
+   carries.
+
+2. **Operator-stated need.** The user, validating the v1 model on real
+   data, called out that they want tags at the posting level *and*
+   want account-level tags that flow to a posting via the posting's
+   account (e.g. every posting against `Visa` carries a `credit-card`
+   tag implicitly). They also called out that the freeform string
+   model is wrong: tags should be normalised, with names rename-able
+   in one place, so a "Walter" → "Walter S." rename is one row
+   instead of N.
+
+PTA prior art that informed the design:
+
+- **hledger** treats `tag:value` as posting-level by default, with
+  transaction-level tags applying to every posting on that
+  transaction. No account-level tags natively; you can fake it via
+  description prefixes.
+- **Beancount** treats `#tag` as transaction-level and doesn't expose
+  posting tags directly; account-level metadata exists but is closer
+  to "type info" than a tag system.
+- **Ledger-cli** has posting tags via `; tag:` comments; transaction
+  tags via the same syntax at the transaction level; no formal
+  account tags but accounts can carry metadata via subdirectives.
+
+The synthesis: posting tags are the most expressive layer (one tag can
+describe one leg of a multi-leg transaction — the `Walter` tag on
+the gift-card half of a credit-card payment). Transaction tags are
+useful as the default-for-all-postings shorthand. Account tags add
+real value for cross-cutting categorisation (`tax-deductible`,
+`joint`, `child-college-fund`) without forcing the operator to tag
+every transaction that touches the account.
+
+The current v1 model can't carry any of this.
+
+## Decision
+
+Replace the single freeform `transaction_tags` table with a
+normalised three-scope tag system.
+
+### Schema
+
+```sql
+-- New: central tag registry, household-scoped.
+CREATE TABLE tags (
+    household_id  UUID    NOT NULL,
+    id            UUID    NOT NULL,
+    name          STRING(64) NOT NULL,
+    description   STRING(500),    -- optional, for the tag-management UI
+    color         STRING(7),      -- optional, "#RRGGBB" for TUI rendering
+    created_at    TIMESTAMP NOT NULL,
+    PRIMARY KEY (household_id, id),
+    FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE,
+    UNIQUE (household_id, name)    -- name unique within household
+);
+
+-- Refactored: transaction_tags carries tag_id, not the string.
+CREATE TABLE transaction_tags (
+    household_id    UUID NOT NULL,
+    transaction_id  UUID NOT NULL,
+    tag_id          UUID NOT NULL,
+    PRIMARY KEY (household_id, transaction_id, tag_id),
+    FOREIGN KEY (household_id, transaction_id)
+      REFERENCES transactions(household_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (household_id, tag_id)
+      REFERENCES tags(household_id, id) ON DELETE CASCADE
+);
+
+-- New: posting-level tags.
+CREATE TABLE posting_tags (
+    household_id UUID NOT NULL,
+    posting_id   UUID NOT NULL,
+    tag_id       UUID NOT NULL,
+    PRIMARY KEY (household_id, posting_id, tag_id),
+    FOREIGN KEY (household_id, posting_id)
+      REFERENCES postings(household_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (household_id, tag_id)
+      REFERENCES tags(household_id, id) ON DELETE CASCADE
+);
+
+-- New: account-level tags.
+CREATE TABLE account_tags (
+    household_id UUID NOT NULL,
+    account_id   UUID NOT NULL,
+    tag_id       UUID NOT NULL,
+    PRIMARY KEY (household_id, account_id, tag_id),
+    FOREIGN KEY (household_id, account_id)
+      REFERENCES accounts(household_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (household_id, tag_id)
+      REFERENCES tags(household_id, id) ON DELETE CASCADE
+);
+```
+
+Every cross-table FK is composite on `household_id` — tenant isolation
+stays a query-builder concern, not a leak waiting to happen.
+
+### Inheritance semantics
+
+Inheritance is **resolved at read time, not stored.** For any
+posting `P`:
+
+```
+effective_tags(P) =
+    direct_tags(P)                              # from posting_tags
+  ∪ direct_tags(P.transaction)                  # from transaction_tags
+  ∪ direct_tags(P.account)                      # from account_tags
+```
+
+For any transaction `T`:
+
+```
+effective_tags(T) =
+    direct_tags(T)                              # from transaction_tags
+  ∪ ⋃ direct_tags(P)  for P in T.postings       # union of posting tags
+  ∪ ⋃ direct_tags(P.account)  for P in T.postings   # union of account tags
+                                                    # via the postings
+```
+
+API + TUI expose **both** direct and effective sets, with provenance
+for inherited tags ("from account Visa"). This is critical: when the
+operator removes a tag they need to see whether the tag was direct or
+inherited and act accordingly (remove the direct edge, or detach from
+the source).
+
+Materialising the union on write was considered and rejected:
+
+- Rename of tag `Walter` → `Walter S.` becomes O(rows) on every
+  materialised view.
+- Account merge (an out-of-scope-today operation but easy to
+  imagine) cascades into every posting's denormalised tag set.
+- The read query is a 3-arm UNION + GROUP BY against indexed PKs —
+  cheap enough for any realistic household scale.
+
+### Backwards compatibility
+
+The existing `transaction_tags` table has rows in shipped databases.
+The migration is **lossless**:
+
+1. Create `tags` table.
+2. For each distinct `(household_id, tag)` in `transaction_tags`:
+   INSERT a row in `tags` with `id = uuid4()`, `name = tag`.
+3. Add nullable `tag_id` column to `transaction_tags`.
+4. UPDATE `transaction_tags` JOIN the lookup, populate `tag_id`.
+5. Mark `tag_id` NOT NULL, add the FK constraint, drop the
+   `tag` string column, drop the old PK, add the new composite PK.
+
+Existing API callers passing `?tag=<name>` continue to work — the
+filter resolves `<name>` → tag id at query time. Operators writing
+tags via `PATCH /v1/transactions/{id}` continue to pass strings; the
+handler resolves to id (or creates the tag if missing, gated by a
+new `?create_missing_tags=true` query param to keep the existing
+strict path).
+
+## Consequences
+
+### Positive
+
+- One canonical tag identity. Renames are O(1).
+- Tags at every layer of the ledger model that makes sense.
+- Inheritance via view = correct semantics for free; no
+  denormalisation hazard.
+- Provenance ("inherited from account Visa") is just metadata on the
+  effective-tags response — UX wins for free.
+- QIF / Beancount / hledger imports map cleanly onto the per-posting
+  + per-transaction model.
+
+### Negative
+
+- Migration touches a shipped table. Backup discipline (RECOVERY.md)
+  is the safety net.
+- Three new repo modules and a meaningful API surface refactor.
+- Two new join tables increase write-path cost on bulk imports
+  marginally. Profile in CI's benchmarks step.
+
+### Open questions deferred
+
+- **Hierarchical tags** (`parent_tag_id`). The schema reserves the
+  optional column but no logic uses it in this ADR. A follow-up ADR
+  can pin the inheritance semantics (does `expense:groceries` inherit
+  `expense`? Probably yes, but the read query gets a recursive CTE).
+- **Tag types / categories** (color, description) are stored but
+  unused beyond display. No business logic gates on them in v1.
+- **Bulk tag operations** (rename, merge, delete-cascade-with-
+  unattaching) are out of this ADR's scope — they ship as needed
+  once the system has real-world tag debt.
+
+## Phasing
+
+Three sequenced PRs.
+
+### PR A — Normalisation migration
+
+- Add `tags` table.
+- Refactor `transaction_tags` to FK by tag_id; backfill in the
+  Alembic migration.
+- Update `TransactionTagRepository` to operate by id (resolve from
+  name internally so the public API surface stays string-passing).
+- Update `?tag=` filter, audit log writers, tests.
+
+No new user-visible behaviour. Existing tag operations work
+identically. Lowest-risk slice; closes the door on the freeform
+model.
+
+### PR B — Posting tags + account tags
+
+- New `posting_tags` + `account_tags` tables.
+- New repo methods on the relevant repositories.
+- API: `tags` field on `PostingCreate` / `PostingRead`;
+  `tags` field on `AccountCreate` / `AccountUpdate` / `AccountRead`.
+- `?tag=` filter on transaction listings respects all three join
+  tables (UNION search).
+- CLI: `tulip accounts edit ACCOUNT --tag ...`,
+  posting-level tags via the transaction-edit grammar.
+- TUI: account modal gets a tag input; transaction modal
+  gets per-posting tag inputs.
+
+### PR C — Inheritance: effective_tags
+
+- View / CTE that computes the UNION described above.
+- New API endpoint `GET /v1/transactions/{id}/effective-tags`
+  returning `{direct, effective, provenance}`.
+- TUI surfacing in the transaction detail pane.
+- #447 (QIF tag import) lands as a sub-PR of B or C — it writes
+  per-split tags to `posting_tags`.
+
+Each PR is independently shippable; B can land without C if the
+operator is comfortable seeing only direct tags initially.

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260521_0000_b2c4f9a1e7d6_normalised_tags.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260521_0000_b2c4f9a1e7d6_normalised_tags.py
@@ -1,0 +1,171 @@
+"""Normalise tags: central ``tags`` table + refactor ``transaction_tags`` FK (ADR-0009).
+
+PR A of the tag redesign. Migrates from the freeform string surface
+(#39) to a normalised tag registry that PRs B and C extend with
+posting + account scopes and inheritance.
+
+Migration is lossless:
+
+1. Create the ``tags`` table.
+2. Backfill: for each distinct ``(household_id, tag)`` row in the
+   existing ``transaction_tags``, insert a row in ``tags`` with a
+   fresh UUID.
+3. Rebuild ``transaction_tags`` with a ``tag_id`` column (SQLite
+   batch_alter_table — no ALTER COLUMN), populated via JOIN against
+   the lookup we just built.
+4. Drop the old ``tag`` string column and the legacy filter index
+   (the new composite PK + the FK on ``tag_id`` cover both lookups).
+
+Revision ID: b2c4f9a1e7d6
+Revises: a8b3c2d1f4e5
+Create Date: 2026-05-21 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b2c4f9a1e7d6"
+down_revision: str | None = "a8b3c2d1f4e5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create ``tags`` + refactor ``transaction_tags`` to FK by tag_id."""
+    # 1. Create the central tag registry.
+    op.create_table(
+        "tags",
+        sa.Column("household_id", sa.Uuid(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("description", sa.String(length=500), nullable=True),
+        sa.Column("color", sa.String(length=7), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["household_id"], ["households.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("household_id", "id", name="pk_tags"),
+        sa.UniqueConstraint("household_id", "name", name="uq_tags_household_name"),
+    )
+
+    # 2. Backfill: walk existing transaction_tags, dedupe by
+    # (household_id, tag), insert into ``tags``. Build the lookup
+    # in Python so we can use uuid4() per row — driver-neutral
+    # (SQLite has no gen_random_uuid()).
+    bind = op.get_bind()
+    existing_pairs = bind.execute(
+        sa.text("SELECT DISTINCT household_id, tag FROM transaction_tags")
+    ).fetchall()
+    name_to_id: dict[tuple[bytes | str, str], str] = {}
+    for household_id, tag in existing_pairs:
+        new_id = str(uuid.uuid4())
+        name_to_id[(household_id, tag)] = new_id
+        bind.execute(
+            sa.text(
+                "INSERT INTO tags (household_id, id, name, created_at) "
+                "VALUES (:hid, :tid, :name, CURRENT_TIMESTAMP)"
+            ),
+            {"hid": household_id, "tid": new_id, "name": tag},
+        )
+
+    # 3. Rebuild ``transaction_tags`` with the new schema. SQLite
+    # doesn't support ALTER COLUMN, so batch_alter_table recreates
+    # the table via copy. The drop-and-recreate also clears the
+    # legacy ``ix_transaction_tags_household_tag`` index.
+    with op.batch_alter_table("transaction_tags") as batch:
+        batch.drop_index("ix_transaction_tags_household_tag")
+
+    # Capture existing rows so we can re-insert with tag_id.
+    existing_rows = bind.execute(
+        sa.text("SELECT household_id, transaction_id, tag FROM transaction_tags")
+    ).fetchall()
+
+    op.drop_table("transaction_tags")
+    op.create_table(
+        "transaction_tags",
+        sa.Column("household_id", sa.Uuid(), nullable=False),
+        sa.Column("transaction_id", sa.Uuid(), nullable=False),
+        sa.Column("tag_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["household_id", "transaction_id"],
+            ["transactions.household_id", "transactions.id"],
+            ondelete="CASCADE",
+            name="fk_transaction_tags_transaction",
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_transaction_tags_tag",
+        ),
+        sa.PrimaryKeyConstraint(
+            "household_id", "transaction_id", "tag_id", name="pk_transaction_tags"
+        ),
+    )
+
+    # 4. Re-insert each historical row with its resolved tag_id.
+    for household_id, transaction_id, tag in existing_rows:
+        tag_id = name_to_id[(household_id, tag)]
+        bind.execute(
+            sa.text(
+                "INSERT INTO transaction_tags "
+                "(household_id, transaction_id, tag_id) "
+                "VALUES (:hid, :tx, :tag_id)"
+            ),
+            {"hid": household_id, "tx": transaction_id, "tag_id": tag_id},
+        )
+
+
+def downgrade() -> None:
+    """Reverse: dehydrate tag_id back to the inline string."""
+    bind = op.get_bind()
+
+    # Snapshot the new shape's data with names resolved.
+    rows = bind.execute(
+        sa.text(
+            "SELECT tt.household_id, tt.transaction_id, t.name "
+            "FROM transaction_tags AS tt "
+            "JOIN tags AS t "
+            "  ON t.household_id = tt.household_id AND t.id = tt.tag_id"
+        )
+    ).fetchall()
+
+    op.drop_table("transaction_tags")
+    op.create_table(
+        "transaction_tags",
+        sa.Column("household_id", sa.Uuid(), nullable=False),
+        sa.Column("transaction_id", sa.Uuid(), nullable=False),
+        sa.Column("tag", sa.String(length=64), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["household_id", "transaction_id"],
+            ["transactions.household_id", "transactions.id"],
+            ondelete="CASCADE",
+            name="fk_transaction_tags_transaction",
+        ),
+        sa.PrimaryKeyConstraint(
+            "household_id", "transaction_id", "tag", name="pk_transaction_tags"
+        ),
+    )
+    op.create_index(
+        "ix_transaction_tags_household_tag",
+        "transaction_tags",
+        ["household_id", "tag"],
+    )
+    for household_id, transaction_id, tag in rows:
+        bind.execute(
+            sa.text(
+                "INSERT INTO transaction_tags "
+                "(household_id, transaction_id, tag) "
+                "VALUES (:hid, :tx, :tag)"
+            ),
+            {"hid": household_id, "tx": transaction_id, "tag": tag},
+        )
+    op.drop_table("tags")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -59,6 +59,7 @@ from tulip_storage.models.shadow_transaction import (
 )
 from tulip_storage.models.sinking_fund import ContributionStrategy, SinkingFund
 from tulip_storage.models.statement_line import StatementLine
+from tulip_storage.models.tag import Tag
 from tulip_storage.models.transaction import Transaction, TransactionStatus
 from tulip_storage.models.transaction_tag import TransactionTag
 from tulip_storage.models.used_mfa_challenge import UsedMfaChallenge
@@ -111,6 +112,7 @@ __all__ = [
     "SinkingFund",
     "SourceFormat",
     "StatementLine",
+    "Tag",
     "Transaction",
     "TransactionStatus",
     "TransactionTag",

--- a/packages/tulip-storage/src/tulip_storage/models/tag.py
+++ b/packages/tulip-storage/src/tulip_storage/models/tag.py
@@ -1,0 +1,38 @@
+"""Normalised tag registry (ADR-0009, #447).
+
+Replaces the freeform-string tag model from #39. A ``Tag`` is a
+household-scoped row identified by ``id``; the tag's display name
+lives in ``name`` and is unique within the household. Join tables
+(``transaction_tags``, ``posting_tags``, ``account_tags``)
+reference tags by ``id`` so a tag rename is O(1).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class Tag(Base):
+    """One household-scoped tag (ADR-0009, PR A)."""
+
+    __tablename__ = "tags"
+    __table_args__ = (UniqueConstraint("household_id", "name", name="uq_tags_household_name"),)
+
+    household_id: Mapped[UUID] = mapped_column(
+        GUID(),
+        ForeignKey("households.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    color: Mapped[str | None] = mapped_column(String(7), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/packages/tulip-storage/src/tulip_storage/models/transaction_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/models/transaction_tag.py
@@ -1,28 +1,27 @@
-"""Transaction-tag model — v1 labels-only tags surface (#39).
+"""Transaction-tag edge — links a transaction to a normalised Tag (ADR-0009).
 
-A free-form string tag attached to a transaction. The composite PK
-``(household_id, transaction_id, tag)`` gives us uniqueness for free
-(no separate UniqueConstraint) and matches the indexing strategy in
-the migration: per-tx tag lookups hit the PK prefix, per-household
-tag-filter lookups hit ``ix_transaction_tags_household_tag``.
+Refactored from the freeform string surface of #39: the ``tag``
+column is now a foreign key into ``tags(id)``, household-scoped via
+the composite ``(household_id, tag_id)`` FK. A tag rename becomes
+``UPDATE tags`` of one row instead of every transaction_tags row.
 
-This is intentionally the smallest useful slice of #39. Out of scope
-for v1: account / posting tags, cascade semantics, key=value pairs,
-filter grammar beyond a single ``?tag=`` parameter.
+See [`docs/adrs/0009-tag-redesign.md`](../../../docs/adrs/0009-tag-redesign.md)
+for the surrounding scope (also covers posting + account tags and
+the read-time inheritance model that ships in PRs B and C).
 """
 
 from __future__ import annotations
 
 from uuid import UUID
 
-from sqlalchemy import ForeignKeyConstraint, String
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from tulip_storage.models.base import GUID, Base
 
 
 class TransactionTag(Base):
-    """One free-form tag attached to a transaction (#39, v1)."""
+    """Edge from a transaction to a normalised :class:`Tag` (ADR-0009)."""
 
     __tablename__ = "transaction_tags"
     __table_args__ = (
@@ -32,8 +31,14 @@ class TransactionTag(Base):
             ondelete="CASCADE",
             name="fk_transaction_tags_transaction",
         ),
+        ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_transaction_tags_tag",
+        ),
     )
 
     household_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
     transaction_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
-    tag: Mapped[str] = mapped_column(String(64), primary_key=True)
+    tag_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -29,6 +29,7 @@ from tulip_storage.repositories.scheduled_job import ScheduledJobRepository
 from tulip_storage.repositories.shadow_transaction import ShadowTransactionRepository
 from tulip_storage.repositories.sinking_fund import SinkingFundRepository
 from tulip_storage.repositories.statement_line import StatementLineRepository
+from tulip_storage.repositories.tag import TagRepository
 from tulip_storage.repositories.transaction import (
     MasterKeyRequiredError,
     TransactionRepository,
@@ -61,6 +62,7 @@ __all__ = [
     "SinkingFundRepository",
     "StatementLineRepository",
     "TagInvalidError",
+    "TagRepository",
     "TransactionRepository",
     "TransactionTagRepository",
     "TrialBalanceRow",

--- a/packages/tulip-storage/src/tulip_storage/repositories/tag.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/tag.py
@@ -1,0 +1,94 @@
+"""Tag repository — CRUD for the normalised tag registry (ADR-0009, PR A).
+
+Tags are household-scoped strings stored once in the ``tags`` table;
+join tables (``transaction_tags`` today; ``posting_tags`` /
+``account_tags`` in PR B) reference them by ``id``. The public API
+of this repo still accepts and returns *names* — the int- vs string-
+based identity of a tag is an implementation detail of the storage
+layer, not something API callers should care about.
+
+``get_or_create_by_name`` is the workhorse: it resolves a tag name to
+its id, creating the row if missing. Idempotent and the right call
+shape for "user passed me a tag string, give me an id I can put in
+the join table."
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+
+from tulip_storage.models import Tag
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class TagRepository:
+    """Per-household repository for the normalised tag registry."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the repo to a session + tenant scope."""
+        self._session = session
+        self._household_id = household_id
+
+    def get_or_create_by_name(self, name: str) -> Tag:
+        """Resolve ``name`` to a :class:`Tag`, creating it if missing.
+
+        ``name`` is taken as-given (already normalised by the caller).
+        The household-scoped unique constraint on ``(household_id, name)``
+        prevents duplicate rows on a race; on the happy path it's a
+        single SELECT + (maybe) one INSERT.
+        """
+        existing = self._session.execute(
+            select(Tag).where(
+                Tag.household_id == self._household_id,
+                Tag.name == name,
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            return existing
+        created = Tag(
+            household_id=self._household_id,
+            id=uuid4(),
+            name=name,
+        )
+        self._session.add(created)
+        self._session.flush()
+        return created
+
+    def get_by_name(self, name: str) -> Tag | None:
+        """Return the tag named ``name``, or ``None``."""
+        return self._session.execute(
+            select(Tag).where(
+                Tag.household_id == self._household_id,
+                Tag.name == name,
+            )
+        ).scalar_one_or_none()
+
+    def list_all(self) -> list[Tag]:
+        """Return every tag in the household, ordered by name."""
+        return list(
+            self._session.execute(
+                select(Tag).where(Tag.household_id == self._household_id).order_by(Tag.name)
+            )
+            .scalars()
+            .all()
+        )
+
+    def rename(self, tag_id: UUID, new_name: str) -> Tag:
+        """Rename a tag in place. O(1) by virtue of normalisation."""
+        tag = self._session.execute(
+            select(Tag).where(
+                Tag.household_id == self._household_id,
+                Tag.id == tag_id,
+            )
+        ).scalar_one()
+        tag.name = new_name
+        self._session.flush()
+        return tag
+
+
+__all__ = ["TagRepository"]

--- a/packages/tulip-storage/src/tulip_storage/repositories/transaction_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/transaction_tag.py
@@ -1,4 +1,15 @@
-"""Repository for the v1 ``transaction_tags`` table (#39)."""
+"""Transaction-tag repository (ADR-0009).
+
+Bridges the public string-passing API and the normalised id-keyed
+``transaction_tags`` join table. Callers pass tag *names*; this
+module resolves them to / from the ``tags`` table behind the
+scenes.
+
+Public surface (``set_tags``, ``list_tags``, ``list_tags_for_
+transactions``, ``find_transaction_ids_by_tag``) is unchanged from
+the #39 shape so the rest of the codebase doesn't need to learn
+about tag ids.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +19,8 @@ from uuid import UUID
 
 from sqlalchemy import delete, select
 
-from tulip_storage.models import TransactionTag
+from tulip_storage.models import Tag, TransactionTag
+from tulip_storage.repositories.tag import TagRepository
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -40,19 +52,20 @@ def normalise_tag(value: str) -> str:
 
 
 class TransactionTagRepository:
-    """Per-household repository for the v1 transaction_tags surface (#39)."""
+    """Per-household repository over the ``transaction_tags`` edge table."""
 
     def __init__(self, session: Session, household_id: UUID) -> None:
         """Bind the repo to a session + household tenant scope."""
         self._session = session
         self._household_id = household_id
+        self._tags = TagRepository(session, household_id)
 
     def set_tags(self, transaction_id: UUID, tags: list[str]) -> list[str]:
         """Replace the transaction's tags with the given set (atomic per-call).
 
-        Each tag is normalised + deduplicated; the stored set is the
-        deduplicated union of the input. Returns the stored list in
-        sorted order for deterministic round-trip.
+        Each name is normalised + deduplicated, then resolved to a
+        :class:`Tag` row (created on demand). Returns the stored list
+        in sorted order for deterministic round-trip.
         """
         normalised = sorted({normalise_tag(t) for t in tags})
         self._session.execute(
@@ -61,26 +74,32 @@ class TransactionTagRepository:
                 TransactionTag.transaction_id == transaction_id,
             )
         )
-        for tag in normalised:
+        for name in normalised:
+            tag = self._tags.get_or_create_by_name(name)
             self._session.add(
                 TransactionTag(
                     household_id=self._household_id,
                     transaction_id=transaction_id,
-                    tag=tag,
+                    tag_id=tag.id,
                 )
             )
         return normalised
 
     def list_tags(self, transaction_id: UUID) -> list[str]:
-        """Return the transaction's tags in sorted order (alphabetical)."""
+        """Return the transaction's tag *names* in sorted order."""
         rows = (
             self._session.execute(
-                select(TransactionTag.tag)
+                select(Tag.name)
+                .join(
+                    TransactionTag,
+                    (TransactionTag.household_id == Tag.household_id)
+                    & (TransactionTag.tag_id == Tag.id),
+                )
                 .where(
                     TransactionTag.household_id == self._household_id,
                     TransactionTag.transaction_id == transaction_id,
                 )
-                .order_by(TransactionTag.tag)
+                .order_by(Tag.name)
             )
             .scalars()
             .all()
@@ -88,40 +107,44 @@ class TransactionTagRepository:
         return list(rows)
 
     def list_tags_for_transactions(self, transaction_ids: list[UUID]) -> dict[UUID, list[str]]:
-        """Batch lookup: return ``{tx_id: [tag, …]}`` for a list of transactions.
-
-        Used by the list-endpoint render so we don't fire one query per
-        row. Tags are sorted within each transaction.
-        """
+        """Batch lookup: return ``{tx_id: [tag, …]}`` for a list of transactions."""
         if not transaction_ids:
             return {}
         rows = self._session.execute(
-            select(TransactionTag.transaction_id, TransactionTag.tag)
+            select(TransactionTag.transaction_id, Tag.name)
+            .join(
+                Tag,
+                (Tag.household_id == TransactionTag.household_id)
+                & (Tag.id == TransactionTag.tag_id),
+            )
             .where(
                 TransactionTag.household_id == self._household_id,
                 TransactionTag.transaction_id.in_(transaction_ids),
             )
-            .order_by(TransactionTag.transaction_id, TransactionTag.tag)
+            .order_by(TransactionTag.transaction_id, Tag.name)
         ).all()
         by_tx: dict[UUID, list[str]] = {tx_id: [] for tx_id in transaction_ids}
-        for tx_id, tag in rows:
-            by_tx[tx_id].append(tag)
+        for tx_id, name in rows:
+            by_tx[tx_id].append(name)
         return by_tx
 
     def find_transaction_ids_by_tag(self, tag: str) -> list[UUID]:
         """Return the household's transaction ids that carry ``tag``.
 
         Used by ``GET /v1/transactions?tag=foo``. The tag is normalised
-        before lookup so the URL filter is case-insensitive. Hits the
-        ``ix_transaction_tags_household_tag`` index.
+        and resolved to its id, then joined against ``transaction_tags``.
+        Unknown tags return an empty list.
         """
         normalised = normalise_tag(tag)
+        existing = self._tags.get_by_name(normalised)
+        if existing is None:
+            return []
         rows = (
             self._session.execute(
                 select(TransactionTag.transaction_id)
                 .where(
                     TransactionTag.household_id == self._household_id,
-                    TransactionTag.tag == normalised,
+                    TransactionTag.tag_id == existing.id,
                 )
                 .order_by(TransactionTag.transaction_id)
             )

--- a/packages/tulip-storage/tests/test_tag_repository.py
+++ b/packages/tulip-storage/tests/test_tag_repository.py
@@ -1,0 +1,79 @@
+"""Unit tests for ``TagRepository`` (ADR-0009, PR A)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_storage.models import Household
+from tulip_storage.repositories import TagRepository
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+def test_get_or_create_creates_on_first_call(session: Session, household: Household) -> None:
+    repo = TagRepository(session, household.id)
+    tag = repo.get_or_create_by_name("birthday")
+    session.commit()
+    assert tag.name == "birthday"
+    assert tag.household_id == household.id
+
+
+def test_get_or_create_returns_existing(session: Session, household: Household) -> None:
+    """Idempotent: calling twice for the same name returns the same row."""
+    repo = TagRepository(session, household.id)
+    first = repo.get_or_create_by_name("walter")
+    session.commit()
+    second = repo.get_or_create_by_name("walter")
+    session.commit()
+    assert first.id == second.id
+
+
+def test_tag_name_is_unique_per_household(session: Session) -> None:
+    """Two households can both have a 'birthday' tag — they're distinct rows."""
+    h1 = Household(id=uuid4(), name="Smith", base_currency="USD")
+    h2 = Household(id=uuid4(), name="Jones", base_currency="USD")
+    session.add_all([h1, h2])
+    session.commit()
+    repo1 = TagRepository(session, h1.id)
+    repo2 = TagRepository(session, h2.id)
+    tag1 = repo1.get_or_create_by_name("birthday")
+    tag2 = repo2.get_or_create_by_name("birthday")
+    session.commit()
+    assert tag1.id != tag2.id
+    assert tag1.household_id == h1.id
+    assert tag2.household_id == h2.id
+
+
+def test_get_by_name_returns_none_for_missing(session: Session, household: Household) -> None:
+    assert TagRepository(session, household.id).get_by_name("nope") is None
+
+
+def test_list_all_returns_sorted(session: Session, household: Household) -> None:
+    repo = TagRepository(session, household.id)
+    for name in ["zebra", "alpha", "mango"]:
+        repo.get_or_create_by_name(name)
+    session.commit()
+    names = [t.name for t in repo.list_all()]
+    assert names == ["alpha", "mango", "zebra"]
+
+
+def test_rename_is_o1(session: Session, household: Household) -> None:
+    """Renaming a tag updates the single row; transaction_tags edges follow
+    via the FK (no rewriting transaction-tag rows needed)."""
+    repo = TagRepository(session, household.id)
+    tag = repo.get_or_create_by_name("walter")
+    session.commit()
+    repo.rename(tag.id, "walter-s.")
+    session.commit()
+    reloaded = repo.get_by_name("walter-s.")
+    assert reloaded is not None
+    assert reloaded.id == tag.id

--- a/packages/tulip-storage/tests/test_tags_migration.py
+++ b/packages/tulip-storage/tests/test_tags_migration.py
@@ -1,0 +1,232 @@
+"""Tests for the ADR-0009 PR A tag normalisation migration (b2c4f9a1e7d6).
+
+Covers:
+
+1. The migration's data backfill — existing transaction_tags rows
+   land with the same tag names after upgrade, now via the FK.
+2. Schema shape post-upgrade: tags table exists, transaction_tags
+   has tag_id column, old ``tag`` string column is gone.
+3. Round-trip: upgrade → downgrade restores the pre-PR-A schema +
+   preserves the inline tag string.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from alembic.command import downgrade, upgrade
+from alembic.config import Config
+from sqlalchemy import create_engine, event, inspect, text
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+
+
+def _make_alembic_cfg(db_url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    cfg.set_main_option(
+        "script_location",
+        str(ALEMBIC_INI.parent / "src" / "tulip_storage" / "migrations"),
+    )
+    return cfg
+
+
+@pytest.fixture
+def fresh_db_url(tmp_path):
+    db_path = tmp_path / "tulip.db"
+    return f"sqlite:///{db_path}"
+
+
+def _seed_household_account_and_tagged_transaction(
+    engine, *, tags: list[str]
+) -> tuple[str, str, str]:
+    """Insert a minimal household + account + transaction with the given tags
+    via raw SQL against the pre-PR-A schema (string-tag).
+
+    Returns the (household_id, transaction_id, account_id) as hex strings.
+    Uses the legacy column layout so the migration's backfill has data to
+    process.
+    """
+    household_id = str(uuid4())
+    account_id = str(uuid4())
+    tx_id = str(uuid4())
+    with engine.begin() as conn:
+        # household
+        conn.execute(
+            text(
+                "INSERT INTO households (id, name, base_currency, ai_policy) "
+                "VALUES (:id, :name, :ccy, '{}')"
+            ),
+            {"id": household_id, "name": "Smith", "ccy": "USD"},
+        )
+        # account
+        conn.execute(
+            text(
+                "INSERT INTO accounts "
+                "(household_id, id, name, type, currency, visibility, "
+                " is_active, is_placeholder) "
+                "VALUES (:hid, :aid, :name, :type, :ccy, :vis, 1, 0)"
+            ),
+            {
+                "hid": household_id,
+                "aid": account_id,
+                "name": "Checking",
+                "type": "ASSET",
+                "ccy": "USD",
+                "vis": "shared",
+            },
+        )
+        # transaction
+        conn.execute(
+            text(
+                "INSERT INTO transactions "
+                "(household_id, id, date, description, status) "
+                "VALUES (:hid, :tid, :dt, :desc, :st)"
+            ),
+            {
+                "hid": household_id,
+                "tid": tx_id,
+                "dt": str(date(2026, 5, 1)),
+                "desc": "Lunch",
+                "st": "POSTED",
+            },
+        )
+        for tag in tags:
+            conn.execute(
+                text(
+                    "INSERT INTO transaction_tags "
+                    "(household_id, transaction_id, tag) "
+                    "VALUES (:hid, :tid, :tag)"
+                ),
+                {"hid": household_id, "tid": tx_id, "tag": tag},
+            )
+    return household_id, tx_id, account_id
+
+
+def test_upgrade_creates_tags_table_with_unique_name_per_household(fresh_db_url):
+    """Post-upgrade, the tags table exists with the expected columns + uniqueness."""
+    cfg = _make_alembic_cfg(fresh_db_url)
+    upgrade(cfg, "head")
+    eng = create_engine(fresh_db_url)
+    try:
+        insp = inspect(eng)
+        assert "tags" in insp.get_table_names()
+        columns = {c["name"] for c in insp.get_columns("tags")}
+        assert columns == {
+            "household_id",
+            "id",
+            "name",
+            "description",
+            "color",
+            "created_at",
+        }
+    finally:
+        eng.dispose()
+
+
+def test_upgrade_replaces_transaction_tags_tag_with_tag_id(fresh_db_url):
+    """Post-upgrade, transaction_tags carries tag_id instead of the string."""
+    cfg = _make_alembic_cfg(fresh_db_url)
+    upgrade(cfg, "head")
+    eng = create_engine(fresh_db_url)
+    try:
+        insp = inspect(eng)
+        columns = {c["name"] for c in insp.get_columns("transaction_tags")}
+        assert "tag_id" in columns
+        assert "tag" not in columns
+    finally:
+        eng.dispose()
+
+
+def test_migration_backfills_existing_tags(fresh_db_url):
+    """Upgrade pauses at the pre-PR-A revision, seeds tagged data, then
+    upgrades through PR A — the inline strings become rows in ``tags`` and
+    ``transaction_tags`` rows resolve cleanly through the FK."""
+    cfg = _make_alembic_cfg(fresh_db_url)
+    # Upgrade to the revision immediately before PR A so the legacy
+    # transaction_tags schema (with the ``tag`` string column) is
+    # available for seeding.
+    upgrade(cfg, "a8b3c2d1f4e5")
+
+    eng = create_engine(fresh_db_url)
+
+    @event.listens_for(eng, "connect")
+    def _enable_fk(dc, _r):
+        cur = dc.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    try:
+        household_id, tx_id, _ = _seed_household_account_and_tagged_transaction(
+            eng, tags=["birthday", "walter"]
+        )
+
+        # Now apply PR A.
+        upgrade(cfg, "b2c4f9a1e7d6")
+
+        with eng.connect() as conn:
+            tags_rows = conn.execute(
+                text("SELECT name FROM tags WHERE household_id = :hid ORDER BY name"),
+                {"hid": household_id},
+            ).fetchall()
+            joined = conn.execute(
+                text(
+                    "SELECT t.name FROM transaction_tags AS tt "
+                    "JOIN tags AS t ON t.household_id = tt.household_id "
+                    "AND t.id = tt.tag_id "
+                    "WHERE tt.household_id = :hid AND tt.transaction_id = :tid "
+                    "ORDER BY t.name"
+                ),
+                {"hid": household_id, "tid": tx_id},
+            ).fetchall()
+
+        assert [r[0] for r in tags_rows] == ["birthday", "walter"]
+        # Both tags resolve through the FK.
+        assert [r[0] for r in joined] == ["birthday", "walter"]
+    finally:
+        eng.dispose()
+
+
+def test_migration_round_trip_preserves_inline_strings(fresh_db_url):
+    """Upgrade → downgrade brings back the inline tag string with the
+    same data the migration backfilled."""
+    cfg = _make_alembic_cfg(fresh_db_url)
+    upgrade(cfg, "a8b3c2d1f4e5")
+    eng = create_engine(fresh_db_url)
+
+    @event.listens_for(eng, "connect")
+    def _enable_fk(dc, _r):
+        cur = dc.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    try:
+        household_id, tx_id, _ = _seed_household_account_and_tagged_transaction(
+            eng, tags=["birthday", "walter"]
+        )
+        upgrade(cfg, "b2c4f9a1e7d6")
+        downgrade(cfg, "a8b3c2d1f4e5")
+
+        with eng.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT tag FROM transaction_tags "
+                    "WHERE household_id = :hid AND transaction_id = :tid "
+                    "ORDER BY tag"
+                ),
+                {"hid": household_id, "tid": tx_id},
+            ).fetchall()
+            tables = {
+                r[0]
+                for r in conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type='table'")
+                ).fetchall()
+            }
+        assert [r[0] for r in rows] == ["birthday", "walter"]
+        # tags table is gone after downgrade.
+        assert "tags" not in tables
+    finally:
+        eng.dispose()


### PR DESCRIPTION
## Summary

PR A of the tag redesign sketched in **ADR-0009**
(\`docs/adrs/0009-tag-redesign.md\`). Replaces the freeform-
string tag surface from #39 with a normalised three-scope
system. This PR ships the foundation only; PRs B and C will
add posting + account scopes and read-time inheritance.

### What lands

**Storage**
- New \`tags\` table: \`(household_id, id, name, description,
  color, created_at)\`. Composite PK; name unique within
  household.
- \`transaction_tags\` refactored: \`tag\` string column →
  \`tag_id\` FK to \`tags.(household_id, id)\`. Composite FK
  keeps tenant isolation intact.
- Alembic migration \`b2c4f9a1e7d6\` backfills existing
  \`(household_id, tag)\` pairs into the new \`tags\` rows
  and populates the FK. **Downgrade is lossless** —
  restores the inline-string shape with the same data.
- New \`TagRepository\` with \`get_or_create_by_name\`,
  \`get_by_name\`, \`list_all\`, \`rename\` (O(1) thanks to
  normalisation).
- \`TransactionTagRepository\` refactored to operate on tag
  ids internally. **Public API surface is unchanged** —
  every existing string-passing caller (API layer, audit,
  tests) keeps working.

**Tests**
- 4 migration tests (schema delta + upgrade backfill +
  round-trip).
- 6 \`TagRepository\` tests.
- All 286 existing storage tests + 16 API tag tests pass
  unchanged.

### Out of scope (lands in B / C)

- \`posting_tags\` + \`account_tags\` tables and their repos.
- Read-time inheritance (\`effective_tags\` query) + the
  provenance API surface.
- TUI surfacing.
- QIF tag import (#447) — lands as a sub-PR of B once
  posting tags exist.

## Test plan

\`\`\`bash
uv run --package tulip-storage pytest packages/tulip-storage/tests/test_tags_migration.py packages/tulip-storage/tests/test_tag_repository.py -q
uv run --package tulip-storage pytest packages/tulip-storage/tests/ -q
uv run --package tulip-api pytest packages/tulip-api/tests/test_transactions_tags.py -q
just lint
just typecheck
\`\`\`

- [x] All 296 storage tests pass (286 existing + 10 new)
- [x] All 16 API tag-test cases still green
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 316 source files)
- [ ] CI green on this PR