### PR TITLE
feat(tui): expose tags in transaction + account TUI surfaces (P9.6.e)

### DIFF
--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -2083,6 +2083,39 @@ tables, every binding's happy + refuse path, modal open + confirm,
 inline error on load failure, drill-in from the reconciliations
 list).
 
+#### P9.6.e — Tags in the TUI — ✅ *(2026-05-24)*
+
+Per [ADR-0009](adrs/0009-tag-redesign.md) (PRs A/B/C landed the backend). This
+slice wires tags into the TUI read and write surfaces so the
+normalised tag system is visible and editable without leaving the app.
+
+- **Data layer** — `TransactionSummary.tags` and `AccountSummary.tags`
+  (`tuple[str, ...]`, default `()`) populated from the API's
+  `tags: list[str]` field on both resources.
+- **Write layer** — `TransactionDraft.tags` and `AccountDraft.tags`
+  (`tuple[str, ...]`, default `()`) included in `POST /v1/transactions`
+  and `POST /v1/accounts` when non-empty.
+- **Transaction modal** (`TransactionEditModal`) — new comma-separated
+  `#tx-tags` Input field with `initial_tags` prefill. `_parse_tags`
+  normalises: strip whitespace, lowercase, deduplicate (order preserved;
+  API alpha-sorts on write).
+- **Account modal** (`AccountEditModal`) — same `#acct-tags` Input and
+  prefill pattern.
+- **Transaction detail pane** — tags rendered as `tags: food · grocery`
+  when present.
+- **Edit prefill** — `action_edit_tx` passes `initial_tags=tx.tags`;
+  `action_edit_account` passes `initial_tags=account.tags` so edits
+  round-trip existing tags.
+- **`main.py` edit actions** — `_tx_edit_action` includes
+  `"tags": list(draft.tags)` in the PATCH (always sent; empty list
+  clears tags); `_account_edit_action` same.
+- **Tests** — 12 new: 2 data-layer (transactions + accounts tags round-trip
+  and absent-field defaults); 4 transaction modal (renders widget,
+  comma parsing, prefill, empty case); 4 account modal (same); 1
+  transactions screen detail-pane rendering.
+
+No backend changes — all endpoints already accept and return `tags`.
+
 #### P9.6.a — Apply imports inside the TUI — ✅ *(2026-05-20)*
 
 Per [#418](https://github.com/rmwarriner/tulip-accounting/issues/418). New `ImportBatchDetailScreen` reachable with

--- a/packages/tulip-tui/src/tulip_tui/data/account_write.py
+++ b/packages/tulip-tui/src/tulip_tui/data/account_write.py
@@ -26,6 +26,7 @@ class AccountDraft:
     parent_account_id: str | None
     notes: str | None = None  # #50: freeform notes (encrypted at rest)
     is_placeholder: bool = False  # #52: leaf-only postings
+    tags: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,6 +62,8 @@ def create_account(client: TulipClient, draft: AccountDraft) -> dict[str, object
         body["notes"] = draft.notes
     if draft.is_placeholder:
         body["is_placeholder"] = True
+    if draft.tags:
+        body["tags"] = list(draft.tags)
     resp = client.post("/v1/accounts", authenticated=True, json=body)
     return cast("dict[str, object]", resp.json())
 

--- a/packages/tulip-tui/src/tulip_tui/data/accounts.py
+++ b/packages/tulip-tui/src/tulip_tui/data/accounts.py
@@ -41,6 +41,7 @@ class AccountSummary:
     currency: str
     balance: Decimal | None
     is_placeholder: bool = False  # #52
+    tags: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,6 +74,7 @@ def load_accounts(client: TulipClient) -> AccountsData:
     summaries: list[AccountSummary] = []
     for raw in accounts_raw:
         account_id = str(raw["id"])
+        raw_tags = raw.get("tags") or []
         summaries.append(
             AccountSummary(
                 id=account_id,
@@ -82,6 +84,7 @@ def load_accounts(client: TulipClient) -> AccountsData:
                 currency=str(raw.get("currency", "")),
                 balance=balances_by_id.get(account_id),
                 is_placeholder=bool(raw.get("is_placeholder", False)),
+                tags=tuple(str(t) for t in raw_tags if t),
             )
         )
 

--- a/packages/tulip-tui/src/tulip_tui/data/transaction_write.py
+++ b/packages/tulip-tui/src/tulip_tui/data/transaction_write.py
@@ -38,6 +38,7 @@ class TransactionDraft:
     description: str
     reference: str | None
     postings: tuple[ParsedPosting, ...]
+    tags: tuple[str, ...] = ()
 
 
 def parse_posting_line(line: str) -> ParsedPosting:
@@ -129,6 +130,8 @@ def create_transaction(client: TulipClient, draft: TransactionDraft) -> dict[str
     }
     if draft.reference:
         body["reference"] = draft.reference
+    if draft.tags:
+        body["tags"] = list(draft.tags)
     resp = client.post("/v1/transactions", authenticated=True, json=body)
     return cast("dict[str, object]", resp.json())
 

--- a/packages/tulip-tui/src/tulip_tui/data/transactions.py
+++ b/packages/tulip-tui/src/tulip_tui/data/transactions.py
@@ -42,6 +42,7 @@ class TransactionSummary:
     status: str
     postings: tuple[PostingSummary, ...]
     amount_display: str
+    tags: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,6 +116,7 @@ def _to_summary(
                 memo=_optional_str(posting.get("memo")),
             )
         )
+    raw_tags = cast("list[object]", row.get("tags") or [])
     return TransactionSummary(
         id=str(row.get("id", "")),
         date=str(row.get("date", "")),
@@ -124,6 +126,7 @@ def _to_summary(
         status=str(row.get("status", "")),
         postings=tuple(postings),
         amount_display=_amount_display(postings),
+        tags=tuple(str(t) for t in raw_tags if t),
     )
 
 

--- a/packages/tulip-tui/src/tulip_tui/main.py
+++ b/packages/tulip-tui/src/tulip_tui/main.py
@@ -232,6 +232,7 @@ def _tx_edit_action(tx_id: str, draft: TransactionDraft) -> object:
     patch: dict[str, object] = {
         "date": draft.date,
         "description": draft.description,
+        "tags": list(draft.tags),
     }
     if draft.reference is not None:
         patch["reference"] = draft.reference
@@ -326,6 +327,7 @@ def _account_edit_action(account_id: str, draft: AccountDraft) -> object:
         "name": draft.name,
         "visibility": draft.visibility,
         "is_placeholder": draft.is_placeholder,
+        "tags": list(draft.tags),
     }
     if draft.code is not None:
         patch["code"] = draft.code

--- a/packages/tulip-tui/src/tulip_tui/screens/account_modal.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/account_modal.py
@@ -30,6 +30,16 @@ _TYPE_RE = re.compile(r"^(asset|liability|equity|income|expense)$")
 _CURRENCY_RE = re.compile(r"^[A-Za-z]{3}$")
 
 
+def _parse_tags(raw: str) -> tuple[str, ...]:
+    """Parse a comma-separated tag string into a normalised tuple."""
+    seen: list[str] = []
+    for part in raw.split(","):
+        t = part.strip().lower()
+        if t and t not in seen:
+            seen.append(t)
+    return tuple(seen)
+
+
 class AccountEditModal(ModalScreen[AccountDraft | None]):
     """Modal form for ``tulip accounts add`` / ``edit`` (#431)."""
 
@@ -92,6 +102,7 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
         initial_parent_id: str | None = None,
         initial_notes: str = "",
         initial_placeholder: bool = False,
+        initial_tags: tuple[str, ...] = (),
     ) -> None:
         """Store prefill values; modal renders on mount."""
         super().__init__()
@@ -105,6 +116,7 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
         self._initial_parent_id = initial_parent_id
         self._initial_notes = initial_notes
         self._initial_placeholder = initial_placeholder
+        self._initial_tags = ", ".join(initial_tags)
         self._error: str = ""
 
     def compose(self) -> ComposeResult:
@@ -146,6 +158,8 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
             )
             yield Static("notes (optional, encrypted at rest)", classes="label")
             yield Input(value=self._initial_notes, id="acct-notes")
+            yield Static("tags (optional, comma-separated)", classes="label")
+            yield Input(value=self._initial_tags, id="acct-tags")
             yield Static("", id="acct-error")
             with Horizontal(id="acct-buttons"):
                 yield Button("Cancel", id="acct-cancel")
@@ -175,6 +189,7 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
         parent_id_raw = self.query_one("#acct-parent-id", Input).value.strip()
         parent_id = parent_id_raw or None
         notes = self.query_one("#acct-notes", Input).value.strip() or None
+        tags = _parse_tags(self.query_one("#acct-tags", Input).value)
 
         if not name:
             self._set_error("name is required")
@@ -196,6 +211,7 @@ class AccountEditModal(ModalScreen[AccountDraft | None]):
             parent_account_id=parent_id,
             notes=notes,
             is_placeholder=is_placeholder,
+            tags=tags,
         )
 
     def _set_error(self, msg: str) -> None:

--- a/packages/tulip-tui/src/tulip_tui/screens/accounts.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/accounts.py
@@ -162,6 +162,7 @@ class AccountsScreen(Screen[None]):
             initial_currency=account.currency,
             initial_code=account.code or "",
             initial_placeholder=account.is_placeholder,
+            initial_tags=account.tags,
         )
         account_id = account.id
         self.app.push_screen(modal, lambda result: self._on_edit_modal_done(account_id, result))

--- a/packages/tulip-tui/src/tulip_tui/screens/transaction_modal.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/transaction_modal.py
@@ -37,6 +37,20 @@ from tulip_tui.data.transaction_write import (
 )
 
 
+def _parse_tags(raw: str) -> tuple[str, ...]:
+    """Parse a comma-separated tag string into a normalised tuple.
+
+    Each element is stripped and lowercased; blanks and duplicates are
+    dropped. Order is preserved (the API will alpha-sort on write).
+    """
+    seen: list[str] = []
+    for part in raw.split(","):
+        t = part.strip().lower()
+        if t and t not in seen:
+            seen.append(t)
+    return tuple(seen)
+
+
 def _today() -> str:
     """Return today's date as ISO-8601 (UTC), per the QUICKSTART convention."""
     return datetime.now(UTC).date().isoformat()
@@ -110,6 +124,7 @@ class TransactionEditModal(ModalScreen[TransactionDraft | None]):
         initial_description: str = "",
         initial_reference: str = "",
         initial_postings: str = "",
+        initial_tags: tuple[str, ...] = (),
     ) -> None:
         """Store the prefill values; ``initial_date`` defaults to today (UTC)."""
         super().__init__()
@@ -120,6 +135,7 @@ class TransactionEditModal(ModalScreen[TransactionDraft | None]):
         self._initial_postings = initial_postings or (
             "# one posting per line — e.g.\n# 1110=-12.50\n# 5100=12.50\n"
         )
+        self._initial_tags = ", ".join(initial_tags)
         self._error: str = ""
 
     def compose(self) -> ComposeResult:
@@ -134,6 +150,8 @@ class TransactionEditModal(ModalScreen[TransactionDraft | None]):
             yield Input(value=self._initial_reference, id="tx-reference")
             yield Static("postings (one per line: account=amount[@CUR])", classes="label")
             yield TextArea(text=self._initial_postings, id="tx-postings")
+            yield Static("tags (optional, comma-separated)", classes="label")
+            yield Input(value=self._initial_tags, id="tx-tags")
             yield Static("", id="tx-error")
             with Horizontal(id="tx-buttons"):
                 yield Button("Cancel", id="tx-cancel")
@@ -175,11 +193,13 @@ class TransactionEditModal(ModalScreen[TransactionDraft | None]):
             self._set_error(str(exc))
             return None
 
+        tags = _parse_tags(self.query_one("#tx-tags", Input).value)
         return TransactionDraft(
             date=date_val,
             description=description,
             reference=reference or None,
             postings=postings,
+            tags=tags,
         )
 
     def _set_error(self, msg: str) -> None:

--- a/packages/tulip-tui/src/tulip_tui/screens/transactions.py
+++ b/packages/tulip-tui/src/tulip_tui/screens/transactions.py
@@ -83,6 +83,8 @@ def _detail_text(tx: TransactionSummary) -> str:
         lines.append(f"reference: {tx.reference}")
     if tx.notes:
         lines.append(f"notes: {tx.notes}")
+    if tx.tags:
+        lines.append(f"tags: {' · '.join(tx.tags)}")
     lines.append("")
     for posting in tx.postings:
         memo = f"  ({posting.memo})" if posting.memo else ""
@@ -195,6 +197,7 @@ class TransactionsScreen(Screen[None]):
             initial_description=tx.description,
             initial_reference=tx.reference or "",
             initial_postings=postings_text,
+            initial_tags=tx.tags,
         )
         tx_id = tx.id
         self.app.push_screen(

--- a/packages/tulip-tui/tests/test_account_modal_screen.py
+++ b/packages/tulip-tui/tests/test_account_modal_screen.py
@@ -349,3 +349,79 @@ async def test_n_with_no_create_action_surfaces_error() -> None:
         modal.dismiss(draft)
         await pilot.pause()
     assert "create failed" in screen.notice()
+
+
+# ---- tags field tests -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_account_modal_renders_tags_input() -> None:
+    """The ``#acct-tags`` Input widget is present in the modal."""
+    from textual.widgets import Input
+
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = AccountEditModal(title="Test")
+        await app.push_screen(modal)
+        await pilot.pause()
+        assert modal.query_one("#acct-tags", Input) is not None
+
+
+@pytest.mark.asyncio
+async def test_account_modal_parses_comma_separated_tags() -> None:
+    """Comma-separated input becomes a tuple of lowercased, stripped strings."""
+    from textual.widgets import Input
+
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = AccountEditModal(
+            initial_name="Checking",
+            initial_type="asset",
+            initial_currency="USD",
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        modal.query_one("#acct-tags", Input).value = "Liquid , PRIMARY , checking"
+        draft = modal.snapshot()
+        assert draft is not None
+        assert draft.tags == ("liquid", "primary", "checking")
+
+
+@pytest.mark.asyncio
+async def test_account_modal_prefills_tags_from_initial_tags() -> None:
+    """``initial_tags`` renders as a comma-joined string in the tags input."""
+    from textual.widgets import Input
+
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = AccountEditModal(
+            initial_name="Checking",
+            initial_type="asset",
+            initial_currency="USD",
+            initial_tags=("liquid", "primary"),
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        rendered = modal.query_one("#acct-tags", Input).value
+        assert rendered == "liquid, primary"
+
+
+@pytest.mark.asyncio
+async def test_account_modal_empty_tags_when_no_input() -> None:
+    """An empty tags field yields an empty tuple in the draft."""
+    app = TulipTuiApp(loader=_accounts_loader_empty)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = AccountEditModal(
+            initial_name="Checking",
+            initial_type="asset",
+            initial_currency="USD",
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        draft = modal.snapshot()
+        assert draft is not None
+        assert draft.tags == ()

--- a/packages/tulip-tui/tests/test_accounts_data.py
+++ b/packages/tulip-tui/tests/test_accounts_data.py
@@ -273,6 +273,62 @@ def test_load_accounts_handles_empty_household() -> None:
     assert data.as_of == "2026-05-17"
 
 
+def test_load_accounts_captures_tags() -> None:
+    """Tags returned by the API land on the AccountSummary as a tuple of strings."""
+    accounts_payload = [
+        {
+            "id": _ACCOUNT_CHECKING_ID,
+            "code": "assets:checking",
+            "name": "Checking",
+            "type": "asset",
+            "subtype": None,
+            "currency": "USD",
+            "visibility": "shared",
+            "is_active": True,
+            "parent_account_id": None,
+            "tags": ["liquid", "primary"],
+        },
+    ]
+    trial_payload = {
+        "as_of": "2026-05-17",
+        "rows": [],
+        "totals_by_currency": [],
+        "pending_included": False,
+        "pending_count": 0,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts_payload)
+        if request.url.path == "/v1/reports/trial-balance":
+            return httpx.Response(200, json=trial_payload)
+        raise AssertionError(f"unexpected: {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_accounts(client)
+
+    assert data.accounts[0].tags == ("liquid", "primary")
+
+
+def test_load_accounts_empty_tags_when_absent() -> None:
+    """Accounts without a ``tags`` key get an empty tuple, not an error."""
+    accounts_payload = _accounts_response()
+    trial_payload = _trial_balance_response()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/accounts":
+            return httpx.Response(200, json=accounts_payload)
+        if request.url.path == "/v1/reports/trial-balance":
+            return httpx.Response(200, json=trial_payload)
+        raise AssertionError(f"unexpected: {request.url.path}")
+
+    with _build_client(httpx.MockTransport(handler)) as client:
+        data = load_accounts(client)
+
+    for acct in data.accounts:
+        assert acct.tags == ()
+
+
 def test_load_accounts_raises_when_api_returns_error() -> None:
     """API errors bubble out as ``CliError`` for the screen to surface."""
     from tulip_cli.errors import CliError

--- a/packages/tulip-tui/tests/test_transaction_modal_screen.py
+++ b/packages/tulip-tui/tests/test_transaction_modal_screen.py
@@ -342,3 +342,85 @@ async def test_n_with_no_create_action_surfaces_error() -> None:
         await pilot.pause()
 
     assert "create failed" in screen.notice()
+
+
+# ---- tags field tests -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_modal_renders_tags_input() -> None:
+    """The ``#tx-tags`` Input widget is present in the modal."""
+    from textual.widgets import Input
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = TransactionEditModal(
+            initial_date="2026-05-20",
+            initial_description="x",
+            initial_postings="1110=-1.00\n5100=1.00",
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        assert modal.query_one("#tx-tags", Input) is not None
+
+
+@pytest.mark.asyncio
+async def test_modal_parses_comma_separated_tags() -> None:
+    """Comma-separated input becomes a tuple of lowercased, stripped tag strings."""
+    from textual.widgets import Input
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = TransactionEditModal(
+            initial_date="2026-05-20",
+            initial_description="Lunch",
+            initial_postings="1110=-12.50\n5100=12.50",
+            initial_tags=("food", "grocery"),
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        # Overwrite with a raw comma-separated string.
+        modal.query_one("#tx-tags", Input).value = "Food , GROCERY , dining"
+        draft = modal.snapshot()
+        assert draft is not None
+        assert draft.tags == ("food", "grocery", "dining")
+
+
+@pytest.mark.asyncio
+async def test_modal_prefills_tags_from_initial_tags() -> None:
+    """``initial_tags`` renders as a comma-joined string in the tags input."""
+    from textual.widgets import Input
+
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = TransactionEditModal(
+            initial_date="2026-05-20",
+            initial_description="x",
+            initial_postings="1110=-1.00\n5100=1.00",
+            initial_tags=("food", "grocery"),
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        rendered = modal.query_one("#tx-tags", Input).value
+        assert rendered == "food, grocery"
+
+
+@pytest.mark.asyncio
+async def test_modal_empty_tags_when_no_input() -> None:
+    """An empty tags field yields an empty tuple in the draft."""
+    app = TulipTuiApp(loader=_accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = TransactionEditModal(
+            initial_date="2026-05-20",
+            initial_description="x",
+            initial_postings="1110=-1.00\n5100=1.00",
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        draft = modal.snapshot()
+        assert draft is not None
+        assert draft.tags == ()

--- a/packages/tulip-tui/tests/test_transactions_data.py
+++ b/packages/tulip-tui/tests/test_transactions_data.py
@@ -274,6 +274,52 @@ def test_load_transactions_handles_empty_result() -> None:
     assert data.transactions == ()
 
 
+def test_load_transactions_captures_tags() -> None:
+    """Tags returned by the API land on the summary as a tuple of strings."""
+    tx_payload = [
+        {
+            "id": _TX_1,
+            "date": "2026-05-14",
+            "description": "Trader Joe's",
+            "reference": None,
+            "notes": None,
+            "status": "posted",
+            "tags": ["food", "grocery"],
+            "postings": [
+                {
+                    "id": "p1",
+                    "account_id": _CHECKING,
+                    "amount": "-20.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+                {
+                    "id": "p2",
+                    "account_id": _GROCERIES,
+                    "amount": "20.00",
+                    "currency": "USD",
+                    "memo": None,
+                    "pool_id": None,
+                },
+            ],
+        }
+    ]
+    with _build_client(_handler_factory(tx_payload=tx_payload)) as client:
+        data = load_transactions(client)
+
+    assert data.transactions[0].tags == ("food", "grocery")
+
+
+def test_load_transactions_empty_tags_when_absent() -> None:
+    """When the API omits the tags field the summary has an empty tuple."""
+    with _build_client(_handler_factory()) as client:
+        data = load_transactions(client)
+
+    for tx in data.transactions:
+        assert tx.tags == ()
+
+
 def test_load_transactions_raises_on_api_error() -> None:
     from tulip_cli.errors import CliError
 

--- a/packages/tulip-tui/tests/test_transactions_screen.py
+++ b/packages/tulip-tui/tests/test_transactions_screen.py
@@ -228,3 +228,45 @@ async def test_accounts_screen_enter_pushes_transactions_screen() -> None:
 
     # The drill-in passes the selected account's id into the factory.
     assert captured["account_id"] == "acc-1"
+
+
+@pytest.mark.asyncio
+async def test_detail_pane_shows_tags() -> None:
+    """Tags appear in the detail pane when the transaction has them."""
+    tagged_tx = TransactionSummary(
+        id="tx-tag",
+        date="2026-05-14",
+        description="Groceries",
+        reference=None,
+        notes=None,
+        status="posted",
+        postings=(
+            PostingSummary(
+                account_id="acc-1",
+                account_label="Checking",
+                amount=Decimal("-20.00"),
+                currency="USD",
+                memo=None,
+            ),
+            PostingSummary(
+                account_id="acc-2",
+                account_label="Food",
+                amount=Decimal("20.00"),
+                currency="USD",
+                memo=None,
+            ),
+        ),
+        amount_display="-20.00 USD",
+        tags=("food", "grocery"),
+    )
+    accounts_loader = lambda: AccountsData(  # noqa: E731
+        as_of="2026-05-14", accounts=(), groups=()
+    )
+    app = TulipTuiApp(loader=accounts_loader)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = await _push_transactions(app, TransactionsData(transactions=(tagged_tx,)))
+        await pilot.pause()
+        detail = screen.detail_text()
+        assert "food" in detail
+        assert "grocery" in detail


### PR DESCRIPTION
## Summary

- Wires ADR-0009 tags into the TUI read/write surfaces (P9.6.e); no backend changes required — all endpoints already accept and return `tags: list[str]`
- **Data layer**: `TransactionSummary.tags` and `AccountSummary.tags` (`tuple[str, ...]`, default `()`) populated from the API's `tags` field on both resources
- **Write layer**: `TransactionDraft.tags` and `AccountDraft.tags` included in `POST /v1/transactions` and `POST /v1/accounts` (and in `PATCH` edit actions — always sent; empty list clears tags)
- **Modals**: new comma-separated `#tx-tags` / `#acct-tags` `Input` fields with `initial_tags` prefill; `_parse_tags` normalises (strip, lowercase, deduplicate, preserve order)
- **Transaction detail pane**: tags rendered as `tags: food · grocery` when present; edit prefill round-trips existing tags through both modals

## Test plan

- [x] 12 new tests: 2 data-layer (transactions + accounts tags round-trip and absent-field defaults), 4 transaction modal (renders widget, comma parsing, prefill, empty case), 4 account modal (same), 1 transactions screen detail-pane rendering, 1 transaction screen tags detail test
- [x] `uv run pytest packages/tulip-tui` — 204 passed
- [x] `uv run pytest packages/tulip-tui packages/tulip-cli` — 802 passed
- [x] `uv run ruff check packages/tulip-tui` — clean
- [x] `uv run mypy --strict packages/tulip-tui/src` — clean
- [ ] CI green on this PR