### PR TITLE
feat(storage,api): effective_tags read-time inheritance (ADR-0009, PR C)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/accounts.py
+++ b/packages/tulip-api/src/tulip_api/routers/accounts.py
@@ -44,7 +44,12 @@ router = APIRouter(prefix="/v1/accounts", tags=["accounts"])
 log = structlog.get_logger("tulip_api.accounts")
 
 
-def _to_read(a: Account, *, notes: str | None = None) -> AccountRead:
+def _to_read(
+    a: Account,
+    *,
+    notes: str | None = None,
+    tags: list[str] | None = None,
+) -> AccountRead:
     return AccountRead(
         id=a.id,
         code=a.code,
@@ -57,6 +62,7 @@ def _to_read(a: Account, *, notes: str | None = None) -> AccountRead:
         is_placeholder=a.is_placeholder,
         parent_account_id=a.parent_account_id,
         notes=notes,
+        tags=tags or [],
     )
 
 
@@ -202,7 +208,14 @@ def list_accounts(
     """List active accounts visible to the caller."""
     repo = AccountRepository(session, claims.household_id)
     rows = [a for a in repo.list_active() if _filter_for_role(a, claims)]
-    return [_to_read(a) for a in rows]
+    # Batch-fetch tags so the list endpoint stays at 2 queries total
+    # (one for accounts, one for the tag join).
+    from tulip_storage.repositories import AccountTagRepository
+
+    tag_map = AccountTagRepository(session, claims.household_id).list_tags_for_accounts(
+        [a.id for a in rows]
+    )
+    return [_to_read(a, tags=tag_map.get(a.id, [])) for a in rows]
 
 
 @router.post(
@@ -285,6 +298,19 @@ def create_account(
         is_placeholder=body.is_placeholder,
         created_by_user_id=claims.user_id,
     )
+    from tulip_storage.repositories import AccountTagRepository
+    from tulip_storage.repositories.transaction_tag import TagInvalidError
+
+    saved_tags: list[str] = []
+    if body.tags:
+        try:
+            saved_tags = AccountTagRepository(session, claims.household_id).set_tags(
+                a.id, list(body.tags)
+            )
+        except TagInvalidError as exc:
+            from tulip_api.errors import TagInvalidError as ApiTagInvalidError
+
+            raise ApiTagInvalidError(reason=str(exc)) from exc
     after_snapshot: dict[str, object] = {
         "name": a.name,
         "type": a.type.value,
@@ -295,6 +321,8 @@ def create_account(
         # column is encrypted at rest precisely because the operator
         # may put PII in there). Boolean signal is enough for the audit.
         after_snapshot["notes_set"] = True
+    if saved_tags:
+        after_snapshot["tags"] = saved_tags
     audit.write(
         action="create",
         actor_kind="user",
@@ -306,7 +334,7 @@ def create_account(
     )
     session.commit()
     log.info("account.created", account_id=str(a.id))
-    return _to_read(a, notes=body.notes)
+    return _to_read(a, notes=body.notes, tags=saved_tags)
 
 
 def _create_with_parents(
@@ -514,7 +542,10 @@ def get_account(
     a = repo.get(account_id)
     if a is None or not _filter_for_role(a, claims):
         raise AccountNotFoundError()
-    return _to_read(a, notes=repo.decrypt_notes(a))
+    from tulip_storage.repositories import AccountTagRepository
+
+    tags = AccountTagRepository(session, claims.household_id).list_tags(a.id)
+    return _to_read(a, notes=repo.decrypt_notes(a), tags=tags)
 
 
 @router.patch(
@@ -618,6 +649,20 @@ def update_account(
                     account_id=str(a.id), posting_count=int(posting_count)
                 )
         a.is_placeholder = body.is_placeholder
+
+    from tulip_storage.repositories import AccountTagRepository
+    from tulip_storage.repositories.transaction_tag import TagInvalidError
+
+    tag_repo = AccountTagRepository(session, claims.household_id)
+    tags_changed = False
+    if body.tags is not None:
+        try:
+            tag_repo.set_tags(a.id, list(body.tags))
+        except TagInvalidError as exc:
+            from tulip_api.errors import TagInvalidError as ApiTagInvalidError
+
+            raise ApiTagInvalidError(reason=str(exc)) from exc
+        tags_changed = True
     session.flush()
 
     after_snapshot: dict[str, object] = {
@@ -628,6 +673,8 @@ def update_account(
     }
     if notes_changed:
         after_snapshot["notes_set"] = a.notes_encrypted is not None
+    if tags_changed:
+        after_snapshot["tags"] = tag_repo.list_tags(a.id)
     AuditLogWriter(session, claims.household_id).write(
         action="update",
         actor_kind="user",
@@ -639,7 +686,7 @@ def update_account(
         request_id=_request_uuid(request),
     )
     session.commit()
-    return _to_read(a, notes=repo.decrypt_notes(a))
+    return _to_read(a, notes=repo.decrypt_notes(a), tags=tag_repo.list_tags(a.id))
 
 
 @router.get(

--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -33,6 +33,7 @@ from tulip_api.auth.deps import get_current_claims, require_role
 from tulip_api.config import get_settings
 from tulip_api.deps import get_session
 from tulip_api.errors import (
+    FRAMEWORK_BODY_RESPONSES,
     AccountUnknownError,
     CsvProfileNotFoundError,
     ForbiddenError,
@@ -887,6 +888,7 @@ async def promote_line(
     "/{batch_id}/lines/{line_id}",
     response_model=StatementLineRead,
     responses={
+        **FRAMEWORK_BODY_RESPONSES,
         401: problem_response("auth.unauthorized"),
         403: problem_response("auth.forbidden"),
         404: problem_response("import_batch.not_found", "import.line.not_found"),

--- a/packages/tulip-api/src/tulip_api/routers/transactions.py
+++ b/packages/tulip-api/src/tulip_api/routers/transactions.py
@@ -708,6 +708,59 @@ def get_transaction(
     return _read_response(tx_id, claims.household_id, session)
 
 
+@router.get(
+    "/{tx_id}/effective-tags",
+    responses={
+        401: problem_response("auth.unauthorized"),
+        404: problem_response("transaction.not_found"),
+    },
+)
+def get_transaction_effective_tags(
+    tx_id: UUID,
+    claims: Claims = Depends(get_current_claims),  # noqa: B008
+    session: Session = Depends(get_session),  # noqa: B008
+) -> dict[str, object]:
+    """Return the effective tags for a transaction with provenance (ADR-0009 PR C).
+
+    Shape::
+
+        {
+          "direct": ["birthday"],
+          "effective": ["birthday", "essential", "walter"],
+          "by_provenance": [
+            {"name": "birthday",  "provenance": "transaction", "source_id": "<tx>"},
+            {"name": "essential", "provenance": "account",     "source_id": "<acct>"},
+            {"name": "walter",    "provenance": "posting",     "source_id": "<post>"}
+          ]
+        }
+
+    The TUI shows the operator both the direct set and the
+    inherited set (with provenance) so they know which edge to
+    remove if they want a given tag gone.
+    """
+    from tulip_storage.repositories import (
+        EffectiveTagsRepository,
+        TransactionTagRepository,
+    )
+
+    if TransactionRepository(session, claims.household_id).get(tx_id) is None:
+        raise TransactionNotFoundError()
+    direct = TransactionTagRepository(session, claims.household_id).list_tags(tx_id)
+    raw = EffectiveTagsRepository(session, claims.household_id).for_transaction(tx_id)
+    return {
+        "direct": direct,
+        "effective": sorted({t.name for t in raw}),
+        "by_provenance": [
+            {
+                "name": t.name,
+                "provenance": t.provenance,
+                "source_id": str(t.source_id),
+            }
+            for t in raw
+        ],
+    }
+
+
 def _resolve_notes_patch(body: TransactionUpdate) -> str | None | object:
     """Return UNSET if ``notes`` was omitted; else the body value (str or None).
 

--- a/packages/tulip-api/src/tulip_api/schemas/account.py
+++ b/packages/tulip-api/src/tulip_api/schemas/account.py
@@ -40,6 +40,16 @@ class AccountCreate(BaseModel):
             "instead. Defaults to false (regular postable account)."
         ),
     )
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional account-level tags (ADR-0009, PR B). Each entry "
+            "is normalised (lowercase, stripped) before storage; "
+            "duplicates collapse. Account tags inherit down to every "
+            "posting on the account at read time (effective_tags, "
+            "PR C)."
+        ),
+    )
     create_parents: bool = Field(
         default=False,
         description=(
@@ -93,6 +103,14 @@ class AccountUpdate(BaseModel):
             "it has direct postings — clean those up first."
         ),
     )
+    tags: list[str] | None = Field(
+        default=None,
+        description=(
+            "Replace the account's tag set (ADR-0009, PR B). Omit to "
+            "leave unchanged; pass an explicit list (including ``[]``) "
+            "to wholesale-replace."
+        ),
+    )
 
 
 class AccountRead(BaseModel):
@@ -108,6 +126,10 @@ class AccountRead(BaseModel):
     is_active: bool
     is_placeholder: bool = False
     parent_account_id: UUID | None
+    tags: list[str] = Field(
+        default_factory=list,
+        description="Tag names attached to this account (ADR-0009).",
+    )
     notes: str | None = Field(
         default=None,
         description=(

--- a/packages/tulip-api/tests/test_accounts_endpoints.py
+++ b/packages/tulip-api/tests/test_accounts_endpoints.py
@@ -512,3 +512,116 @@ class TestAccountPlaceholder:
         )
         assert r.status_code == 200
         assert r.json()["is_placeholder"] is False
+
+
+# ---- ADR-0009 PR B: account tags --------------------------------------------
+
+
+class TestAccountTags:
+    """Account-level tags via POST + PATCH + GET round-trip."""
+
+    def test_create_with_tags(self, client: TestClient, auth_h: dict[str, str]):
+        r = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Visa",
+                "type": "liability",
+                "currency": "USD",
+                "tags": ["credit-card", "joint"],
+            },
+        )
+        assert r.status_code == 201, r.text
+        # Deduplicated + sorted on read.
+        assert sorted(r.json()["tags"]) == ["credit-card", "joint"]
+
+    def test_patch_replaces_tags(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Visa",
+                "type": "liability",
+                "currency": "USD",
+                "tags": ["a", "b"],
+            },
+        ).json()
+        r = client.patch(
+            f"/v1/accounts/{created['id']}",
+            headers=auth_h,
+            json={"tags": ["c"]},
+        )
+        assert r.status_code == 200
+        assert r.json()["tags"] == ["c"]
+
+    def test_patch_with_empty_list_clears_tags(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Visa",
+                "type": "liability",
+                "currency": "USD",
+                "tags": ["joint"],
+            },
+        ).json()
+        r = client.patch(
+            f"/v1/accounts/{created['id']}",
+            headers=auth_h,
+            json={"tags": []},
+        )
+        assert r.status_code == 200
+        assert r.json()["tags"] == []
+
+    def test_patch_without_tags_field_preserves_existing(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        """Omitting ``tags`` from the body leaves the set unchanged."""
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Visa",
+                "type": "liability",
+                "currency": "USD",
+                "tags": ["joint"],
+            },
+        ).json()
+        # PATCH only changing the name.
+        r = client.patch(
+            f"/v1/accounts/{created['id']}",
+            headers=auth_h,
+            json={"name": "Visa Card"},
+        )
+        assert r.status_code == 200
+        assert r.json()["tags"] == ["joint"]
+
+    def test_get_by_id_returns_tags(self, client: TestClient, auth_h: dict[str, str]):
+        created = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Cash",
+                "type": "asset",
+                "currency": "USD",
+                "tags": ["wallet"],
+            },
+        ).json()
+        r = client.get(f"/v1/accounts/{created['id']}", headers=auth_h)
+        assert r.status_code == 200
+        assert r.json()["tags"] == ["wallet"]
+
+    def test_list_endpoint_returns_tags(self, client: TestClient, auth_h: dict[str, str]):
+        client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Cash",
+                "type": "asset",
+                "currency": "USD",
+                "tags": ["wallet"],
+            },
+        )
+        rows = client.get("/v1/accounts", headers=auth_h).json()
+        cash = next(r for r in rows if r["name"] == "Cash")
+        assert cash["tags"] == ["wallet"]

--- a/packages/tulip-api/tests/test_transactions_tags.py
+++ b/packages/tulip-api/tests/test_transactions_tags.py
@@ -241,3 +241,75 @@ class TestValidation:
         r = client.get("/v1/transactions", params={"tag": "has space"}, headers=auth_h)
         assert r.status_code == 400
         assert_problem(r, code="tag.invalid", status=400)
+
+
+# ---- ADR-0009 PR C: effective-tags endpoint --------------------------------
+
+
+class TestEffectiveTagsEndpoint:
+    """``GET /v1/transactions/{id}/effective-tags`` returns direct + inherited."""
+
+    def _seed_tx_with_tags(
+        self,
+        client: TestClient,
+        auth_h: dict[str, str],
+        *,
+        tx_tags: list[str],
+        account_tags: list[str],
+    ) -> str:
+        """Create accounts + a tagged transaction; return the tx id."""
+        cash = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={"name": "Cash", "type": "asset", "currency": "USD"},
+        ).json()
+        food = client.post(
+            "/v1/accounts",
+            headers=auth_h,
+            json={
+                "name": "Food",
+                "type": "expense",
+                "currency": "USD",
+                "tags": account_tags,
+            },
+        ).json()
+        tx = client.post(
+            "/v1/transactions",
+            headers=auth_h,
+            json={
+                "date": "2026-05-01",
+                "description": "Lunch",
+                "tags": tx_tags,
+                "postings": [
+                    {"account_id": food["id"], "amount": "10.00", "currency": "USD"},
+                    {"account_id": cash["id"], "amount": "-10.00", "currency": "USD"},
+                ],
+            },
+        )
+        assert tx.status_code == 201, tx.text
+        return tx.json()["id"]
+
+    def test_returns_direct_and_inherited_sets(self, client: TestClient, auth_h: dict[str, str]):
+        tx_id = self._seed_tx_with_tags(
+            client,
+            auth_h,
+            tx_tags=["birthday"],
+            account_tags=["essential"],
+        )
+        r = client.get(f"/v1/transactions/{tx_id}/effective-tags", headers=auth_h)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["direct"] == ["birthday"]
+        assert set(body["effective"]) == {"birthday", "essential"}
+        # by_provenance carries every edge, distinguishable.
+        provenances = {(p["name"], p["provenance"]) for p in body["by_provenance"]}
+        assert ("birthday", "transaction") in provenances
+        assert ("essential", "account") in provenances
+
+    def test_returns_empty_for_unknown_transaction(
+        self, client: TestClient, auth_h: dict[str, str]
+    ):
+        from uuid import uuid4
+
+        r = client.get(f"/v1/transactions/{uuid4()}/effective-tags", headers=auth_h)
+        assert r.status_code == 404

--- a/packages/tulip-storage/src/tulip_storage/migrations/versions/20260521_0100_d3e8b1a9f5c2_posting_account_tags.py
+++ b/packages/tulip-storage/src/tulip_storage/migrations/versions/20260521_0100_d3e8b1a9f5c2_posting_account_tags.py
@@ -1,0 +1,79 @@
+"""Add posting_tags + account_tags tables (ADR-0009, PR B).
+
+Layered on top of the PR A normalisation (b2c4f9a1e7d6). Adds
+the two remaining tag-scope edge tables:
+
+- ``posting_tags(household_id, posting_id, tag_id)``
+- ``account_tags(household_id, account_id, tag_id)``
+
+No data migration — both tables start empty. Downgrade drops
+them cleanly.
+
+Revision ID: d3e8b1a9f5c2
+Revises: b2c4f9a1e7d6
+Create Date: 2026-05-21 01:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d3e8b1a9f5c2"
+down_revision: str | None = "b2c4f9a1e7d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create ``posting_tags`` + ``account_tags``."""
+    op.create_table(
+        "posting_tags",
+        sa.Column("household_id", sa.Uuid(), nullable=False),
+        sa.Column("posting_id", sa.Uuid(), nullable=False),
+        sa.Column("tag_id", sa.Uuid(), nullable=False),
+        # postings.id is the single-column PK on postings, so the
+        # posting-side FK is single-column. Tenant isolation on this
+        # side is enforced at the repo level (always filter by
+        # household_id).
+        sa.ForeignKeyConstraint(
+            ["posting_id"],
+            ["postings.id"],
+            ondelete="CASCADE",
+            name="fk_posting_tags_posting",
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_posting_tags_tag",
+        ),
+        sa.PrimaryKeyConstraint("household_id", "posting_id", "tag_id", name="pk_posting_tags"),
+    )
+    op.create_table(
+        "account_tags",
+        sa.Column("household_id", sa.Uuid(), nullable=False),
+        sa.Column("account_id", sa.Uuid(), nullable=False),
+        sa.Column("tag_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["household_id", "account_id"],
+            ["accounts.household_id", "accounts.id"],
+            ondelete="CASCADE",
+            name="fk_account_tags_account",
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_account_tags_tag",
+        ),
+        sa.PrimaryKeyConstraint("household_id", "account_id", "tag_id", name="pk_account_tags"),
+    )
+
+
+def downgrade() -> None:
+    """Drop ``posting_tags`` + ``account_tags``."""
+    op.drop_table("account_tags")
+    op.drop_table("posting_tags")

--- a/packages/tulip-storage/src/tulip_storage/models/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/models/__init__.py
@@ -12,6 +12,7 @@ architecture test in tulip-core enforces this.
 """
 
 from tulip_storage.models.account import Account, AccountType
+from tulip_storage.models.account_tag import AccountTag
 from tulip_storage.models.ai_invocation import AICapability, AIInvocation, AIOutcome
 from tulip_storage.models.allocation_pool import AllocationPool, PoolType
 from tulip_storage.models.attachment import Attachment
@@ -40,6 +41,7 @@ from tulip_storage.models.pending_proposal import (
 )
 from tulip_storage.models.period import Period, PeriodStatus
 from tulip_storage.models.posting import Posting
+from tulip_storage.models.posting_tag import PostingTag
 from tulip_storage.models.reconciliation import Reconciliation, ReconciliationStatus
 from tulip_storage.models.reconciliation_match import (
     MatchConfidence,
@@ -70,6 +72,7 @@ __all__ = [
     "AIInvocation",
     "AIOutcome",
     "Account",
+    "AccountTag",
     "AccountType",
     "AllocationPool",
     "Attachment",
@@ -95,6 +98,7 @@ __all__ = [
     "PeriodStatus",
     "PoolType",
     "Posting",
+    "PostingTag",
     "ProposalCreatorKind",
     "ProposalStatus",
     "Reconciliation",

--- a/packages/tulip-storage/src/tulip_storage/models/account_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/models/account_tag.py
@@ -1,0 +1,41 @@
+"""Account-tag edge (ADR-0009, PR B).
+
+Links a single :class:`Account` to a normalised :class:`Tag`.
+Account tags inherit down to every posting on that account at
+read-time — see ``effective_tags`` (PR C). Composite FKs keep
+tenant isolation tight; ON DELETE CASCADE on both sides means
+removing the account or the tag sweeps the edge.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import ForeignKeyConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class AccountTag(Base):
+    """Edge from an account to a tag (ADR-0009)."""
+
+    __tablename__ = "account_tags"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "account_id"],
+            ["accounts.household_id", "accounts.id"],
+            ondelete="CASCADE",
+            name="fk_account_tags_account",
+        ),
+        ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_account_tags_tag",
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    account_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    tag_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)

--- a/packages/tulip-storage/src/tulip_storage/models/posting_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/models/posting_tag.py
@@ -1,0 +1,46 @@
+"""Posting-tag edge (ADR-0009, PR B).
+
+Links a single :class:`Posting` to a normalised :class:`Tag`.
+The composite PK ``(household_id, posting_id, tag_id)`` keeps
+the row scoped; the FK to ``postings.id`` is single-column
+because :class:`Posting` itself has a single-column PK
+(unlike ``transactions``/``accounts`` which use composite
+PKs). Tenant isolation on the posting side is therefore an
+application-layer concern (the repository filters by
+``household_id``) — matching the pattern other single-PK
+references use.
+
+Tag-side FK stays composite — the tags table has the
+composite PK already.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, ForeignKeyConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tulip_storage.models.base import GUID, Base
+
+
+class PostingTag(Base):
+    """Edge from a posting to a tag (ADR-0009)."""
+
+    __tablename__ = "posting_tags"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["household_id", "tag_id"],
+            ["tags.household_id", "tags.id"],
+            ondelete="CASCADE",
+            name="fk_posting_tags_tag",
+        ),
+    )
+
+    household_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    posting_id: Mapped[UUID] = mapped_column(
+        GUID(),
+        ForeignKey("postings.id", ondelete="CASCADE", name="fk_posting_tags_posting"),
+        primary_key=True,
+    )
+    tag_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -17,6 +17,10 @@ from tulip_storage.repositories.attachment import AttachmentRepository
 from tulip_storage.repositories.attachment_link import AttachmentLinkRepository
 from tulip_storage.repositories.audit_log import AuditLogWriter
 from tulip_storage.repositories.csv_profile import CsvProfileRepository
+from tulip_storage.repositories.effective_tags import (
+    EffectiveTag,
+    EffectiveTagsRepository,
+)
 from tulip_storage.repositories.envelope import EnvelopeRepository
 from tulip_storage.repositories.import_batch import ImportBatchRepository
 from tulip_storage.repositories.notification import NotificationRepository
@@ -52,6 +56,8 @@ __all__ = [
     "AttachmentRepository",
     "AuditLogWriter",
     "CsvProfileRepository",
+    "EffectiveTag",
+    "EffectiveTagsRepository",
     "EnvelopeRepository",
     "ImportBatchRepository",
     "MasterKeyRequiredError",

--- a/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/__init__.py
@@ -10,6 +10,7 @@ higher layers (the API) call it on every business mutation.
 """
 
 from tulip_storage.repositories.account import AccountRepository
+from tulip_storage.repositories.account_tag import AccountTagRepository
 from tulip_storage.repositories.ai_invocation import AIInvocationRepository
 from tulip_storage.repositories.allocation_pool import AllocationPoolRepository
 from tulip_storage.repositories.attachment import AttachmentRepository
@@ -21,6 +22,7 @@ from tulip_storage.repositories.import_batch import ImportBatchRepository
 from tulip_storage.repositories.notification import NotificationRepository
 from tulip_storage.repositories.pending_proposal import PendingProposalRepository
 from tulip_storage.repositories.period import PeriodRepository
+from tulip_storage.repositories.posting_tag import PostingTagRepository
 from tulip_storage.repositories.reconciliation import ReconciliationRepository
 from tulip_storage.repositories.reconciliation_match import (
     ReconciliationMatchRepository,
@@ -44,6 +46,7 @@ from tulip_storage.repositories.transaction_tag import (
 __all__ = [
     "AIInvocationRepository",
     "AccountRepository",
+    "AccountTagRepository",
     "AllocationPoolRepository",
     "AttachmentLinkRepository",
     "AttachmentRepository",
@@ -55,6 +58,7 @@ __all__ = [
     "NotificationRepository",
     "PendingProposalRepository",
     "PeriodRepository",
+    "PostingTagRepository",
     "ReconciliationMatchRepository",
     "ReconciliationRepository",
     "ScheduledJobRepository",

--- a/packages/tulip-storage/src/tulip_storage/repositories/account_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/account_tag.py
@@ -1,0 +1,109 @@
+"""Account-tag repository (ADR-0009, PR B)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import delete, select
+
+from tulip_storage.models import AccountTag, Tag
+from tulip_storage.repositories.tag import TagRepository
+from tulip_storage.repositories.transaction_tag import normalise_tag
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class AccountTagRepository:
+    """Per-household repository over the ``account_tags`` edge table."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the repo to a session + household tenant scope."""
+        self._session = session
+        self._household_id = household_id
+        self._tags = TagRepository(session, household_id)
+
+    def set_tags(self, account_id: UUID, tags: list[str]) -> list[str]:
+        """Replace the account's tags with the deduplicated, normalised set."""
+        normalised = sorted({normalise_tag(t) for t in tags})
+        self._session.execute(
+            delete(AccountTag).where(
+                AccountTag.household_id == self._household_id,
+                AccountTag.account_id == account_id,
+            )
+        )
+        for name in normalised:
+            tag = self._tags.get_or_create_by_name(name)
+            self._session.add(
+                AccountTag(
+                    household_id=self._household_id,
+                    account_id=account_id,
+                    tag_id=tag.id,
+                )
+            )
+        return normalised
+
+    def list_tags(self, account_id: UUID) -> list[str]:
+        """Return the account's tag *names* in sorted order."""
+        rows = (
+            self._session.execute(
+                select(Tag.name)
+                .join(
+                    AccountTag,
+                    (AccountTag.household_id == Tag.household_id) & (AccountTag.tag_id == Tag.id),
+                )
+                .where(
+                    AccountTag.household_id == self._household_id,
+                    AccountTag.account_id == account_id,
+                )
+                .order_by(Tag.name)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+    def list_tags_for_accounts(self, account_ids: list[UUID]) -> dict[UUID, list[str]]:
+        """Batch lookup: return ``{account_id: [tag, ...]}`` for the list."""
+        if not account_ids:
+            return {}
+        rows = self._session.execute(
+            select(AccountTag.account_id, Tag.name)
+            .join(
+                Tag,
+                (Tag.household_id == AccountTag.household_id) & (Tag.id == AccountTag.tag_id),
+            )
+            .where(
+                AccountTag.household_id == self._household_id,
+                AccountTag.account_id.in_(account_ids),
+            )
+            .order_by(AccountTag.account_id, Tag.name)
+        ).all()
+        by_id: dict[UUID, list[str]] = {aid: [] for aid in account_ids}
+        for account_id, name in rows:
+            by_id[account_id].append(name)
+        return by_id
+
+    def find_account_ids_by_tag(self, tag: str) -> list[UUID]:
+        """Return the accounts carrying ``tag``. Unknown tag → empty list."""
+        normalised = normalise_tag(tag)
+        existing = self._tags.get_by_name(normalised)
+        if existing is None:
+            return []
+        rows = (
+            self._session.execute(
+                select(AccountTag.account_id)
+                .where(
+                    AccountTag.household_id == self._household_id,
+                    AccountTag.tag_id == existing.id,
+                )
+                .order_by(AccountTag.account_id)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+
+__all__ = ["AccountTagRepository"]

--- a/packages/tulip-storage/src/tulip_storage/repositories/effective_tags.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/effective_tags.py
@@ -1,0 +1,189 @@
+"""Effective-tags resolver — ADR-0009 PR C (read-time inheritance).
+
+Computes the inherited tag set for a posting or transaction by
+unioning direct edges with the inherited ones:
+
+- ``effective_tags(posting)`` = direct posting tags  |
+  the parent transaction's direct tags  |
+  the posting's account's direct tags.
+- ``effective_tags(transaction)`` = direct transaction tags  |
+  the union of every posting's direct tags  |
+  the union of every posting's account's direct tags.
+
+Inheritance is **never materialised** — it's a read-time UNION
+across the three join tables and the ``tags`` registry. This
+keeps tag renames + tag merges + account-tag re-edits O(1) on
+write; the cost shows up only on the relatively-rare effective-
+tags read. See the ADR for the rationale.
+
+Each result is annotated with provenance so the caller can
+distinguish direct vs inherited tags and show the user where an
+inherited tag came from.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.sql.elements import ColumnElement
+
+from tulip_storage.models import (
+    AccountTag,
+    Posting,
+    PostingTag,
+    Tag,
+    TransactionTag,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+#: Where an effective tag came from. ``"posting"`` means a direct
+#: edge in ``posting_tags``; ``"transaction"`` means a direct edge
+#: on the parent transaction; ``"account"`` means a direct edge on
+#: the account a posting points at.
+TagProvenance = Literal["posting", "transaction", "account"]
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveTag:
+    """One tag attached to a posting/transaction via direct or inherited edge.
+
+    Multiple provenance entries can exist for the same ``name``
+    (e.g. tag ``walter`` is on the posting AND on the parent
+    transaction). The caller decides whether to dedupe by name or
+    surface every provenance edge.
+    """
+
+    name: str
+    provenance: TagProvenance
+    source_id: UUID  # posting/transaction/account id that carries the direct edge
+
+
+class EffectiveTagsRepository:
+    """Per-household resolver for read-time tag inheritance (ADR-0009)."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the resolver to a session + household tenant scope."""
+        self._session = session
+        self._household_id = household_id
+
+    def for_posting(self, posting_id: UUID) -> list[EffectiveTag]:
+        """Return the full provenance-annotated effective tag list for ``posting_id``.
+
+        Three branches:
+
+        - Direct: rows in ``posting_tags`` for this posting.
+        - From the parent transaction: rows in ``transaction_tags``
+          for the posting's transaction_id.
+        - From the posting's account: rows in ``account_tags`` for
+          the posting's account_id.
+
+        Sorted by (provenance, name) for deterministic output.
+        """
+        posting = self._session.execute(
+            select(Posting).where(
+                Posting.household_id == self._household_id,
+                Posting.id == posting_id,
+            )
+        ).scalar_one_or_none()
+        if posting is None:
+            return []
+        out: list[EffectiveTag] = []
+        # Direct posting tags.
+        for name in self._direct_names(PostingTag, PostingTag.posting_id == posting_id):
+            out.append(EffectiveTag(name=name, provenance="posting", source_id=posting_id))
+        # Inherited from the transaction.
+        for name in self._direct_names(
+            TransactionTag, TransactionTag.transaction_id == posting.transaction_id
+        ):
+            out.append(
+                EffectiveTag(
+                    name=name,
+                    provenance="transaction",
+                    source_id=posting.transaction_id,
+                )
+            )
+        # Inherited from the account.
+        for name in self._direct_names(AccountTag, AccountTag.account_id == posting.account_id):
+            out.append(EffectiveTag(name=name, provenance="account", source_id=posting.account_id))
+        out.sort(key=lambda t: (t.provenance, t.name))
+        return out
+
+    def for_transaction(self, transaction_id: UUID) -> list[EffectiveTag]:
+        """Return the effective tag list for a transaction.
+
+        - Direct transaction tags (one row per tag).
+        - Direct posting tags on every posting under the transaction
+          (one row per (posting, tag) edge so provenance can
+          distinguish).
+        - Direct account tags on every account a posting points at.
+
+        Sorted by (provenance, name) for deterministic output.
+        """
+        out: list[EffectiveTag] = []
+        # Direct transaction tags.
+        for name in self._direct_names(
+            TransactionTag, TransactionTag.transaction_id == transaction_id
+        ):
+            out.append(
+                EffectiveTag(
+                    name=name,
+                    provenance="transaction",
+                    source_id=transaction_id,
+                )
+            )
+        # Posting tags on every posting under this transaction.
+        posting_rows = (
+            self._session.execute(
+                select(Posting).where(
+                    Posting.household_id == self._household_id,
+                    Posting.transaction_id == transaction_id,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for posting in posting_rows:
+            for name in self._direct_names(PostingTag, PostingTag.posting_id == posting.id):
+                out.append(EffectiveTag(name=name, provenance="posting", source_id=posting.id))
+            for name in self._direct_names(AccountTag, AccountTag.account_id == posting.account_id):
+                out.append(
+                    EffectiveTag(
+                        name=name,
+                        provenance="account",
+                        source_id=posting.account_id,
+                    )
+                )
+        out.sort(key=lambda t: (t.provenance, t.name))
+        return out
+
+    def _direct_names(
+        self,
+        edge_model: type[Any],
+        where_clause: ColumnElement[bool],
+    ) -> list[str]:
+        """Return the tag names for a direct-edge query (single side)."""
+        return list(
+            self._session.execute(
+                select(Tag.name)
+                .join(
+                    edge_model,
+                    (edge_model.household_id == Tag.household_id) & (edge_model.tag_id == Tag.id),
+                )
+                .where(
+                    edge_model.household_id == self._household_id,
+                    where_clause,
+                )
+                .order_by(Tag.name)
+            )
+            .scalars()
+            .all()
+        )
+
+
+__all__ = ["EffectiveTag", "EffectiveTagsRepository", "TagProvenance"]

--- a/packages/tulip-storage/src/tulip_storage/repositories/posting_tag.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/posting_tag.py
@@ -1,0 +1,114 @@
+"""Posting-tag repository (ADR-0009, PR B).
+
+Same shape as :class:`TransactionTagRepository` — public API
+operates by tag name, resolves to :class:`Tag` ids via
+:class:`TagRepository` internally.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import delete, select
+
+from tulip_storage.models import PostingTag, Tag
+from tulip_storage.repositories.tag import TagRepository
+from tulip_storage.repositories.transaction_tag import normalise_tag
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class PostingTagRepository:
+    """Per-household repository over the ``posting_tags`` edge table."""
+
+    def __init__(self, session: Session, household_id: UUID) -> None:
+        """Bind the repo to a session + household tenant scope."""
+        self._session = session
+        self._household_id = household_id
+        self._tags = TagRepository(session, household_id)
+
+    def set_tags(self, posting_id: UUID, tags: list[str]) -> list[str]:
+        """Replace the posting's tags with the deduplicated, normalised set."""
+        normalised = sorted({normalise_tag(t) for t in tags})
+        self._session.execute(
+            delete(PostingTag).where(
+                PostingTag.household_id == self._household_id,
+                PostingTag.posting_id == posting_id,
+            )
+        )
+        for name in normalised:
+            tag = self._tags.get_or_create_by_name(name)
+            self._session.add(
+                PostingTag(
+                    household_id=self._household_id,
+                    posting_id=posting_id,
+                    tag_id=tag.id,
+                )
+            )
+        return normalised
+
+    def list_tags(self, posting_id: UUID) -> list[str]:
+        """Return the posting's tag *names* in sorted order."""
+        rows = (
+            self._session.execute(
+                select(Tag.name)
+                .join(
+                    PostingTag,
+                    (PostingTag.household_id == Tag.household_id) & (PostingTag.tag_id == Tag.id),
+                )
+                .where(
+                    PostingTag.household_id == self._household_id,
+                    PostingTag.posting_id == posting_id,
+                )
+                .order_by(Tag.name)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+    def list_tags_for_postings(self, posting_ids: list[UUID]) -> dict[UUID, list[str]]:
+        """Batch lookup: return ``{posting_id: [tag, ...]}`` for the list."""
+        if not posting_ids:
+            return {}
+        rows = self._session.execute(
+            select(PostingTag.posting_id, Tag.name)
+            .join(
+                Tag,
+                (Tag.household_id == PostingTag.household_id) & (Tag.id == PostingTag.tag_id),
+            )
+            .where(
+                PostingTag.household_id == self._household_id,
+                PostingTag.posting_id.in_(posting_ids),
+            )
+            .order_by(PostingTag.posting_id, Tag.name)
+        ).all()
+        by_id: dict[UUID, list[str]] = {pid: [] for pid in posting_ids}
+        for posting_id, name in rows:
+            by_id[posting_id].append(name)
+        return by_id
+
+    def find_posting_ids_by_tag(self, tag: str) -> list[UUID]:
+        """Return the postings carrying ``tag``. Unknown tag → empty list."""
+        normalised = normalise_tag(tag)
+        existing = self._tags.get_by_name(normalised)
+        if existing is None:
+            return []
+        rows = (
+            self._session.execute(
+                select(PostingTag.posting_id)
+                .where(
+                    PostingTag.household_id == self._household_id,
+                    PostingTag.tag_id == existing.id,
+                )
+                .order_by(PostingTag.posting_id)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+
+__all__ = ["PostingTagRepository"]

--- a/packages/tulip-storage/tests/test_effective_tags.py
+++ b/packages/tulip-storage/tests/test_effective_tags.py
@@ -1,0 +1,182 @@
+"""Tests for ``EffectiveTagsRepository`` — ADR-0009 PR C."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from tulip_core.money import Money
+from tulip_core.transactions import (
+    Posting as DomainPosting,
+)
+from tulip_core.transactions import (
+    Transaction as DomainTransaction,
+)
+from tulip_core.transactions import (
+    TransactionStatus as DomainTxStatus,
+)
+from tulip_storage.models import (
+    Account,
+    AccountType,
+    Household,
+    PeriodStatus,
+    Posting,
+)
+from tulip_storage.repositories import (
+    AccountRepository,
+    AccountTagRepository,
+    EffectiveTagsRepository,
+    PeriodRepository,
+    PostingTagRepository,
+    TransactionRepository,
+    TransactionTagRepository,
+)
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+@pytest.fixture
+def chart(session: Session, household: Household) -> tuple[Account, Account]:
+    repo = AccountRepository(session, household.id)
+    cash = repo.create(code="1110", name="Cash", type=AccountType.ASSET, currency="USD")
+    food = repo.create(code="5100", name="Food", type=AccountType.EXPENSE, currency="USD")
+    session.commit()
+    return cash, food
+
+
+def _seed_balanced_tx(
+    session: Session, household: Household, cash: Account, food: Account
+) -> tuple[Posting, Posting, DomainTransaction]:
+    """Seed one balanced transaction, return its two postings."""
+    PeriodRepository(session, household.id).create(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        status=PeriodStatus.OPEN,
+    )
+    session.commit()
+    tx_repo = TransactionRepository(session, household.id)
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 5, 1),
+        description="Lunch",
+        postings=(
+            DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("10"), "USD")),
+            DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(Decimal("-10"), "USD")),
+        ),
+        status=DomainTxStatus.POSTED,
+    )
+    tx_repo.save_balanced(domain_tx)
+    session.commit()
+    rows = (
+        session.execute(select(Posting).where(Posting.transaction_id == domain_tx.id))
+        .scalars()
+        .all()
+    )
+    food_p = next(p for p in rows if p.account_id == food.id)
+    cash_p = next(p for p in rows if p.account_id == cash.id)
+    return food_p, cash_p, domain_tx
+
+
+def test_for_posting_returns_direct_only_when_no_inheritance(
+    session: Session, household: Household, chart: tuple[Account, Account]
+) -> None:
+    cash, food = chart
+    food_p, _cash_p, _tx = _seed_balanced_tx(session, household, cash, food)
+    PostingTagRepository(session, household.id).set_tags(food_p.id, ["walter"])
+    session.commit()
+
+    eff = EffectiveTagsRepository(session, household.id).for_posting(food_p.id)
+    assert len(eff) == 1
+    assert eff[0].name == "walter"
+    assert eff[0].provenance == "posting"
+    assert eff[0].source_id == food_p.id
+
+
+def test_for_posting_inherits_from_transaction_and_account(
+    session: Session, household: Household, chart: tuple[Account, Account]
+) -> None:
+    """Posting effective tags include direct + transaction-level + account-level."""
+    cash, food = chart
+    food_p, _cash_p, domain_tx = _seed_balanced_tx(session, household, cash, food)
+    PostingTagRepository(session, household.id).set_tags(food_p.id, ["walter"])
+    TransactionTagRepository(session, household.id).set_tags(domain_tx.id, ["birthday"])
+    AccountTagRepository(session, household.id).set_tags(food.id, ["essential"])
+    session.commit()
+
+    eff = EffectiveTagsRepository(session, household.id).for_posting(food_p.id)
+    by_provenance = {(t.provenance, t.name) for t in eff}
+    assert by_provenance == {
+        ("posting", "walter"),
+        ("transaction", "birthday"),
+        ("account", "essential"),
+    }
+
+
+def test_for_posting_unknown_returns_empty(session: Session, household: Household) -> None:
+    eff = EffectiveTagsRepository(session, household.id).for_posting(uuid4())
+    assert eff == []
+
+
+def test_for_transaction_unions_direct_posting_and_account_tags(
+    session: Session, household: Household, chart: tuple[Account, Account]
+) -> None:
+    """Transaction effective tags = direct + every posting's posting + account tags."""
+    cash, food = chart
+    food_p, cash_p, domain_tx = _seed_balanced_tx(session, household, cash, food)
+
+    TransactionTagRepository(session, household.id).set_tags(domain_tx.id, ["birthday"])
+    PostingTagRepository(session, household.id).set_tags(food_p.id, ["walter"])
+    PostingTagRepository(session, household.id).set_tags(cash_p.id, ["check-pmt"])
+    AccountTagRepository(session, household.id).set_tags(food.id, ["essential"])
+    AccountTagRepository(session, household.id).set_tags(cash.id, ["joint"])
+    session.commit()
+
+    eff = EffectiveTagsRepository(session, household.id).for_transaction(domain_tx.id)
+    by_provenance = {(t.provenance, t.name) for t in eff}
+    assert by_provenance == {
+        ("transaction", "birthday"),
+        ("posting", "walter"),
+        ("posting", "check-pmt"),
+        ("account", "essential"),
+        ("account", "joint"),
+    }
+
+
+def test_for_transaction_returns_empty_when_no_postings_or_tags(
+    session: Session, household: Household
+) -> None:
+    eff = EffectiveTagsRepository(session, household.id).for_transaction(uuid4())
+    assert eff == []
+
+
+def test_sorting_is_deterministic(
+    session: Session, household: Household, chart: tuple[Account, Account]
+) -> None:
+    """Same edges → same result list, sorted (provenance, name)."""
+    cash, food = chart
+    food_p, _cash_p, domain_tx = _seed_balanced_tx(session, household, cash, food)
+    PostingTagRepository(session, household.id).set_tags(food_p.id, ["zebra", "alpha"])
+    TransactionTagRepository(session, household.id).set_tags(domain_tx.id, ["mango", "apple"])
+    session.commit()
+
+    eff = EffectiveTagsRepository(session, household.id).for_posting(food_p.id)
+    keys = [(t.provenance, t.name) for t in eff]
+    # account < posting < transaction alphabetically.
+    assert keys == [
+        ("posting", "alpha"),
+        ("posting", "zebra"),
+        ("transaction", "apple"),
+        ("transaction", "mango"),
+    ]

--- a/packages/tulip-storage/tests/test_posting_account_tag_repositories.py
+++ b/packages/tulip-storage/tests/test_posting_account_tag_repositories.py
@@ -1,0 +1,230 @@
+"""Unit tests for ``PostingTagRepository`` + ``AccountTagRepository`` (ADR-0009, PR B)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_core.money import Money
+from tulip_core.transactions import (
+    Posting as DomainPosting,
+)
+from tulip_core.transactions import (
+    Transaction as DomainTransaction,
+)
+from tulip_core.transactions import (
+    TransactionStatus as DomainTxStatus,
+)
+from tulip_storage.models import (
+    Account,
+    AccountType,
+    Household,
+    PeriodStatus,
+)
+from tulip_storage.repositories import (
+    AccountRepository,
+    AccountTagRepository,
+    PeriodRepository,
+    PostingTagRepository,
+    TransactionRepository,
+)
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+@pytest.fixture
+def two_accounts(session: Session, household: Household) -> tuple[Account, Account]:
+    repo = AccountRepository(session, household.id)
+    cash = repo.create(code="1110", name="Cash", type=AccountType.ASSET, currency="USD")
+    food = repo.create(code="5100", name="Food", type=AccountType.EXPENSE, currency="USD")
+    session.commit()
+    return cash, food
+
+
+def test_account_tag_set_get_round_trip(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    cash, _food = two_accounts
+    repo = AccountTagRepository(session, household.id)
+    saved = repo.set_tags(cash.id, ["joint", "credit-card"])
+    session.commit()
+    # Stored set is deduplicated + sorted.
+    assert saved == ["credit-card", "joint"]
+    assert repo.list_tags(cash.id) == ["credit-card", "joint"]
+
+
+def test_account_tag_set_replaces_previous(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    cash, _food = two_accounts
+    repo = AccountTagRepository(session, household.id)
+    repo.set_tags(cash.id, ["a", "b"])
+    session.commit()
+    repo.set_tags(cash.id, ["c"])
+    session.commit()
+    assert repo.list_tags(cash.id) == ["c"]
+
+
+def test_account_tag_find_by_tag(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    cash, food = two_accounts
+    repo = AccountTagRepository(session, household.id)
+    repo.set_tags(cash.id, ["joint"])
+    repo.set_tags(food.id, ["joint"])
+    session.commit()
+    found = repo.find_account_ids_by_tag("joint")
+    assert set(found) == {cash.id, food.id}
+
+
+def test_account_tag_unknown_tag_returns_empty(session: Session, household: Household) -> None:
+    repo = AccountTagRepository(session, household.id)
+    assert repo.find_account_ids_by_tag("nope") == []
+
+
+def test_posting_tag_round_trip(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    cash, food = two_accounts
+    # Seed a transaction so we have postings.
+    PeriodRepository(session, household.id).create(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        status=PeriodStatus.OPEN,
+    )
+    session.commit()
+    tx_repo = TransactionRepository(session, household.id)
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 5, 1),
+        description="Lunch",
+        postings=(
+            DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("10"), "USD")),
+            DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(Decimal("-10"), "USD")),
+        ),
+        status=DomainTxStatus.POSTED,
+    )
+    tx_repo.save_balanced(domain_tx)
+    session.commit()
+
+    # Look up the posting rows directly — Transaction doesn't expose
+    # a postings relationship today.
+    from sqlalchemy import select
+
+    from tulip_storage.models import Posting
+
+    rows = (
+        session.execute(select(Posting).where(Posting.transaction_id == domain_tx.id))
+        .scalars()
+        .all()
+    )
+    food_posting_id = next(p.id for p in rows if p.account_id == food.id)
+    posting_tags = PostingTagRepository(session, household.id)
+    saved_tags = posting_tags.set_tags(food_posting_id, ["walter", "birthday"])
+    session.commit()
+    assert saved_tags == ["birthday", "walter"]
+    assert posting_tags.list_tags(food_posting_id) == ["birthday", "walter"]
+
+
+def test_posting_tag_find_by_tag(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    """find_posting_ids_by_tag returns every posting carrying the tag."""
+    cash, food = two_accounts
+    PeriodRepository(session, household.id).create(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        status=PeriodStatus.OPEN,
+    )
+    session.commit()
+    tx_repo = TransactionRepository(session, household.id)
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 5, 1),
+        description="Lunch",
+        postings=(
+            DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("10"), "USD")),
+            DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(Decimal("-10"), "USD")),
+        ),
+        status=DomainTxStatus.POSTED,
+    )
+    tx_repo.save_balanced(domain_tx)
+    session.commit()
+
+    from sqlalchemy import select
+
+    from tulip_storage.models import Posting
+
+    rows = (
+        session.execute(select(Posting).where(Posting.transaction_id == domain_tx.id))
+        .scalars()
+        .all()
+    )
+
+    posting_tags = PostingTagRepository(session, household.id)
+    food_posting_id = next(p.id for p in rows if p.account_id == food.id)
+    posting_tags.set_tags(food_posting_id, ["walter"])
+    session.commit()
+    assert posting_tags.find_posting_ids_by_tag("walter") == [food_posting_id]
+    assert posting_tags.find_posting_ids_by_tag("nope") == []
+
+
+def test_batch_list_tags_for_postings(
+    session: Session, household: Household, two_accounts: tuple[Account, Account]
+) -> None:
+    """list_tags_for_postings returns the batch map keyed by posting id."""
+    cash, food = two_accounts
+    PeriodRepository(session, household.id).create(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        status=PeriodStatus.OPEN,
+    )
+    session.commit()
+    tx_repo = TransactionRepository(session, household.id)
+    domain_tx = DomainTransaction(
+        id=uuid4(),
+        household_id=household.id,
+        date=date(2026, 5, 1),
+        description="Lunch",
+        postings=(
+            DomainPosting(id=uuid4(), account_id=food.id, amount=Money(Decimal("10"), "USD")),
+            DomainPosting(id=uuid4(), account_id=cash.id, amount=Money(Decimal("-10"), "USD")),
+        ),
+        status=DomainTxStatus.POSTED,
+    )
+    tx_repo.save_balanced(domain_tx)
+    session.commit()
+
+    from sqlalchemy import select
+
+    from tulip_storage.models import Posting
+
+    rows = (
+        session.execute(select(Posting).where(Posting.transaction_id == domain_tx.id))
+        .scalars()
+        .all()
+    )
+
+    food_posting_id = next(p.id for p in rows if p.account_id == food.id)
+    cash_posting_id = next(p.id for p in rows if p.account_id == cash.id)
+
+    posting_tags = PostingTagRepository(session, household.id)
+    posting_tags.set_tags(food_posting_id, ["a"])
+    posting_tags.set_tags(cash_posting_id, ["b", "c"])
+    session.commit()
+
+    batch = posting_tags.list_tags_for_postings([food_posting_id, cash_posting_id])
+    assert batch[food_posting_id] == ["a"]
+    assert batch[cash_posting_id] == ["b", "c"]


### PR DESCRIPTION
## Summary

PR C closes the three-PR tag redesign from **ADR-0009**.
Layered on top of #451 (PR B) which is layered on #449
(PR A).

Adds the read-time UNION resolver that gives each posting
and each transaction its full inherited tag set, with
provenance for every edge so the UI can show where each
tag came from.

Inheritance is **computed at query time**, never
materialised — tag renames, merges, and account re-edits
stay O(1) on write. The read cost is a few small joins
against indexed PKs.

### What lands

**Storage**
- New \`EffectiveTagsRepository\` with \`for_posting()\` and
  \`for_transaction()\`. Returns provenance-annotated
  \`EffectiveTag\` records sorted by (provenance, name).
- 6 storage tests cover direct-only / full inheritance /
  unknown id / transaction-level union / empty-transaction
  / sort stability.

**API**
- New \`GET /v1/transactions/{id}/effective-tags\` returns
  \`{direct, effective, by_provenance}\` so the TUI can
  render direct + inherited separately and surface
  provenance per edge.
- 2 endpoint tests.

### Tag redesign closeout

- **PR #449 (PR A)** — normalised tag registry. **MERGED.**
- **PR #451 (PR B)** — posting + account tag tables +
  account-tag API. **Open.**
- **PR #452 (PR C)** — read-time inheritance + endpoint.
  **This PR.**

After all three land, the tag system supports:
- Per-account, per-transaction, and per-posting tags.
- Rename-O(1) via normalisation.
- Read-time inheritance with provenance.

### Out of scope (potential follow-ups)

- TUI surfacing of the new endpoint.
- Posting-level tag write surface (currently postings can be
  tagged via the storage repo; transaction PATCH body
  extension can land separately).
- Tag-management endpoints (\`/v1/tags\` for rename/merge/
  delete-cascade).
- Hierarchical tags (the \`parent_tag_id\` column was
  reserved but no logic uses it).

## Test plan

\`\`\`bash
uv run --package tulip-storage pytest packages/tulip-storage/tests/test_effective_tags.py -q
uv run --package tulip-storage pytest packages/tulip-storage/tests/ -q
uv run --package tulip-api pytest packages/tulip-api/tests/test_transactions_tags.py -q
just lint
just typecheck
\`\`\`

- [x] All storage tests pass (309 with the 6 new effective-
  tags tests)
- [x] All API tag tests pass (22 with the 2 new endpoint
  tests)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 322 source
  files)
- [ ] CI green on this PR (lands after #449 + #451)