### PR TITLE
fix(import): plug unpaired QIF transfers with Imbalance:Unknown (closes #448)

### DIFF
--- a/packages/tulip-api/src/tulip_api/routers/imports.py
+++ b/packages/tulip-api/src/tulip_api/routers/imports.py
@@ -74,11 +74,13 @@ from tulip_api.services.import_apply import (
     LineAlreadyPromotedError,
     LineExcludedError,
     PlaceholderAccountError,
+    _get_or_create_imbalance_account,
     apply_batch,
     promote_statement_line,
     serialize_parsed_line_raw_json,
 )
 from tulip_api.services.qif_multi_account import pair_transfers
+from tulip_core.money import Money
 from tulip_core.reconciliation.categorizer import get_categorizer
 from tulip_core.transactions import Posting as DomainPosting
 from tulip_core.transactions import Transaction as DomainTransaction
@@ -537,7 +539,7 @@ async def upload_multi_account_qif(
             ) from exc
 
     # Match reciprocal cross-account transfer legs.
-    pairs, warnings = pair_transfers(parsed_by_account, name_to_uuid)
+    pairs, unpaired_legs, warnings = pair_transfers(parsed_by_account, name_to_uuid)
 
     # Attachment + per-account dedup. The attachment covers the whole file;
     # re-importing it is a duplicate for every account it touches.
@@ -655,11 +657,49 @@ async def upload_multi_account_qif(
         line_repo.mark_promoted(from_sl.id, tx.id)
         line_repo.mark_promoted(to_sl.id, tx.id)
 
+    # Unpaired transfer legs — plug with Imbalance:Unknown so the
+    # household lands balanced from the start (#448). Operator re-
+    # targets during reconciliation. Same shape as paired transfers
+    # (one balanced PENDING transaction per leg), the only difference
+    # being the counter-posting account.
+    for leg in unpaired_legs:
+        imbalance = _get_or_create_imbalance_account(
+            session=session,
+            household_id=claims.household_id,
+            currency=leg.line.amount.currency,
+            actor_user_id=claims.user_id,
+        )
+        line = leg.line
+        domain_tx = DomainTransaction(
+            id=uuid4(),
+            household_id=claims.household_id,
+            date=line.posted_date,
+            description=line.description,
+            postings=(
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=name_to_uuid[leg.account],
+                    amount=line.amount,
+                ),
+                DomainPosting(
+                    id=uuid4(),
+                    account_id=imbalance.id,
+                    amount=Money(-line.amount.amount, line.amount.currency),
+                ),
+            ),
+            status=DomainTxStatus.PENDING,
+            created_by_user_id=claims.user_id,
+        )
+        tx = tx_repo.save_balanced(domain_tx, imported_from_id=batches[leg.account].id)
+        sl = line_index[(leg.account, line.line_number)]
+        line_repo.mark_promoted(sl.id, tx.id)
+
     session.commit()
     log.info(
         "import.multi_account.created",
         batch_count=len(chunks),
         transfer_count=len(pairs),
+        unpaired_count=len(unpaired_legs),
         warning_count=len(warnings),
     )
 

--- a/packages/tulip-api/src/tulip_api/services/qif_multi_account.py
+++ b/packages/tulip-api/src/tulip_api/services/qif_multi_account.py
@@ -42,10 +42,27 @@ class TransferPair:
     to_line: ParsedStatementLine
 
 
+@dataclass(frozen=True, slots=True)
+class UnpairedTransferLeg:
+    """A QIF transfer leg with no matching reciprocal in the same upload (#448).
+
+    Banktivity sometimes exports only one side of a transfer (e.g.
+    the 401(k) employer-side records reference ``L[Checking]`` but
+    Checking's QIF doesn't have a reciprocal). The upload handler
+    lands these as balanced PENDING transactions with an
+    ``Imbalance:Unknown`` plug on the counter-posting side; the
+    operator re-pairs during reconciliation.
+    """
+
+    account: str
+    target: str
+    line: ParsedStatementLine
+
+
 def pair_transfers(
     parsed_by_account: dict[str, list[ParsedStatementLine]],
     account_map: dict[str, UUID],
-) -> tuple[list[TransferPair], list[str]]:
+) -> tuple[list[TransferPair], list[UnpairedTransferLeg], list[str]]:
     """Match reciprocal QIF transfer legs across the imported accounts.
 
     Two legs pair when they are reciprocal: ``A → B`` for ``-X`` on date
@@ -54,14 +71,21 @@ def pair_transfers(
     greedy — the first eligible reciprocal wins — which is correct for
     QIF exports, where a transfer's two legs are exact mirrors.
 
-    Returns ``(pairs, warnings)``. Each warning names a leg that could
-    not be paired (unmapped target, or no reciprocal); the caller lands
-    those as ordinary one-sided statement lines.
+    Returns ``(pairs, unpaired_legs, warnings)``:
+
+    - ``pairs`` — matched reciprocals; caller turns each into one
+      balanced PENDING tx at upload time.
+    - ``unpaired_legs`` — transfer legs whose counterpart wasn't in
+      the upload (#448). Caller plugs each with ``Imbalance:Unknown``
+      so the household lands balanced from the start.
+    - ``warnings`` — operator-facing messages describing each
+      unpaired leg (or unmapped target).
     """
     # Collect every transfer leg as (account, target, line). Non-transfer
     # records and legs pointing at an unmapped account are skipped here —
     # the latter with a warning, since the user probably meant to map it.
     legs: list[tuple[str, str, ParsedStatementLine]] = []
+    unpaired: list[UnpairedTransferLeg] = []
     warnings: list[str] = []
     for account, lines in parsed_by_account.items():
         for line in lines:
@@ -69,9 +93,15 @@ def pair_transfers(
             if target is None:
                 continue  # ordinary record — becomes a normal statement line
             if target not in account_map:
+                # The target account isn't in this upload. We still want
+                # the leg to land as a balanced tx, so plug with
+                # Imbalance:Unknown via the unpaired path (#448).
+                unpaired.append(UnpairedTransferLeg(account, target, line))
                 warnings.append(
-                    f"{account!r} line {line.line_number}: transfer to unmapped "
-                    f"account {target!r} — landed as a one-sided line."
+                    f"{account!r} line {line.line_number}: transfer to "
+                    f"unmapped account {target!r} — landed with "
+                    "Imbalance:Unknown plug; re-target during "
+                    "reconciliation."
                 )
                 continue
             legs.append((account, target, line))
@@ -95,9 +125,12 @@ def pair_transfers(
                 partner_idx = j
                 break
         if partner_idx is None:
+            unpaired.append(UnpairedTransferLeg(acct_a, target_b, line_a))
             warnings.append(
-                f"{acct_a!r} line {line_a.line_number}: transfer to {target_b!r} "
-                f"has no matching reciprocal leg — landed as a one-sided line."
+                f"{acct_a!r} line {line_a.line_number}: transfer to "
+                f"{target_b!r} has no matching reciprocal leg — landed "
+                "with Imbalance:Unknown plug; re-target during "
+                "reconciliation."
             )
             continue
         consumed.add(i)
@@ -108,4 +141,4 @@ def pair_transfers(
             pairs.append(TransferPair(acct_a, target_b, line_a, line_b))
         else:
             pairs.append(TransferPair(target_b, acct_a, line_b, line_a))
-    return pairs, warnings
+    return pairs, unpaired, warnings

--- a/packages/tulip-api/tests/test_imports_endpoint.py
+++ b/packages/tulip-api/tests/test_imports_endpoint.py
@@ -488,14 +488,21 @@ class TestUploadMultiAccountQif:
             )
             assert len(promoted) == 2
 
-    def test_unpaired_transfer_leg_falls_back_with_warning(
+    def test_unpaired_transfer_leg_plugs_with_imbalance(
         self,
         client: TestClient,
         auth_h: dict[str, str],
+        session_maker,
     ):
-        # multi_account.qif's Savings leg targets Checking but Checking has
-        # no reciprocal — it lands as a plain line + a warning.
+        """#448: an unpaired transfer leg lands as a balanced PENDING
+        transaction with an Imbalance:Unknown counter-posting. Operator
+        re-targets later via reconciliation."""
         import json
+        from decimal import Decimal
+
+        from sqlalchemy import select
+
+        from tulip_storage.models import Account, Posting, StatementLine, Transaction
 
         checking = self._acct(client, auth_h, "Checking", "1110")
         savings = self._acct(client, auth_h, "Savings", "1200")
@@ -516,7 +523,29 @@ class TestUploadMultiAccountQif:
         body = r.json()
         assert body["transfer_count"] == 0
         assert len(body["warnings"]) == 1
-        assert "no matching reciprocal" in body["warnings"][0]
+        # Warning text reflects the new behaviour.
+        assert "Imbalance:Unknown plug" in body["warnings"][0]
+
+        with session_maker() as s:
+            # Exactly one tx — the unpaired transfer's Imbalance plug.
+            txns = list(s.execute(select(Transaction)).scalars())
+            assert len(txns) == 1
+            postings = list(
+                s.execute(select(Posting).where(Posting.transaction_id == txns[0].id)).scalars()
+            )
+            assert len(postings) == 2
+            # Postings net to zero.
+            assert sum(p.amount for p in postings) == Decimal("0")
+            # One of the postings lands on the auto-created Imbalance acct.
+            imbalance = s.execute(select(Account).where(Account.code == "9999.USD")).scalar_one()
+            assert any(p.account_id == imbalance.id for p in postings)
+            # The source statement line is marked promoted to it.
+            promoted = list(
+                s.execute(
+                    select(StatementLine).where(StatementLine.promoted_transaction_id == txns[0].id)
+                ).scalars()
+            )
+            assert len(promoted) == 1
 
     def test_unmapped_account_is_rejected(
         self,

--- a/packages/tulip-api/tests/test_qif_multi_account_service.py
+++ b/packages/tulip-api/tests/test_qif_multi_account_service.py
@@ -44,7 +44,7 @@ def test_reciprocal_legs_pair() -> None:
         "Checking": [_line(1, "-200.00", target="Savings")],
         "Savings": [_line(1, "200.00", target="Checking")],
     }
-    pairs, warnings = pair_transfers(parsed, _MAP)
+    pairs, _unpaired, warnings = pair_transfers(parsed, _MAP)
     assert warnings == []
     assert len(pairs) == 1
     pair = pairs[0]
@@ -61,7 +61,7 @@ def test_orientation_is_independent_of_account_order() -> None:
         "Savings": [_line(1, "200.00", target="Checking")],
         "Checking": [_line(1, "-200.00", target="Savings")],
     }
-    pairs, warnings = pair_transfers(parsed, _MAP)
+    pairs, _unpaired, warnings = pair_transfers(parsed, _MAP)
     assert warnings == []
     assert [(p.from_account, p.to_account) for p in pairs] == [("Checking", "Savings")]
 
@@ -71,7 +71,7 @@ def test_leg_with_no_reciprocal_warns_and_is_not_paired() -> None:
         "Checking": [_line(1, "-200.00", target="Savings")],
         "Savings": [_line(1, "50.00", target=None)],  # plain deposit, not a transfer
     }
-    pairs, warnings = pair_transfers(parsed, _MAP)
+    pairs, _unpaired, warnings = pair_transfers(parsed, _MAP)
     assert pairs == []
     assert len(warnings) == 1
     assert "no matching reciprocal" in warnings[0]
@@ -80,10 +80,35 @@ def test_leg_with_no_reciprocal_warns_and_is_not_paired() -> None:
 
 def test_transfer_to_unmapped_account_warns() -> None:
     parsed = {"Checking": [_line(1, "-200.00", target="Brokerage")]}
-    pairs, warnings = pair_transfers(parsed, _MAP)
+    pairs, _unpaired, warnings = pair_transfers(parsed, _MAP)
     assert pairs == []
     assert len(warnings) == 1
     assert "unmapped account 'Brokerage'" in warnings[0]
+
+
+def test_unpaired_leg_surfaces_in_unpaired_list_for_imbalance_plug() -> None:
+    """#448: unpaired transfer legs are returned so the upload handler
+    can plug them with Imbalance:Unknown."""
+    parsed = {
+        "Checking": [_line(1, "-200.00", target="Savings")],
+        "Savings": [_line(1, "50.00", target=None)],  # not a reciprocal
+    }
+    pairs, unpaired, _warnings = pair_transfers(parsed, _MAP)
+    assert pairs == []
+    assert len(unpaired) == 1
+    assert unpaired[0].account == "Checking"
+    assert unpaired[0].target == "Savings"
+    assert unpaired[0].line.line_number == 1
+
+
+def test_unmapped_target_also_surfaces_as_unpaired() -> None:
+    """A leg whose target isn't in account_map also lands in the
+    unpaired list — same Imbalance:Unknown plug pattern."""
+    parsed = {"Checking": [_line(1, "-200.00", target="Brokerage")]}
+    _pairs, unpaired, _warnings = pair_transfers(parsed, _MAP)
+    assert len(unpaired) == 1
+    assert unpaired[0].account == "Checking"
+    assert unpaired[0].target == "Brokerage"
 
 
 def test_non_transfer_lines_are_ignored() -> None:
@@ -103,7 +128,7 @@ def test_non_transfer_lines_are_ignored() -> None:
         ],
         "Savings": [_line(1, "50.00", target=None)],
     }
-    pairs, warnings = pair_transfers(parsed, _MAP)
+    pairs, _unpaired, warnings = pair_transfers(parsed, _MAP)
     assert pairs == []
     assert warnings == []
 
@@ -115,7 +140,7 @@ def test_cross_currency_legs_do_not_pair() -> None:
         "Checking": [_line(1, "-200.00", target="Savings", currency="USD")],
         "Savings": [_line(1, "200.00", target="Checking", currency="EUR")],
     }
-    pairs, warnings = pair_transfers(parsed, _MAP)
+    pairs, _unpaired, warnings = pair_transfers(parsed, _MAP)
     assert pairs == []
     assert len(warnings) == 2
 
@@ -125,7 +150,7 @@ def test_date_mismatch_does_not_pair() -> None:
         "Checking": [_line(1, "-200.00", target="Savings", on=date(2026, 1, 10))],
         "Savings": [_line(1, "200.00", target="Checking", on=date(2026, 1, 12))],
     }
-    pairs, warnings = pair_transfers(parsed, _MAP)
+    pairs, _unpaired, warnings = pair_transfers(parsed, _MAP)
     assert pairs == []
     assert len(warnings) == 2
 
@@ -141,6 +166,6 @@ def test_two_transfers_same_amount_pair_greedily() -> None:
             _line(2, "200.00", target="Checking"),
         ],
     }
-    pairs, warnings = pair_transfers(parsed, _MAP)
+    pairs, _unpaired, warnings = pair_transfers(parsed, _MAP)
     assert warnings == []
     assert len(pairs) == 2


### PR DESCRIPTION
## Summary

Banktivity multi-account QIFs frequently emit only one side of a
transfer (the user's Banktivity export had 36 such legs across 4
account pairs: BNSF 401(k) → Checking, Kia K5 Lease → Checking,
Mortgage Escrow → Mortgage, Sinking Funds → Checking).

Before this PR those legs sat in their batches as un-promoted
statement lines with a warning. They'd only land balanced when
the user ran apply on each batch — leaving the household in a
half-state between upload and apply.

This PR matches GnuCash's QIF importer: every unpaired transfer
leg is plugged with \`Imbalance:Unknown\` at upload time, so the
household lands balanced end-to-end. The operator re-targets
during reconciliation.

## Test plan

\`\`\`bash
uv run --package tulip-api pytest packages/tulip-api/tests/test_qif_multi_account_service.py -q
uv run --package tulip-api pytest packages/tulip-api/tests/test_imports_endpoint.py::TestUploadMultiAccountQif -q
just lint
just typecheck
\`\`\`

- [x] 10 service tests pass (2 new for unpaired-list shape)
- [x] 6 endpoint tests pass (renamed/extended existing case
  to verify the Imbalance plug transaction lands cleanly)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 322 source files)
- [ ] CI green on this PR
- [ ] Manual smoke against the user's Banktivity export
  post-merge: 36 unpaired-transfer warnings should now also
  produce 36 balanced PENDING transactions (vs the previous
  one-sided statement lines).

Beta-blocker queue: #450 (PR #453) → **#448 (this PR)** → #447
(QIF tag parsing — last item).