### PR TITLE
fix(import): resolve QIF categories by hierarchical name path (closes #450)

### DIFF
--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -376,7 +376,15 @@ async def promote_statement_line(
             )
         ]
         for split in splits:
+            # #450: prefer the path-aware resolver so GnuCash-rooted
+            # charts (Expenses:Wants:Personal:Gifts) accept Banktivity-
+            # style category strings (Wants:Personal:Gifts) without
+            # falling through to Imbalance:Unknown. Code lookup stays
+            # as the fast path for charts that put colon-paths in the
+            # ``code`` column.
             split_account = accounts.get_by_code(split.category)
+            if split_account is None:
+                split_account = accounts.find_by_name_path(split.category)
             if split_account is None:
                 split_account = _get_or_create_imbalance_account(
                     session=session,
@@ -425,7 +433,13 @@ async def promote_statement_line(
             ),
             session=session,
         )
+        # #450: try code first, then hierarchical name-path. The
+        # categorizer often returns colon-paths from the chart's name
+        # column when the chart has no ``code`` populated (the
+        # GnuCash-imported shape).
         resolved = accounts.get_by_code(suggestion.account_code)
+        if resolved is None:
+            resolved = accounts.find_by_name_path(suggestion.account_code)
         if resolved is None:
             raise CategorizeUnknownAccountError(suggestion.account_code, household_id)
         other_account = resolved

--- a/packages/tulip-api/tests/services/test_import_apply.py
+++ b/packages/tulip-api/tests/services/test_import_apply.py
@@ -531,6 +531,73 @@ class TestPromoteSplitLine:
             assert bank.amount == Decimal("2814.50")
 
     @pytest.mark.asyncio
+    async def test_split_resolves_by_name_path_when_code_misses(self, session_maker, setup):
+        """#450: GnuCash-rooted chart accepts Banktivity-style colon-paths.
+
+        The chart has ``Expenses:Wants:Personal:Gifts`` (no ``code``
+        populated for any node). QIF emits ``Wants:Personal:Gifts``.
+        ``get_by_code`` misses → ``find_by_name_path`` resolves the
+        suffix → posting lands on the gift account, not
+        Imbalance:Unknown.
+        """
+        # Build the chart hierarchy without populating ``code``.
+        with session_maker() as s:
+            repo = AccountRepository(s, setup["household_id"])
+            expenses = repo.create(name="Expenses", type=AccountType.EXPENSE, currency="USD")
+            wants = repo.create(
+                name="Wants",
+                type=AccountType.EXPENSE,
+                currency="USD",
+                parent_account_id=expenses.id,
+            )
+            personal = repo.create(
+                name="Personal",
+                type=AccountType.EXPENSE,
+                currency="USD",
+                parent_account_id=wants.id,
+            )
+            gifts = repo.create(
+                name="Gifts",
+                type=AccountType.EXPENSE,
+                currency="USD",
+                parent_account_id=personal.id,
+            )
+            gifts_id = gifts.id
+            s.commit()
+
+        line_id = self._seed_split_line(
+            session_maker,
+            setup,
+            total="-50.00",
+            splits=[
+                {
+                    "amount": "-50.00",
+                    "currency": "USD",
+                    "category": "Wants:Personal:Gifts",
+                    "memo": None,
+                },
+            ],
+        )
+
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], line_id)
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            postings = list(s.query(Posting).filter_by(transaction_id=tx.id).all())
+            # 2 postings: bank-side + the split (resolved to Gifts).
+            assert len(postings) == 2
+            other = next(p for p in postings if p.account_id != setup["cash_id"])
+            assert other.account_id == gifts_id
+
+    @pytest.mark.asyncio
     async def test_unknown_split_category_falls_back_to_imbalance(self, session_maker, setup):
         """A split whose category doesn't exist routes to Imbalance:Unknown."""
         line_id = self._seed_split_line(

--- a/packages/tulip-storage/src/tulip_storage/repositories/account.py
+++ b/packages/tulip-storage/src/tulip_storage/repositories/account.py
@@ -184,6 +184,92 @@ class AccountRepository:
             return rows[0]
         return None
 
+    def find_by_name_path(self, path: str) -> Account | None:
+        """Resolve a colon-delimited account name path (#450).
+
+        Mirrors the CLI's hierarchical-path resolver so the import-apply
+        flow can match QIF / GnuCash category strings like
+        ``Wants:Personal:Gifts`` against accounts whose stored name
+        chain is ``Expenses:Wants:Personal:Gifts`` (root → leaf).
+
+        Behaviour:
+        - Splits ``path`` on ``:`` into tokens; lowercase for case-
+          insensitive comparison.
+        - Optional first token can be a Tulip type token
+          (``assets`` / ``asset`` / ``liabilities`` / ... / ``expenses``)
+          to constrain the search.
+        - For every active account in the household, the account's
+          name chain (root → leaf) is reconstructed by walking
+          ``parent_account_id``. The path tokens must equal the chain's
+          trailing suffix.
+        - Returns the unique match, or ``None`` for no-match /
+          ambiguous (multiple-match) inputs. The caller falls through
+          to ``Imbalance:Unknown`` on ``None``.
+        """
+        if not path or path.strip() == "":
+            return None
+        # Strip a tag suffix if any (``<path>/<tags>``) — defensive even
+        # before #447 lands the parser-side fix. The first ``/`` ends
+        # the category portion.
+        category_text = path.split("/", 1)[0].strip()
+        if ":" in category_text:
+            tokens = [t.strip().lower() for t in category_text.split(":") if t.strip()]
+        else:
+            tokens = [category_text.lower()] if category_text else []
+        if not tokens:
+            return None
+
+        # Optional type constraint via root segment.
+        type_constraint: str | None = None
+        type_aliases = {
+            "asset": "asset",
+            "assets": "asset",
+            "liability": "liability",
+            "liabilities": "liability",
+            "equity": "equity",
+            "equities": "equity",
+            "income": "income",
+            "incomes": "income",
+            "expense": "expense",
+            "expenses": "expense",
+        }
+        if len(tokens) > 1 and tokens[0] in type_aliases:
+            type_constraint = type_aliases[tokens[0]]
+            tokens = tokens[1:]
+        if not tokens:
+            return None
+
+        # Build the chart in-memory once. For a typical household
+        # (50-200 accounts) this is cheap and well-bounded.
+        all_active = self.list_active()
+        by_id: dict[UUID, Account] = {a.id: a for a in all_active}
+
+        def name_chain(a: Account) -> list[str]:
+            names: list[str] = []
+            seen: set[UUID] = set()
+            cur: Account | None = a
+            while cur is not None:
+                if cur.id in seen:
+                    break
+                seen.add(cur.id)
+                names.append(cur.name.lower())
+                cur = (
+                    by_id.get(cur.parent_account_id) if cur.parent_account_id is not None else None
+                )
+            names.reverse()
+            return names
+
+        matches: list[Account] = []
+        for account in all_active:
+            if type_constraint is not None and account.type.value != type_constraint:
+                continue
+            chain = name_chain(account)
+            if len(chain) >= len(tokens) and chain[-len(tokens) :] == tokens:
+                matches.append(account)
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
     def list_active(self) -> list[Account]:
         """Return all active accounts in this household, ordered by code/name."""
         return list(

--- a/packages/tulip-storage/tests/test_account_path_lookup.py
+++ b/packages/tulip-storage/tests/test_account_path_lookup.py
@@ -1,0 +1,142 @@
+"""Tests for ``AccountRepository.find_by_name_path`` (#450).
+
+Powers the QIF import-apply category resolution: a Banktivity-style
+\"Wants:Personal:Gifts\" must match a GnuCash-rooted chart's
+\"Expenses:Wants:Personal:Gifts\" without forcing the operator to
+re-tag every category.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from tulip_storage.models import Account, AccountType, Household
+from tulip_storage.repositories import AccountRepository
+
+
+@pytest.fixture
+def household(session: Session) -> Household:
+    h = Household(id=uuid4(), name="Smith", base_currency="USD")
+    session.add(h)
+    session.commit()
+    return h
+
+
+def _create_chain(
+    session: Session,
+    household: Household,
+    *,
+    type_: AccountType = AccountType.EXPENSE,
+    names: list[str],
+) -> Account:
+    """Build a hierarchical chain of accounts; return the leaf."""
+    repo = AccountRepository(session, household.id)
+    parent_id = None
+    leaf: Account | None = None
+    for name in names:
+        leaf = repo.create(
+            name=name,
+            type=type_,
+            currency="USD",
+            parent_account_id=parent_id,
+        )
+        parent_id = leaf.id
+    session.commit()
+    assert leaf is not None
+    return leaf
+
+
+def test_matches_with_type_prefix(session: Session, household: Household) -> None:
+    """``Expenses:Wants:Personal:Gifts`` resolves to the leaf."""
+    leaf = _create_chain(session, household, names=["Expenses", "Wants", "Personal", "Gifts"])
+    repo = AccountRepository(session, household.id)
+    found = repo.find_by_name_path("Expenses:Wants:Personal:Gifts")
+    assert found is not None
+    assert found.id == leaf.id
+
+
+def test_matches_suffix_without_type_prefix(session: Session, household: Household) -> None:
+    """``Wants:Personal:Gifts`` (no type root) still resolves — the chart
+    has ``Expenses:Wants:Personal:Gifts`` and the path matches the
+    trailing suffix."""
+    leaf = _create_chain(session, household, names=["Expenses", "Wants", "Personal", "Gifts"])
+    repo = AccountRepository(session, household.id)
+    found = repo.find_by_name_path("Wants:Personal:Gifts")
+    assert found is not None
+    assert found.id == leaf.id
+
+
+def test_case_insensitive_match(session: Session, household: Household) -> None:
+    leaf = _create_chain(session, household, names=["Expenses", "Wants", "Personal", "Gifts"])
+    repo = AccountRepository(session, household.id)
+    found = repo.find_by_name_path("wants:PERSONAL:Gifts")
+    assert found is not None
+    assert found.id == leaf.id
+
+
+def test_returns_none_on_no_match(session: Session, household: Household) -> None:
+    _create_chain(session, household, names=["Expenses", "Wants", "Gifts"])
+    repo = AccountRepository(session, household.id)
+    assert repo.find_by_name_path("Nope:Whatever") is None
+
+
+def test_returns_none_on_ambiguous_match(session: Session, household: Household) -> None:
+    """Two siblings with the same name → ambiguous; return None."""
+    repo = AccountRepository(session, household.id)
+    parent = repo.create(name="Expenses", type=AccountType.EXPENSE, currency="USD")
+    branch_a = repo.create(
+        name="Wants",
+        type=AccountType.EXPENSE,
+        currency="USD",
+        parent_account_id=parent.id,
+    )
+    branch_b = repo.create(
+        name="Wants",
+        type=AccountType.EXPENSE,
+        currency="USD",
+        parent_account_id=parent.id,
+    )
+    repo.create(
+        name="Gifts",
+        type=AccountType.EXPENSE,
+        currency="USD",
+        parent_account_id=branch_a.id,
+    )
+    repo.create(
+        name="Gifts",
+        type=AccountType.EXPENSE,
+        currency="USD",
+        parent_account_id=branch_b.id,
+    )
+    session.commit()
+    assert repo.find_by_name_path("Wants:Gifts") is None
+
+
+def test_type_prefix_constrains_search(session: Session, household: Household) -> None:
+    """``Income:Salary`` doesn't match an expense account named ``Salary``."""
+    _create_chain(session, household, names=["Salary"], type_=AccountType.EXPENSE)
+    repo = AccountRepository(session, household.id)
+    # Without type prefix the leaf matches.
+    assert repo.find_by_name_path("Salary") is not None
+    # With ``Income:`` constraint it doesn't (it's an expense).
+    assert repo.find_by_name_path("Income:Salary") is None
+
+
+def test_strips_tag_suffix(session: Session, household: Household) -> None:
+    """Defensive: ``<path>/<tag>`` resolves to the path's leaf
+    (the parser-side fix is #447; the resolver shouldn't be picky)."""
+    leaf = _create_chain(session, household, names=["Expenses", "Wants", "Gifts"])
+    repo = AccountRepository(session, household.id)
+    found = repo.find_by_name_path("Wants:Gifts/Birthday")
+    assert found is not None
+    assert found.id == leaf.id
+
+
+def test_empty_or_whitespace_returns_none(session: Session, household: Household) -> None:
+    repo = AccountRepository(session, household.id)
+    assert repo.find_by_name_path("") is None
+    assert repo.find_by_name_path("   ") is None
+    assert repo.find_by_name_path(":::") is None


### PR DESCRIPTION
## Summary

The GnuCash → Tulip chart migration leaves every category
account with a populated \`name\` + \`parent_account_id\` chain
(e.g. \`Expenses → Wants → Personal → Gifts\`) but an empty
\`code\` column. The import-apply flow only looked up split
categories via \`get_by_code\`, so a Banktivity QIF category
like \`Wants:Personal:Gifts\` silently fell through to
\`Imbalance:Unknown\` — losing every income / expense category
on a freshly-migrated chart.

This was the highest-impact gap from the beta audit: the user
had already imported 700 statement lines and most of them lost
their category attribution.

## Fix

- New \`AccountRepository.find_by_name_path(path)\` does
  case-insensitive, suffix-aware hierarchical resolution.
- \`import_apply.py\` tries \`get_by_code\` first (fast path for
  code-populated charts), then \`find_by_name_path\`, then
  \`Imbalance:Unknown\`. Both the split path and the
  categorizer-result path get the same chain.
- Defensively strips a trailing \`<path>/<tag>\` suffix so the
  resolver works even before #447 (parser-side tag stripping)
  lands.

## Test plan

\`\`\`bash
uv run --package tulip-storage pytest packages/tulip-storage/tests/test_account_path_lookup.py -q
uv run --package tulip-api pytest packages/tulip-api/tests/services/test_import_apply.py -q
just lint
just typecheck
\`\`\`

- [x] 8 new \`test_account_path_lookup\` tests cover with /
  without type prefix, case-insensitive, no-match, ambiguous,
  type constraint, tag-suffix stripping, empty / whitespace.
- [x] 1 new integration test covers the end-to-end GnuCash-
  rooted chart shape.
- [x] 317 storage tests + 35 apply-service tests pass.
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 322 source files)
- [ ] CI green on this PR
- [ ] Manual smoke: re-import \`2026-05-20_Banktivity_Export.qif\`
  post-merge + docker rebuild; verify split-line postings land
  on the right categories instead of Imbalance:Unknown.

Next in the beta-blocker queue: #447 (QIF per-split tag
parsing) + #448 (Imbalance:Unknown auto-plug for unpaired
transfers).