### PR TITLE
feat(import): per-split QIF tags land on their individual postings (#447 follow-up)

### DIFF
--- a/packages/tulip-api/src/tulip_api/services/import_apply.py
+++ b/packages/tulip-api/src/tulip_api/services/import_apply.py
@@ -397,6 +397,11 @@ async def promote_statement_line(
                 amount=Money(line.amount, line.currency),
             )
         ]
+        # #447 follow-up: capture each split's posting id so we can
+        # attach the split's tags directly to that posting (not just
+        # the parent transaction). Same ordering as ``splits`` for a
+        # 1:1 zip below.
+        split_posting_ids: list[UUID] = []
         for split in splits:
             # #450: prefer the path-aware resolver so GnuCash-rooted
             # charts (Expenses:Wants:Personal:Gifts) accept Banktivity-
@@ -414,9 +419,11 @@ async def promote_statement_line(
                     currency=line.currency,
                     actor_user_id=actor_user_id,
                 )
+            split_posting_id = uuid4()
+            split_posting_ids.append(split_posting_id)
             postings.append(
                 DomainPosting(
-                    id=uuid4(),
+                    id=split_posting_id,
                     account_id=split_account.id,
                     amount=Money(-split.amount.amount, line.currency),
                     memo=split.memo,
@@ -440,6 +447,12 @@ async def promote_statement_line(
             transaction_id=tx.id,
             line_raw_json=line.raw_json,
             splits=splits,
+        )
+        _apply_qif_posting_tags(
+            session=session,
+            household_id=household_id,
+            splits=splits,
+            split_posting_ids=split_posting_ids,
         )
         StatementLineRepository(session, household_id).mark_promoted(line.id, tx.id)
         return tx
@@ -512,14 +525,9 @@ def _apply_qif_tags_from_raw_json(
     """Apply QIF tags to the newly-created transaction (#447).
 
     The line-level tags (L-line suffix + per-split union) land on
-    ``transaction_tags`` via :class:`TransactionTagRepository`. Each
-    split's individual tags ALSO land on the corresponding posting
-    via :class:`PostingTagRepository` once the schema is in place
-    (PR #451) — but per-posting wiring during apply happens in a
-    follow-up because identifying which posting matches which split
-    requires walking the saved postings. For now the line-level
-    union covers the common case and unblocks the user's Banktivity
-    import.
+    ``transaction_tags`` via :class:`TransactionTagRepository`.
+    The paired :func:`_apply_qif_posting_tags` writes the per-split
+    subset to ``posting_tags`` so per-split attribution survives.
     """
     from tulip_storage.repositories import TransactionTagRepository
     from tulip_storage.repositories.transaction_tag import TagInvalidError
@@ -540,6 +548,41 @@ def _apply_qif_tags_from_raw_json(
         # (e.g. with spaces) are silently dropped rather than failing
         # the whole import. Operator can re-tag manually if needed.
         return
+
+
+def _apply_qif_posting_tags(
+    *,
+    session: Session,
+    household_id: UUID,
+    splits: tuple[ParsedSplit, ...],
+    split_posting_ids: list[UUID],
+) -> None:
+    """Apply each split's tags to its specific posting (#447 follow-up).
+
+    Banktivity emits per-split tags via the ``S<category>/<tag>:<tag>``
+    syntax — semantically those tags describe the split (one line item),
+    not the parent transaction. The transaction-level write in
+    :func:`_apply_qif_tags_from_raw_json` takes the union for cross-
+    cutting reporting (``--tag walter`` finds every walter-touching
+    transaction); this helper writes the per-split subset to
+    ``posting_tags`` so per-posting attribution survives.
+
+    Caller passes ``split_posting_ids`` in the same order as ``splits``.
+    """
+    from tulip_storage.repositories import PostingTagRepository
+    from tulip_storage.repositories.transaction_tag import TagInvalidError
+
+    if not splits or len(splits) != len(split_posting_ids):
+        return
+    repo = PostingTagRepository(session, household_id)
+    for split, posting_id in zip(splits, split_posting_ids, strict=True):
+        if not split.tags:
+            continue
+        try:
+            repo.set_tags(posting_id, list(split.tags))
+        except TagInvalidError:
+            # Match the transaction-level policy: drop malformed silently.
+            continue
 
 
 async def apply_batch(

--- a/packages/tulip-api/tests/services/test_import_apply.py
+++ b/packages/tulip-api/tests/services/test_import_apply.py
@@ -1059,6 +1059,60 @@ class TestPromoteWithQifTags:
             tags = TransactionTagRepository(s, setup["household_id"]).list_tags(tx.id)
         assert sorted(tags) == ["tulipdrive", "warranty"]
 
+    @pytest.mark.asyncio
+    async def test_per_split_tags_attach_to_individual_postings(self, session_maker, setup):
+        """#447 follow-up: each split's tags land on its specific posting,
+        not just the union on the parent transaction."""
+        line_id = self._seed_split_line(
+            session_maker,
+            setup,
+            total="-58.99",
+            splits=[
+                {
+                    "amount": "-45.27",
+                    "currency": "USD",
+                    "category": "Needs:Utilities",
+                    "memo": None,
+                    "tags": ["tulipdrive"],
+                },
+                {
+                    "amount": "-13.72",
+                    "currency": "USD",
+                    "category": "Needs:Insurance",
+                    "memo": None,
+                    "tags": ["warranty"],
+                },
+            ],
+        )
+        with session_maker() as s:
+            batch = _reload(s, ImportBatch, setup["household_id"], setup["batch_id"])
+            line = _reload(s, StatementLine, setup["household_id"], line_id)
+            tx = await promote_statement_line(
+                session=s,
+                household_id=setup["household_id"],
+                batch=batch,
+                line=line,
+                categorizer=NullCategorizer(),
+                actor_user_id=None,
+            )
+            s.commit()
+            from tulip_storage.repositories import PostingTagRepository
+
+            # The three postings: bank-side (no tags) + utilities (tulipdrive)
+            # + insurance (warranty).
+            postings = list(s.query(Posting).filter_by(transaction_id=tx.id).all())
+            assert len(postings) == 3
+            repo = PostingTagRepository(s, setup["household_id"])
+            tags_by_posting = repo.list_tags_for_postings([p.id for p in postings])
+            utilities = next(p for p in postings if p.amount == Decimal("45.27"))
+            insurance = next(p for p in postings if p.amount == Decimal("13.72"))
+            bank = next(p for p in postings if p.amount == Decimal("-58.99"))
+            assert tags_by_posting[utilities.id] == ["tulipdrive"]
+            assert tags_by_posting[insurance.id] == ["warranty"]
+            # Bank-side posting carries no per-posting tag (no split it
+            # corresponds to).
+            assert tags_by_posting[bank.id] == []
+
     def _seed_split_line(
         self,
         session_maker,


### PR DESCRIPTION
## Summary

#455 wired QIF tags through to \`transaction_tags\` at the parent
level. That covered cross-cutting reporting (\`tulip transactions
list --tag walter\` finds every walter-touching transaction) but
collapsed per-split attribution: a Banktivity split like
\`SWants:Personal:Gifts/Birthday:Walter\` has its tags on the
SPLIT semantically, not the parent — and a multi-split row where
each split has different tags lost that distinction.

You said upfront you wanted tags at the posting level. The
storage schema (PR B) and parser (PR C / #455) already supported
it; this PR closes the loop on the apply path.

## Changes

- \`promote_statement_line\` tracks each split's saved posting id
  as it builds the postings list (1:1 with \`ParsedSplit.tags\`).
- New \`_apply_qif_posting_tags\` writes per-split tags via
  \`PostingTagRepository.set_tags\` after \`save_balanced\`.
- Transaction-level union remains in place — they coexist (list-
  by-tag queries hit \`transaction_tags\`; per-posting reads hit
  \`posting_tags\` + the PR C inheritance UNION).

## Test plan

\`\`\`bash
uv run --package tulip-api pytest packages/tulip-api/tests/services/test_import_apply.py -q
just lint
just typecheck
\`\`\`

- [x] 30 apply-service tests pass (1 new for per-posting attribution)
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 322 source files)
- [ ] CI green on this PR
- [ ] Manual smoke against the freshly-imported Banktivity QIF:
  \`tulip transactions list --tag walter\` should still surface
  the transaction, but inspecting that transaction's postings
  via the API should show the \`walter\` tag on the specific
  posting that came from the walter-tagged split.

Closes the last of the deferred items from the ADR-0009 tag
redesign and the beta-blocker wave.