### PR TITLE
feat(cli): tulip transactions recategorize (bulk re-target on description match)

### DIFF
--- a/packages/tulip-cli/src/tulip_cli/commands/transactions.py
+++ b/packages/tulip-cli/src/tulip_cli/commands/transactions.py
@@ -23,6 +23,7 @@ default; ``show`` renders header-plus-postings.
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from dataclasses import dataclass
@@ -1151,6 +1152,284 @@ def edit_transaction(
                         f"(reversal {body_out['reversal_id']})."
                     )
                 return
+    except CliError as err:
+        err.render()
+        raise typer.Exit(err.exit_code) from None
+
+
+@transactions_app.command("recategorize")
+def recategorize_transactions(
+    ctx: typer.Context,
+    to: Annotated[
+        str,
+        typer.Option(
+            "--to",
+            help=(
+                "Target account that should replace --from on matching "
+                "transactions. Accepts UUID, code, name, or colon-path "
+                "(e.g. 'Expenses:Wants:Groceries')."
+            ),
+        ),
+    ],
+    from_account: Annotated[
+        str,
+        typer.Option(
+            "--from",
+            help=(
+                "Re-target postings currently on this account. Typically "
+                "an Imbalance variant after an import that fell through "
+                "the categorizer. Accepts UUID, code, name, or colon-path."
+            ),
+        ),
+    ],
+    description_contains: Annotated[
+        str | None,
+        typer.Option(
+            "--description-contains",
+            help=(
+                "Case-insensitive substring filter on transaction "
+                "description. Omit to match every transaction touching "
+                "--from (rare; usually you want a vendor filter)."
+            ),
+        ),
+    ] = None,
+    include_posted: Annotated[
+        bool,
+        typer.Option(
+            "--include-posted",
+            help=(
+                "Also re-categorize POSTED transactions via void+replace "
+                "(creates a reversal sibling + a replacement; each POSTED "
+                "tx in the result set produces 3 ledger rows). RECONCILED "
+                "transactions are still skipped — those need manual "
+                "review via `tulip transactions edit`."
+            ),
+        ),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Print the planned changes without writing.",
+        ),
+    ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip the interactive confirmation prompt.",
+        ),
+    ] = False,
+) -> None:
+    r"""Bulk-replace one account with another on matching transactions.
+
+    Designed for cleaning up an Imbalance:Unknown backlog after a fresh
+    import: every transaction whose description contains the given
+    substring has its --from posting re-targeted to --to. Posting
+    amounts, memos, and the bank-side posting are preserved untouched.
+
+    Example::
+
+        tulip transactions recategorize \
+            --from "Imbalance:Unknown" \
+            --to "Expenses:Wants:Groceries" \
+            --description-contains "Walmart"
+
+    Only PENDING transactions are touched in v1; POSTED and RECONCILED
+    transactions are skipped with a note since they require the
+    void-and-recreate flow that ``tulip transactions edit`` uses.
+    """
+    config: Config = ctx.obj["config"]
+    as_json: bool = ctx.obj["json"]
+    needle = description_contains.lower() if description_contains else None
+
+    try:
+        with _client(config, as_json=as_json) as client:
+            from_id = _resolve_account_id_for_filter(client, from_account)
+            to_id = _resolve_account_id_for_filter(client, to)
+            if from_id == to_id:
+                raise CliError(
+                    problem={
+                        "type": "/.well-known/errors/recategorize.same_account",
+                        "title": "--from and --to resolved to the same account",
+                        "status": 400,
+                        "detail": (
+                            f"--from {from_account!r} and --to {to!r} both "
+                            f"resolve to {from_id}. The re-categorize would "
+                            "be a no-op; check your account identifiers."
+                        ),
+                        "code": "recategorize.same_account",
+                    },
+                    as_json=as_json,
+                )
+
+            # Pull every tx touching --from across the eligible statuses.
+            # PENDING is always eligible; POSTED is included on opt-in.
+            # RECONCILED is intentionally excluded — those need manual
+            # review via `tulip transactions edit`.
+            eligible_statuses = ["pending"]
+            if include_posted:
+                eligible_statuses.append("posted")
+            candidates: list[dict[str, Any]] = []
+            for st in eligible_statuses:
+                response = client.get(
+                    "/v1/transactions",
+                    authenticated=True,
+                    params={"status": st, "account_id": from_id},
+                )
+                candidates.extend(response.json())
+            if needle is not None:
+                candidates = [
+                    tx
+                    for tx in candidates
+                    if isinstance(tx.get("description"), str)
+                    and needle in tx["description"].lower()
+                ]
+            actionable: list[dict[str, Any]] = []
+            skipped_status_count = 0
+            for tx in candidates:
+                tx_status = str(tx.get("status", "")).lower()
+                if tx_status == "reconciled":
+                    skipped_status_count += 1
+                    continue
+                if tx_status not in ("pending", "posted"):
+                    skipped_status_count += 1
+                    continue
+                # Only re-target postings actually on --from.
+                target_postings = [
+                    p for p in tx.get("postings", []) if p.get("account_id") == from_id
+                ]
+                if not target_postings:
+                    # Server filtered by account_id; defensive skip.
+                    continue
+                actionable.append(tx)
+
+            if not actionable:
+                if as_json:
+                    sys.stdout.write(
+                        json.dumps(
+                            {
+                                "matched": 0,
+                                "updated": 0,
+                                "skipped_reconciled": skipped_status_count,
+                            }
+                        )
+                        + "\n"
+                    )
+                else:
+                    typer.echo("No matching transactions to re-categorize.")
+                    if skipped_status_count:
+                        typer.echo(
+                            f"({skipped_status_count} RECONCILED transaction(s) "
+                            "skipped — use `tulip transactions edit` for those.)"
+                        )
+                return
+
+            posted_count = sum(
+                1 for tx in actionable if str(tx.get("status", "")).lower() == "posted"
+            )
+            if not as_json and not yes and not dry_run:
+                typer.echo(
+                    f"Will re-target {len(actionable)} transaction(s) "
+                    f"from {from_account!r} → {to!r}."
+                )
+                if posted_count:
+                    typer.echo(
+                        f"  {posted_count} are POSTED — those will void+replace "
+                        "(each produces a reversal sibling + a replacement)."
+                    )
+                if skipped_status_count:
+                    typer.echo(
+                        f"  ({skipped_status_count} RECONCILED transaction(s) "
+                        "skipped — use `tulip transactions edit` for those.)"
+                    )
+                typer.confirm("Proceed?", abort=True)
+
+            updated = 0
+            updated_via_replace = 0
+            errors: list[tuple[str, str]] = []
+            for tx in actionable:
+                new_postings = [
+                    {
+                        "account_id": to_id
+                        if p.get("account_id") == from_id
+                        else p.get("account_id"),
+                        "amount": p.get("amount"),
+                        "currency": p.get("currency"),
+                        "memo": p.get("memo"),
+                        "pool_id": p.get("pool_id"),
+                    }
+                    for p in tx.get("postings", [])
+                ]
+                tx_id = tx["id"]
+                tx_status = str(tx.get("status", "")).lower()
+                if dry_run:
+                    if not as_json:
+                        via = "replace" if tx_status == "posted" else "patch"
+                        typer.echo(
+                            f"  would re-target {tx_id[:8]} via {via} "
+                            f"({tx.get('description', '')[:50]!r})"
+                        )
+                    updated += 1
+                    if tx_status == "posted":
+                        updated_via_replace += 1
+                    continue
+                try:
+                    if tx_status == "posted":
+                        client.post(
+                            f"/v1/transactions/{tx_id}/replace",
+                            json={
+                                "date": tx["date"],
+                                "description": tx["description"],
+                                "reference": tx.get("reference"),
+                                "postings": new_postings,
+                                "reason": (
+                                    f"Bulk re-categorize: {from_account} → {to} "
+                                    "(via `tulip transactions recategorize`)"
+                                ),
+                            },
+                            authenticated=True,
+                        )
+                        updated_via_replace += 1
+                    else:
+                        client.patch(
+                            f"/v1/transactions/{tx_id}",
+                            json={"postings": new_postings},
+                            authenticated=True,
+                        )
+                    updated += 1
+                except CliError as err:
+                    errors.append((str(tx_id), str(err.problem.get("code", "unknown"))))
+
+            if as_json:
+                sys.stdout.write(
+                    json.dumps(
+                        {
+                            "matched": len(actionable),
+                            "updated": updated,
+                            "updated_via_replace": updated_via_replace,
+                            "skipped_reconciled": skipped_status_count,
+                            "errors": [{"id": tid, "code": code} for tid, code in errors],
+                            "dry_run": dry_run,
+                        }
+                    )
+                    + "\n"
+                )
+            else:
+                verb = "would update" if dry_run else "updated"
+                typer.echo(
+                    f"{verb.capitalize()} {updated} of {len(actionable)} matching transaction(s)."
+                )
+                if updated_via_replace:
+                    typer.echo(
+                        f"  {updated_via_replace} via void+replace "
+                        "(POSTED transactions; each creates a reversal sibling)."
+                    )
+                if errors:
+                    typer.echo(f"  {len(errors)} error(s):")
+                    for tid, code in errors:
+                        typer.echo(f"    {tid[:8]}: {code}")
     except CliError as err:
         err.render()
         raise typer.Exit(err.exit_code) from None

--- a/packages/tulip-cli/tests/test_transactions_recategorize.py
+++ b/packages/tulip-cli/tests/test_transactions_recategorize.py
@@ -1,0 +1,311 @@
+"""Unit tests for ``tulip transactions recategorize``.
+
+Uses ``httpx.MockTransport`` to drive the request dispatch without a
+live API: verifies PATCH for PENDING vs POST /replace for POSTED, the
+description-contains filter, and dry-run behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import UUID
+
+import httpx
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from tulip_cli.auth.tokens import TokenSet, TokenStore
+from tulip_cli.main import app
+
+_API = "https://api.example.com"
+_FROM = UUID("11111111-1111-1111-1111-111111111111")
+_TO = UUID("22222222-2222-2222-2222-222222222222")
+_BANK = UUID("33333333-3333-3333-3333-333333333333")
+_PENDING_TX = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_POSTED_TX = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+def _seed_token_store(tmp_path: Path) -> TokenStore:
+    store = TokenStore(file_path=tmp_path / "tokens.json")
+    store.save(
+        _API,
+        TokenSet(
+            email="alice@example.com",
+            access_token="access",
+            refresh_token="refresh",
+            access_expires_at=9_999_999_999,
+        ),
+    )
+    return store
+
+
+def _account_row(account_id: UUID, name: str, code: str | None = None) -> dict:
+    return {
+        "id": str(account_id),
+        "name": name,
+        "code": code,
+        "type": "expense",
+        "subtype": None,
+        "currency": "USD",
+        "visibility": "shared",
+        "is_active": True,
+        "is_placeholder": False,
+        "parent_account_id": None,
+        "tags": [],
+        "notes": None,
+    }
+
+
+def _tx_row(
+    *,
+    tx_id: UUID,
+    status: str,
+    description: str,
+    from_account: UUID = _FROM,
+) -> dict:
+    return {
+        "id": str(tx_id),
+        "date": "2026-05-01",
+        "description": description,
+        "reference": None,
+        "notes": None,
+        "status": status,
+        "postings": [
+            {
+                "id": "11000000-0000-0000-0000-000000000001",
+                "account_id": str(_BANK),
+                "amount": "-12.50",
+                "currency": "USD",
+                "memo": None,
+                "pool_id": None,
+            },
+            {
+                "id": "11000000-0000-0000-0000-000000000002",
+                "account_id": str(from_account),
+                "amount": "12.50",
+                "currency": "USD",
+                "memo": None,
+                "pool_id": None,
+            },
+        ],
+        "paired_shadow_tx_id": None,
+        "voided_by_transaction_id": None,
+        "voided_at": None,
+        "tags": [],
+    }
+
+
+def _build_handler(captured: list[httpx.Request]) -> httpx.MockTransport:
+    """Return a transport that handles the recategorize flow."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        path = request.url.path
+        if path == "/v1/accounts":
+            return httpx.Response(
+                200,
+                json=[
+                    _account_row(_FROM, "Imbalance: Unknown", code=None),
+                    _account_row(_TO, "Groceries", code="51310"),
+                    _account_row(_BANK, "Checking", code="1110"),
+                ],
+            )
+        if path == f"/v1/accounts/{_FROM}":
+            return httpx.Response(200, json=_account_row(_FROM, "Imbalance: Unknown"))
+        if path == f"/v1/accounts/{_TO}":
+            return httpx.Response(200, json=_account_row(_TO, "Groceries", code="51310"))
+        if path == f"/v1/accounts/{_BANK}":
+            return httpx.Response(200, json=_account_row(_BANK, "Checking", code="1110"))
+        if path == "/v1/transactions" and request.method == "GET":
+            status = request.url.params.get("status")
+            account_id_param = request.url.params.get("account_id")
+            assert account_id_param == str(_FROM)
+            if status == "pending":
+                return httpx.Response(
+                    200,
+                    json=[
+                        _tx_row(tx_id=_PENDING_TX, status="pending", description="Walmart"),
+                        _tx_row(
+                            tx_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"),
+                            status="pending",
+                            description="Target",
+                        ),
+                    ],
+                )
+            if status == "posted":
+                return httpx.Response(
+                    200,
+                    json=[_tx_row(tx_id=_POSTED_TX, status="posted", description="Walmart")],
+                )
+            return httpx.Response(200, json=[])
+        if path == f"/v1/transactions/{_PENDING_TX}" and request.method == "PATCH":
+            body = json.loads(request.content.decode())
+            assert any(p["account_id"] == str(_TO) for p in body["postings"])
+            return httpx.Response(
+                200,
+                json=_tx_row(tx_id=_PENDING_TX, status="pending", description="Walmart"),
+            )
+        if path == f"/v1/transactions/{_POSTED_TX}/replace" and request.method == "POST":
+            body = json.loads(request.content.decode())
+            assert any(p["account_id"] == str(_TO) for p in body["postings"])
+            assert body.get("reason")
+            return httpx.Response(
+                201,
+                json={
+                    "source_id": str(_POSTED_TX),
+                    "reversal_id": "44444444-4444-4444-4444-444444444444",
+                    "replacement_id": "55555555-5555-5555-5555-555555555555",
+                    "voided_at": "2026-05-21T00:00:00+00:00",
+                    "paired_shadow_tx_id_voided": None,
+                    "paired_shadow_tx_id_for_replacement": None,
+                },
+            )
+        return httpx.Response(404, json={"path": path})
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture
+def runner(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> CliRunner:
+    """CliRunner wired so the CLI uses our mock transport + seeded tokens."""
+    monkeypatch.setenv("TULIP_TOKEN_STORE", str(tmp_path / "tokens.json"))
+    _seed_token_store(tmp_path)
+    return CliRunner()
+
+
+def _invoke(
+    runner: CliRunner,
+    captured: list[httpx.Request],
+    *args: str,
+    input_: str | None = None,
+) -> typer.testing.Result:
+    import tulip_cli.http as http_mod
+
+    real_init = http_mod.TulipClient.__init__
+
+    def patched_init(self, config, *, token_store=None, as_json=False, transport=None):
+        if transport is None:
+            transport = _build_handler(captured)
+        real_init(
+            self,
+            config,
+            token_store=token_store,
+            as_json=as_json,
+            transport=transport,
+        )
+
+    http_mod.TulipClient.__init__ = patched_init
+    try:
+        return runner.invoke(
+            app,
+            ["--api-url", _API, *args],
+            input=input_,
+        )
+    finally:
+        http_mod.TulipClient.__init__ = real_init
+
+
+def test_recategorize_dry_run_lists_planned_changes(runner: CliRunner) -> None:
+    """--dry-run prints planned re-targets without issuing PATCH/POST."""
+    captured: list[httpx.Request] = []
+    result = _invoke(
+        runner,
+        captured,
+        "transactions",
+        "recategorize",
+        "--from",
+        str(_FROM),
+        "--to",
+        str(_TO),
+        "--description-contains",
+        "Walmart",
+        "--dry-run",
+        "--yes",
+    )
+    assert result.exit_code == 0, result.output
+    assert "would re-target" in result.output
+    assert "Would update 1 of 1" in result.output
+    # No write requests issued during dry-run.
+    write_requests = [
+        r
+        for r in captured
+        if r.method in ("PATCH", "POST")
+        and "/v1/transactions/" in r.url.path
+        and r.url.path.endswith("/replace") is not None
+    ]
+    # Only the /v1/transactions list calls are GETs; verify zero writes.
+    assert all(r.method == "GET" for r in captured if "/v1/transactions" in r.url.path)
+    del write_requests  # unused; kept for the comment above
+
+
+def test_recategorize_pending_uses_patch(runner: CliRunner) -> None:
+    """PENDING transactions are dispatched via PATCH /v1/transactions/{id}."""
+    captured: list[httpx.Request] = []
+    result = _invoke(
+        runner,
+        captured,
+        "transactions",
+        "recategorize",
+        "--from",
+        str(_FROM),
+        "--to",
+        str(_TO),
+        "--description-contains",
+        "Walmart",
+        "--yes",
+    )
+    assert result.exit_code == 0, result.output
+    patch_calls = [r for r in captured if r.method == "PATCH"]
+    assert len(patch_calls) == 1
+    assert str(_PENDING_TX) in patch_calls[0].url.path
+    assert "Updated 1 of 1" in result.output
+
+
+def test_recategorize_posted_with_include_flag_uses_replace(
+    runner: CliRunner,
+) -> None:
+    """POSTED transactions are dispatched via POST /v1/transactions/{id}/replace
+    only when ``--include-posted`` is set."""
+    captured: list[httpx.Request] = []
+    result = _invoke(
+        runner,
+        captured,
+        "transactions",
+        "recategorize",
+        "--from",
+        str(_FROM),
+        "--to",
+        str(_TO),
+        "--description-contains",
+        "Walmart",
+        "--include-posted",
+        "--yes",
+    )
+    assert result.exit_code == 0, result.output
+    replace_calls = [r for r in captured if r.method == "POST" and r.url.path.endswith("/replace")]
+    assert len(replace_calls) == 1
+    assert str(_POSTED_TX) in replace_calls[0].url.path
+    patch_calls = [r for r in captured if r.method == "PATCH"]
+    # 1 PATCH (pending) + 1 replace (posted)
+    assert len(patch_calls) == 1
+    assert "via void+replace" in result.output
+
+
+def test_recategorize_same_account_rejects(runner: CliRunner) -> None:
+    """--from and --to resolving to the same id is rejected."""
+    captured: list[httpx.Request] = []
+    result = _invoke(
+        runner,
+        captured,
+        "transactions",
+        "recategorize",
+        "--from",
+        str(_FROM),
+        "--to",
+        str(_FROM),
+        "--yes",
+    )
+    assert result.exit_code != 0
+    assert "same account" in result.output.lower()


### PR DESCRIPTION
## Summary

After a fresh import + apply, the categorizer dumps every non-
split transaction onto Imbalance:Unknown when no AI categorizer
is configured. Cleaning that up one-tx-at-a-time via the editor
is tedious for a household with hundreds of pre-categorized
vendor records (the user's freshly-migrated Banktivity data has
~190 such transactions).

This command bulk-replaces one account with another on every
matching transaction.

\`\`\`bash
tulip transactions recategorize \
    --from \"Imbalance:Unknown\" \
    --to \"Expenses:Wants:Groceries\" \
    --description-contains \"Walmart\"
\`\`\`

## Behaviour

- \`--description-contains\` is a case-insensitive substring filter.
- **PENDING** transactions are PATCHed in place.
- **POSTED** transactions are skipped by default; \`--include-posted\`
  opts in to the void+replace flow (each produces a reversal
  sibling + a replacement, matching \`transactions edit\`'s
  behaviour).
- **RECONCILED** transactions are always skipped — they need
  manual review.
- \`--dry-run\` prints planned changes without writing.
- Interactive confirmation by default; \`--yes\` / \`-y\` skips it.
- Bank-side postings untouched — only postings actually on
  \`--from\` get swapped to \`--to\`. Amounts, memos, and pool tags
  are preserved.

## Test plan

\`\`\`bash
uv run --package tulip-cli pytest packages/tulip-cli/tests/test_transactions_recategorize.py -q
just lint
just typecheck
\`\`\`

- [x] 4 unit tests pass: dry-run, PENDING-via-PATCH, POSTED-via-
  replace, same-account rejection.
- [x] \`just lint\` clean
- [x] \`just typecheck\` clean (no issues found in 322 source files)
- [x] Manual smoke against a fresh Banktivity import: 11 Walmart
  POSTED transactions correctly re-categorized from
  Imbalance:Unknown → Groceries via void+replace; the 11
  reversal siblings landed alongside, 11 replacements on
  Groceries are the new active entries.
- [ ] CI green on this PR

## Closes the post-import workflow gap

With the beta-blockers + tag redesign already shipped, this is
the next leverage point for daily use: any vendor that recurs
in the import (Walmart, Target, electric utility, etc.) can be
cleaned up in one command per pattern, instead of N editor
invocations.