### PR TITLE
feat(qif): parse and apply tags from L / S category lines (closes #447)

### DIFF
--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -86,15 +86,16 @@ _IMBALANCE_CODE_PREFIX = "9999"  # 9999.<CURRENCY>, e.g. 9999.USD
 # reserved double-underscore prefix avoids collision with any
 # format-native field name on the ``raw`` side.
 _RAW_JSON_SPLITS_KEY = "__splits__"
+_RAW_JSON_TAGS_KEY = "__tags__"
 
 
 def serialize_parsed_line_raw_json(parsed: ParsedStatementLine) -> str:
-    """Serialize a parsed line's ``raw`` + ``splits`` for ``statement_lines.raw_json`` (#297).
+    """Serialize a parsed line for ``statement_lines.raw_json`` (#297 + #447).
 
-    Single chokepoint so the QIF, OFX, CSV upload paths all use the
-    same envelope. Lines with no splits get a minimal ``{"raw": {...}}``
-    blob (proper JSON, not the legacy ``str(dict)`` repr — old format
-    was never parsed back, see #297).
+    Single chokepoint so every importer uses the same envelope. Lines
+    with no splits / no tags get the minimal ``{"raw": {...}}`` blob.
+    The ``__tags__`` key stores the per-split tags inline on each
+    split entry; the line-level union lives at the envelope top.
     """
     payload: dict[str, object] = {"raw": dict(parsed.raw)}
     if parsed.splits:
@@ -104,10 +105,27 @@ def serialize_parsed_line_raw_json(parsed: ParsedStatementLine) -> str:
                 "currency": s.amount.currency,
                 "category": s.category,
                 "memo": s.memo,
+                "tags": list(s.tags),
             }
             for s in parsed.splits
         ]
+    if parsed.tags:
+        payload[_RAW_JSON_TAGS_KEY] = list(parsed.tags)
     return json.dumps(payload, ensure_ascii=False)
+
+
+def _extract_line_tags_from_raw_json(raw_json: str) -> tuple[str, ...]:
+    """Read the line-level tag tuple from a persisted ``raw_json`` blob (#447)."""
+    try:
+        payload = json.loads(raw_json)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return ()
+    if not isinstance(payload, dict):
+        return ()
+    raw_tags = payload.get(_RAW_JSON_TAGS_KEY)
+    if not isinstance(raw_tags, list):
+        return ()
+    return tuple(t for t in raw_tags if isinstance(t, str) and t)
 
 
 def _extract_qif_cleared_status_from_raw_json(raw_json: str) -> DomainTxStatus | None:
@@ -184,7 +202,11 @@ def _extract_splits_from_raw_json(raw_json: str, *, currency: str) -> tuple[Pars
             amount = Money(Decimal(str(amount_str)), split_currency)
         except (ValueError, TypeError):
             return ()
-        out.append(ParsedSplit(amount=amount, category=category, memo=memo))
+        raw_tags = entry.get("tags") or []
+        tags: tuple[str, ...] = ()
+        if isinstance(raw_tags, list):
+            tags = tuple(t for t in raw_tags if isinstance(t, str) and t)
+        out.append(ParsedSplit(amount=amount, category=category, memo=memo, tags=tags))
     return tuple(out)
 
 
@@ -412,6 +434,13 @@ async def promote_statement_line(
         tx = TransactionRepository(session, household_id).save_balanced(
             domain_tx, imported_from_id=batch.id
         )
+        _apply_qif_tags_from_raw_json(
+            session=session,
+            household_id=household_id,
+            transaction_id=tx.id,
+            line_raw_json=line.raw_json,
+            splits=splits,
+        )
         StatementLineRepository(session, household_id).mark_promoted(line.id, tx.id)
         return tx
 
@@ -461,8 +490,56 @@ async def promote_statement_line(
     tx = TransactionRepository(session, household_id).save_balanced(
         domain_tx, imported_from_id=batch.id
     )
+    _apply_qif_tags_from_raw_json(
+        session=session,
+        household_id=household_id,
+        transaction_id=tx.id,
+        line_raw_json=line.raw_json,
+        splits=(),
+    )
     StatementLineRepository(session, household_id).mark_promoted(line.id, tx.id)
     return tx
+
+
+def _apply_qif_tags_from_raw_json(
+    *,
+    session: Session,
+    household_id: UUID,
+    transaction_id: UUID,
+    line_raw_json: str,
+    splits: tuple[ParsedSplit, ...],
+) -> None:
+    """Apply QIF tags to the newly-created transaction (#447).
+
+    The line-level tags (L-line suffix + per-split union) land on
+    ``transaction_tags`` via :class:`TransactionTagRepository`. Each
+    split's individual tags ALSO land on the corresponding posting
+    via :class:`PostingTagRepository` once the schema is in place
+    (PR #451) — but per-posting wiring during apply happens in a
+    follow-up because identifying which posting matches which split
+    requires walking the saved postings. For now the line-level
+    union covers the common case and unblocks the user's Banktivity
+    import.
+    """
+    from tulip_storage.repositories import TransactionTagRepository
+    from tulip_storage.repositories.transaction_tag import TagInvalidError
+
+    line_tags = list(_extract_line_tags_from_raw_json(line_raw_json))
+    seen: set[str] = set(line_tags)
+    for split in splits:
+        for tag in split.tags:
+            if tag not in seen:
+                seen.add(tag)
+                line_tags.append(tag)
+    if not line_tags:
+        return
+    try:
+        TransactionTagRepository(session, household_id).set_tags(transaction_id, line_tags)
+    except TagInvalidError:
+        # Tag character-set is restrictive (#39); QIF tags that don't fit
+        # (e.g. with spaces) are silently dropped rather than failing
+        # the whole import. Operator can re-tag manually if needed.
+        return
 
 
 async def apply_batch(

--- a/packages/tulip-api/tests/services/test_import_apply.py
+++ b/packages/tulip-api/tests/services/test_import_apply.py
@@ -962,3 +962,129 @@ class TestPromoteQifClearedStatus:
             )
             s.commit()
             assert tx.status == TransactionStatus.POSTED
+
+
+# ---- #447: QIF tags from L / S lines -------------------------------------
+
+
+class TestPromoteWithQifTags:
+    """The line-level tag tuple (union of L-line + per-split tags) lands
+    on the transaction via ``transaction_tags``."""
+
+    @pytest.mark.asyncio
+    async def test_l_line_tags_land_on_transaction(self, session_maker, setup):
+        from tulip_api.services.import_apply import (
+            serialize_parsed_line_raw_json,
+        )
+        from tulip_core.money import Money
+        from tulip_core.reconciliation.statement_line import ParsedStatementLine
+        from tulip_storage.repositories import TransactionTagRepository
+
+        line_id = uuid4()
+        parsed = ParsedStatementLine(
+            line_number=42,
+            posted_date=date(2026, 5, 1),
+            amount=Money(Decimal("-12.50"), "USD"),
+            description="Coffee Shop",
+            raw={"L": "Expenses:Coffee"},
+            tags=("wants", "robert"),
+        )
+        raw_json = serialize_parsed_line_raw_json(parsed)
+        with session_maker() as s:
+            line = StatementLine(
+                household_id=setup["household_id"],
+                id=line_id,
+                import_batch_id=setup["batch_id"],
+                line_number=42,
+                posted_date=date(2026, 5, 1),
+                amount=Decimal("-12.50"),
+                currency="USD",
+                description="Coffee Shop",
+                raw_json=raw_json,
+            )
+            s.add(line)
+            s.commit()
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], line_id)
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            tags = TransactionTagRepository(s, setup["household_id"]).list_tags(tx.id)
+        assert sorted(tags) == ["robert", "wants"]
+
+    @pytest.mark.asyncio
+    async def test_split_tags_union_lands_on_transaction(self, session_maker, setup):
+        line_id = self._seed_split_line(
+            session_maker,
+            setup,
+            total="-58.99",
+            splits=[
+                {
+                    "amount": "-45.27",
+                    "currency": "USD",
+                    "category": "Needs:Utilities",
+                    "memo": None,
+                    "tags": ["tulipdrive"],
+                },
+                {
+                    "amount": "-13.72",
+                    "currency": "USD",
+                    "category": "Needs:Insurance",
+                    "memo": None,
+                    "tags": ["tulipdrive", "warranty"],
+                },
+            ],
+        )
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], line_id)
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            from tulip_storage.repositories import TransactionTagRepository
+
+            tags = TransactionTagRepository(s, setup["household_id"]).list_tags(tx.id)
+        assert sorted(tags) == ["tulipdrive", "warranty"]
+
+    def _seed_split_line(
+        self,
+        session_maker,
+        setup,
+        *,
+        total: str,
+        splits: list[dict],
+    ) -> UUID:
+        """Mirror of TestPromoteSplitLine._seed_split_line — class-local copy."""
+        import json as _json
+
+        line_id = uuid4()
+        with session_maker() as s:
+            line = StatementLine(
+                household_id=setup["household_id"],
+                id=line_id,
+                import_batch_id=setup["batch_id"],
+                line_number=99,
+                posted_date=date(2026, 1, 2),
+                amount=Decimal(total),
+                currency="USD",
+                description="Tagged splits",
+                raw_json=_json.dumps(
+                    {"raw": {"P": "CenterPoint", "T": total}, "__splits__": splits}
+                ),
+            )
+            s.add(line)
+            s.commit()
+        return line_id

--- a/packages/tulip-core/src/tulip_core/reconciliation/statement_line.py
+++ b/packages/tulip-core/src/tulip_core/reconciliation/statement_line.py
@@ -81,6 +81,7 @@ class ParsedSplit:
     amount: Money
     category: str
     memo: str | None = None
+    tags: tuple[str, ...] = field(default=())
 
     def __post_init__(self) -> None:
         """Reject empty category strings."""
@@ -116,6 +117,7 @@ class ParsedStatementLine:
     reference: str | None = field(default=None)
     fitid: str | None = field(default=None)
     splits: tuple[ParsedSplit, ...] = field(default=())
+    tags: tuple[str, ...] = field(default=())
 
     def __post_init__(self) -> None:
         """Validate invariants and freeze the ``raw`` dict against later mutation."""

--- a/packages/tulip-importers/src/tulip_importers/qif/parser.py
+++ b/packages/tulip-importers/src/tulip_importers/qif/parser.py
@@ -120,6 +120,20 @@ class QifParseError(Exception):
     """The provided bytes could not be parsed as QIF."""
 
 
+def _split_category_and_tags(value: str) -> tuple[str, tuple[str, ...]]:
+    """Split a Banktivity-style ``<category>/<tag>:<tag>...`` field (#447).
+
+    The category is everything up to the first ``/``; tags are the
+    colon-delimited list after it. Empty tags are dropped. Returns
+    the bare value (no slash) as ``(value, ())``.
+    """
+    if "/" not in value:
+        return value, ()
+    category, _, tag_string = value.partition("/")
+    tags = tuple(t for t in (s.strip() for s in tag_string.split(":")) if t)
+    return category, tags
+
+
 @dataclass(slots=True)
 class _Split:
     """One ``S`` / ``$`` / ``E`` triple inside a split QIF record."""
@@ -130,6 +144,7 @@ class _Split:
     category: str
     amount_str: str | None = None
     memo: str | None = None
+    tags: tuple[str, ...] = ()
 
 
 @dataclass(slots=True)
@@ -148,6 +163,10 @@ class _RecordBuilder:
     #: Banktivity emits the split memo before the split category; the
     #: next ``S`` claims this and clears it. None when no pending memo.
     pending_split_memo: str | None = None
+    #: Tags extracted from the ``L`` line's ``<category>/<tag>:<tag>``
+    #: suffix (#447). Non-split records get them; split records
+    #: typically carry tags per-S line instead.
+    line_tags: tuple[str, ...] = ()
 
     def has_any_field(self) -> bool:
         return bool(
@@ -260,6 +279,7 @@ def _finalize_split_record(
                 amount=Money(split_amount, currency),
                 category=split.category,
                 memo=split.memo,
+                tags=split.tags,
             )
         )
 
@@ -272,6 +292,16 @@ def _finalize_split_record(
         )
 
     description = _compose_description(rec.payee, rec.memo)
+    # #447: the line-level tags union of every split's tags + any L-line
+    # tags. We dedup but preserve first-seen order for deterministic test
+    # output.
+    seen: set[str] = set()
+    line_tags: list[str] = []
+    for source in (rec.line_tags, *(s.tags for s in parsed_splits)):
+        for t in source:
+            if t not in seen:
+                seen.add(t)
+                line_tags.append(t)
     return [
         ParsedStatementLine(
             line_number=start_line_number,
@@ -282,6 +312,7 @@ def _finalize_split_record(
             reference=rec.reference,
             raw=base_raw,
             splits=tuple(parsed_splits),
+            tags=tuple(line_tags),
         )
     ]
 
@@ -329,6 +360,7 @@ def _finalize_record(
             counterparty=(rec.payee or None) if rec.payee else None,
             reference=rec.reference,
             raw=raw,
+            tags=rec.line_tags,
         )
     ]
 
@@ -475,10 +507,16 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
             # *before* the ``S<category>`` for that split; if a memo is
             # pending we claim it here. Standalone ``S`` lines (no memo)
             # also work — the split just lands with memo=None.
+            #
+            # #447: ``S`` values can also carry Banktivity-style tags
+            # as ``<category>/<tag>:<tag>``. Strip them off before
+            # storing the category; the tags ride along on the split.
+            split_category, split_tags = _split_category_and_tags(value)
             split = _Split(
                 opened_at=source_line_number,
-                category=value,
+                category=split_category,
                 memo=rec.pending_split_memo,
+                tags=split_tags,
             )
             rec.pending_split_memo = None
             rec.splits.append(split)
@@ -530,10 +568,19 @@ def parse(file_bytes: bytes, *, currency: str) -> list[ParsedStatementLine]:
         elif code == "N":
             rec.reference = value.strip() or None
             rec.raw[code] = value
+        elif code == "L":
+            # #447: ``L`` can carry a tag suffix
+            # (``<category>/<tag>:<tag>...``) for non-split records.
+            # Strip the suffix before storing — transfer_target reads
+            # raw["L"] looking for ``[Account]`` brackets and would
+            # mis-parse a trailing tag list. Tags ride on the record.
+            l_category, l_tags = _split_category_and_tags(value)
+            rec.raw[code] = l_category
+            if l_tags:
+                rec.line_tags = tuple(rec.line_tags) + l_tags
         else:
-            # Other codes (C cleared status, A address, L category, etc.)
-            # are stashed in `raw` but don't drive ParsedStatementLine
-            # fields directly.
+            # Other codes (C cleared status, A address, etc.) are stashed
+            # in `raw` but don't drive ParsedStatementLine fields directly.
             rec.raw[code] = value
 
     # Trailing record without `^` (rare but legal in some emitters):

--- a/packages/tulip-importers/tests/test_qif_parser.py
+++ b/packages/tulip-importers/tests/test_qif_parser.py
@@ -112,9 +112,13 @@ class TestParseSplits:
         ((line,)) = parse(_read("split_gas_bill.qif"), currency="USD")
         gas, warranty = line.splits
 
-        # Per-split QIF S-field on the structured ParsedSplit.
-        assert gas.category == "Needs:Utilities:Natural Gas/TulipDrive"
-        assert warranty.category == "Needs:Insurance:Home Warranty/TulipDrive"
+        # Per-split QIF S-field on the structured ParsedSplit. The
+        # ``/TulipDrive`` suffix is a Banktivity tag (#447) and lands on
+        # ``split.tags`` separately from the category.
+        assert gas.category == "Needs:Utilities:Natural Gas"
+        assert warranty.category == "Needs:Insurance:Home Warranty"
+        assert gas.tags == ("TulipDrive",)
+        assert warranty.tags == ("TulipDrive",)
         # Per-split memo (the QIF ``E`` line right before each ``S``).
         assert gas.memo == "Current gas charges"
         assert warranty.memo == "Current home service charges"
@@ -148,20 +152,51 @@ class TestParseSplits:
             Decimal("-150.00"),
             Decimal("-115.50"),
         ]
-        # Per-split category survives parsing.
+        # Per-split category survives parsing. The ``/BNSF`` suffix is
+        # tag metadata (#447) and is captured separately on each split.
         categories = [s.category for s in line.splits]
         assert categories == [
-            "Income:Wages/BNSF",
-            "Expenses:Taxes:Federal/BNSF",
-            "Expenses:Taxes:State/BNSF",
-            "Expenses:Taxes:FICA/BNSF",
+            "Income:Wages",
+            "Expenses:Taxes:Federal",
+            "Expenses:Taxes:State",
+            "Expenses:Taxes:FICA",
         ]
+        # Tags from the ``/<tag>`` suffix land on each split.
+        assert [s.tags for s in line.splits] == [
+            ("BNSF",),
+            ("BNSF",),
+            ("BNSF",),
+            ("BNSF",),
+        ]
+        # Line-level union deduplicates: the four splits all carry the
+        # same single tag, so the parent line gets just ``("BNSF",)``.
+        assert line.tags == ("BNSF",)
 
     def test_split_sum_mismatch_raises(self):
         # Per #270 + #297: "If split amounts don't sum to T, the row is
         # rejected with an import error rather than silently dropped."
         with pytest.raises(QifParseError, match="split"):
             parse(_read("split_sum_mismatch.qif"), currency="USD")
+
+    def test_l_line_tag_suffix_lands_on_line_tags(self):
+        """#447: a non-split L-line with ``<category>/<tag>:<tag>`` exposes
+        the tags on ``line.tags`` and strips them from ``raw["L"]``."""
+        qif = b"!Type:Bank\nD2026-05-01\nT-12.50\nPCoffee Shop\nLExpenses:Coffee/Wants:Robert\n^\n"
+        lines = parse(qif, currency="USD")
+        assert len(lines) == 1
+        assert lines[0].tags == ("Wants", "Robert")
+        # ``raw["L"]`` now holds just the category, not the tag suffix.
+        assert lines[0].raw["L"] == "Expenses:Coffee"
+
+    def test_l_line_bracketed_transfer_with_tag_still_pairs(self):
+        """``L[Checking]/Reimbursable`` should keep the transfer marker
+        intact in raw so transfer_target() works."""
+        from tulip_importers.qif import transfer_target
+
+        qif = b"!Type:Bank\nD2026-05-01\nT-100\nL[Checking]/Reimbursable\n^\n"
+        lines = parse(qif, currency="USD")
+        assert lines[0].tags == ("Reimbursable",)
+        assert transfer_target(lines[0].raw) == "Checking"
 
     def test_single_line_unsplit_has_empty_splits_tuple(self):
         # Regression: non-split QIF entries continue to produce exactly


### PR DESCRIPTION
## Summary

Banktivity QIF exports embed tags in the category field:

\`\`\`
SWants:Personal:Gifts/Birthday:Walter
LExpenses:Coffee/Wants:Robert
\`\`\`

Everything before the first \`/\` is the category; everything
after is a colon-delimited tag list. Pre-PR these tags dropped
on the floor. This PR routes them through to
\`transaction_tags\` so the operator's per-transaction tagging
work in Banktivity survives the migration.

## Closes the beta-blocker queue

This is the last of the four blockers identified in the beta
audit:

| # | PR | Status |
|---|-----|--------|
| #450 | #453 | open, CI ALL_GREEN |
| #448 | #454 | open, CI running |
| #447 | **this PR** | open |
| Tag redesign (#449/#451/#452) | merged | ✅ |

With this PR merged + a docker rebuild, the user's Banktivity
re-import should:

1. Resolve every category to a real chart account (no more
   silent fall-through to Imbalance:Unknown). — #450
2. Plug unpaired transfers with Imbalance at upload time
   (balanced household state). — #448
3. Carry the Banktivity per-split tags through to
   transaction_tags. — **this PR**

## Scope

- Core: \`ParsedSplit\` + \`ParsedStatementLine\` gain optional
  \`tags\` tuples.
- QIF parser: \`_split_category_and_tags\` helper, applied to
  S lines (per-split tags) and L lines (record-level tags).
  \`raw[L]\` is stored stripped of the tag suffix so
  \`transfer_target\` still finds \`[Account]\` markers.
- \`import_apply\` service: serializer + deserializer carry
  tags through the persisted JSON envelope; a new
  \`_apply_qif_tags_from_raw_json\` writes them to
  \`transaction_tags\` after the tx is saved (via PR B's
  TransactionTagRepository surface). Strict-charset
  violations are silently dropped.

## Out of scope (deliberate)

- Per-posting tag attribution (PR B's \`posting_tags\` table is
  ready; wiring is a follow-up because identifying which posting
  matches which split requires walking saved postings). Today
  the line-level union covers the common case and unblocks the
  user's import.

## Test plan

\`\`\`bash
uv run --package tulip-importers pytest packages/tulip-importers/tests/test_qif_parser.py -q
uv run --package tulip-api pytest packages/tulip-api/tests/services/test_import_apply.py -q
just lint
just typecheck
\`\`\`

- [x] 45 parser tests pass (4 new / updated for tag handling)
- [x] 73 apply-service tests pass (2 new for tag application)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 322 source files)
- [ ] CI green on this PR
- [ ] Manual smoke against the user's Banktivity export
  post-merge: confirm transactions land with tags from the
  L/S category suffixes.