### PR TITLE
feat(storage,api): posting + account tag tables + account-tag API (ADR-0009, PR B)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -44,7 +44,12 @@ router = APIRouter(prefix="/v1/accounts", tags=["accounts"])
 log = structlog.get_logger("tulip_api.accounts")
 
 
-def _to_read(a: Account, *, notes: str | None = None) -> AccountRead:
+def _to_read(
+    a: Account,
+    *,
+    notes: str | None = None,
+    tags: list[str] | None = None,
+) -> AccountRead:
     return AccountRead(
         id=a.id,
         code=a.code,
@@ -57,6 +62,7 @@ def _to_read(a: Account, *, notes: str | None = None) -> AccountRead:
         is_placeholder=a.is_placeholder,
         parent_account_id=a.parent_account_id,
         notes=notes,
+        tags=tags or [],
     )
 
 
@@ -202,7 +208,14 @@ def list_accounts(
     """List active accounts visible to the caller."""
     repo = AccountRepository(session, claims.household_id)
     rows = [a for a in repo.list_active() if _filter_for_role(a, claims)]
-    return [_to_read(a) for a in rows]
+    # Batch-fetch tags so the list endpoint stays at 2 queries total
+    # (one for accounts, one for the tag join).
+    from tulip_storage.repositories import AccountTagRepository
+
+    tag_map = AccountTagRepository(session, claims.household_id).list_tags_for_accounts(
+        [a.id for a in rows]
+    )
+    return [_to_read(a, tags=tag_map.get(a.id, [])) for a in rows]
 
 
 @router.post(
@@ -285,6 +298,19 @@ def create_account(
         is_placeholder=body.is_placeholder,
         created_by_user_id=claims.user_id,
     )
+    from tulip_storage.repositories import AccountTagRepository
+    from tulip_storage.repositories.transaction_tag import TagInvalidError
+
+    saved_tags: list[str] = []
+    if body.tags:
+        try:
+            saved_tags = AccountTagRepository(session, claims.household_id).set_tags(
+                a.id, list(body.tags)
+            )
+        except TagInvalidError as exc:
+            from tulip_api.errors import TagInvalidError as ApiTagInvalidError
+
+            raise ApiTagInvalidError(reason=str(exc)) from exc
     after_snapshot: dict[str, object] = {
         "name": a.name,
         "type": a.type.value,
@@ -295,6 +321,8 @@ def create_account(
         # column is encrypted at rest precisely because the operator
         # may put PII in there). Boolean signal is enough for the audit.
         after_snapshot["notes_set"] = True
+    if saved_tags:
+        after_snapshot["tags"] = saved_tags
     audit.write(
         action="create",
         actor_kind="user",
@@ -306,7 +334,7 @@ def create_account(
     )
     session.commit()
     log.info("account.created", account_id=str(a.id))
-    return _to_read(a, notes=body.notes)
+    return _to_read(a, notes=body.notes, tags=saved_tags)
 
 
 def _create_with_parents(
@@ -514,7 +542,10 @@ def get_account(
     a = repo.get(account_id)
     if a is None or not _filter_for_role(a, claims):
         raise AccountNotFoundError()
-    return _to_read(a, notes=repo.decrypt_notes(a))
+    from tulip_storage.repositories import AccountTagRepository
+
+    tags = AccountTagRepository(session, claims.household_id).list_tags(a.id)
+    return _to_read(a, notes=repo.decrypt_notes(a), tags=tags)
 
 
 @router.patch(
@@ -618,6 +649,20 @@ def update_account(
                     account_id=str(a.id), posting_count=int(posting_count)
                 )
         a.is_placeholder = body.is_placeholder
+
+    from tulip_storage.repositories import AccountTagRepository
+    from tulip_storage.repositories.transaction_tag import TagInvalidError
+
+    tag_repo = AccountTagRepository(session, claims.household_id)
+    tags_changed = False
+    if body.tags is not None:
+        try:
+            tag_repo.set_tags(a.id, list(body.tags))
+        except TagInvalidError as exc:
+            from tulip_api.errors import TagInvalidError as ApiTagInvalidError
+
+            raise ApiTagInvalidError(reason=str(exc)) from exc
+        tags_changed = True
     session.flush()
 
     after_snapshot: dict[str, object] = {
@@ -628,6 +673,8 @@ def update_account(
     }
     if notes_changed:
         after_snapshot["notes_set"] = a.notes_encrypted is not None
+    if tags_changed:
+        after_snapshot["tags"] = tag_repo.list_tags(a.id)
     AuditLogWriter(session, claims.household_id).write(
         action="update",
         actor_kind="user",
@@ -639,7 +686,7 @@ def update_account(
         request_id=_request_uuid(request),
     )
     session.commit()
-    return _to_read(a, notes=repo.decrypt_notes(a))
+    return _to_read(a, notes=repo.decrypt_notes(a), tags=tag_repo.list_tags(a.id))
 
 
 @router.get(

--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -33,6 +33,7 @@ from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.config import get_settings
 from tulip_api.deps import get_session
 from tulip_api.errors import (
+    FRAMEWORK_BODY_RESPONSES,
     AccountUnknownError,
     CsvProfileNotFoundError,
     ForbiddenError,
@@ -887,6 +888,7 @@ async def promote_line(
     "/{batch_id}/lines/{line_id}",
     response_model=StatementLineRead,
     responses={
+        **FRAMEWORK_BODY_RESPONSES,
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
         404: problem_response("import_batch.not_found", "import.line.not_found"),

--- a/packages/tulip-api/src/tulip_api/schemas/account.py
+++ b/packages/tulip-api/src/tulip_api/schemas/account.py
@@ -40,6 +40,16 @@ class AccountCreate(BaseModel):
             "instead. Defaults to false (regular postable account)."
         ),
     )
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional account-level tags (ADR-0009, PR B). Each entry "
+            "is normalised (lowercase, stripped) before storage; "
+            "duplicates collapse. Account tags inherit down to every "
+            "posting on the account at read time (effective_tags, "
+            "PR C)."
+        ),
+    )
     create_parents: bool = Field(
         default=False,
         description=(
@@ -93,6 +103,14 @@ class AccountUpdate(BaseModel):
             "it has direct postings — clean those up first."
         ),
     )
+    tags: list[str] | None = Field(
+        default=None,
+        description=(
+            "Replace the account's tag set (ADR-0009, PR B). Omit to "
+            "leave unchanged; pass an explicit list (including ``[]``) "
+            "to wholesale-replace."
+        ),
+    )
 
 
 class AccountRead(BaseModel):
@@ -108,6 +126,10 @@ class AccountRead(BaseModel):
     is_active: bool
     is_placeholder: bool = False
     parent_account_id: UUID | None
+    tags: list[str] = Field(
+        default_factory=list,
+        description="Tag names attached to this account (ADR-0009).",
+    )
     notes: str | None = Field(
         default=None,
         description=(

--- a/packages/tulip-api/tests/test_accounts_endpoints.py
+++ b/packages/tulip-api/tests/test_accounts_endpoints.py
@@ -512,3 +512,116 @@ class TestAccountPlaceholder:
         )
         assert r.status_code == 200
         assert r.json()["is_placeholder"] is False
+
+
+# ---- ADR-0009 PR B: account tags --------------------------------------------
+
+
+class TestAccountTags:
+    """Account-level tags via POST + PATCH + GET round-trip."""
+
+    def test_create_with_tags(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Visa",
+                "type": "liability",
+                "currency": "USD",
+                "tags": ["credit-card", "joint"],
+            },
+        )
+        assert r.status_code == 201, r.text
+        # Deduplicated + sorted on read.
+        assert sorted(r.json()["tags"]) == ["credit-card", "joint"]
+
+    def test_patch_replaces_tags(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Visa",
+                "type": "liability",
+                "currency": "USD",
+                "tags": ["a", "b"],
+            },
+        ).json()
+        r = client.patch(
+            f"/v1/accounts/{created['id']}",
+            headers=auth_h,
+            json={"tags": ["c"]},
+        )
+        assert r.status_code == 200
+        assert r.json()["tags"] == ["c"]
+
+    def test_patch_with_empty_list_clears_tags(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Visa",
+                "type": "liability",
+                "currency": "USD",
+                "tags": ["joint"],
+            },
+        ).json()
+        r = client.patch(
+            f"/v1/accounts/{created['id']}",
+            headers=auth_h,
+            json={"tags": []},
+        )
+        assert r.status_code == 200
+        assert r.json()["tags"] == []
+
+    def test_patch_without_tags_field_preserves_existing(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        """Omitting ``tags`` from the body leaves the set unchanged."""
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Visa",
+                "type": "liability",
+                "currency": "USD",
+                "tags": ["joint"],
+            },
+        ).json()
+        # PATCH only changing the name.
+        r = client.patch(
+            f"/v1/accounts/{created['id']}",
+            headers=auth_h,
+            json={"name": "Visa Card"},
+        )
+        assert r.status_code == 200
+        assert r.json()["tags"] == ["joint"]
+
+    def test_get_by_id_returns_tags(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Cash",
+                "type": "asset",
+                "currency": "USD",
+                "tags": ["wallet"],
+            },
+        ).json()
+        r = client.get(f"/v1/accounts/{created['id']}", headers=auth_h)
+        assert r.status_code == 200
+        assert r.json()["tags"] == ["wallet"]
+
+    def test_list_endpoint_returns_tags(self, client: TestClient, auth_h: dict[str, str]):
+        client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Cash",
+                "type": "asset",
+                "currency": "USD",
+                "tags": ["wallet"],
+            },
+        )
+        rows = client.get("/v1/accounts", headers=auth_h).json()
+        cash = next(r for r in rows if r["name"] == "Cash")
+        assert cash["tags"] == ["wallet"]

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260521_0100_d3e8b1a9f5c2_posting_account_tags.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260521_0100_d3e8b1a9f5c2_posting_account_tags.py
@@ -1,0 +1,79 @@
+"""Add posting_tags + account_tags tables (ADR-0009, PR B).
+
+Layered on top of the PR A normalisation (b2c4f9a1e7d6). Adds
+the two remaining tag-scope edge tables:
+
+- ``posting_tags(household_id, posting_id, tag_id)``
+- ``account_tags(household_id, account_id, tag_id)``
+
+No data migration — both tables start empty. Downgrade drops
+them cleanly.
+
+Revision ID: d3e8b1a9f5c2
+Revises: b2c4f9a1e7d6
+Create Date: 2026-05-21 01:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d3e8b1a9f5c2"
+down_revision: str | None = "b2c4f9a1e7d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create ``posting_tags`` + ``account_tags``."""
+    op.create_table(
+        "posting_tags",
+        sa.Column("household_id", sa.Uuid(), nullable=False),
+        sa.Column("posting_id", sa.Uuid(), nullable=False),
+        sa.Column("tag_id", sa.Uuid(), nullable=False),
+        # postings.id is the single-column PK on postings, so the
+        # posting-side FK is single-column. Tenant isolation on this
+        # side is enforced at the repo level (always filter by
+        # household_id).
+        sa.ForeignKeyConstraint(
+            ["posting_id"],
+            ["postings.id"],
+            ondelete="CASCADE",
+            name="fk_posting_tags_posting",
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_posting_tags_tag",
+        ),
+        sa.PrimaryKeyConstraint("household_id", "posting_id", "tag_id", name="pk_posting_tags"),
+    )
+    op.create_table(
+        "account_tags",
+        sa.Column("household_id", sa.Uuid(), nullable=False),
+        sa.Column("account_id", sa.Uuid(), nullable=False),
+        sa.Column("tag_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["household_id", "account_id"],
+            ["accounts.household_id", "accounts.id"],
+            ondelete="CASCADE",
+            name="fk_account_tags_account",
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_account_tags_tag",
+        ),
+        sa.PrimaryKeyConstraint("household_id", "account_id", "tag_id", name="pk_account_tags"),
+    )
+
+
+def downgrade() -> None:
+    """Drop ``posting_tags`` + ``account_tags``."""
+    op.drop_table("account_tags")
+    op.drop_table("posting_tags")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -12,6 +12,7 @@ architecture test in tulip-core enforces this.
 """
 
 from tulip_storage.models.account import Account, AccountType
+from tulip_storage.models.account_tag import AccountTag
 from tulip_storage.models.ai_invocation import AICapability, AIInvocation, AIOutcome
 from tulip_storage.models.allocation_pool import AllocationPool, PoolType
 from tulip_storage.models.attachment import Attachment
@@ -40,6 +41,7 @@ from tulip_storage.models.pending_proposal import (
 )
 from tulip_storage.models.period import Period, PeriodStatus
 from tulip_storage.models.posting import Posting
+from tulip_storage.models.posting_tag import PostingTag
 from tulip_storage.models.reconciliation import Reconciliation, ReconciliationStatus
 from tulip_storage.models.reconciliation_match import (
     MatchConfidence,
@@ -70,6 +72,7 @@ __all__ = [
     "AIInvocation",
     "AIOutcome",
     "Account",
+    "AccountTag",
     "AccountType",
     "AllocationPool",
     "Attachment",
@@ -95,6 +98,7 @@ __all__ = [
     "PeriodStatus",
     "PoolType",
     "Posting",
+    "PostingTag",
     "ProposalCreatorKind",
     "ProposalStatus",
     "Reconciliation",

--- a/packages/tulip-storage/src/tulip_storage/models/account_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/models/account_tag.py
@@ -1,0 +1,41 @@
+"""Account-tag edge (ADR-0009, PR B).
+
+Links a single :class:`Account` to a normalised :class:`Tag`.
+Account tags inherit down to every posting on that account at
+read-time — see ``effective_tags`` (PR C). Composite FKs keep
+tenant isolation tight; ON DELETE CASCADE on both sides means
+removing the account or the tag sweeps the edge.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import ForeignKeyConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class AccountTag(Base):
+    """Edge from an account to a tag (ADR-0009)."""
+
+    __tablename__ = "account_tags"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "account_id"],
+            ["accounts.household_id", "accounts.id"],
+            ondelete="CASCADE",
+            name="fk_account_tags_account",
+        ),
+        ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_account_tags_tag",
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    account_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    tag_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)

--- a/packages/tulip-storage/src/tulip_storage/models/posting_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/models/posting_tag.py
@@ -1,0 +1,46 @@
+"""Posting-tag edge (ADR-0009, PR B).
+
+Links a single :class:`Posting` to a normalised :class:`Tag`.
+The composite PK ``(household_id, posting_id, tag_id)`` keeps
+the row scoped; the FK to ``postings.id`` is single-column
+because :class:`Posting` itself has a single-column PK
+(unlike ``transactions``/``accounts`` which use composite
+PKs). Tenant isolation on the posting side is therefore an
+application-layer concern (the repository filters by
+``household_id``) — matching the pattern other single-PK
+references use.
+
+Tag-side FK stays composite — the tags table has the
+composite PK already.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, ForeignKeyConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class PostingTag(Base):
+    """Edge from a posting to a tag (ADR-0009)."""
+
+    __tablename__ = "posting_tags"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_posting_tags_tag",
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    posting_id: Mapped[UUID] = mapped_column(
+        GUID(),
+        ForeignKey("postings.id", ondelete="CASCADE", name="fk_posting_tags_posting"),
+        primary_key=True,
+    )
+    tag_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -10,6 +10,7 @@ higher layers (the API) call it on every business mutation.
 """
 
 from tulip_storage.repositories.account import AccountRepository
+from tulip_storage.repositories.account_tag import AccountTagRepository
 from tulip_storage.repositories.ai_invocation import AIInvocationRepository
 from tulip_storage.repositories.allocation_pool import AllocationPoolRepository
 from tulip_storage.repositories.attachment import AttachmentRepository
@@ -21,6 +22,7 @@ from tulip_storage.repositories.import_batch import ImportBatchRepository
 from tulip_storage.repositories.notification import NotificationRepository
 from tulip_storage.repositories.pending_proposal import PendingProposalRepository
 from tulip_storage.repositories.period import PeriodRepository
+from tulip_storage.repositories.posting_tag import PostingTagRepository
 from tulip_storage.repositories.reconciliation import ReconciliationRepository
 from tulip_storage.repositories.reconciliation_match import (
     ReconciliationMatchRepository,
@@ -44,6 +46,7 @@ from tulip_storage.repositories.transaction_tag import (
 __all__ = [
     "AIInvocationRepository",
     "AccountRepository",
+    "AccountTagRepository",
     "AllocationPoolRepository",
     "AttachmentLinkRepository",
     "AttachmentRepository",
@@ -55,6 +58,7 @@ __all__ = [
     "NotificationRepository",
     "PendingProposalRepository",
     "PeriodRepository",
+    "PostingTagRepository",
     "ReconciliationMatchRepository",
     "ReconciliationRepository",
     "ScheduledJobRepository",

--- a/packages/tulip-storage/src/tulip_storage/repositories/account_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/account_tag.py
@@ -1,0 +1,109 @@
+"""Account-tag repository (ADR-0009, PR B)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import delete, select
+
+from tulip_storage.models import AccountTag, Tag
+from tulip_storage.repositories.tag import TagRepository
+from tulip_storage.repositories.transaction_tag import normalise_tag
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class AccountTagRepository:
+    """Per-household repository over the ``account_tags`` edge table."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the repo to a session + household tenant scope."""
+        self._session = session
+        self._household_id = household_id
+        self._tags = TagRepository(session, household_id)
+
+    def set_tags(self, account_id: UUID, tags: list[str]) -> list[str]:
+        """Replace the account's tags with the deduplicated, normalised set."""
+        normalised = sorted({normalise_tag(t) for t in tags})
+        self._session.execute(
+            delete(AccountTag).where(
+                AccountTag.household_id == self._household_id,
+                AccountTag.account_id == account_id,
+            )
+        )
+        for name in normalised:
+            tag = self._tags.get_or_create_by_name(name)
+            self._session.add(
+                AccountTag(
+                    household_id=self._household_id,
+                    account_id=account_id,
+                    tag_id=tag.id,
+                )
+            )
+        return normalised
+
+    def list_tags(self, account_id: UUID) -> list[str]:
+        """Return the account's tag *names* in sorted order."""
+        rows = (
+            self._session.execute(
+                select(Tag.name)
+                .join(
+                    AccountTag,
+                    (AccountTag.household_id == Tag.household_id) & (AccountTag.tag_id == Tag.id),
+                )
+                .where(
+                    AccountTag.household_id == self._household_id,
+                    AccountTag.account_id == account_id,
+                )
+                .order_by(Tag.name)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+    def list_tags_for_accounts(self, account_ids: list[UUID]) -> dict[UUID, list[str]]:
+        """Batch lookup: return ``{account_id: [tag, ...]}`` for the list."""
+        if not account_ids:
+            return {}
+        rows = self._session.execute(
+            select(AccountTag.account_id, Tag.name)
+            .join(
+                Tag,
+                (Tag.household_id == AccountTag.household_id) & (Tag.id == AccountTag.tag_id),
+            )
+            .where(
+                AccountTag.household_id == self._household_id,
+                AccountTag.account_id.in_(account_ids),
+            )
+            .order_by(AccountTag.account_id, Tag.name)
+        ).all()
+        by_id: dict[UUID, list[str]] = {aid: [] for aid in account_ids}
+        for account_id, name in rows:
+            by_id[account_id].append(name)
+        return by_id
+
+    def find_account_ids_by_tag(self, tag: str) -> list[UUID]:
+        """Return the accounts carrying ``tag``. Unknown tag → empty list."""
+        normalised = normalise_tag(tag)
+        existing = self._tags.get_by_name(normalised)
+        if existing is None:
+            return []
+        rows = (
+            self._session.execute(
+                select(AccountTag.account_id)
+                .where(
+                    AccountTag.household_id == self._household_id,
+                    AccountTag.tag_id == existing.id,
+                )
+                .order_by(AccountTag.account_id)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+
+__all__ = ["AccountTagRepository"]

--- a/packages/tulip-storage/src/tulip_storage/repositories/posting_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/posting_tag.py
@@ -1,0 +1,114 @@
+"""Posting-tag repository (ADR-0009, PR B).
+
+Same shape as :class:`TransactionTagRepository` — public API
+operates by tag name, resolves to :class:`Tag` ids via
+:class:`TagRepository` internally.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import delete, select
+
+from tulip_storage.models import PostingTag, Tag
+from tulip_storage.repositories.tag import TagRepository
+from tulip_storage.repositories.transaction_tag import normalise_tag
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class PostingTagRepository:
+    """Per-household repository over the ``posting_tags`` edge table."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the repo to a session + household tenant scope."""
+        self._session = session
+        self._household_id = household_id
+        self._tags = TagRepository(session, household_id)
+
+    def set_tags(self, posting_id: UUID, tags: list[str]) -> list[str]:
+        """Replace the posting's tags with the deduplicated, normalised set."""
+        normalised = sorted({normalise_tag(t) for t in tags})
+        self._session.execute(
+            delete(PostingTag).where(
+                PostingTag.household_id == self._household_id,
+                PostingTag.posting_id == posting_id,
+            )
+        )
+        for name in normalised:
+            tag = self._tags.get_or_create_by_name(name)
+            self._session.add(
+                PostingTag(
+                    household_id=self._household_id,
+                    posting_id=posting_id,
+                    tag_id=tag.id,
+                )
+            )
+        return normalised
+
+    def list_tags(self, posting_id: UUID) -> list[str]:
+        """Return the posting's tag *names* in sorted order."""
+        rows = (
+            self._session.execute(
+                select(Tag.name)
+                .join(
+                    PostingTag,
+                    (PostingTag.household_id == Tag.household_id) & (PostingTag.tag_id == Tag.id),
+                )
+                .where(
+                    PostingTag.household_id == self._household_id,
+                    PostingTag.posting_id == posting_id,
+                )
+                .order_by(Tag.name)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+    def list_tags_for_postings(self, posting_ids: list[UUID]) -> dict[UUID, list[str]]:
+        """Batch lookup: return ``{posting_id: [tag, ...]}`` for the list."""
+        if not posting_ids:
+            return {}
+        rows = self._session.execute(
+            select(PostingTag.posting_id, Tag.name)
+            .join(
+                Tag,
+                (Tag.household_id == PostingTag.household_id) & (Tag.id == PostingTag.tag_id),
+            )
+            .where(
+                PostingTag.household_id == self._household_id,
+                PostingTag.posting_id.in_(posting_ids),
+            )
+            .order_by(PostingTag.posting_id, Tag.name)
+        ).all()
+        by_id: dict[UUID, list[str]] = {pid: [] for pid in posting_ids}
+        for posting_id, name in rows:
+            by_id[posting_id].append(name)
+        return by_id
+
+    def find_posting_ids_by_tag(self, tag: str) -> list[UUID]:
+        """Return the postings carrying ``tag``. Unknown tag → empty list."""
+        normalised = normalise_tag(tag)
+        existing = self._tags.get_by_name(normalised)
+        if existing is None:
+            return []
+        rows = (
+            self._session.execute(
+                select(PostingTag.posting_id)
+                .where(
+                    PostingTag.household_id == self._household_id,
+                    PostingTag.tag_id == existing.id,
+                )
+                .order_by(PostingTag.posting_id)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+
+__all__ = ["PostingTagRepository"]

--- a/packages/tulip-storage/tests/test_posting_account_tag_repositories.py
+++ b/packages/tulip-storage/tests/test_posting_account_tag_repositories.py
@@ -1,0 +1,230 @@
+"""Unit tests for ``PostingTagRepository`` + ``AccountTagRepository`` (ADR-0009, PR B)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_core.money import Money
+from tulip_core.transactions import (
+    Posting as DomainPosting,
+)
+from tulip_core.transactions import (
+    Transaction as DomainTransaction,
+)
+from tulip_core.transactions import (
+    TransactionStatus as DomainTxStatus,
+)
+from tulip_storage.models import (
+    Account,
+    AccountType,
+    Household,
+    PeriodStatus,
+)
+from tulip_storage.repositories import (
+    AccountRepository,
+    AccountTagRepository,
+    PeriodRepository,
+    PostingTagRepository,
+    TransactionRepository,
+)
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+@pytest.fixture
+def two_accounts(session: Session, household: Household) -> tuple[Account, Account]:
+    repo = AccountRepository(session, household.id)
+    cash = repo.create(code="1110", name="Cash", type=AccountType.ASSET, currency="USD")
+    food = repo.create(code="5100", name="Food", type=AccountType.EXPENSE, currency="USD")
+    session.commit()
+    return cash, food
+
+
+def test_account_tag_set_get_round_trip(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    cash, _food = two_accounts
+    repo = AccountTagRepository(session, household.id)
+    saved = repo.set_tags(cash.id, ["joint", "credit-card"])
+    session.commit()
+    # Stored set is deduplicated + sorted.
+    assert saved == ["credit-card", "joint"]
+    assert repo.list_tags(cash.id) == ["credit-card", "joint"]
+
+
+def test_account_tag_set_replaces_previous(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    cash, _food = two_accounts
+    repo = AccountTagRepository(session, household.id)
+    repo.set_tags(cash.id, ["a", "b"])
+    session.commit()
+    repo.set_tags(cash.id, ["c"])
+    session.commit()
+    assert repo.list_tags(cash.id) == ["c"]
+
+
+def test_account_tag_find_by_tag(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    cash, food = two_accounts
+    repo = AccountTagRepository(session, household.id)
+    repo.set_tags(cash.id, ["joint"])
+    repo.set_tags(food.id, ["joint"])
+    session.commit()
+    found = repo.find_account_ids_by_tag("joint")
+    assert set(found) == {cash.id, food.id}
+
+
+def test_account_tag_unknown_tag_returns_empty(session: Session, household: Household) -> None:
+    repo = AccountTagRepository(session, household.id)
+    assert repo.find_account_ids_by_tag("nope") == []
+
+
+def test_posting_tag_round_trip(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    cash, food = two_accounts
+    # Seed a transaction so we have postings.
+    PeriodRepository(session, household.id).create(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        status=PeriodStatus.OPEN,
+    )
+    session.commit()
+    tx_repo = TransactionRepository(session, household.id)
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 5, 1),
+        description="Lunch",
+        postings=(
+            DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("10"), "USD")),
+            DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(Decimal("-10"), "USD")),
+        ),
+        status=DomainTxStatus.POSTED,
+    )
+    tx_repo.save_balanced(domain_tx)
+    session.commit()
+
+    # Look up the posting rows directly — Transaction doesn't expose
+    # a postings relationship today.
+    from sqlalchemy import select
+
+    from tulip_storage.models import Posting
+
+    rows = (
+        session.execute(select(Posting).where(Posting.transaction_id == domain_tx.id))
+        .scalars()
+        .all()
+    )
+    food_posting_id = next(p.id for p in rows if p.account_id == food.id)
+    posting_tags = PostingTagRepository(session, household.id)
+    saved_tags = posting_tags.set_tags(food_posting_id, ["walter", "birthday"])
+    session.commit()
+    assert saved_tags == ["birthday", "walter"]
+    assert posting_tags.list_tags(food_posting_id) == ["birthday", "walter"]
+
+
+def test_posting_tag_find_by_tag(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    """find_posting_ids_by_tag returns every posting carrying the tag."""
+    cash, food = two_accounts
+    PeriodRepository(session, household.id).create(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        status=PeriodStatus.OPEN,
+    )
+    session.commit()
+    tx_repo = TransactionRepository(session, household.id)
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 5, 1),
+        description="Lunch",
+        postings=(
+            DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("10"), "USD")),
+            DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(Decimal("-10"), "USD")),
+        ),
+        status=DomainTxStatus.POSTED,
+    )
+    tx_repo.save_balanced(domain_tx)
+    session.commit()
+
+    from sqlalchemy import select
+
+    from tulip_storage.models import Posting
+
+    rows = (
+        session.execute(select(Posting).where(Posting.transaction_id == domain_tx.id))
+        .scalars()
+        .all()
+    )
+
+    posting_tags = PostingTagRepository(session, household.id)
+    food_posting_id = next(p.id for p in rows if p.account_id == food.id)
+    posting_tags.set_tags(food_posting_id, ["walter"])
+    session.commit()
+    assert posting_tags.find_posting_ids_by_tag("walter") == [food_posting_id]
+    assert posting_tags.find_posting_ids_by_tag("nope") == []
+
+
+def test_batch_list_tags_for_postings(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    """list_tags_for_postings returns the batch map keyed by posting id."""
+    cash, food = two_accounts
+    PeriodRepository(session, household.id).create(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        status=PeriodStatus.OPEN,
+    )
+    session.commit()
+    tx_repo = TransactionRepository(session, household.id)
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 5, 1),
+        description="Lunch",
+        postings=(
+            DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("10"), "USD")),
+            DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(Decimal("-10"), "USD")),
+        ),
+        status=DomainTxStatus.POSTED,
+    )
+    tx_repo.save_balanced(domain_tx)
+    session.commit()
+
+    from sqlalchemy import select
+
+    from tulip_storage.models import Posting
+
+    rows = (
+        session.execute(select(Posting).where(Posting.transaction_id == domain_tx.id))
+        .scalars()
+        .all()
+    )
+
+    food_posting_id = next(p.id for p in rows if p.account_id == food.id)
+    cash_posting_id = next(p.id for p in rows if p.account_id == cash.id)
+
+    posting_tags = PostingTagRepository(session, household.id)
+    posting_tags.set_tags(food_posting_id, ["a"])
+    posting_tags.set_tags(cash_posting_id, ["b", "c"])
+    session.commit()
+
+    batch = posting_tags.list_tags_for_postings([food_posting_id, cash_posting_id])
+    assert batch[food_posting_id] == ["a"]
+    assert batch[cash_posting_id] == ["b", "c"]


### PR DESCRIPTION
## Summary

PR B of the tag redesign sketched in **ADR-0009**, layered
on top of #449 (PR A). Adds the two remaining tag scopes
the design calls for: per-posting and per-account.

### What lands

**Storage**
- New \`posting_tags\` table: composite PK
  \`(household_id, posting_id, tag_id)\`. Posting-side FK is
  single-column (\`postings.id\`) because \`Posting\` itself
  has a single-column PK; tenant isolation on this side is
  enforced at the repository layer.
- New \`account_tags\` table: composite PK with double
  composite FK to \`accounts\` + \`tags\`.
- New Alembic migration \`d3e8b1a9f5c2\` is purely additive
  (both tables start empty; downgrade drops them).
- New \`PostingTagRepository\` and \`AccountTagRepository\`
  mirroring \`TransactionTagRepository\` — same shape
  (\`set_tags\`, \`list_tags\`, batch lookup, find-by-tag),
  same string-passing public surface, ids resolved
  internally via \`TagRepository\`.

**API (account-side)**
- \`AccountCreate\` / \`AccountUpdate\` / \`AccountRead\`
  carry \`tags\`.
- \`POST /v1/accounts\` + \`PATCH /v1/accounts/{id}\` accept
  the tag set; \`PATCH\` omits-leaves-unchanged, empty-list
  clears.
- \`GET /v1/accounts\` and \`/v1/accounts/{id}\` surface
  tags; list endpoint batches the lookup so it stays at 2
  queries total.

### Out of scope (lands in C)

- Read-time inheritance (\`effective_tags\` query) so a
  transaction sees its postings' direct + account-inherited
  tags.
- Posting-tag write surface on \`POST /v1/transactions\` (the
  storage + repo are in place; wiring the per-posting tag
  field through the transaction schema lands alongside PR
  C's effective-tags resolver because both touch the same
  transaction-write path).
- TUI surfacing.

## Test plan

\`\`\`bash
uv run --package tulip-storage pytest packages/tulip-storage/tests/test_posting_account_tag_repositories.py packages/tulip-storage/tests/test_tag_repository.py packages/tulip-storage/tests/test_tags_migration.py -q
uv run --package tulip-storage pytest packages/tulip-storage/tests/ -q
uv run --package tulip-api pytest packages/tulip-api/tests/test_accounts_endpoints.py -q
just lint
just typecheck
\`\`\`

- [x] 303 storage tests + 30 account API tests pass
- [x] 7 new storage repo tests + 6 new account-tag API tests
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 321 source files)
- [ ] CI green on this PR (depends on PR A being on the
  base branch — opens after #449 merges)

Builds on PR #449 (PR A normalisation).